### PR TITLE
Fix an error passing spark.executor.extraJavaOptions

### DIFF
--- a/packages/spark_standalone/templates/proj_root/scripts/run_perf_common.py
+++ b/packages/spark_standalone/templates/proj_root/scripts/run_perf_common.py
@@ -45,7 +45,7 @@ def run_spark_sql(
         cmd.extend([k, v])
     for k, v in SPARK_CONFIGS.items():
         cmd.append("--conf")
-        value = '"{}"'.format(" ".join(v)) if type(v) is list else v
+        value = " ".join(v) if type(v) is list else v
         cmd.append(f"{k}={value}")
     cmd.extend(["-f", sql_file])
     if database:


### PR DESCRIPTION
to Spark executors. Currently, the format of `spark.executor.extraJavaOptions` being passed is `spark.executor.extraJavaOptions="option1 option2"`, but the expected format is `"spark.executor.extraJavaOptions=option1 option2"`.
As a result, `spark.executor.extraJavaOptions` is not being consumed by Spark executor processes with the following warning in executor's `stderr` output:
`WARN SystemPropertyUtil: Unable to parse the boolean system property `