### PR TITLE
Report zero in DjangoBench and Mediawiki if too many failed requests; reduce verbosity in DjangoBench uwsgi log

### DIFF
--- a/benchpress/plugins/parsers/django_workload.py
+++ b/benchpress/plugins/parsers/django_workload.py
@@ -79,6 +79,8 @@ class DjangoWorkloadParser(Parser):
     Full Siege output is available in /tmp/siege_out_[N]
     """
 
+    DJANGO_MIN_AVAILABILITY = 99
+
     def parse_dw_data(self, data, metric):
         """Helper method to handle errors when extracting metrics and values"""
 
@@ -139,6 +141,9 @@ class DjangoWorkloadParser(Parser):
                 self.parse_dw_key_val(dw_line, dw_metrics)
 
         if "Transaction rate_trans/sec" in dw_metrics:
+            if dw_metrics["Availability_%"] < self.DJANGO_MIN_AVAILABILITY:
+                dw_metrics["error"] = "Too many unsuccessful requests"
+                dw_metrics["Transaction rate_trans/sec"] = 0
             rps = dw_metrics["Transaction rate_trans/sec"]
             dw_metrics["score"] = float(rps) / DJANGO_BASELINE
 

--- a/benchpress/plugins/parsers/mediawiki.py
+++ b/benchpress/plugins/parsers/mediawiki.py
@@ -14,13 +14,28 @@ MEDIAWIKI_MLP_BASELINE = BASELINES["mediawiki"]
 
 
 class MediawikiParser(JSONParser):
+    MEDIAWIKI_MIN_AVAILABILITY = 0.95
+
     def parse(self, stdout, stderr, returncode):
         metrics = super().parse(stdout, stderr, returncode)
         if "Combined" in metrics:
+            nginx_hits = metrics["Combined"]["Nginx hits"]
+            nginx_200 = metrics["Combined"]["Nginx 200"]
+            availability = nginx_200 / nginx_hits
+            is_good_run = True
+            if availability < self.MEDIAWIKI_MIN_AVAILABILITY:
+                metrics["error"] = (
+                    f"Too many unsuccessful requests, availability was {100 * availability:.2f}%"
+                )
+                is_good_run = False
             if "Siege RPS" in metrics["Combined"]:
+                if not is_good_run:
+                    metrics["Combined"]["Siege RPS"] = 0
                 rps = metrics["Combined"]["Siege RPS"]
                 metrics["score"] = float(rps) / MEDIAWIKI_MLP_BASELINE
             elif "Wrk RPS" in metrics["Combined"]:
+                if not is_good_run:
+                    metrics["Combined"]["Wrk RPS"] = 0
                 rps = metrics["Combined"]["Wrk RPS"]
                 metrics["score"] = float(rps) / MEDIAWIKI_MLP_BASELINE
         return metrics

--- a/packages/django_workload/templates/0003-bundle_tray_caching.patch
+++ b/packages/django_workload/templates/0003-bundle_tray_caching.patch
@@ -33,7 +33,7 @@ index 36cf90b..7d0cba8 100644
 -            BundleEntryModel.objects
 -            .filter(userid__in=self.request.user.following).limit(10))
 +                BundleEntryModel.objects.filter(userid__in=self.request.user.following).limit(10))
-+        logger.warning('[perf] bundle_tray::bundle_entry.objects.filter: {}'.format(time.time() - start_time))
++        logger.debug('[perf] bundle_tray::bundle_entry.objects.filter: {}'.format(time.time() - start_time))
 +
 +
          # only one bundle per user
@@ -61,7 +61,7 @@ index 36cf90b..7d0cba8 100644
 +            for user in UserModel.objects.filter(id__in=list(userids)):
 +                userinfo[user.id] = user.json_data
 +            cache.set_many(userinfo, 60 * 5)
-+        logger.warning('[perf] bundle_tray::user_model.objects.filter: {}'.format(time.time() - start_time))
++        logger.debug('[perf] bundle_tray::user_model.objects.filter: {}'.format(time.time() - start_time))
 +
          # fetch entry information
          feedentryinfo = {}
@@ -98,7 +98,7 @@ index 36cf90b..7d0cba8 100644
              }
              for b in bundles if b.id in first_bundleids
          ]}
-+        logger.warning('[perf] bundle_tray::feed_entry.objects.filter+bundle_process: {}'.format(time.time() - start_time))
++        logger.debug('[perf] bundle_tray::feed_entry.objects.filter+bundle_process: {}'.format(time.time() - start_time))
          return result
 
      def dup_sort_data(self, bundle_list, conf):


### PR DESCRIPTION
Summary:
- Report zero RPS and score if too many failed requests in Mediawiki (<95% availability) and DjangoBench (<99% availability).
- Reduce verbosity to django-uwsgi.log in DjangoBench, do not log bundle tray latency unless in debug mode.

Differential Revision: D77031945


