### PR TITLE
Change to shared_lock for the concurrent hashmap in DCPerf.

### DIFF
--- a/packages/chm/ConcurrentHashMap.h
+++ b/packages/chm/ConcurrentHashMap.h
@@ -91,7 +91,7 @@ class ConcurrentHashMap {
     size_t shard =
         keyToSubMapIndex(key); // Determine which shard contains this key
     {
-      std::unique_lock lock{*mutexes_[shard]}; // Acquire lock for this shard
+      std::shared_lock lock{*mutexes_[shard]}; // Acquire lock for this shard
       auto iter = subMap(shard).find(key);
       if (iter != subMap(shard).end()) {
         return std::pair<data_type, bool>(iter->second, true);


### PR DESCRIPTION
Summary: The original implementation used an overly strong lock (unique_lock) for the getValue function, which has now been corrected. Consequently, we are updating our implementation to align with this change.

Reviewed By: excelle08

Differential Revision: D77458826


