### PR TITLE
Adding Media wiki mini

### DIFF
--- a/benchpress/config/jobs.yml
+++ b/benchpress/config/jobs.yml
@@ -31,6 +31,36 @@
           - 'oss-performance/perf.data'
 
 - benchmark: oss_performance_mediawiki
+  name: oss_performance_mediawiki_mini
+  description: Default run for oss_performance_mediawiki
+  args:
+    - '-r/usr/local/hphpi/legacy/bin/hhvm'
+    - '-nnginx'
+    - '-L {load_generator}'
+    - '-s {lg_path}'
+    - '--'
+    - '--mediawiki'
+    - '--client-duration={duration}'
+    - '--client-timeout={timeout}'
+    - '--run-as-root'
+    - '--i-am-not-benchmarking'
+    - '--hhvm-extra-arguments="-vEval.JitRetranslateAllSeconds={warmup_seconds}"'
+    - '{extra_args}'
+  vars:
+    - 'load_generator=wrk'
+    - 'lg_path=benchmarks/oss_performance_mediawiki/wrk/wrk'
+    - 'duration=0.1m'
+    - 'timeout=2m'
+    - 'warmup_seconds=45'
+    - 'extra_args='
+  hooks:
+    - hook: copymove
+      options:
+        is_move: true
+        after:
+          - 'oss-performance/perf.data'
+
+- benchmark: oss_performance_mediawiki
   name: oss_performance_mediawiki_mlp
   description: Tuned +MLP run for oss_performance_mediawiki
   args:


### PR DESCRIPTION
Summary:
This diff adds a config for media_wiki mini job. I am changing the oss_performance code that will add more options for reducing execution time that needs to be added to the mini job config. So, those options will be added to the config

Also, we need to add --temp-dir to the mini config, but  Ideally, we want to add the --temp-dir, only if the user provide a value for that. So, we need to decide on how to do it.

Differential Revision: D77192531


