### PR TITLE
Fix Feedsim query interval precision

### DIFF
--- a/packages/feedsim/third_party/src/oldisim/src/DriverNode.cc
+++ b/packages/feedsim/third_party/src/oldisim/src/DriverNode.cc
@@ -331,7 +331,10 @@ DriverNode::DriverNodeThread::~DriverNodeThread() {}
 
 DriverNode::DriverNodeThread::DriverNodeThread(DriverNode& _driver_node)
     : driver_node(_driver_node) {
-  node_thread.impl_->base = event_base_new();  // create event base;
+  event_config *config = event_config_new();
+  event_config_set_flag(config, EVENT_BASE_FLAG_PRECISE_TIMER);
+  node_thread.impl_->base = event_base_new_with_config(config);
+  event_config_free(config);
 }
 
 void DriverNode::DriverNodeThread::Init() {


### PR DESCRIPTION
Each thread of the driver node adds delays of typically 50 ms to 100 ms between queries using a libevent timer, in order to match the queries per second specified via the command line. This is achieved by libevent with the epoll_pwait() syscall whose 1 ms timeout precision is good enough for the benchmark. However, every time epoll_pwait() returns, libevent triggers events that have either timed out (such as timers) or become ready due to file descriptor events (such as network sockets). In the former case, the timeout check is done by comparing the current absolute time with the event's absolute target timeout time. If the event has not expired yet, the remaining time is waited in the next epoll_pwait() call.

By default, libevent gets the current time from CLOCK_MONOTONIC_COARSE whose time value is updated every (1 / CONFIG_HZ) second, which is 10 ms when CONFIG_HZ=100, way too imprecise compared to the delays in the driver node. The delays never get too short because epoll_pwait() waits the correct amount of ms. But the imprecise current time does mean the timeout check often causes extra time to be waited in another epoll_pwait() call. The consequence is that delays are quite a bit longer than intended and queries are sent at a lower rate. The script search_qps.sh keeps trying a lower qps when the intended qps cannot be achieved, resulting in a very low final qps in the end.

Sample strace of epoll_pwait() for 10 ms clock precision (CONFIG_HZ=100) where the initial wait is 61 ms but many additional waits happen because CLOCK_MONOTONIC_COARSE only increments every 10 ms:

  epoll_pwait(53, [], 32, 61, NULL, 8)    = 0
  epoll_pwait(53, [], 32, 1, NULL, 8)     = 0
  epoll_pwait(53, [], 32, 1, NULL, 8)     = 0
  epoll_pwait(53, [], 32, 1, NULL, 8)     = 0
  epoll_pwait(53, [], 32, 1, NULL, 8)     = 0
  epoll_pwait(53, [], 32, 1, NULL, 8)     = 0
  epoll_pwait(53, [], 32, 1, NULL, 8)     = 0
  epoll_pwait(53, [], 32, 1, NULL, 8)     = 0
  epoll_pwait(53, [], 32, 1, NULL, 8)     = 0

Switch to the precise timer implementation (based on timerfd) to resolve this issue.