### PR TITLE
FeedSim: Support multiple values for fixed-qps experiments

### DIFF
--- a/packages/feedsim/README.md
+++ b/packages/feedsim/README.md
@@ -278,7 +278,8 @@ Usage: run.sh [-h] [-t <thrift_threads>] [-c <ranking_cpu_threads>]
     -a When searching for the optimal QPS, automatically adjust the number of cliient driver threads by
        min(requested_qps / 4, 384 / 5) in each iteration (experimental feature).
     -q Number of QPS to request. If this is present, feedsim will run a fixed-QPS experiment instead of searching
-       for a QPS that meets latency target.
+       for a QPS that meets latency target. If multiple comma-separated values are specified, a fixed-QPS experiment
+       will be run for each QPS value.
     -d Duration of each load testing experiment, in seconds. Default: 300
     -p Port to use by the LeafNodeRank server and the load drievrs. Default: 11222
     -o Result output file name. Default: "feedsim_results.txt"

--- a/packages/feedsim/run.sh
+++ b/packages/feedsim/run.sh
@@ -57,7 +57,8 @@ Usage: ${0##*/} [-h] [-t <thrift_threads>] [-c <ranking_cpu_threads>]
     -a When searching for the optimal QPS, automatically adjust the number of cliient driver threads by
        min(requested_qps / 4, $(nproc) / 5) in each iteration (experimental feature).
     -q Number of QPS to request. If this is present, feedsim will run a fixed-QPS experiment instead of searching
-       for a QPS that meets latency target.
+       for a QPS that meets latency target. If multiple comma-separated values are specified, a fixed-QPS experiment
+       will be run for each QPS value.
     -d Duration of fixed-QPS load testing experiment, in seconds. Default: 300
     -w Duration of warmup in fixed-QPS experiment, in seconds. Default: 120
     -p Port to use by the LeafNodeRank server and the load drievrs. Default: 11222

--- a/packages/feedsim/third_party/src/scripts/search_qps.sh
+++ b/packages/feedsim/third_party/src/scripts/search_qps.sh
@@ -316,8 +316,23 @@ if [ "$warmup_time" -gt 0 ]; then
 fi
 
 if [[ -n "$fixed_qps" ]]; then
-  run_loadtest measured_qps measured_latency $fixed_qps
-  printf "final requested_qps = %.2f, measured_qps = %.2f, latency = %.2f\n" $fixed_qps $measured_qps $measured_latency
+  fixed_qps_array=$(echo $fixed_qps | sed "s/,/ /g") # split fixed_qps by commas
+  fixed_qps_count=$(echo $fixed_qps_array | wc -w) # count the number of fixed qps values provided
+
+  if [ $fixed_qps_count -eq 1 ]; then
+    benchreps_tell_state "before fixed_qps_single"
+    run_loadtest measured_qps measured_latency $fixed_qps
+    printf "final requested_qps = %.2f, measured_qps = %.2f, latency = %.2f\n" $fixed_qps $measured_qps $measured_latency
+    benchreps_tell_state "after fixed_qps_single"
+  else
+    for fixed_qps_el in $fixed_qps_array; do
+      benchreps_tell_state "before fixed_qps_iter $fixed_qps_el"
+      run_loadtest measured_qps measured_latency $fixed_qps_el
+      printf "final requested_qps = %.2f, measured_qps = %.2f, latency = %.2f\n" $fixed_qps_el $measured_qps $measured_latency
+      benchreps_tell_state "after fixed_qps_iter $fixed_qps_el"
+      sleep 7 # wait between iterations
+    done
+  fi
   exit 0
 fi
 


### PR DESCRIPTION
FeedSim supports running fixed-QPS experiments in which the target QPS is taken as an input from the user and is not automatically determined based on calibration runs. 

This PR adds the option to specify multiple QPS values. A feedsim experiment will be performed sequentially for each of these values but with a single setup & warmup period at the beginning. This is a QoL feature as it reduces the overhead of loading the graph, waiting for NodeLeafRank to startup, and doing the warmup run. 

Instead of running `path/to/feedsim/run.sh -q 250`, you can run `path/to/feedsim/run.sh -q 50,100,150,200,250` to run feedsim with 5 different drivers running at the specified QPS.