### PR TITLE
FeedSim: GCC 13 Build Fixes on Ubuntu 22

### DIFF
--- a/packages/feedsim/patches/ubuntu-22-compatibility/folly.diff
+++ b/packages/feedsim/patches/ubuntu-22-compatibility/folly.diff
@@ -28,3 +28,15 @@ index 706715f..48ab1af 100644
 
  namespace folly {
 
+diff --git a/folly/detail/AtFork.cpp b/folly/detail/AtFork.cpp
+index eb6daac00..81d661961 100644
+--- a/folly/detail/AtFork.cpp
++++ b/folly/detail/AtFork.cpp
+@@ -18,6 +18,7 @@
+
+ #include <list>
+ #include <mutex>
++#include <system_error>
+
+ #include <folly/ScopeGuard.h>
+ #include <folly/lang/Exception.h>

--- a/packages/feedsim/patches/ubuntu-22-compatibility/rsocket-cpp.diff
+++ b/packages/feedsim/patches/ubuntu-22-compatibility/rsocket-cpp.diff
@@ -2,6 +2,19 @@
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 79750f7b..6eb9186c 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -170,7 +170,7 @@ if (COMPILER_HAS_W_NOEXCEPT_TYPE)
+   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-noexcept-type")
+ endif()
+
+-if (NOT MSVC)
++if (NOT MSVC AND NOT (CMAKE_COMPILER_IS_GNUCC AND CMAKE_CXX_COMPILER_VERSION VERSION_GREATER 13))
+   set(EXTRA_CXX_FLAGS ${EXTRA_CXX_FLAGS} -Werror)
+ endif()
+
 diff --git a/yarpl/Refcounted.h b/yarpl/Refcounted.h
 index e88886f..ac0a495 100644
 --- a/yarpl/Refcounted.h


### PR DESCRIPTION
This PR fixes building FeedSim on Ubuntu 22 with gcc 13. rsocket-cpp is compiled without `-Werror` as gcc 13 throws many different warnings that cannot be fixed easily. 