### PR TITLE
Changed taobench server memory size calculation to match the client. 

### DIFF
--- a/packages/tao_bench/run.py
+++ b/packages/tao_bench/run.py
@@ -81,7 +81,7 @@ def run_server(args):
     n_dispatchers = int(n_threads * args.dispatcher_to_fast_ratio)
     n_slow_threads = int(n_threads * args.slow_to_fast_ratio)
     # memory size
-    n_mem = int(args.memsize * MEM_USAGE_FACTOR) * 1024
+    n_mem = int(args.memsize * 1024 * MEM_USAGE_FACTOR)
     # port number
     if args.port_number > 0:
         port_num = args.port_number


### PR DESCRIPTION
This fixes a rounding error in the hit ratio, that is introduced by casting differently between server and client.

Currently, run.py puts parentheses in different places when integer casting for memory size on server versus client. This leads to a difference the memory sizes, which affects hit ratio. See the relevant lines of code below:

Server:
https://github.com/facebookresearch/DCPerf/blob/main/packages/tao_bench/run.py#L84 
n_mem = int(args.memsize * MEM_USAGE_FACTOR) * 1024

Client
https://github.com/facebookresearch/DCPerf/blob/main/packages/tao_bench/run.py#L157
mem_size_mb = int(args.server_memsize * 1024 * MEM_USAGE_FACTOR)

I changed the server, but you should also be able to change the client and get the same results.

This difference causes an unstable hit_ratio which can deviate from the target of 0.900. In some cases, the difference can be large enough that the test fails the parsing check of 0.890 configured here https://github.com/facebookresearch/DCPerf/blob/main/packages/tao_bench/run.py#L157

Here are some examples that I've tested:

For the default case of memsize = 64 GB:
Server memory size: 49152 MB
Client memory size: 49152 MB
hit_rate: 0.900

For the case of memsize = 65 GB:
Server memory size: 49152 MB
Client memory size: 49920 MB
hit_rate: 0.886

For the extreme case of memsize = 9 G:
Server memory size: 6144 MB
Client memory size: 6912 MB
hit_rate: 0.800

You can do the math and see how the differences in memory size work out to the hit rate I mentioned. I've also confirmed this by running taobench with these memory sizes and the logs confirm the same hit ratios.