### PR TITLE
Revert the portion of D70239810 that changed DCPerf codebase

### DIFF
--- a/benchpress/cli/commands/clean.py
+++ b/benchpress/cli/commands/clean.py
@@ -31,7 +31,7 @@ class CleanCommand(BenchpressCommand):
             # Clean out benchmark dependencies regardless if it's installed or not
             if job.cleanup_script != "":
                 clean_benchmark(job.cleanup_script, job.install_script)
-                click.echo(f"Cleaning out dependencies of {job.name} job")
+                click.echo("Cleaning out dependencies of {} job".format(job.name))
             else:
                 click.echo(
                     f"Job {job.name} doesn't have a cleanup script in the jobs.yml file"

--- a/benchpress/cli/commands/command.py
+++ b/benchpress/cli/commands/command.py
@@ -12,7 +12,7 @@ from abc import ABCMeta, abstractmethod
 TABLE_FORMAT = "plain"
 
 
-class BenchpressCommand(metaclass=ABCMeta):
+class BenchpressCommand(object, metaclass=ABCMeta):
     @abstractmethod
     def populate_parser(self, parser):
         pass

--- a/benchpress/cli/commands/install.py
+++ b/benchpress/cli/commands/install.py
@@ -58,11 +58,15 @@ class InstallCommand(BenchpressCommand):
             for hook in job.hooks:
                 retcode = install_tool(hook[0])
                 if retcode > 0:
-                    click.echo(f"Installing required tool {hook[0]} for {job.name}")
+                    click.echo(
+                        "Installing required tool {} for {}".format(hook[0], job.name)
+                    )
                 elif retcode == 0:
-                    click.echo(f"Tool {hook[0]} already installed")
+                    click.echo("Tool {} already installed".format(hook[0]))
             if args.force or not verify_install(job.install_script):
-                click.echo(f"Installing benchmark for {job.name}: {job.description}")
+                click.echo(
+                    "Installing benchmark for {}: {}".format(job.name, job.description)
+                )
                 # TODO(cltorres) Filter inherited environment vars
                 env = os.environ
                 env = initialize_env_vars(job, env=env, toolchain=args.toolchain)
@@ -72,4 +76,4 @@ class InstallCommand(BenchpressCommand):
                     click.echo(f"{var}={env[var]}")
                 install_benchmark(job.install_script, env=env)
             else:
-                click.echo(f"Benchmark for {job.name} already installed")
+                click.echo("Benchmark for {} already installed".format(job.name))

--- a/benchpress/cli/commands/run.py
+++ b/benchpress/cli/commands/run.py
@@ -68,7 +68,7 @@ class RunCommand(BenchpressCommand):
 
         jobs = get_target_jobs(jobs, args.jobs).values()
 
-        click.echo(f"Will run {len(jobs)} job(s)")
+        click.echo("Will run {} job(s)".format(len(jobs)))
 
         history = History(args.results)
         now = datetime.now(timezone.utc)
@@ -136,9 +136,9 @@ class RunCommand(BenchpressCommand):
 
         for job in jobs:
             if not verify_install(job.install_script):
-                click.echo(f"Benchmark {job.name} not installed")
+                click.echo("Benchmark {} not installed".format(job.name))
                 continue
-            click.echo(f'Running "{job.name}": {job.description}')
+            click.echo('Running "{}": {}'.format(job.name, job.description))
 
             if args.dry_run:
                 job_cmd = job.dry_run(args.role, role_in)
@@ -178,7 +178,7 @@ class RunCommand(BenchpressCommand):
             final_metrics["benchmark_name"] = job.name
             final_metrics["benchmark_desc"] = job.description
             # Hooks structured as: hook_name: hook_options
-            job_hooks = [f"{hook[0]}: {hook[2]}" for hook in job.hooks]
+            job_hooks = ["{}: {}".format(hook[0], hook[2]) for hook in job.hooks]
             final_metrics["benchmark_hooks"] = job_hooks
 
             try:

--- a/benchpress/cli/main.py
+++ b/benchpress/cli/main.py
@@ -11,6 +11,7 @@ import logging
 import os
 import shlex
 import sys
+import typing
 
 import click
 from benchpress import config, logging_config
@@ -44,12 +45,12 @@ class Benchpress:
     def __init__(
         self,
         config: config.BenchpressConfig,
-        uuid: str | None = None,
-        timestamp: int | None = None,
+        uuid: typing.Optional[str] = None,
+        timestamp: typing.Optional[int] = None,
         iteration_num: int = 1,
-        override_job_args: str | None = None,
-        hook_bg_duration: str | None = None,
-        hook_path: str | None = None,
+        override_job_args: typing.Optional[str] = None,
+        hook_bg_duration: typing.Optional[str] = None,
+        hook_path: typing.Optional[str] = None,
     ):
         self.config = config
         self.uuid = uuid
@@ -236,8 +237,10 @@ def parse_override_job_args(override_job_args):
         return (job, args)
     except Exception:
         click.echo(
-            "Could not properly parse --override_job_args flag. "
-            "Run ./automark exec -h to see an example of what to pass in."
+            (
+                "Could not properly parse --override_job_args flag. "
+                "Run ./automark exec -h to see an example of what to pass in."
+            )
         )
         raise
 
@@ -273,7 +276,9 @@ def load_config(args) -> config.BenchpressConfig:
                     exit(1)
 
                 logger.warning("Overriding default benchmarks!")
-                logger.info(f'Loading benchmarks from "{benchmarks_specs_path}"')
+                logger.info(
+                    'Loading benchmarks from "{}"'.format(benchmarks_specs_path)
+                )
                 with open(benchmarks_specs_path) as bs:
                     # Reads everything into memory
                     benchmarks_specs = bs.read()
@@ -291,11 +296,13 @@ def load_config(args) -> config.BenchpressConfig:
 
                 # jobs file path existence check
                 if not os.path.exists(jobs_specs_path):
-                    logger.error(f'jobs file with name "{jobs_specs_path}" not found')
+                    logger.error(
+                        'jobs file with name "{}" not found'.format(jobs_specs_path)
+                    )
                     exit(1)
 
                 logger.warning("Overriding default jobs!")
-                logger.info(f'Loading jobs from "{jobs_specs_path}"')
+                logger.info('Loading jobs from "{}"'.format(jobs_specs_path))
                 with open(jobs_specs_path) as jb:
                     # Reads everything into memory
                     jobs_specs = jb.read()
@@ -305,7 +312,9 @@ def load_config(args) -> config.BenchpressConfig:
             if args.toolchain_file:
                 toolchain_specs_path = os.path.abspath(args.toolchain_file)
                 logger.warning("Overriding default toolchain config!")
-                logger.info(f'Loading toolchain config from "{toolchain_specs_path}"')
+                logger.info(
+                    'Loading toolchain config from "{}"'.format(toolchain_specs_path)
+                )
                 with open(toolchain_specs_path) as ts:
                     toolchain_specs = ts.read()
 

--- a/benchpress/config/__init__.py
+++ b/benchpress/config/__init__.py
@@ -29,10 +29,9 @@ Constants:
 
 import importlib.resources
 import logging
-from collections.abc import Iterator
 from contextlib import AbstractContextManager
 from pathlib import Path
-from typing import IO
+from typing import IO, Iterator, Union
 
 import yaml
 from benchpress.lib import open_source
@@ -79,9 +78,9 @@ class BenchpressConfig:
 
     def load(
         self,
-        benchmarks_specs_stream: bytes | IO[bytes] | str | IO[str],
-        jobs_specs_stream: bytes | IO[bytes] | str | IO[str],
-        toolchain_specs_stream: bytes | IO[bytes] | str | IO[str],
+        benchmarks_specs_stream: Union[bytes, IO[bytes], str, IO[str]],
+        jobs_specs_stream: Union[bytes, IO[bytes], str, IO[str]],
+        toolchain_specs_stream: Union[bytes, IO[bytes], str, IO[str]],
     ):
         self.benchmarks_specs = yaml.safe_load(benchmarks_specs_stream)
         self.jobs_specs = yaml.safe_load(jobs_specs_stream)

--- a/benchpress/lib/dmidecode.py
+++ b/benchpress/lib/dmidecode.py
@@ -110,8 +110,8 @@ def _parse_dmidecode(dmidecode_output: str):
 
 
 def _parse_dmihandle_record(
-    dmihandle_lines: list[str],
-) -> dict[str, typing.Any]:
+    dmihandle_lines: typing.List[str],
+) -> typing.Dict[str, typing.Any]:
     dmihandle_data = collections.OrderedDict()
     dmihandle_data["_title"] = dmihandle_lines[1]
     list_acc = []

--- a/benchpress/lib/history.py
+++ b/benchpress/lib/history.py
@@ -63,16 +63,16 @@ class History:
         rootdir = os.path.join(self.path, job_name)
         for directory, _, files in os.walk(rootdir):
             for f in files:
-                with open(os.path.join(directory, f)) as record:
+                with open(os.path.join(directory, f), "r") as record:
                     record = json.load(record)
                     try:
                         entry = HistoryEntry(record)
                         results.append(entry)
                     except KeyError as e:
-                        logger.error(f"Invalid entry format (missing {e})")
+                        logger.error("Invalid entry format (missing {})".format(e))
                         raise e
 
-        logger.info(f"Loaded {len(results)} results from {self.path}")
+        logger.info("Loaded {} results from {}".format(len(results), self.path))
         # sort by most recent first
         return sorted(results, key=lambda r: r.timestamp, reverse=True)
 

--- a/benchpress/lib/hook.py
+++ b/benchpress/lib/hook.py
@@ -7,7 +7,7 @@
 from abc import ABCMeta, abstractmethod
 
 
-class Hook(metaclass=ABCMeta):
+class Hook(object, metaclass=ABCMeta):
     """Hook allows jobs to run some Python code before/after a job runs."""
 
     @abstractmethod

--- a/benchpress/lib/job.py
+++ b/benchpress/lib/job.py
@@ -10,6 +10,7 @@ import subprocess
 import sys
 import tempfile
 import threading
+import typing
 from subprocess import CalledProcessError
 
 import click
@@ -152,12 +153,12 @@ class Job:
     def check_role(self, role, role_input):
         """move complex if else for role check here"""
         if len(self.role_args) == 0 and role != "":
-            logger.error(f"the job {self.name} does not have roles")
+            logger.error("the job {} does not have roles".format(self.name))
             exit(1)
         elif len(self.role_args) == 0 and role == "":
             self.substitude_vars(role, role_input)
         elif len(self.role_args) > 0 and role == "":
-            logger.error(f"you must select a role in {self.name} job")
+            logger.error("you must select a role in {} job".format(self.name))
             exit(1)
         elif len(self.role_args) > 0 and role != "":
             if role not in self.role_args:
@@ -186,7 +187,7 @@ class Job:
     def start_hooks(self):
         """Executes hooks before job starts."""
         # take care of preprocessing setup via hook
-        logger.info(f'Running setup hooks for "{self.name}"')
+        logger.info('Running setup hooks for "{}"'.format(self.name))
         for _name, hook, opts in self.hooks:
             logger.info("Running %s %s", hook, opts)
             hook.before_job(opts, self)
@@ -205,9 +206,9 @@ class Job:
         self.check_role(role, role_input)
 
         try:
-            logger.info(f'Starting "{self.name}"')
+            logger.info('Starting "{}"'.format(self.name))
             cmd = get_safe_cmd([self.binary] + self.args)
-            click.echo(f"Job execution command: {cmd}")
+            click.echo("Job execution command: {}".format(cmd))
             process = subprocess.Popen(
                 cmd,
                 stdout=subprocess.PIPE,
@@ -255,7 +256,7 @@ class Job:
             stderr_storage.close()
 
             if self.stdout:
-                with open(self.stdout) as metrics_file:
+                with open(self.stdout, "r") as metrics_file:
                     stdout = metrics_file.read()
             self._print_output_summary(stdout, stderr)
             logger.info(f"stderr output: {stderr}")
@@ -269,7 +270,7 @@ class Job:
                 exit(1)
                 # raise CalledProcessError(process.returncode, cmd, output)
             self.copy_output(stderr, stdout)
-            logger.info(f'Parsing results for "{self.name}"')
+            logger.info('Parsing results for "{}"'.format(self.name))
             try:
                 return self.parser.parse(
                     stdout.splitlines(), stderr.splitlines(), returncode
@@ -278,11 +279,11 @@ class Job:
                 logger.error(
                     "Failed to parse results, this might mean the" " benchmark failed"
                 )
-                logger.error(f"stdout:\n{stdout}")
-                logger.error(f"stderr:\n{stderr}")
+                logger.error("stdout:\n{}".format(stdout))
+                logger.error("stderr:\n{}".format(stderr))
                 raise
         except OSError as e:
-            logger.error(f'"{self.name}" failed ({e})')
+            logger.error('"{}" failed ({})'.format(self.name, e))
             if e.errno == errno.ENOENT:
                 logger.error("Binary not found, did you forget to install it?")
             raise  # make sure it passes the exception up the chain
@@ -292,7 +293,7 @@ class Job:
 
     def stop_hooks(self):
         """Stops hooks after job is finished."""
-        logger.info(f'Running cleanup hooks for "{self.name}"')
+        logger.info('Running cleanup hooks for "{}"'.format(self.name))
         # run hooks in reverse this time so it operates like a stack
         for _name, hook, opts in reversed(self.hooks):
             hook.after_job(opts, self)
@@ -329,7 +330,7 @@ class JobSuiteBuilder:
                     self.suites[tag] = []
                 self.suites[tag].append(job.name)
 
-    def get_suites(self) -> dict[str, str]:
+    def get_suites(self) -> typing.Dict[str, str]:
         return self.suites
 
 
@@ -338,7 +339,7 @@ def get_target_jobs(all_jobs, args_jobs):
     job_objs = {}
     for name in picked_jobs:
         if name not in all_jobs:
-            logger.error(f'No job "{name}" found')
+            logger.error('No job "{}" found'.format(name))
             exit(1)
         if hasattr(all_jobs[name], "config"):
             job_objs[name] = all_jobs[name]

--- a/benchpress/lib/job_listing.py
+++ b/benchpress/lib/job_listing.py
@@ -6,7 +6,7 @@
 
 # pyre-unsafe
 
-from collections.abc import Mapping
+from typing import List, Mapping, Optional
 
 import tabulate
 
@@ -17,7 +17,7 @@ TABLE_HEADERS = ["Job", "Description"]
 TABLE_HEADERS_TAG = ["Job", "Tags", "Description"]
 
 
-def formalize_tags(configs) -> Mapping[str, list[str]]:
+def formalize_tags(configs) -> Mapping[str, List[str]]:
     tags = {k: [] for k in JOB_TAG_GROUP}
     for config in configs:
         for k in tags:
@@ -25,7 +25,7 @@ def formalize_tags(configs) -> Mapping[str, list[str]]:
     return tags
 
 
-def get_tag_str(tags: Mapping[str, list[str]]) -> str:
+def get_tag_str(tags: Mapping[str, List[str]]) -> str:
     all_tags = []
     for k in tags:
         all_tags += sorted(tags[k])
@@ -33,9 +33,9 @@ def get_tag_str(tags: Mapping[str, list[str]]) -> str:
 
 
 def create_job_listing(
-    jobs: list[Mapping],
+    jobs: List[Mapping],
     table_format: str,
-    group_key: str | None = None,
+    group_key: Optional[str] = None,
 ) -> str:
     headers = TABLE_HEADERS_TAG
     sections = {"default": []}

--- a/benchpress/lib/parser.py
+++ b/benchpress/lib/parser.py
@@ -7,7 +7,7 @@
 from abc import ABCMeta, abstractmethod
 
 
-class Parser(metaclass=ABCMeta):
+class Parser(object, metaclass=ABCMeta):
     """Parser is the link between benchmark output and the rest of the system.
     A Parser is given the benchmark's stdout and stderr and returns the exported
     metrics.

--- a/benchpress/lib/reporter.py
+++ b/benchpress/lib/reporter.py
@@ -13,7 +13,7 @@ from abc import ABCMeta, abstractmethod
 from benchpress.lib import baseline, util
 
 
-class Reporter(metaclass=ABCMeta):
+class Reporter(object, metaclass=ABCMeta):
     """A Reporter is used to record job results in your infrastructure."""
 
     @abstractmethod

--- a/benchpress/lib/sys_specs.py
+++ b/benchpress/lib/sys_specs.py
@@ -48,7 +48,7 @@ def get_os_kernel():
 def get_kernel_cmdline():
     if not os.path.exists("/proc/cmdline"):
         return []
-    with open("/proc/cmdline") as f:
+    with open("/proc/cmdline", "r") as f:
         kern_cmdline = f.read()
     return shlex.split(kern_cmdline)
 
@@ -68,7 +68,7 @@ def get_sysctl_data():
     kernel_params_dict = {}
     for kernel_param in kernel_params:
         if "=" in kernel_param:
-            param, param_val = (param.strip() for param in kernel_param.split("="))
+            param, param_val = [param.strip() for param in kernel_param.split("=")]
             kernel_params_dict[param] = param_val
 
     return kernel_params_dict
@@ -116,7 +116,7 @@ def get_cpu_mem_data():
     cpu_mem_dict = {}
     for mem_stat in cpu_mem_data:
         if ":" in mem_stat:
-            mem, stat = (mem.strip() for mem in mem_stat.split(":"))
+            mem, stat = [mem.strip() for mem in mem_stat.split(":")]
             if (
                 " " in stat
             ):  # Change units of CPU mem due to some legacy issue in RedHat
@@ -151,7 +151,7 @@ def get_os_release_data():
     os_release_data_dict = {}
     for os_info in os_release_data:
         if "=" in os_info:
-            param, param_val = (param.strip() for param in os_info.split("="))
+            param, param_val = [param.strip() for param in os_info.split("=")]
             param = param.lower()
             param_val = param_val.replace('"', "")
             os_release_data_dict[param] = param_val

--- a/benchpress/lib/util.py
+++ b/benchpress/lib/util.py
@@ -54,7 +54,7 @@ def issue_background_command(cmd, stdout, stderr, env=None):
 
 def verify_install(install_script):
     if os.path.exists("benchmark_installs.txt"):
-        with open("benchmark_installs.txt") as benchmark_installs:
+        with open("benchmark_installs.txt", "r") as benchmark_installs:
             for benchmark_install in benchmark_installs:
                 if install_script.strip() == benchmark_install.strip():
                     return True
@@ -104,7 +104,7 @@ def install_tool(tool_name):
 
 
 def create_benchmark_metrics_dir(run_id):
-    benchmark_metrics_dir = f"benchmark_metrics_{run_id}"
+    benchmark_metrics_dir = "benchmark_metrics_{}".format(run_id)
     try:
         os.mkdir(benchmark_metrics_dir)
     except OSError as exc:
@@ -120,7 +120,7 @@ def clean_benchmark(clean_script, install_script):
     clean_benchmark_proc.wait()
     if clean_benchmark_proc.returncode == 0:
         if os.path.exists("benchmark_installs.txt"):
-            with open("benchmark_installs.txt") as benchmark_installs_fp:
+            with open("benchmark_installs.txt", "r") as benchmark_installs_fp:
                 lines = benchmark_installs_fp.readlines()
             with open("benchmark_installs.txt", "w") as benchmark_installs_fp:
                 for line in lines:
@@ -152,9 +152,9 @@ def generate_run_id():
 
 def initialize_env_vars(
     job,
-    env: typing.Mapping[str, str | None],
+    env: typing.Mapping[str, typing.Optional[str]],
     toolchain: str,
-) -> dict[str, str]:
+) -> typing.Dict[str, str]:
     """
     Populates the installer enviornment variables with Benchpress default vars.
 

--- a/benchpress/plugins/hooks/cpu_limit.py
+++ b/benchpress/plugins/hooks/cpu_limit.py
@@ -26,7 +26,7 @@ class CpuLimit(Hook):
         try:
             int(mask, 16)
         except ValueError:
-            raise ValueError(f"{mask} is not a valid CPU mask")
+            raise ValueError("{} is not a valid CPU mask".format(mask))
 
         # modify the job config to run taskset with the given mask instead of
         # directly running the benchmark binary

--- a/benchpress/plugins/hooks/emon.py
+++ b/benchpress/plugins/hooks/emon.py
@@ -45,7 +45,7 @@ class Emon(Hook):
         iteration_num = job.iteration_num
         self.default_stdout_path = os.path.join(
             self.benchmark_metrics_dir,
-            f"{job_name}_emon_hook_output_{iteration_num}.dat",
+            "{}_emon_hook_output_{}.dat".format(job_name, iteration_num),
         )
         self.stdout = None
         self.bg_emon_proc = self._start_background_emon(opts)
@@ -88,7 +88,7 @@ class Emon(Hook):
                     items = line.split("=")
                     env[items[0]] = items[1]
         except Exception as e:
-            logger.warning(f"Is Emon being installed correctly? ({str(e):s})")
+            logger.warning("Is Emon being installed correctly? ({:s})".format(str(e)))
         return env
 
     def _fetch_event_file(self, dst_dir, opts):
@@ -102,7 +102,9 @@ class Emon(Hook):
                 shutil.copyfile(src_xml_file, dst_xml_file)
                 return dst_event_file
             else:
-                logger.error(f"{src_event_file} or {src_xml_file} does not exist!")
+                logger.error(
+                    "{} or {} does not exist!".format(src_event_file, src_xml_file)
+                )
         else:
             logger.error("arch_event_file & arch_xml options are required for emon!")
         return None
@@ -125,5 +127,5 @@ class Emon(Hook):
                 proc.wait()
             return True
         except Exception as e:
-            logger.warning(f"Is Emon being installed correctly? ({str(e):s})")
+            logger.warning("Is Emon being installed correctly? ({:s})".format(str(e)))
         return False

--- a/benchpress/plugins/hooks/file.py
+++ b/benchpress/plugins/hooks/file.py
@@ -27,13 +27,15 @@ class FileHook(Hook):
     def before_job(self, opts, job):
         for opt in opts:
             path = opt["path"]
-            logger.info(f'Creating "{path}"')
+            logger.info('Creating "{}"'.format(path))
             if opt["type"] == "dir":
                 try:
                     os.makedirs(path)
                 except OSError as e:
                     if e.errno == errno.EEXIST:
-                        logger.warning(f'"{path}" already exists, proceeding anyway')
+                        logger.warning(
+                            '"{}" already exists, proceeding anyway'.format(path)
+                        )
                     else:
                         # other errors should be fatal
                         raise
@@ -43,7 +45,7 @@ class FileHook(Hook):
     def after_job(self, opts, job):
         for opt in opts:
             path = opt["path"]
-            logger.info(f'Deleting "{path}"')
+            logger.info('Deleting "{}"'.format(path))
             if opt["type"] == "dir":
                 shutil.rmtree(path)
             if opt["type"] == "file":

--- a/benchpress/plugins/hooks/perf_monitors/cpufreq_cpuinfo.py
+++ b/benchpress/plugins/hooks/perf_monitors/cpufreq_cpuinfo.py
@@ -15,7 +15,7 @@ from . import logger, Monitor
 
 class CPUFreq(Monitor):
     def __init__(self, interval, job_uuid):
-        super().__init__(interval, "cpufreq_cpuinfo", job_uuid)
+        super(CPUFreq, self).__init__(interval, "cpufreq_cpuinfo", job_uuid)
         self.run_freq_collector = False
         self.supported = os.path.exists(
             "/sys/devices/system/cpu/cpu0/cpufreq/cpuinfo_cur_freq"
@@ -28,7 +28,7 @@ class CPUFreq(Monitor):
         freqs = []
         for cpu in self.cpus:
             with open(
-                f"/sys/devices/system/cpu/cpu{cpu}/cpufreq/cpuinfo_cur_freq"
+                f"/sys/devices/system/cpu/cpu{cpu}/cpufreq/cpuinfo_cur_freq", "r"
             ) as f:
                 freqs.append(float(f.read()))
 

--- a/benchpress/plugins/hooks/perf_monitors/cpufreq_scaling.py
+++ b/benchpress/plugins/hooks/perf_monitors/cpufreq_scaling.py
@@ -15,7 +15,7 @@ from . import logger, Monitor
 
 class CPUFreq(Monitor):
     def __init__(self, interval, job_uuid):
-        super().__init__(interval, "cpufreq_scaling", job_uuid)
+        super(CPUFreq, self).__init__(interval, "cpufreq_scaling", job_uuid)
         self.run_freq_collector = False
         self.supported = os.path.exists(
             "/sys/devices/system/cpu/cpu0/cpufreq/scaling_cur_freq"
@@ -28,7 +28,7 @@ class CPUFreq(Monitor):
         freqs = []
         for cpu in self.cpus:
             with open(
-                f"/sys/devices/system/cpu/cpu{cpu}/cpufreq/scaling_cur_freq"
+                f"/sys/devices/system/cpu/cpu{cpu}/cpufreq/scaling_cur_freq", "r"
             ) as f:
                 freqs.append(float(f.read()))
 

--- a/benchpress/plugins/hooks/perf_monitors/memstat.py
+++ b/benchpress/plugins/hooks/perf_monitors/memstat.py
@@ -23,14 +23,14 @@ MULTIPLIERS = {
 
 class MemStat(Monitor):
     def __init__(self, interval, job_uuid, additional_counters=()):
-        super().__init__(interval, "mem-stat", job_uuid)
+        super(MemStat, self).__init__(interval, "mem-stat", job_uuid)
         counters = {"MemTotal", "MemFree", "MemAvailable", "SwapTotal", "SwapFree"}
         self.counters = counters.union(set(additional_counters))
         self.run_collector = False
 
     def do_collect(self):
         meminfo = {}
-        with open("/proc/meminfo") as f:
+        with open("/proc/meminfo", "r") as f:
             for line in f:
                 cells = line.split()
                 key = cells[0].strip(":")

--- a/benchpress/plugins/hooks/perf_monitors/mpstat.py
+++ b/benchpress/plugins/hooks/perf_monitors/mpstat.py
@@ -13,13 +13,13 @@ from . import Monitor
 
 class MPStat(Monitor):
     def __init__(self, interval, job_uuid):
-        super().__init__(interval, "mpstat", job_uuid)
+        super(MPStat, self).__init__(interval, "mpstat", job_uuid)
         self.headers = []
 
     def run(self):
         args = ["mpstat", "-u", f"{self.interval}"]
         self.proc = subprocess.Popen(args, stdout=subprocess.PIPE, encoding="utf-8")
-        super().run()
+        super(MPStat, self).run()
 
     def process_output(self, line):
         """

--- a/benchpress/plugins/hooks/perf_monitors/netstat.py
+++ b/benchpress/plugins/hooks/perf_monitors/netstat.py
@@ -15,7 +15,7 @@ from . import logger, Monitor
 
 class NetStat(Monitor):
     def __init__(self, interval, job_uuid, additional_counters=()):
-        super().__init__(interval, "net-stat", job_uuid)
+        super(NetStat, self).__init__(interval, "net-stat", job_uuid)
         counters = {"rx_bytes", "rx_packets", "tx_bytes", "tx_packets"}
         self.counters = counters.union(set(additional_counters))
         self.run_collector = False
@@ -36,7 +36,7 @@ class NetStat(Monitor):
                     logger.warning("unsupported net counter - " + counter)
                     bad_counters.append(counter)
                     continue
-                with open(fpath) as f:
+                with open(fpath, "r") as f:
                     value = float(f.read())
                 result[netif][counter] = value
         if len(bad_counters) > 0:

--- a/benchpress/plugins/hooks/perf_monitors/perfstat.py
+++ b/benchpress/plugins/hooks/perf_monitors/perfstat.py
@@ -40,7 +40,7 @@ def unpack_perf_stat_line(line, delim=","):
 
 class PerfStat(Monitor):
     def __init__(self, interval, job_uuid, additional_events=(), delim=","):
-        super().__init__(interval, "perf-stat", job_uuid)
+        super(PerfStat, self).__init__(interval, "perf-stat", job_uuid)
         self.events = ["instructions", "cycles"] + list(additional_events)
         self.delim = delim
 
@@ -94,4 +94,4 @@ class PerfStat(Monitor):
             "1",
         ]
         self.proc = subprocess.Popen(args, stdout=subprocess.PIPE, encoding="utf-8")
-        super().run()
+        super(PerfStat, self).run()

--- a/benchpress/plugins/hooks/perf_monitors/power.py
+++ b/benchpress/plugins/hooks/perf_monitors/power.py
@@ -35,18 +35,20 @@ class Power(Monitor):
             ):
                 sensor = {}
                 sensor["path"] = os.path.join("/sys/class/hwmon/", hwmon, "device")
-                with open(os.path.join(sensor["path"], "power1_oem_info")) as oem_info:
+                with open(
+                    os.path.join(sensor["path"], "power1_oem_info"), "r"
+                ) as oem_info:
                     sensor["name"] = oem_info.read().strip()
                 with open(
-                    os.path.join(sensor["path"], "power1_average_interval")
+                    os.path.join(sensor["path"], "power1_average_interval"), "r"
                 ) as interval:
                     sensor["original_interval"] = int(interval.read().strip())
                 with open(
-                    os.path.join(sensor["path"], "power1_average_interval_min")
+                    os.path.join(sensor["path"], "power1_average_interval_min"), "r"
                 ) as min_interval:
                     sensor["interval_min"] = int(min_interval.read().strip())
                 with open(
-                    os.path.join(sensor["path"], "power1_average_interval_max")
+                    os.path.join(sensor["path"], "power1_average_interval_max"), "r"
                 ) as max_interval:
                     sensor["interval_max"] = int(max_interval.read().strip())
                 sensors.append(sensor)
@@ -71,14 +73,14 @@ class Power(Monitor):
         Get the average power of the given sensor, in watts
         Note, the unit of the raw value in power1_average is microWatt
         """
-        with open(os.path.join(sensor["path"], "power1_average")) as f:
+        with open(os.path.join(sensor["path"], "power1_average"), "r") as f:
             try:
                 return float(f.read()) / 1e6
             except OSError as e:
                 return f"<err{e.errno}>"
 
     def __init__(self, job_uuid, interval=1.0, sensor_interval_ms=None):
-        super().__init__(interval, "power", job_uuid)
+        super(Power, self).__init__(interval, "power", job_uuid)
         self.power_sensors = self.search_sensors()
         if sensor_interval_ms is None:
             sensor_interval_ms = 1000 * self.interval

--- a/benchpress/plugins/hooks/perf_monitors/topdown.py
+++ b/benchpress/plugins/hooks/perf_monitors/topdown.py
@@ -108,7 +108,7 @@ def get_amd_zen_generation(cpuinfo: dict):
 
 class IntelPerfSpect(Monitor):
     def __init__(self, job_uuid, interval=125, perfspect_path=None):
-        super().__init__(interval, "perfspect", job_uuid)
+        super(IntelPerfSpect, self).__init__(interval, "perfspect", job_uuid)
         if perfspect_path is None:
             self.perfspect_path = os.path.join(BP_BASEPATH, "perfspect")
         else:
@@ -143,7 +143,7 @@ class IntelPerfSpect(Monitor):
         self.proc = subprocess.Popen(
             args, stdout=subprocess.PIPE, stderr=subprocess.PIPE, encoding="utf-8"
         )
-        super().run()
+        super(IntelPerfSpect, self).run()
 
     def terminate(self):
         if not self.supported:
@@ -187,7 +187,7 @@ class BasePerfUtil(Monitor):
         perfutils_path=None,
         perf_postproc_args=None,
     ):
-        super().__init__(0, name, job_uuid)
+        super(BasePerfUtil, self).__init__(0, name, job_uuid)
         if perfutils_path is None:
             self.perfutils_path = os.path.join(BP_BASEPATH, "perfutils")
         else:
@@ -213,7 +213,7 @@ class BasePerfUtil(Monitor):
             return
         cmd = [perf_collect_script]
         self.proc = subprocess.Popen(cmd, stdout=subprocess.PIPE, encoding="utf-8")
-        super().run()
+        super(BasePerfUtil, self).run()
 
     def gen_csv(self):
         pass
@@ -306,7 +306,7 @@ class ARMPerfUtil(Monitor):
     )
 
     def __init__(self, job_uuid, interval=5):
-        super().__init__(interval, "arm-perf-collector", job_uuid)
+        super(ARMPerfUtil, self).__init__(interval, "arm-perf-collector", job_uuid)
         self.avail = self.install_if_not_available()
         if not self.avail:
             logger.warning(
@@ -358,7 +358,7 @@ class ARMPerfUtil(Monitor):
             stderr=subprocess.PIPE,
             encoding="utf-8",
         )
-        super().run()
+        super(ARMPerfUtil, self).run()
 
     def write_csv(self):
         """
@@ -386,7 +386,7 @@ class ARMPerfUtil(Monitor):
 
 class NVPerfUtil(BasePerfUtil):
     def __init__(self, job_uuid, **kwargs):
-        super().__init__(
+        super(NVPerfUtil, self).__init__(
             job_uuid,
             "nv-perf-collector",
             perf_collect_script_name="collect_nvda_neoversev2_perf_counters.sh",

--- a/benchpress/plugins/hooks/tao_instruction.py
+++ b/benchpress/plugins/hooks/tao_instruction.py
@@ -35,7 +35,7 @@ class TaoInstructionHook(Hook):
             if os.path.exists(instruction_path):
                 break
         time.sleep(1)
-        with open(instruction_path) as f:
+        with open(instruction_path, "r") as f:
             instruction_text = f.read()
         logger.warning(instruction_text)
         os.remove(instruction_path)

--- a/benchpress/plugins/hooks/toplev.py
+++ b/benchpress/plugins/hooks/toplev.py
@@ -55,7 +55,7 @@ class Toplev(Hook):
         iteration_num = job.iteration_num
         self.default_stdout_path = os.path.join(
             benchmark_metrics_dir,
-            f"{job_name}_toplev_hook_output_{iteration_num}",
+            "{}_toplev_hook_output_{}".format(job_name, iteration_num),
         )
 
         if "background_mode" in opts and opts["background_mode"]:

--- a/benchpress/plugins/hooks/user_script.py
+++ b/benchpress/plugins/hooks/user_script.py
@@ -32,7 +32,7 @@ class UserScript(Hook):
         iteration_num = job.iteration_num
         self.default_stdout_path = os.path.join(
             benchmark_metrics_dir,
-            f"{job_name}_{hook_name}_hook_output_{iteration_num}",
+            "{}_{}_hook_output_{}".format(job_name, hook_name, iteration_num),
         )
 
         if "background_mode" in opts and opts["background_mode"]:

--- a/benchpress/plugins/parsers/fb_fiosynth.py
+++ b/benchpress/plugins/parsers/fb_fiosynth.py
@@ -29,6 +29,8 @@ class Fiosynth_Parser(Parser):
             fiosynth_reader = csv.DictReader(io.StringIO(stdout))
             fiosynth_data = [metrics for metrics in fiosynth_reader]
         except Exception as e:
-            logger.error(f"Error thrown while parsing the fb_fiosynth csv file: {e}")
+            logger.error(
+                "Error thrown while parsing the fb_fiosynth csv file: {}".format(e)
+            )
 
         return fiosynth_data

--- a/benchpress/plugins/parsers/mlc.py
+++ b/benchpress/plugins/parsers/mlc.py
@@ -58,7 +58,7 @@ class MlcParser(Parser):
             func_name = "parse_" + key.replace(" ", "_")
             sub_metrics = getattr(self, func_name)(stdout[start_idx:end_idx])
         except Exception as e:
-            logger.error(f"Error thrown while parsing '{key}': {str(e)}")
+            logger.error("Error thrown while parsing '{}': {}".format(key, str(e)))
         return sub_metrics
 
     @staticmethod

--- a/benchpress/plugins/parsers/wdl.py
+++ b/benchpress/plugins/parsers/wdl.py
@@ -24,7 +24,7 @@ class WDLParser(Parser):
         for benchmark in benchmarks:
             out_file = "benchmarks/wdl_bench/out_" + benchmark + ".json"
 
-            with open(out_file) as out_f:
+            with open(out_file, "r") as out_f:
                 out = json.load(out_f)
                 for k, v in out.items():
                     metrics[benchmark + k] = v

--- a/packages/common/affinitize/lib/schedule_lib.py
+++ b/packages/common/affinitize/lib/schedule_lib.py
@@ -7,8 +7,8 @@
 import glob
 import os
 import re
-from collections.abc import Iterator, Sequence
 from itertools import cycle, islice, repeat
+from typing import Dict, Iterator, List, Sequence, Tuple
 
 
 class NestedDict(dict):
@@ -60,10 +60,12 @@ def walk(n: NestedDict):
     / threads in numerical order.
     """
     if next(iter(n.values())) == 1:
-        yield from sorted(n.keys())
+        for c in sorted(n.keys()):
+            yield c
     else:
         for v in sorted(n.values()):
-            yield from walk(v)
+            for c in walk(v):
+                yield c
 
 
 def perf_walk(n: NestedDict):
@@ -75,7 +77,8 @@ def perf_walk(n: NestedDict):
     second threads etc.
     """
     if next(iter(n.values())) == 1:
-        yield from sorted(n.keys())
+        for c in sorted(n.keys()):
+            yield c
     else:
         stop_at = None
         # Note: values are sorted, so we start allocating from cores with fewest
@@ -104,15 +107,15 @@ def mask(iter: Iterator, n: int):
 
 def get_siblings_for_cpu(cpu_path: str) -> str:
     siblings = ""
-    with open(os.path.join(cpu_path, "topology", "thread_siblings_list")) as f:
+    with open(os.path.join(cpu_path, "topology", "thread_siblings_list"), "r") as f:
         siblings = f.read()
     return siblings
 
 
 def filter_single_thread_per_core(
-    cpus: list[list[tuple[int, str]]],
-    cpu_to_siblings_map: dict[int, str],
-) -> list[tuple[int, str]]:
+    cpus: List[List[Tuple[int, str]]],
+    cpu_to_siblings_map: Dict[int, str],
+) -> List[Tuple[int, str]]:
     """
     Ideally, we would like to iterate over the physical cores and
     not over all the CPUs because there could be many CPUs per
@@ -132,8 +135,8 @@ def filter_single_thread_per_core(
 
 
 def filter_sort_cpus(
-    cpu_paths: list[str], iterate_physical_cores: bool, ordered: bool
-) -> list[tuple[int, str]]:
+    cpu_paths: List[str], iterate_physical_cores: bool, ordered: bool
+) -> List[Tuple[int, str]]:
     """
     Filters and sorts the CPU information.
     """

--- a/packages/django_workload/templates/ib.py
+++ b/packages/django_workload/templates/ib.py
@@ -79,11 +79,11 @@ urlpatterns = [
 
     with open("urls_template.txt", "w") as fo:
         for i in range(num_endpoints):
-            fo.write(f"http://localhost:8000/feed_timeline{i} 26\n")
-            fo.write(f"http://localhost:8000/timeline{i} 25\n")
-            fo.write(f"http://localhost:8000/bundle_tray{i} 25\n")
-            fo.write(f"http://localhost:8000/inbox{i} 19\n")
-            fo.write(f"http://localhost:8000/seen{i} POST <seen.json 5\n")
+            fo.write("http://localhost:8000/feed_timeline{} 26\n".format(i))
+            fo.write("http://localhost:8000/timeline{} 25\n".format(i))
+            fo.write("http://localhost:8000/bundle_tray{} 25\n".format(i))
+            fo.write("http://localhost:8000/inbox{} 19\n".format(i))
+            fo.write("http://localhost:8000/seen{} POST <seen.json 5\n".format(i))
 
 
 if "__main__" == __name__:

--- a/packages/health_check/collect-cpu-util.py
+++ b/packages/health_check/collect-cpu-util.py
@@ -11,7 +11,7 @@ cpu_util = {}
 
 
 def get_cpu_ticks():
-    with open("/proc/stat") as f:
+    with open("/proc/stat", "r") as f:
         cpu = f.readline()
     curr_ticks = [int(x) for x in cpu.split()[1:]]
     return curr_ticks

--- a/packages/spark_standalone/templates/fetch_dataset.py
+++ b/packages/spark_standalone/templates/fetch_dataset.py
@@ -36,7 +36,7 @@ def fetch_file(dst_path, filename, for_real):
 
 
 def fetch_dataset(dst_path, file_list, for_real):
-    with open(file_list) as fp:
+    with open(file_list, "rt") as fp:
         metadata = json.load(fp)
     dir_list = metadata["dirs"]
     file_list = metadata["files"]

--- a/packages/spark_standalone/templates/nvme_tcp/utils.py
+++ b/packages/spark_standalone/templates/nvme_tcp/utils.py
@@ -8,6 +8,7 @@ import logging
 import logging.config
 import os
 import subprocess
+from typing import Dict, List
 
 
 CommandLogFormat = "\033[36m>>>> %(message)s\033[0m"
@@ -48,7 +49,7 @@ def exec_cmd(
 
 
 def run_cmd(
-    cmd: list[str],
+    cmd: List[str],
     for_real: bool,
     print_cmd: bool = True,
 ) -> str:
@@ -61,10 +62,10 @@ def run_cmd(
     return ""
 
 
-def get_os_release() -> dict[str, str]:
+def get_os_release() -> Dict[str, str]:
     if not os.path.exists("/etc/os-release"):
         return {}
-    with open("/etc/os-release") as f:
+    with open("/etc/os-release", "r") as f:
         os_release_text = f.read()
     os_release = {}
     for line in os_release_text.splitlines():

--- a/packages/spark_standalone/templates/proj_root/scripts/config_spark.py
+++ b/packages/spark_standalone/templates/proj_root/scripts/config_spark.py
@@ -5,6 +5,7 @@
 # LICENSE file in the root directory of this source tree.
 
 import socket
+from typing import Dict
 
 from utils import read_sys_configs
 
@@ -156,16 +157,16 @@ def check_platform(platform: str) -> None:
         exit(1)
 
 
-def get_hardware_info(platform: str) -> dict:
+def get_hardware_info(platform: str) -> Dict:
     check_platform(platform)
     return ALL_HARDWARE_INFO[platform]
 
 
-def get_standalone_cli_args(platform: str) -> dict:
+def get_standalone_cli_args(platform: str) -> Dict:
     check_platform(platform)
     return STANDALONE_CLI_ARGS[platform]
 
 
-def get_standalone_configs(platform: str) -> dict:
+def get_standalone_configs(platform: str) -> Dict:
     check_platform(platform)
     return STANDALONE_CONFIGS[platform]

--- a/packages/spark_standalone/templates/proj_root/scripts/utils.py
+++ b/packages/spark_standalone/templates/proj_root/scripts/utils.py
@@ -9,10 +9,11 @@ import os
 import pathlib
 import platform
 import subprocess
+from typing import Dict, List, Optional
 
 
 def exec_cmd(
-    cmd: list[str],
+    cmd: List[str],
     for_real: bool,
     print_cmd: bool = True,
 ) -> None:
@@ -34,13 +35,13 @@ def launch_proc(cmd, cwd, stdout, stderr, env):
 
 
 def run_cmd(
-    cmd: list[str],
+    cmd: List[str],
     cwd: str,
-    outfile: str | None,
-    env: dict[str, str],
+    outfile: Optional[str],
+    env: Dict[str, str],
     for_real: bool,
     print_cmd: bool = True,
-) -> str | None:
+) -> Optional[str]:
     env_setting = [f"{k}={v}" for k, v in env.items()]
     if print_cmd:
         print(" ".join(env_setting + cmd))
@@ -49,7 +50,7 @@ def run_cmd(
         for k, v in env.items():
             exec_env[k] = v
         if outfile:
-            with open(outfile, "w") as fp:
+            with open(outfile, "wt") as fp:
                 proc = launch_proc(cmd, cwd, fp, fp, exec_env)
                 proc.wait()
             return None
@@ -60,7 +61,7 @@ def run_cmd(
     return None
 
 
-def read_sys_configs() -> dict[str, int]:
+def read_sys_configs() -> Dict[str, int]:
     # cpu core
     cmd = ["lscpu", "--json"]
     stdout = run_cmd(cmd, cwd=".", outfile=None, env={}, for_real=True, print_cmd=False)
@@ -118,7 +119,7 @@ def find_java_home() -> str:
     return java_home
 
 
-def read_environ() -> dict[str, str]:
+def read_environ() -> Dict[str, str]:
     # default env values
     env_vars = {}
     env_vars["PROJ_ROOT"] = "/".join(os.path.abspath(__file__).split("/")[:-2])
@@ -144,7 +145,7 @@ def read_environ() -> dict[str, str]:
 def get_os_release() -> dict[str, str]:
     if not os.path.exists("/etc/os-release"):
         return {}
-    with open("/etc/os-release") as f:
+    with open("/etc/os-release", "r") as f:
         os_release_text = f.read()
     os_release = {}
     for line in os_release_text.splitlines():

--- a/packages/spark_standalone/templates/runner.py
+++ b/packages/spark_standalone/templates/runner.py
@@ -188,7 +188,7 @@ def run(args):
             if "IOPS" in line and "write" in line:
                 value = iops()
                 total_iops_write += value
-        with open(f"{WORK_DIR}/results.txt", "a") as fp:  # internal
+        with open(f"{WORK_DIR}/results.txt", "at") as fp:  # internal
             fp.write(f"total_iops_read : {total_iops_read}\n")
             fp.write(f"total_iops_write : {total_iops_write}\n")
     exec_cmd(f"mkdir -p {DATASET_DIR}")

--- a/packages/tao_bench/args_utils.py
+++ b/packages/tao_bench/args_utils.py
@@ -6,7 +6,7 @@
 
 import os
 from argparse import _HelpAction, ArgumentParser
-from collections.abc import Sequence
+from typing import List, Sequence, Tuple
 
 MAX_CLIENT_CONN = 32768
 MEM_USAGE_FACTOR = 0.75  # to prevent OOM
@@ -27,7 +27,7 @@ def get_warmup_time(args, secs_per_gb=5, min_time=1200):
 
 def get_proc_meminfo():
     results = {}
-    with open("/proc/meminfo") as f:
+    with open("/proc/meminfo", "r") as f:
         for line in f:
             key, value = line.split(":", maxsplit=1)
             vals = value.strip().split(" ", maxsplit=1)
@@ -58,7 +58,7 @@ def find_long_option_string(option_strings: Sequence[str]) -> str:
     return ""
 
 
-def get_opt_strings(parser: ArgumentParser) -> list[tuple[str, str]]:
+def get_opt_strings(parser: ArgumentParser) -> List[Tuple[str, str]]:
     res = []
     for action in parser._actions:
         if isinstance(action, _HelpAction):
@@ -71,7 +71,7 @@ def get_opt_strings(parser: ArgumentParser) -> list[tuple[str, str]]:
     return res
 
 
-def add_common_server_args(server_parser: ArgumentParser) -> list[tuple[str, str]]:
+def add_common_server_args(server_parser: ArgumentParser) -> List[Tuple[str, str]]:
     server_parser.add_argument(
         "--memsize", type=float, required=True, help="memory size, e.g. 64 or 96"
     )
@@ -158,7 +158,7 @@ def add_common_server_args(server_parser: ArgumentParser) -> list[tuple[str, str
     return get_opt_strings(server_parser)
 
 
-def add_common_client_args(client_parser: ArgumentParser) -> list[tuple[str, str]]:
+def add_common_client_args(client_parser: ArgumentParser) -> List[Tuple[str, str]]:
     client_parser.add_argument(
         "--server-hostname", type=str, required=True, help="server hostname"
     )

--- a/packages/tao_bench/run.py
+++ b/packages/tao_bench/run.py
@@ -11,6 +11,7 @@ import pathlib
 import shlex
 import subprocess
 import time
+from typing import List
 
 import args_utils
 
@@ -28,7 +29,7 @@ def get_affinitize_nic_path():
 
 
 def run_cmd(
-    cmd: list[str],
+    cmd: List[str],
     timeout=None,
     for_real=True,
 ) -> str:

--- a/packages/tao_bench/run_autoscale.py
+++ b/packages/tao_bench/run_autoscale.py
@@ -28,7 +28,7 @@ def find_numa_nodes():
     for node_dir in os.listdir("/sys/devices/system/node"):
         if node_dir.startswith("node"):
             node_id = node_dir[4]
-            with open(f"/sys/devices/system/node/{node_dir}/cpulist") as f:
+            with open(f"/sys/devices/system/node/{node_dir}/cpulist", "r") as f:
                 numa_nodes[node_id] = f.read().strip()
     return numa_nodes
 
@@ -222,7 +222,7 @@ def distribute_cores(n_parts):
     # check for SMT
     is_smt_active = False
     try:
-        with open("/sys/devices/system/cpu/smt/active") as f:
+        with open("/sys/devices/system/cpu/smt/active", "r") as f:
             smt = f.read().strip()
             if smt == "1":
                 is_smt_active = True
@@ -334,7 +334,7 @@ def run_server(args):
 
     for i in range(args.num_servers):
         logpath = servers[i][2]
-        with open(logpath) as log:
+        with open(logpath, "r") as log:
             parser = TaoBenchParser(f"server_{i}.csv")
             res = parser.parse(log, None, procs[i].returncode)
             if "role" in res and res["role"] == "server":


### PR DESCRIPTION
Summary: D70239810 authored by a bot changed the codebase of DCPerf (fbcode//cea/chips/benchpress) to use some modern features that are available in Python 3.10+. However this will break DCPerf's OSS run, considering the default Python interpreter in CentOS 9 is 3.9 so some of the newer features are not supported. Therefore we need to revert the changes.

Differential Revision: D70342397
