### PR TITLE
Enabling Django to take a snapshot and restore from it

### DIFF
--- a/benchpress/config/jobs.yml
+++ b/benchpress/config/jobs.yml
@@ -222,6 +222,35 @@
           - 'benchmarks/django_workload/django-workload/client/perf.data'
 
 - benchmark: django_workload
+  name: django_workload_mini
+  description: A short version of django-workload, where we can load the database from a snapshot
+  tee_output: true
+  roles:
+    standalone:
+      args:
+        - '-r standalone'
+        - '-d {duration}'
+        - '-i {iterations}'
+        - '-p {reps}'
+        - '-l ./siege.log'
+        - '-s urls.txt'
+        - '-c 127.0.0.1'
+        - '-m 50000'
+        - '-M 100000'
+        - '-L {snapshot_path}'
+      vars:
+        - 'duration=1M'
+        - 'iterations=1'
+        - 'reps=0'
+        - 'snapshot_path=benchmarks/django_workload/cassandra_snapshots/synthetic_dataset_snapshot'
+  hooks:
+    - hook: copymove
+      options:
+        is_move: true
+        after:
+          - 'benchmarks/django_workload/django-workload/client/perf.data'
+
+- benchmark: django_workload
   name: django_workload_custom
   description: Django-workload benchmark with custom parameters
   tee_output: true

--- a/packages/django_workload/templates/run.sh
+++ b/packages/django_workload/templates/run.sh
@@ -10,12 +10,15 @@ SCRIPT_ROOT="$(dirname "$(readlink -f "$0")")"
 BENCHPRESS_ROOT="$(readlink -f "${SCRIPT_ROOT}/../../..")"
 MEMCACHED_PID=
 CLEANUP_REQS=0
-
+TABLE_NAMES="bundle_entry_model bundle_seen_model feed_entry_model inbox_entries user_model"
+CASSANDRA_DATA_PATH="/data/cassandra/data"
+KEY_SPACE_NAME="db"
 if [ -z "$JAVA_HOME" ]; then
   _JAVA_HOME="$("${BENCHPRESS_ROOT}"/packages/common/find_java_home.py)"
   export JAVA_HOME="${_JAVA_HOME}"
   echo "JAVA_HOME is not set, so setting it to ${JAVA_HOME}."
 fi
+
 
 # shellcheck disable=SC2317
 cleanup() {
@@ -38,6 +41,7 @@ cleanup() {
   CLEANUP_REQS=$((CLEANUP_REQS + 1))
 }
 
+
 trap 'cleanup' ERR EXIT SIGINT SIGTERM
 
 show_help() {
@@ -51,6 +55,9 @@ For role "server", "clientserver":
     -c          ip address of the cassandra server (required)
     -m          minimum icachebuster calling rounds (default 100000)
     -M          maximum icachebuster calling rounds (default 200000)
+    -L          when provided snapshot loading is enabled, meaning that the database is loaded from a snapshot stored in the specifed path (default disabled)
+    -t          when provided snapshot taking is enabled, meaning that the a snapshot of the generetaed database will be stored in the specifed path (default disabled)
+
 For role "client", "clientserver":
     -x          number of client workers (default 1.2*NPROC)
     -i          number of iterations (default 7)
@@ -65,6 +72,7 @@ For role "client":
 For role "db":
     -y          number of cassandra concurrent writes (default 128)
     -b          ip address that cassandra will bind to (default to the first IP from "hostname -i": `hostname -i`)
+
 
 EOF
 }
@@ -104,6 +112,101 @@ run_benchmark() {
   python3 ./run-siege -i "${iterations}" -r "${reps}"
 }
 
+load_snapshot(){
+  extra_options="-h ${cassandra_addr_IPV6}" # the IPV^ is essential for the standlone version, wehre we pass IPV4 version as cassandra_IP. This line is equievalnet to this :extra_options="-h ::FFFF:127.0.0.1
+  #https://docs.datastax.com/en/cassandra-oss/3.0/cassandra/operations/opsBackupSnapshotRestore.html
+  # for nodetool V3 there is no import command. So, according to the mentioned documentaion, we need to copy the snapshot files to the corresponding table folders
+  echo "Loading snapshot from ${snapshot_dir} to ${CASSANDRA_DATA_PATH}/${KEY_SPACE_NAME} "
+  source_directory=${snapshot_dir}
+  dest_directory=${CASSANDRA_DATA_PATH}/${KEY_SPACE_NAME}
+
+  # Check if destination directory exists
+  if [ ! -d "$source_directory" ]; then
+    echo "Error: $source_directory does not exist"
+    exit 1
+  fi
+
+  # For each table, check if there's a directory in source_directory that starts with the table name
+  # If so, copy its content to the corresponding directory in dest_directory
+  for table in ${TABLE_NAMES}; do
+    # Find directories in source_directory that start with the table name
+    for src_dir in ${source_directory}/${table}*/; do
+      if [ -d "$src_dir" ]; then
+        # Find the corresponding directory in dest_directory
+        for dst_dir in ${dest_directory}/${table}*/; do
+          if [ -d "$dst_dir" ]; then
+            echo "Copying content from ${src_dir} to ${dst_dir}"
+            cp -rf "${src_dir}"* "${dst_dir}" || echo "Failed to copy from ${src_dir} to ${dst_dir}"
+          fi
+        done
+      fi
+    done
+  done
+
+   # Loop through each table in TABLE_NAMES and refresh it
+  #echo "Refreshing tables in ${KEY_SPACE_NAME}..."
+  for table in ${TABLE_NAMES}; do
+    #echo "Refreshing table: ${table}"
+    ${BENCHPRESS_ROOT}/benchmarks/django_workload/apache-cassandra/bin/nodetool ${extra_options} refresh -- ${KEY_SPACE_NAME} ${table} || exit 1
+  done
+  # The documentation says that the node should be restarted but it is not necessary and the node frrezes sometimes if we restart it, So for now the restart code is commented until we are sure that the restart is unecessary
+  #pgrep -f cassandra | xargs kill
+  #./apache-cassandra/bin/cassandra -R -f -p cassandra.pid > cassandra.log 2>&1 & #Send to the background doese not work this way
+  #wait_for_cassandra_to_start
+
+
+  echo "End of loading snapshot ..."
+}
+wait_for_cassandra_to_start() {
+   # Wait for cassandra to start
+  retries=60
+  if ! nc -z "${cassandra_addr}" 9042; then
+    echo "Waiting for Cassandra to start..."
+    while ! nc -z "${cassandra_addr}" 9042; do
+      sleep 1
+      retries=$((retries-1))
+      if [[ "$retries" -le 0 ]]; then
+        echo "Cassandra could not start."
+        exit 1
+      fi
+    done
+    echo "Cassandra is ready."
+  fi
+}
+
+take_snapshot(){
+  snapshot_name=$(basename "${snapshot_dir}")
+  for table_dir in ${CASSANDRA_DATA_PATH}/${KEY_SPACE_NAME}/*/; do
+    # The nodetool returns an error if the snapshot already exists, so we have to remove the existing one
+    if [ -d "${table_dir}snapshots/${snapshot_name}" ]; then
+      echo "The ${snapshot_name} exists in the ${CASSANDRA_DATA_PATH}/${KEY_SPACE_ANEM}. So, we are removing it to take a new snashopt"
+      rm -rf ${table_dir}snapshots/${snapshot_name}
+    fi
+  done
+  echo "Taking snapshot ..."
+
+  #extra_options="-h ::FFFF:127.0.0.1 -p 7199" # the documention says this port should be used, but it did not work
+  #extra_options="-h ::FFFF:127.0.0.1 -p 9042" # this port also is tried, but it did not work
+  extra_options="-h ${cassandra_addr_IPV6}"
+  command_options="-t ${snapshot_name}"
+  # Our nodetool is v3, so unfortunately the new nodetool commands for taking a snapshot and importing a snapshot does not work, so we need to use the following commands based on the following documentation
+  #https://docs.datastax.com/en/cassandra-oss/3.0/cassandra/operations/opsBackupTakesSnapshot.html
+  ${BENCHPRESS_ROOT}/benchmarks/django_workload/apache-cassandra/bin/nodetool ${extra_options}  cleanup ${KEY_SPACE_NAME} || exit 1
+  ${BENCHPRESS_ROOT}/benchmarks/django_workload/apache-cassandra/bin/nodetool ${extra_options}  snapshot ${KEY_SPACE_NAME} ${command_options} || exit 1
+
+
+  # The snapshot taken by the nodetool is scattered among several directories and has no option for storing in a user specified folder
+  # So, we need to collect all the folders of a snapshot that the nodetool creates and move it to a user specifed path or the default path
+  # This way, the snapshot will be stored in one folder that can easily be moved and be reused
+  # Copy snapshot files to a new directory
+  for table_dir in ${CASSANDRA_DATA_PATH}/${KEY_SPACE_NAME}/*/; do
+    table_dir_name=$(basename "${table_dir}")
+    mkdir -p "${snapshot_dir}/${table_dir_name}" || exit 1
+    cp -rf ${table_dir}snapshots/${snapshot_name}/* ${snapshot_dir}/${table_dir_name}/ || exit 1
+  done
+  echo "The snapshot is stored in ${snapshot_dir} "
+}
+
 start_cassandra() {
   cd "${SCRIPT_ROOT}/.." || exit 1
   # Set the listening address
@@ -122,8 +225,9 @@ start_cassandra() {
   sed "s/__HOST_IP__/${HOST_IP}/g" < ${CASSANDRA_YAML}.template > ${CASSANDRA_YAML}.tmp
   sed "s/__CONCUR_WRITES__/${cassandra_concur_writes}/g" < ${CASSANDRA_YAML}.tmp > ${CASSANDRA_YAML}.tmp2
   mv -f "${CASSANDRA_YAML}.tmp2" "${CASSANDRA_YAML}"
-  # Start Cassandra
+
   ./apache-cassandra/bin/cassandra -R -f -p cassandra.pid > cassandra.log 2>&1
+
 }
 
 start_django_server() {
@@ -133,6 +237,7 @@ start_django_server() {
   # Start Memcached
   cd "${SCRIPT_ROOT}/.." || exit 1
   ./django-workload/services/memcached/run-memcached > memcached.log 2>&1 &
+
   MEMCACHED_PID=$!
 
   # Start django-workload
@@ -146,25 +251,24 @@ start_django_server() {
   # shellcheck disable=SC1090,SC1091
   source "${SCRIPT_ROOT}/../django-workload/django-workload/venv/bin/activate"
 
-  # Wait for cassandra to start
-  retries=60
-  if ! nc -z "${cassandra_addr}" 9042; then
-    echo "Waiting for Cassandra to start..."
-    while ! nc -z "${cassandra_addr}" 9042; do
-      sleep 1
-      retries=$((retries-1))
-      if [[ "$retries" -le 0 ]]; then
-        echo "Cassandra could not start."
-        exit 1
-      fi
-    done
-    echo "Cassandra is ready."
-  fi
+  wait_for_cassandra_to_start
+
   # Create database schema
   export LD_LIBRARY_PATH=${SCRIPT_ROOT}/../django-workload/django-workload/:${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}
-  DJANGO_SETTINGS_MODULE=cluster_settings ./venv/bin/django-admin flush
-  DJANGO_SETTINGS_MODULE=cluster_settings ./venv/bin/django-admin setup
+    if [ "$load_a_snapshot" = true ]; then
+      #DJANGO_SETTINGS_MODULE=cluster_settings ./venv/bin/django-admin flush
+      load_snapshot
+      # we need to restart Cassandra after loaing an snapshot
+      echo "Cassandra is loaded using the snapshot"
+    else
+      echo "Generating database "
+      DJANGO_SETTINGS_MODULE=cluster_settings ./venv/bin/django-admin flush
+      DJANGO_SETTINGS_MODULE=cluster_settings ./venv/bin/django-admin setup
 
+    fi
+    if [ "$take_a_snapshot" = true ]; then
+      take_snapshot
+    fi
   echo "Running django server with ${num_server_workers} uWSGI workers"
 
   venv/bin/uwsgi \
@@ -209,12 +313,13 @@ start_clientserver() {
   start_django_server "${cassandra_addr}" "${num_server_workers}" &
 
   # Wait for the server to start
-  local retries=150
+  local retries_init=150
+  local retries=$retries_init
   while ! nc -z localhost 8000; do
       sleep 1
       retries=$((retries-1))
       if [[ "$retries" -le 0 ]]; then
-          echo "Django server could not start within 150s"
+          echo "Django server could not start within ${retries_init}s"
           exit 1
       fi
   done
@@ -252,6 +357,9 @@ main() {
   local cassandra_addr
   cassandra_addr='::1'
 
+  local cassandra_addr
+  cassandra_addr_IPV6=''
+
   local server_addr
   server_addr='::1'
 
@@ -264,7 +372,16 @@ main() {
   local django_ib_max
   django_ib_max="200000"
 
-  while getopts 'w:x:y:i:p:d:l:s:r:c:z:b:m:M:' OPTION "${@}"; do
+  local take_a_snapshot
+  take_a_snapshot=false
+
+  local load_a_snapshot
+  load_a_snapshot=false
+
+  local snapshot_dir
+  snapshot_dir="${BENCHPRESS_ROOT}/benchmarks/django_workload/cassandra_snapshots/synthetic_dataset_snapshot"
+
+  while getopts 'w:x:y:i:p:d:l:s:r:c:z:b:m:M:L:t:' OPTION "${@}"; do
     case "$OPTION" in
       w)
         # Use readlink to get absolute path if relative is given
@@ -315,6 +432,28 @@ main() {
       M)
         django_ib_max="${OPTARG}"
         ;;
+      t)
+        take_a_snapshot=true
+        snapshot_dir="${OPTARG}"
+        # Check if snapshot_dir is a relative path and prepend BENCHPRESS_ROOT if it is
+        if [[ ! "${snapshot_dir}" = /* ]]; then
+          snapshot_dir="${BENCHPRESS_ROOT}/${snapshot_dir}"
+        fi
+        ;;
+
+      L)
+        load_a_snapshot=true
+        snapshot_dir="${OPTARG}"
+        # Check if snapshot_dir is a relative path and prepend BENCHPRESS_ROOT if it is
+        if [[ ! "${snapshot_dir}" = /* ]]; then
+          snapshot_dir="${BENCHPRESS_ROOT}/${snapshot_dir}"
+        fi
+        # Check if snapshot_dir exists
+        if [ ! -d "$snapshot_dir" ]; then
+          echo "Error: Snapshot directory $snapshot_dir does not exist"
+          exit 1
+        fi
+        ;;
       ?)
         show_help >&2
         exit 1
@@ -322,6 +461,15 @@ main() {
     esac
   done
   shift "$((OPTIND - 1))"
+
+  # Check if $cassandra_addr is in IPv4 format, if so convert to IPv6 format
+  if [[ $cassandra_addr =~ ^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+    # IPv4 format detected, convert to IPv6 format
+    cassandra_addr_IPV6="::FFFF:$cassandra_addr"
+  else
+    # Not IPv4 format, just copy the value
+    cassandra_addr_IPV6="$cassandra_addr"
+  fi
 
   readonly num_server_workers
   readonly num_client_workers
@@ -337,6 +485,9 @@ main() {
   readonly cassandra_bind_addr
   readonly django_ib_min
   readonly django_ib_max
+  readonly take_a_snapshot
+  readonly load_a_snapshot
+
 
   if [ "$role" = "db" ]; then
     start_cassandra "$num_cassandra_writes" "$cassandra_bind_addr";


### PR DESCRIPTION
Summary:
The Django benchmark generates data and load dataset at the benchmarking time. This diff mainly enables Django to (i) take a snapshot, (ii) use a snapshot to load a dataset. In addition this diff, creates a new job for Django where the duration is smaller and uses a snapshot.

Unfortunately, the Cassandra version that we have in the DCPerf is very old, and taking a snapshot and restore from it was different from the documentation that I found for V3 and I only managed to make this work by trying and error of many things.

So, the next step for this diff might be updating the Cassandar for DCPerf

Reviewed By: YifanYuan3

Differential Revision: D75101136


