### PR TITLE
Solution to the Feedsim unstable-run and log-file truncation issues in the feedsim_autoscale job on large core count systems

### DIFF
--- a/packages/feedsim/run-feedsim-multi.sh
+++ b/packages/feedsim/run-feedsim-multi.sh
@@ -4,6 +4,7 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
+BREPS_LFILE=/tmp/feedsim_log.txt
 IS_FIXED_QPS=0
 FIXQPS_SUFFIX=""
 THIS_CMD="$0 $*"
@@ -62,13 +63,14 @@ function get_cpu_range() {
     echo "$RES"
 }
 
+echo > $BREPS_LFILE
 # shellcheck disable=SC2086
 for i in $(seq 1 ${NUM_INSTANCES}); do
     CORE_RANGE="$(get_cpu_range "${NUM_INSTANCES}" "$((i - 1))")"
-    CMD="taskset --cpu-list ${CORE_RANGE} ${FEEDSIM_ROOT}/run.sh -p ${PORT} -o feedsim_results_${FIXQPS_SUFFIX}${i}.txt $*"
+    CMD="IS_AUTOSCALE_RUN=1 taskset --cpu-list ${CORE_RANGE} ${FEEDSIM_ROOT}/run.sh -p ${PORT} -o feedsim_results_${FIXQPS_SUFFIX}${i}.txt $*"
     echo "$CMD" > "${FEEDSIM_LOG_PREFIX}${i}.log"
     # shellcheck disable=SC2068,SC2069
-    stdbuf -i0 -o0 -e0 taskset --cpu-list "${CORE_RANGE}" "${FEEDSIM_ROOT}"/run.sh -p "${PORT}" -o "feedsim_results_${FIXQPS_SUFFIX}${i}.txt" $@ 2>&1 > "${FEEDSIM_LOG_PREFIX}${i}.log" &
+    IS_AUTOSCALE_RUN=1 stdbuf -i0 -o0 -e0 taskset --cpu-list "${CORE_RANGE}" "${FEEDSIM_ROOT}"/run.sh -p "${PORT}" -o "feedsim_results_${FIXQPS_SUFFIX}${i}.txt" $@ 2>&1 > "${FEEDSIM_LOG_PREFIX}${i}.log" &
     PIDS+=("$!")
     PHY_CORE_ID=$((PHY_CORE_ID + CORES_PER_INST))
     SMT_ID=$((SMT_ID + CORES_PER_INST))

--- a/packages/feedsim/run.sh
+++ b/packages/feedsim/run.sh
@@ -67,7 +67,7 @@ EOF
 cleanup() {
   trap - SIGINT SIGTERM ERR EXIT
 
-  pkill -2 LeafNodeRank || true # Ignore exit status code of pkill
+  kill -SIGINT $LEAF_PID || true # Ignore exit status code of kill
 }
 
 msg() {

--- a/packages/feedsim/run.sh
+++ b/packages/feedsim/run.sh
@@ -106,7 +106,9 @@ main() {
     local result_filename
     result_filename="feedsim_results.txt"
 
-    echo > $BREPS_LFILE
+    if [ -z "$IS_AUTOSCALE_RUN" ]; then
+       echo > $BREPS_LFILE
+    fi
     benchreps_tell_state "start"
 
     while :; do


### PR DESCRIPTION
The current PR solves the next two issues:

1. Avoid killing all leaf node service instances (LeafNodeRank), including the ones that were executed by other feedsim-autoscale instances. With this change, the cleanup function will only kill the process with the current LeafNodeRank PID. Finally, this change solves the issue related to the unstable run in the feedsim_autoscale job on high core count machines (i.e. one or more of the instances exited early and produced very low measured QPS), avoiding the rerunning of the benchmark with a fixed-QPS setting.
2. This change avoids the "feedsim_log.txt" file be truncated every time a new Feedsim instance is launched (IS_AUTOSCALE_RUN variable is set) when using the feedsim_autoscale job. It allows to save the execution history of all instances in such a file.