### PR TITLE
remove unnecessary check functions in mediawiki

### DIFF
--- a/packages/mediawiki/0001-oss-performance-scalable-hhvm.diff
+++ b/packages/mediawiki/0001-oss-performance-scalable-hhvm.diff
@@ -780,3 +780,19 @@ index 3ca1bfb..ff616de 100644
  opcache.memory_consumption=1024
  opcache.consistency_checks=0
 +
+diff --git a/base/SystemChecks.php b/base/SystemChecks.php
+index 4784108..091175c 100644
+--- a/base/SystemChecks.php
++++ b/base/SystemChecks.php
+@@ -10,9 +10,9 @@
+ 
+ class SystemChecks {
+   public static function CheckAll(PerfOptions $options): void {
+-    self::CheckNotRoot($options);
++    // self::CheckNotRoot($options);
+     self::CheckPortAvailability($options);
+-    self::CheckCPUFreq();
++    // self::CheckCPUFreq();
+     self::CheckTCPTimeWaitReuse();
+     self::CheckForAuditd($options);
+   }


### PR DESCRIPTION
Summary: these two functions are not necessary for our use cases and may creates some extra manual work. so we remove it.

Reviewed By: charles-typ

Differential Revision: D74299395


