### PR TITLE
remove per-socket argument in grace script

### DIFF
--- a/perfutils/collect_nvda_neoversev2_perf_counters.sh
+++ b/perfutils/collect_nvda_neoversev2_perf_counters.sh
@@ -119,7 +119,7 @@ trap wrapup SIGINT SIGTERM
 perf_stat() {
   local ev="$1"
   local interval_ms="$2"
-  perf stat $ev -x, -I "${interval_ms}" --per-socket -a --log-fd 1 &
+  perf stat $ev -x, -I "${interval_ms}" -a --log-fd 1 &
   PERF_PID="$!"
   wait "$PERF_PID"
 }

--- a/perfutils/generate_arm_perf_report.py
+++ b/perfutils/generate_arm_perf_report.py
@@ -31,8 +31,8 @@ def read_csv(perf_csv_file):
         perf_csv_file,
         names=[
             "timestamp",
-            "socket",
-            "numcpus",
+            # "socket",
+            # "numcpus",
             "counter_value",
             "counter_unit",
             "event_name",
@@ -109,8 +109,9 @@ def concat_series(metrics, shortest_length_series):
 
 
 def get_num_sockets(group):
-    socket_series = group.socket
-    return len(socket_series.reset_index().groupby("socket").index)
+    # socket_series = group.socket
+    # return len(socket_series.reset_index().groupby("socket").index)
+    return 1
 
 
 def get_duration_series(group):


### PR DESCRIPTION
Summary: as titled. We don't have such multi-socket use cases for now, and this argument may cause some collection issues on grace with linux perf v6.14+.

Reviewed By: charles-typ

Differential Revision: D76314533


