### PR TITLE
Fix VideoTranscodeBench argument default values

### DIFF
--- a/benchpress/config/jobs.yml
+++ b/benchpress/config/jobs.yml
@@ -748,11 +748,15 @@
     - '--levels {levels}'
     - '--output {output}'
     - '--runtime {runtime}'
+    - '--parallelism {parallelism}'
+    - '--procs {procs}'
   vars:
     - 'encoder=aom'
     - 'levels=0:0'
     - 'output=video_transcode_bench_results.txt'
     - 'runtime=medium'
+    - 'parallelism=1'
+    - 'procs=-1'
   hooks:
     - hook: cpu-mpstat
       options:
@@ -775,11 +779,15 @@
     - '--levels {levels}'
     - '--output {output}'
     - '--runtime {runtime}'
+    - '--parallelism {parallelism}'
+    - '--procs {procs}'
   vars:
     - 'encoder=x264'
     - 'levels=0:0'
     - 'output=video_transcode_bench_results.txt'
     - 'runtime=medium'
+    - 'parallelism=1'
+    - 'procs=-1'
   hooks:
     - hook: cpu-mpstat
       options:

--- a/packages/video_transcode_bench/run.sh
+++ b/packages/video_transcode_bench/run.sh
@@ -65,6 +65,12 @@ main() {
     local runtime
     runtime="medium"
 
+    local lp
+    lp="1"
+
+    local procs
+    procs="-1"
+
     while :; do
         case $1 in
             --levels)
@@ -193,7 +199,7 @@ main() {
     num_files=$(find ./datasets/cuts/ | wc -l)
     num_files=$(echo "$num_files * 8" | bc -l | awk '{print int($0)}')
     num_proc=$(nproc)
-    if [ -z "$procs" ] || [ $procs -eq -1 ]; then
+    if [ $procs -eq -1 ]; then
         if [ "$num_files" -lt "$num_proc" ]; then
             num_pool="num_pool = $num_files"
         else
@@ -203,10 +209,7 @@ main() {
         num_pool="num_pool = $procs"
     fi
 
-    lp_number="lp_number = 1"
-    if [ ! -z "$lp" ]; then
-        lp_number="lp_number = $lp"
-    fi
+    lp_number="lp_number = $lp"
     sed -i "/^CLIP\_DIRS/a ${lp_number}" ./generate_commands_all.py
 
     sed -i "/^CLIP\_DIRS/a ${range}" ./generate_commands_all.py


### PR DESCRIPTION
Running the libaom encoder with the command

  ./benchpress_cli.py run video_transcode_bench_aom

fails with

  ./benchmarks/video_transcode_bench/run.sh: line 196: procs: unbound variable

because run.sh enforces unbound variable checks with `set -u`, but the variable `procs` is not declared when `--proc` is not passed.

To fix this:

  - add missing default value declarations of `procs` and `lp` in `run.sh`, to be consistent with other variables
  - add `parallelism` and `procs` to `jobs.yml` for the libaom and x264 encoders (which is already the case for the SVT-AV1 encoder) so the options can be overridden via `benchpress_cli.py`'s `extra_args`.

The bug was introduced when the `procs` and `parallelism` options were added for the SVT-AV1 encoder but the libaom and x264 encoders were not handled during that change.