### PR TITLE
Solving the issue of unsynchronized startup of multiple instances in feedsim_autoscale job, during the final 5-minutes run.

### DIFF
--- a/packages/feedsim/run-feedsim-multi.sh
+++ b/packages/feedsim/run-feedsim-multi.sh
@@ -67,10 +67,10 @@ echo > $BREPS_LFILE
 # shellcheck disable=SC2086
 for i in $(seq 1 ${NUM_INSTANCES}); do
     CORE_RANGE="$(get_cpu_range "${NUM_INSTANCES}" "$((i - 1))")"
-    CMD="IS_AUTOSCALE_RUN=1 taskset --cpu-list ${CORE_RANGE} ${FEEDSIM_ROOT}/run.sh -p ${PORT} -o feedsim_results_${FIXQPS_SUFFIX}${i}.txt $*"
+    CMD="IS_AUTOSCALE_RUN=${NUM_INSTANCES} taskset --cpu-list ${CORE_RANGE} ${FEEDSIM_ROOT}/run.sh -p ${PORT} -o feedsim_results_${FIXQPS_SUFFIX}${i}.txt $*"
     echo "$CMD" > "${FEEDSIM_LOG_PREFIX}${i}.log"
     # shellcheck disable=SC2068,SC2069
-    IS_AUTOSCALE_RUN=1 stdbuf -i0 -o0 -e0 taskset --cpu-list "${CORE_RANGE}" "${FEEDSIM_ROOT}"/run.sh -p "${PORT}" -o "feedsim_results_${FIXQPS_SUFFIX}${i}.txt" $@ 2>&1 > "${FEEDSIM_LOG_PREFIX}${i}.log" &
+    IS_AUTOSCALE_RUN=${NUM_INSTANCES} stdbuf -i0 -o0 -e0 taskset --cpu-list "${CORE_RANGE}" "${FEEDSIM_ROOT}"/run.sh -p "${PORT}" -o "feedsim_results_${FIXQPS_SUFFIX}${i}.txt" $@ 2>&1 > "${FEEDSIM_LOG_PREFIX}${i}.log" &
     PIDS+=("$!")
     PHY_CORE_ID=$((PHY_CORE_ID + CORES_PER_INST))
     SMT_ID=$((SMT_ID + CORES_PER_INST))


### PR DESCRIPTION
This PR is to address the issue where instances will execute their final 5-minutes “final_qps” stage at different times, such at they are running out of sync by 2+ minutes. 
- In the “_packages/feedsim/run-feedsim-multi.sh_” script, the value of the “IS_AUTOSCALE_RUN” variable was changed from “1” to “${NUM_INSTANCES}” (lines 70 and 73). On the one hand, this script is executed when we run a **feedsim_autoscale** job, and it executes multiple feedsim instances by running the “_packages/feedsim/run.sh_” script. On the other hand, if we run a **feedsim_default** job, the “_packages/feedsim/run.sh_” script is directly executed.
- We used to use the “IS_AUTOSCALE_RUN” variable to detect, inside the “_packages/feedsim/run.sh_” script (line 109), when we are/are-not executing multiple instances (using **feedsim_autoscale** job), by checking if the "$IS_AUTOSCALE_RUN" is defined. If it is NOT null (ignoring the value of the variable), that means we are running a **feedsim_autoscale** job. Otherwise, if it is null, means that we are running a **feedsim_default** job.
- Now, we are setting the variable’s value to the number of instances, without affecting the logic inside the “_packages/feedsim/run.sh_” script, since we just check if it is/is-not null.
- However, the variable is now also used inside the “_packages/feedsim/third_party/src/scripts/search_qps.sh_” script (lines 397 and 398) to check, once the current instance has finished the “gap_qps” stage (the optimal QPS was found) and before starting the final 5-minutes “final_qps” stage, how many instances have already finished their “gap_qps” stage. Firstly, the script checks if we are running a **feedsim_autoscale** job ( "$IS_AUTOSCALE_RUN" is not null), and if it is, checks if it is running more than 1 instance. So, if we are running 2 or more instances it will check if all the instances have already finished their respective “gap_qps” stage. If that is true, it will continue to execute the “final_qps” stage. Otherwise, it will be checking every second until all instances finish their “gap_qps” stage.
- With this change we ensure that, when running a **feedsim_autoscale** job, all instances will synchronize their final 5-minutes “final_qps” stage during the last 5 minutes of the benchmark execution. So that the system and microarch metrics that are collected during the last 5 minutes of the benchmark will reflect the correct system performance.