### PR TITLE
Add buck targets for generate_*_perf_reports

### DIFF
--- a/perfutils/generate_amd_perf_report.py
+++ b/perfutils/generate_amd_perf_report.py
@@ -9,6 +9,7 @@ import functools
 import io
 import itertools
 import subprocess
+import typing
 
 import click
 import pandas as pd
@@ -2376,7 +2377,7 @@ def get_memory_info():
 )
 def main(
     amd_perf_csv_file: click.Path,
-    series: click.File,
+    series: typing.TextIO,
     format: click.Choice,
     arch: click.Choice,
 ) -> None:

--- a/perfutils/generate_arm_perf_report.py
+++ b/perfutils/generate_arm_perf_report.py
@@ -8,6 +8,7 @@ import csv
 import functools
 import io
 import itertools
+import typing
 
 import click
 import pandas as pd
@@ -804,7 +805,7 @@ def nvidia_scf_mem_latency_ns(grouped_df):
 )
 def main(
     perf_csv_file: click.Path,
-    series: click.File,
+    series: typing.TextIO,
     format: click.Choice,
 ) -> None:
     df = read_csv(perf_csv_file)


### PR DESCRIPTION
Summary: Add buck targets for both generate_[cpu]_perf_reports.py scripts to easily run without installing third-party depedencies

Reviewed By: excelle08, YifanYuan3

Differential Revision: D73624196


