### PR TITLE
In taobench 2-inst, changed the way taskset core range is calculated …

### DIFF
--- a/packages/tao_bench/run_2x.py
+++ b/packages/tao_bench/run_2x.py
@@ -56,8 +56,8 @@ def run_server(args):
     core_list = list(os.sched_getaffinity(0))
     part = n_cores // 4
     # Pin each instance to physical cpu core and corresponding vcpu
-    cores_range_1 = ', '.join([str(i) for i in (core_list[:part]+core_list[part*2:part*3])])
-    cores_range_2 = ', '.join([str(i) for i in (core_list[part:part*2]+core_list[part*3:part*4])])
+    cores_range_1 = ','.join([str(i) for i in (core_list[:part]+core_list[part*2:part*3])])
+    cores_range_2 = ','.join([str(i) for i in (core_list[part:part*2]+core_list[part*3:part*4])])
     # memory size - split in half for each server
     n_mem = int(args.memsize)
     mem_per_inst = n_mem // 2


### PR DESCRIPTION
In taobench 2-inst, changed the way taskset core range is calculated to account for non-contiguous core list (such as seen with core offlining)

By default DCPerf/packages/tao_bench/run_2x.py assumes all your cores are contiguous, so it tasksets the application to the wrong cores if you offline cores. Let me show the code and the wrong output.
 
In this scenario, there are 112 cores with 0-55 being the first SMT siblings and 56-111 being the second SMT sibling. I've arranged so that 24c/48t are online: 0-23, 56-79. For 2-instance we should taskset half the cores (with their corresponding siblings) to each instance, so the first instance should receive cores 0-11, 56-67 and the second instance instance should receive 12-23, 68-79. As you can see from the commands copied from the logs below, the default code incorrectly assigns cores 0-11, 24-35 to the first instance.
 
Spawn server instance: taskset --cpu-list 0-11,24-35 /root/Cache/DCPerf/packages/tao_bench/run.py server --memsize 128 --nic-channel-ratio 0.5 --fast-threads-ratio 0.75 --dispatcher-to-fast-ratio 0.25 --slow-to-fast-ratio 3 --interface-name eth0 --port-number 11211 --warmup-time 2400 --test-time 720 --real
Spawn server instance: taskset --cpu-list 12-23,36-47 /root/Cache/DCPerf/packages/tao_bench/run.py server --memsize 128 --nic-channel-ratio 0.5 --fast-threads-ratio 0.75 --dispatcher-to-fast-ratio 0.25 --slow-to-fast-ratio 3 --interface-name eth0 --port-number 11212 --warmup-time 2400 --test-time 720 --real
 
Here is the code that calculates the cpu-list:
 
My solution is to just take the os.sched_getaffinity list directly and divide that, assuming that the ordering remains the same. You also could clean it up so that it remains in the same format as before (0-11,56-67).

Here is the new output:
Spawn server instance: taskset --cpu-list 0,1,2,3,4,5,6,7,8,9,10,11,56,57,58,59,60,61,62,63,64,65,66,67 /root/Cache/DCPerf/packages/tao_bench/run.py server --memsize 128 --nic-channel-ratio 0.5 --fast-threads-ratio 0.75 --dispatcher-to-fast-ratio 0.25 --slow-to-fast-ratio 3 --interface-name eth0 --port-number 11211 --warmup-time 2400 --test-time 720 --real
Spawn server instance: taskset --cpu-list 12,13,14,15,16,17,18,19,20,21,22,23,68,69,70,71,72,73,74,75,76,77,78,79 /root/Cache/DCPerf/packages/tao_bench/run.py server --memsize 128 --nic-channel-ratio 0.5 --fast-threads-ratio 0.75 --dispatcher-to-fast-ratio 0.25 --slow-to-fast-ratio 3 --interface-name eth0 --port-number 11212 --warmup-time 2400 --test-time 720 --real
