### PR TITLE
Fix QPS modulation in DriverNode when --qps target is higher than plaform performance.

### DIFF
--- a/packages/feedsim/third_party/src/workloads/ranking/DriverNodeRank.cc
+++ b/packages/feedsim/third_party/src/workloads/ranking/DriverNodeRank.cc
@@ -70,7 +70,7 @@ void RecomputeDelayTimerHandler(evutil_socket_t listener, int16_t flags,
                (stats.end_time_ - stats.start_time_) * 1000000000;
 
   // Adjust delay based on QPS
-  this_thread->request_delay *= (qps / this_thread->qps_per_thread);
+  this_thread->request_delay = (1000000 / this_thread->qps_per_thread) * (qps / this_thread->qps_per_thread);
 
   AddRecomputeDelayTimer(*this_thread);
 }


### PR DESCRIPTION
That change fixes QPS modulation. Without that fix driver would reduce request delay to 0 over time when --qps target provided is higher than the platform can deliver.

../oldisim/src/DriverNode.cc(361): DriverNodeThread started... now

../workloads/ranking/DriverNodeRank.cc(76): A: QPS_target: 132.419998, QPS: 106.213454, delay: 6056

../workloads/ranking/DriverNodeRank.cc(76): A: QPS_target: 132.419998, QPS: 114.963954, delay: 5257

../workloads/ranking/DriverNodeRank.cc(76): A: QPS_target: 132.419998, QPS: 108.263097, delay: 4297

../workloads/ranking/DriverNodeRank.cc(76): A: QPS_target: 132.419998, QPS: 112.255715, delay: 3642

../workloads/ranking/DriverNodeRank.cc(76): A: QPS_target: 132.419998, QPS: 114.156282, delay: 3139

../workloads/ranking/DriverNodeRank.cc(76): A: QPS_target: 132.419998, QPS: 101.193764, delay: 2398

../workloads/ranking/DriverNodeRank.cc(76): A: QPS_target: 132.419998, QPS: 105.137493, delay: 1903

../workloads/ranking/DriverNodeRank.cc(76): A: QPS_target: 132.419998, QPS: 99.222223, delay: 1425

../workloads/ranking/DriverNodeRank.cc(76): A: QPS_target: 132.419998, QPS: 98.211332, delay: 1056

../workloads/ranking/DriverNodeRank.cc(76): A: QPS_target: 132.419998, QPS: 99.306638, delay: 791

../workloads/ranking/DriverNodeRank.cc(76): A: QPS_target: 132.419998, QPS: 91.113630, delay: 544

../workloads/ranking/DriverNodeRank.cc(76): A: QPS_target: 132.419998, QPS: 97.032876, delay: 398

../workloads/ranking/DriverNodeRank.cc(76): A: QPS_target: 132.419998, QPS: 61.123376, delay: 183

../workloads/ranking/DriverNodeRank.cc(76): A: QPS_target: 132.419998, QPS: 96.235939, delay: 132

../workloads/ranking/DriverNodeRank.cc(76): A: QPS_target: 132.419998, QPS: 84.171335, delay: 83

../workloads/ranking/DriverNodeRank.cc(76): A: QPS_target: 132.419998, QPS: 88.164842, delay: 55

../workloads/ranking/DriverNodeRank.cc(76): A: QPS_target: 132.419998, QPS: 91.088451, delay: 37

../workloads/ranking/DriverNodeRank.cc(76): A: QPS_target: 132.419998, QPS: 89.105470, delay: 24

../workloads/ranking/DriverNodeRank.cc(76): A: QPS_target: 132.419998, QPS: 89.183737, delay: 16

../workloads/ranking/DriverNodeRank.cc(76): A: QPS_target: 132.419998, QPS: 95.119357, delay: 11

../workloads/ranking/DriverNodeRank.cc(76): A: QPS_target: 132.419998, QPS: 92.168492, delay: 7

../workloads/ranking/DriverNodeRank.cc(76): A: QPS_target: 132.419998, QPS: 89.146512, delay: 4

../workloads/ranking/DriverNodeRank.cc(76): A: QPS_target: 132.419998, QPS: 63.119148, delay: 1

../workloads/ranking/DriverNodeRank.cc(76): A: QPS_target: 132.419998, QPS: 59.158181, delay: 0

../workloads/ranking/DriverNodeRank.cc(76): A: QPS_target: 132.419998, QPS: 84.201019, delay: 0

../workloads/ranking/DriverNodeRank.cc(76): A: QPS_target: 132.419998, QPS: 83.204083, delay: 0