### PR TITLE
Update formula for cpu cores range calculation

### DIFF
--- a/packages/tao_bench/run_2x.py
+++ b/packages/tao_bench/run_2x.py
@@ -52,8 +52,10 @@ def compose_server_cmd(args, cpu_core_range, memsize, port_number):
 def run_server(args):
     # core ranges for each server instance
     n_cores = len(os.sched_getaffinity(0))
-    cores_range_1 = f"0-{n_cores // 2 - 1}"
-    cores_range_2 = f"{n_cores // 2}-{n_cores - 1}"
+    part = n_cores // 4
+    # Pin each instance to physical cpu core and corresponding vcpu
+    cores_range_1 = f"0-{part - 1}, {part * 2}-{part *2 + part -1}"
+    cores_range_2 = f"{part}-{part * 2 - 1}, {part *2 + part}-{n_cores - 1}"
     # memory size - split in half for each server
     n_mem = int(args.memsize)
     mem_per_inst = n_mem // 2


### PR DESCRIPTION
For TaoBench2x, with current core range calculation, one tao_server instance is pinned to physical cpu cores and the other tao_server instance is pinned to vcpu cores. As a result, the QPS from each instance is not balanced.

Core pinning in a way that the physical cpu cores and their corresponding vcpu get bound to one instance of tao_server will reduce ccx traffic / latency.

In my experiments, this method gave an uplift of 5-7% in the total QPS for TaoBench2x.
