### PR TITLE
Enabling Django to skip dataset setup and use setup from previous runs or copied data from other systems

### DIFF
--- a/benchpress/config/jobs.yml
+++ b/benchpress/config/jobs.yml
@@ -222,7 +222,7 @@
           - 'benchmarks/django_workload/django-workload/client/perf.data'
 
 - benchmark: django_workload
-  name: django_workload_mini
+  name: django_workload_arm_mini
   description: A short version of django-workload, where we can load the database from a snapshot
   tee_output: true
   roles:
@@ -237,18 +237,44 @@
         - '-c 127.0.0.1'
         - '-m 50000'
         - '-M 100000'
-        - '-L {snapshot_path}'
+        - '-S'
       vars:
         - 'duration=1M'
         - 'iterations=1'
-        - 'reps=0'
-        - 'snapshot_path=benchmarks/django_workload/cassandra_snapshots/synthetic_dataset_snapshot'
+        - 'reps=1000'
   hooks:
     - hook: copymove
       options:
         is_move: true
         after:
           - 'benchmarks/django_workload/django-workload/client/perf.data'
+
+- benchmark: django_workload
+  name: django_workload_mini
+  description: A short version of django-workload, where we can load the database from a snapshot
+  tee_output: true
+  roles:
+    standalone:
+      args:
+        - '-r standalone'
+        - '-d {duration}'
+        - '-i {iterations}'
+        - '-p {reps}'
+        - '-l ./siege.log'
+        - '-s urls.txt'
+        - '-c 127.0.0.1'
+        - '-S'
+      vars:
+        - 'duration=1M'
+        - 'iterations=1'
+        - 'reps=1000'
+  hooks:
+    - hook: copymove
+      options:
+        is_move: true
+        after:
+          - 'benchmarks/django_workload/django-workload/client/perf.data'
+
 
 - benchmark: django_workload
   name: django_workload_custom


### PR DESCRIPTION
Summary: Adding an option for just skipping the dataset setup and use data in the Cassandra folder (either from previous runs/or copied from another system)

Reviewed By: YifanYuan3, excelle08

Differential Revision: D75845036
