### PR TITLE
renaming Spark job to mini

### DIFF
--- a/benchpress/config/jobs.yml
+++ b/benchpress/config/jobs.yml
@@ -449,7 +449,7 @@
           - 'benchmarks/spark_standalone/work'
 
 - benchmark: spark_standalone
-  name: spark_standalone_remote_5GB_Dataset
+  name: spark_standalone_remote_mini
   description: Spark standalone using remote SSDs for database and shuffling point; compute & memory bound as in prod
   args:
     - 'run'


### PR DESCRIPTION
Summary: Just renaming the added job for Spark to park_standalone_remote

Reviewed By: excelle08

Differential Revision: D75468617
