### PR TITLE
Create a benchmark job 'sleep' to leverage Benchpress's features to monitor non-DCPerf workloads

### DIFF
--- a/benchpress/config/benchmarks.yml
+++ b/benchpress/config/benchmarks.yml
@@ -146,3 +146,8 @@ health_check:
   cleanup_script: ./packages/health_check/cleanup_health_check.sh
   path: ./benchmarks/health_check/run.sh
   metrics: []
+
+sleep:
+  path: /usr/bin/sleep
+  parser: returncode
+  metrics: []

--- a/benchpress/config/jobs.yml
+++ b/benchpress/config/jobs.yml
@@ -806,3 +806,13 @@
     client:
       args:
         - '-r client'
+
+- benchmark: sleep
+  name: sleep
+  description: >
+    Sleep for a period of time. Can be used to leverage Benchpress's Perf
+    Monitoring Hook to monitor some external workloads.
+  args:
+    - '{duration}'
+  vars:
+    - 'duration'

--- a/benchpress/lib/util.py
+++ b/benchpress/lib/util.py
@@ -53,6 +53,9 @@ def issue_background_command(cmd, stdout, stderr, env=None):
 
 
 def verify_install(install_script):
+    if not install_script:
+        # install_script not set means this "benchmark" does not need installation
+        return True
     if os.path.exists("benchmark_installs.txt"):
         with open("benchmark_installs.txt", "r") as benchmark_installs:
             for benchmark_install in benchmark_installs:

--- a/perfutils/generate_amd_perf_report.py
+++ b/perfutils/generate_amd_perf_report.py
@@ -9,6 +9,7 @@ import functools
 import io
 import itertools
 import subprocess
+import typing
 
 import click
 import pandas as pd
@@ -2376,7 +2377,7 @@ def get_memory_info():
 )
 def main(
     amd_perf_csv_file: click.Path,
-    series: click.File,
+    series: typing.TextIO,
     format: click.Choice,
     arch: click.Choice,
 ) -> None:

--- a/perfutils/generate_arm_perf_report.py
+++ b/perfutils/generate_arm_perf_report.py
@@ -8,6 +8,7 @@ import csv
 import functools
 import io
 import itertools
+import typing
 
 import click
 import pandas as pd
@@ -804,7 +805,7 @@ def nvidia_scf_mem_latency_ns(grouped_df):
 )
 def main(
     perf_csv_file: click.Path,
-    series: click.File,
+    series: typing.TextIO,
     format: click.Choice,
 ) -> None:
     df = read_csv(perf_csv_file)


### PR DESCRIPTION
Summary: Create a benchmark job 'sleep' to leverage Benchpress's features to monitor non-DCPerf workloads

Reviewed By: YifanYuan3

Differential Revision: D73547249


