### PR TITLE
Parameterize tao_bench port number for multi-instance support

### DIFF
--- a/benchpress/config/jobs.yml
+++ b/benchpress/config/jobs.yml
@@ -261,7 +261,7 @@
 - benchmark: tao_bench
   name: tao_bench_custom
   description:
-      Tao benchmark using custom amount of memory.
+      Tao benchmark using custom amount of memory and ports.
       MAKE SURE to start clients within 1 minute.
   roles:
     server:
@@ -273,12 +273,14 @@
         - '--dispatcher-to-fast-ratio=0.25'
         - '--slow-to-fast-ratio=3'
         - '--interface-name={interface_name}'
+        - '--port-number={port_number}'
         - '--warmup-time={warmup_time}'
         - '--test-time={test_time}'
         - '--real'
       vars:
         - 'interface_name=eth0'
         - 'memsize=64'
+        - 'port_number=11211'
         - 'warmup_time=1200'
         - 'test_time=360'
     client:
@@ -289,6 +291,7 @@
         - '--server-memsize={server_memsize}'
         - '--target-hit-ratio=0.9'
         - '--tunning-factor=0.807'
+        - '--server-port-number={server_port_number}'
         - '--warmup-time={warmup_time}'
         - '--test-time={test_time}'
         - '--real'
@@ -296,6 +299,7 @@
         - 'server_hostname'
         - 'server_memsize=64'
         - 'clients_per_thread=380'
+        - 'server_port_number=11211'
         - 'warmup_time=1200'
         - 'test_time=360'
 

--- a/jobs.yml
+++ b/jobs.yml
@@ -261,7 +261,7 @@
 - benchmark: tao_bench
   name: tao_bench_custom
   description:
-      Tao benchmark using custom amount of memory.
+      Tao benchmark using custom amount of memory and ports.
       MAKE SURE to start clients within 1 minute.
   roles:
     server:
@@ -273,12 +273,14 @@
         - '--dispatcher-to-fast-ratio=0.25'
         - '--slow-to-fast-ratio=3'
         - '--interface-name={interface_name}'
+        - '--port-number={port_number}'
         - '--warmup-time={warmup_time}'
         - '--test-time={test_time}'
         - '--real'
       vars:
         - 'interface_name=eth0'
         - 'memsize=64'
+        - 'port_number=11211'
         - 'warmup_time=1200'
         - 'test_time=360'
     client:
@@ -289,6 +291,7 @@
         - '--server-memsize={server_memsize}'
         - '--target-hit-ratio=0.9'
         - '--tunning-factor=0.807'
+        - '--server-port-number={server_port_number}'
         - '--warmup-time={warmup_time}'
         - '--test-time={test_time}'
         - '--real'
@@ -296,6 +299,7 @@
         - 'server_hostname'
         - 'server_memsize=64'
         - 'clients_per_thread=380'
+        - 'server_port_number=11211'
         - 'warmup_time=1200'
         - 'test_time=360'
 

--- a/packages/tao_bench/run.py
+++ b/packages/tao_bench/run.py
@@ -82,6 +82,11 @@ def run_server(args):
     n_slow_threads = int(n_threads * args.slow_to_fast_ratio)
     # memory size
     n_mem = int(args.memsize * MEM_USAGE_FACTOR) * 1024
+    # port number
+    if args.port_number > 0:
+        port_num = args.port_number
+    else:
+        server_port_num = 11211
     print(
         f"Use {n_channels} NIC channels, {n_threads} fast threads and {n_mem} MB cache memory"
     )
@@ -115,6 +120,8 @@ def run_server(args):
         str(n_threads),
         "-B",
         "binary",
+        "-p",
+        str(port_num),
         "-I",
         "16m",
         "-Z",
@@ -139,6 +146,11 @@ def get_client_cmd(args, n_seconds):
         n_clients = args.clients_per_thread
     else:
         n_clients = 380
+    # server port number
+    if args.server_port_number > 0:
+        server_port_num = args.server_port_number
+    else:
+        server_port_num = 11211
 
     # mem size
     n_bytes_per_item = 434  # average from collected distribution
@@ -157,7 +169,7 @@ def get_client_cmd(args, n_seconds):
         "-s",
         s_host,
         "-p",
-        "11211",
+        str(server_port_num),
         "-P",
         "memcache_binary",
         f"--cert={s_cert}",
@@ -253,6 +265,12 @@ def init_parser():
         action="store_true",
         help="hard bind NIC channels to cores",
     )
+    server_parser.add_argument(
+        "--port-number",
+        type=int,
+        default=11211,
+        help="port number of server",
+    )
     # client-side arguments
     client_parser.add_argument(
         "--server-hostname", type=str, required=True, help="server hostname"
@@ -283,6 +301,12 @@ def init_parser():
         type=int,
         default=380,
         help="Number of clients per thread",
+    )
+    client_parser.add_argument(
+        "--server-port-number",
+        type=int,
+        default=11211,
+        help="port number of server",
     )
     # for both server & client
     for x_parser in [server_parser, client_parser]:


### PR DESCRIPTION
This branch enables the parameterizing the port number for the tao_bench client and server to enable multi-instance data collection.

All that is required for multi-instance is to use different ports for the instances of taobench. I tested this with two copies of the DCPerf directory on the server, passing a different port to each one and passing different ports to each client, so each each client accesses only one instance. You can also taskset each of the instances to a subset of the cores as well.  I haven't tested this running both servers from the same directory.

Here is are sample commands for a multi-instance run:
Server instance 1:
taskset -c 0-15 python3 ./benchpress_cli.py run tao_bench_64g -r server -i '{"interface_name":"eth0","warmup_time":"1200","test_time":"360","port_number":"11211"}'
Server instance 2 (run from a duplicated directory of DCPerf): 
taskset -c 16-31 python3 ./benchpress_cli.py run tao_bench_64g -r server -i '{"interface_name":"eth0","warmup_time":"1200","test_time":"360","port_number":"11212"}'
Client1:
python3 ./benchpress_cli.py run tao_bench_64g -r client -i '{"server_hostname":"192.168.55.3","warmup_time":"1200","test_time":"360","server_port_number":"11211"}'
Client2:
'{"server_hostname":"192.168.55.3","warmup_time":"1200","test_time":"360","server_port_number":"11212"}'

External scripts can be used to run the instances simultaneously and collate the data after running. For example, adding total QPS of each instance together to get a total value (though it is sometimes useful to see both values).  This functionality could be added to DCPerf itself, but that isn't included here. 