### PR TITLE
Taobench Arm64 Ubunttu

### DIFF
--- a/packages/tao_bench/install_tao_bench_aarch64.sh
+++ b/packages/tao_bench/install_tao_bench_aarch64.sh
@@ -21,13 +21,23 @@ else
     echo "Warning: unsupported platform ${LINUX_DIST_ID}-${LINUX_DIST_ID}"
 fi
 
-sudo dnf install -y cmake autoconf automake \
+if [ "$LINUX_DIST_ID" = "ubuntu" ]; then
+  sudo apt install -y cmake autoconf automake flex bison \
+    libevent-dev openssl libssl-dev \
+    libzstd-dev lz4 liblz4-dev xzip libsnappy-dev zlib1g-dev bzip2 \
+    libaio-dev libunwind-dev patch libghc-double-conversion-dev \
+    libsodium-dev  libfmt-dev libtool perl git \
+    libgoogle-glog-dev python3-dev pkg-config \
+    git libpcre3 libpcre3-dev libgflags2.2 libgflags-dev
+elif [ "$LINUX_DIST_ID" = "centos" ]; then
+  sudo dnf install -y cmake autoconf automake \
     libevent-devel openssl openssl-devel \
     zlib-devel bzip2-devel xz-devel lz4-devel libzstd-devel \
     snappy-devel libaio-devel libunwind-devel patch \
     double-conversion-devel libsodium-devel \
     gflags-devel-2.2.2 fmt-devel perl libtool pcre-devel \
     git python3-devel ${GLOG_NAME}
+fi
 
 # Installing dependencies
 mkdir -p "${TAO_BENCH_DEPS}"
@@ -102,6 +112,9 @@ fi
 if ! [ -d "${FMT_INSTALLED_PATH}" ]; then
     echo "Cannot find path to fmt" && exit 1
 fi
+if ! [ -d "${FMT_INSTALLED_PATH}/lib64" ] && [ "$LINUX_DIST_ID" = "ubuntu" ]; then
+    ln -s -f "${FMT_INSTALLED_PATH}/lib" "${FMT_INSTALLED_PATH}/lib64"
+fi
 
 # Build and install
 if ! [ -f "/usr/bin/aclocal-1.16" ]; then
@@ -147,6 +160,10 @@ make -j"$(nproc)" || ( automake --add-missing && make -j"$(nproc)" )
 cp memtier_benchmark "${TAO_BENCH_ROOT}/tao_bench_client"
 popd # memtier_client
 popd # $TAO_BENCH_ROOT
+
+if [ "$LINUX_DIST_ID" = "ubuntu" ]; then
+  cp build-deps/lib/libcrypto.so.1.1 /lib/aarch64-linux-gnu/
+fi
 
 # Extract certificates
 tar -zxf "${COMMON_DIR}/certs.tar.gz" -C "${TAO_BENCH_ROOT}/"


### PR DESCRIPTION
Taobench on Arm64 Ubuntu

Changes include:

1. Install the dependencies on ubuntu
2. Copy the FMT/lib to FTM/lib64
3. Copy libcrypto.so.1.1 to /lib/aarch64-linux-gnu/