### PR TITLE
Add Cinder as the python interpreter in DjangoBench

### DIFF
--- a/benchpress/config/jobs.yml
+++ b/benchpress/config/jobs.yml
@@ -187,11 +187,13 @@
         - '-l ./siege.log'
         - '-s urls.txt'
         - '-c {db_addr}'
+        - '-I {interpreter}'
       vars:
         - 'db_addr'
         - 'duration=5M'
         - 'iterations=7'
         - 'reps=0'
+        - 'interpreter=cpython'
     db:
       args:
         - '-r db'
@@ -207,10 +209,12 @@
         - '-l ./siege.log'
         - '-s urls.txt'
         - '-c 127.0.0.1'
+        - '-I {interpreter}'
       vars:
         - 'duration=5M'
         - 'iterations=7'
         - 'reps=0'
+        - 'interpreter=cpython'
   hooks:
     - hook: copymove
       options:
@@ -234,11 +238,13 @@
         - '-c {db_addr}'
         - '-m 50000'
         - '-M 100000'
+        - '-I {interpreter}'
       vars:
         - 'db_addr'
         - 'duration=5M'
         - 'iterations=7'
         - 'reps=0'
+        - 'interpreter=cpython'
     db:
       args:
         - '-r db'
@@ -256,10 +262,12 @@
         - '-c 127.0.0.1'
         - '-m 50000'
         - '-M 100000'
+        - '-I {interpreter}'
       vars:
         - 'duration=5M'
         - 'iterations=7'
         - 'reps=0'
+        - 'interpreter=cpython'
   hooks:
     - hook: copymove
       options:
@@ -284,10 +292,12 @@
         - '-m 50000'
         - '-M 100000'
         - '-S'
+        - '-I {interpreter}'
       vars:
         - 'duration=1M'
         - 'iterations=1'
         - 'reps=1000'
+        - 'interpreter=cpython'
   hooks:
     - hook: copymove
       options:
@@ -310,10 +320,12 @@
         - '-s urls.txt'
         - '-c 127.0.0.1'
         - '-S'
+        - '-I {interpreter}'
       vars:
         - 'duration=1M'
         - 'iterations=1'
         - 'reps=1000'
+        - 'interpreter=cpython'
   hooks:
     - hook: copymove
       options:
@@ -340,6 +352,7 @@
         - '-x {client_workers}'
         - '-m {ib_min}'
         - '-M {ib_max}'
+        - '-I {interpreter}'
       vars:
         - 'duration=5M'
         - 'iterations=7'
@@ -349,6 +362,7 @@
         - 'db_addr'
         - 'server_workers'
         - 'client_workers'
+        - 'interpreter=cpython'
     client:
       args:
         - '-r client'
@@ -372,11 +386,13 @@
         - '-w {server_workers}'
         - '-m {ib_min}'
         - '-M {ib_max}'
+        - '-I {interpreter}'
       vars:
         - 'db_addr'
         - 'server_workers'
         - 'ib_min=100000'
         - 'ib_max=200000'
+        - 'interpreter=cpython'
     db:
       args:
         - '-r db'

--- a/benchpress/plugins/parsers/django_workload.py
+++ b/benchpress/plugins/parsers/django_workload.py
@@ -110,6 +110,9 @@ class DjangoWorkloadParser(Parser):
             hit_percentage = round(hit_percentage, 3)
             url_key = "URL_hit_percentages_" + metric
             dw_metrics[url_key] = hit_percentage
+        elif metric == "Interpreter":
+            # Handle interpreter type as a string, not a float
+            dw_metrics[metric] = data.strip()
         else:
             """Determine if metrics are faulty or invalid; notify service that
             benchmark execution has failed"""


### PR DESCRIPTION
Summary:
- Added Cinder as a Python interpreter option in DjangoBench
- Modified installer scripts to download, build and install Cinder
- Created two virtual environments (venv_cpython and venv_cinder)
- Added -I option to select the interpreter (cpython or cinder)
- Updated the result parser to handle the interpreter type
- Updated jobs.yml to expose the interpreter option

Differential Revision: D78694864


