### PR TITLE
Update all installer scripts to add Cinder support

### DIFF
--- a/benchpress/config/jobs.yml
+++ b/benchpress/config/jobs.yml
@@ -187,11 +187,13 @@
         - '-l ./siege.log'
         - '-s urls.txt'
         - '-c {db_addr}'
+        - '-I {interpreter}'
       vars:
         - 'db_addr'
         - 'duration=5M'
         - 'iterations=7'
         - 'reps=0'
+        - 'interpreter=cpython'
     db:
       args:
         - '-r db'
@@ -207,10 +209,12 @@
         - '-l ./siege.log'
         - '-s urls.txt'
         - '-c 127.0.0.1'
+        - '-I {interpreter}'
       vars:
         - 'duration=5M'
         - 'iterations=7'
         - 'reps=0'
+        - 'interpreter=cpython'
   hooks:
     - hook: copymove
       options:
@@ -234,11 +238,13 @@
         - '-c {db_addr}'
         - '-m 50000'
         - '-M 100000'
+        - '-I {interpreter}'
       vars:
         - 'db_addr'
         - 'duration=5M'
         - 'iterations=7'
         - 'reps=0'
+        - 'interpreter=cpython'
     db:
       args:
         - '-r db'
@@ -256,10 +262,12 @@
         - '-c 127.0.0.1'
         - '-m 50000'
         - '-M 100000'
+        - '-I {interpreter}'
       vars:
         - 'duration=5M'
         - 'iterations=7'
         - 'reps=0'
+        - 'interpreter=cpython'
   hooks:
     - hook: copymove
       options:
@@ -284,10 +292,12 @@
         - '-m 50000'
         - '-M 100000'
         - '-S'
+        - '-I {interpreter}'
       vars:
         - 'duration=1M'
         - 'iterations=1'
         - 'reps=1000'
+        - 'interpreter=cpython'
   hooks:
     - hook: copymove
       options:
@@ -310,10 +320,12 @@
         - '-s urls.txt'
         - '-c 127.0.0.1'
         - '-S'
+        - '-I {interpreter}'
       vars:
         - 'duration=1M'
         - 'iterations=1'
         - 'reps=1000'
+        - 'interpreter=cpython'
   hooks:
     - hook: copymove
       options:
@@ -340,6 +352,7 @@
         - '-x {client_workers}'
         - '-m {ib_min}'
         - '-M {ib_max}'
+        - '-I {interpreter}'
       vars:
         - 'duration=5M'
         - 'iterations=7'
@@ -349,6 +362,7 @@
         - 'db_addr'
         - 'server_workers'
         - 'client_workers'
+        - 'interpreter=cpython'
     client:
       args:
         - '-r client'
@@ -372,11 +386,13 @@
         - '-w {server_workers}'
         - '-m {ib_min}'
         - '-M {ib_max}'
+        - '-I {interpreter}'
       vars:
         - 'db_addr'
         - 'server_workers'
         - 'ib_min=100000'
         - 'ib_max=200000'
+        - 'interpreter=cpython'
     db:
       args:
         - '-r db'

--- a/benchpress/plugins/parsers/django_workload.py
+++ b/benchpress/plugins/parsers/django_workload.py
@@ -110,6 +110,9 @@ class DjangoWorkloadParser(Parser):
             hit_percentage = round(hit_percentage, 3)
             url_key = "URL_hit_percentages_" + metric
             dw_metrics[url_key] = hit_percentage
+        elif metric == "Interpreter":
+            # Handle interpreter type as a string, not a float
+            dw_metrics[metric] = data.strip()
         else:
             """Determine if metrics are faulty or invalid; notify service that
             benchmark execution has failed"""

--- a/packages/django_workload/install_django_workload_x86_64_centos9.sh
+++ b/packages/django_workload/install_django_workload_x86_64_centos9.sh
@@ -39,8 +39,7 @@ fi
 pushd "${DJANGO_WORKLOAD_DEPS}"
 # cassandra-driver-3.29.1_x86_64.whl
 wget "https://files.pythonhosted.org/packages/eb/d5/e437271aea182e33db32e0990703b4e0d7025e4fba67829c5fd65dba926a/cassandra_driver-3.29.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
-# Cython-0.29.tar.gz
-wget "https://files.pythonhosted.org/packages/6c/9f/f501ba9d178aeb1f5bf7da1ad5619b207c90ac235d9859961c11829d0160/Cython-0.29.21.tar.gz"
+# Removed Cython download as it's not needed
 # Django-5.2.tar.gz
 wget "https://files.pythonhosted.org/packages/1b/11/7aff961db37e1ea501a2bb663d27a8ce97f3683b9e5b83d3bfead8b86fa4/django-5.2.3-py3-none-any.whl"
 # django-cassandra-engine-1.6.2.tar.gz
@@ -185,12 +184,29 @@ if ! [ -d Python-3.10.2 ]; then
     cd ../
 fi
 
-# Create virtual env to run Python 3.10
-[ ! -d venv ] && Python-3.10.2/python -m venv venv
-# Allow unbound variables for active script
+# Download and build Cinder
+if ! [ -d "cinder" ]; then
+    git clone -b cinder/3.10 https://github.com/facebookincubator/cinder.git
+    pushd cinder
+    mkdir -p cinder-build
+    ./configure --prefix="$(pwd)/cinder-build" --enable-optimizations
+    make -j
+    make install
+    popd
+fi
+
+# Create virtual environments for both CPython and Cinder
+# Create CPython virtual env
+[ ! -d venv_cpython ] && Python-3.10.2/python -m venv venv_cpython
+
+# Create Cinder virtual env
+[ ! -d venv_cinder ] && "${DJANGO_SERVER_ROOT}/cinder/cinder-build/bin/python3" -m venv venv_cinder
+
+# Install packages in both virtual environments
+# First, CPython environment
 set +u
 # shellcheck disable=SC1091
-source venv/bin/activate
+source ./venv_cpython/bin/activate
 set -u
 if ! [ -f setup.py.bak ]; then
     #sed -i 's/django-cassandra-engine/django-cassandra-engine >= 1.6, < 1.9/' setup.py
@@ -202,7 +218,6 @@ fi
 cp setup.py.bak setup.py
 
 # Install dependencies using third_party pip dependencies
-pip3.10 install "Cython>=0.29.21,<=0.29.32" --no-index --find-links file://"${DJANGO_WORKLOAD_DEPS}"
 pip3.10 install "django-statsd-mozilla" --no-index --find-links file://"${DJANGO_WORKLOAD_DEPS}"
 pip3.10 install "numpy>=1.19" --no-index --find-links file://"${DJANGO_WORKLOAD_DEPS}"
 pip3.10 install -e . --no-index --find-links file://"${DJANGO_WORKLOAD_DEPS}"
@@ -265,7 +280,20 @@ git apply --check "${TEMPLATES_DIR}/0005-django_middleware_settings.patch" && gi
 popd
 
 deactivate
-popd
+
+# Now install packages in Cinder environment
+pushd "${DJANGO_SERVER_ROOT}"  # Make sure we're in the right directory
+export CPATH="${DJANGO_SERVER_ROOT}/cinder/cinder-build/include:${DJANGO_SERVER_ROOT}/cinder/Include"
+source ./venv_cinder/bin/activate
+set -u
+
+# Install dependencies using third_party pip dependencies
+pip3.10 install "django-statsd-mozilla" --no-index --find-links file://"${DJANGO_WORKLOAD_DEPS}"
+pip3.10 install "numpy>=1.19" --no-index --find-links file://"${DJANGO_WORKLOAD_DEPS}"
+pip3.10 install -e . --no-index --find-links file://"${DJANGO_WORKLOAD_DEPS}"
+
+deactivate
+popd  # ${DJANGO_SERVER_ROOT}
 
 # Install siege
 pushd "${DJANGO_PKG_ROOT}" || exit 1

--- a/packages/django_workload/install_django_workload_x86_64_ubuntu22.sh
+++ b/packages/django_workload/install_django_workload_x86_64_ubuntu22.sh
@@ -38,8 +38,6 @@ fi
 pushd "${DJANGO_WORKLOAD_DEPS}"
 # cassandra-driver-3.29.1_x86_64.whl
 wget "https://files.pythonhosted.org/packages/eb/d5/e437271aea182e33db32e0990703b4e0d7025e4fba67829c5fd65dba926a/cassandra_driver-3.29.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
-# Cython-0.29.tar.gz
-wget "https://files.pythonhosted.org/packages/6c/9f/f501ba9d178aeb1f5bf7da1ad5619b207c90ac235d9859961c11829d0160/Cython-0.29.21.tar.gz"
 # Django-4.1-py3-none-any.whl
 wget "https://files.pythonhosted.org/packages/9b/41/e1e7d6ecc3bc76681dfdc6b373566822bc2aab96fa3eceaaed70accc28b6/Django-4.1-py3-none-any.whl"
 # Dulwich 0.21.2.tar.gz
@@ -212,7 +210,6 @@ fi
 cp setup.py.bak setup.py
 
 # Install dependencies using third_party pip dependencies
-pip3 install "Cython>=0.29.21,<=0.29.32" --no-index --find-links file://"${DJANGO_WORKLOAD_DEPS}"
 pip3 install "django-statsd-mozilla" --no-index --find-links file://"${DJANGO_WORKLOAD_DEPS}"
 pip3 install "numpy>=1.19" --no-index --find-links file://"${DJANGO_WORKLOAD_DEPS}"
 pip3 install -e . --no-index --find-links file://"${DJANGO_WORKLOAD_DEPS}"
@@ -288,7 +285,7 @@ pip3 install "numpy>=1.19" --no-index --find-links file://"${DJANGO_WORKLOAD_DEP
 pip3 install -e . --no-index --find-links file://"${DJANGO_WORKLOAD_DEPS}"
 
 deactivate
-popd
+popd  # ${DJANGO_SERVER_ROOT}
 
 # Install siege
 pushd "${DJANGO_PKG_ROOT}" || exit 1


### PR DESCRIPTION
Summary:
- Updated all installer scripts to add Cinder as a Python interpreter option
- Modified install_django_workload.sh, install_django_workload_aarch64.sh, install_django_workload_aarch64_ubuntu22.sh, and install_django_workload_x86_64_centos9.sh
- Ensured consistent behavior across all platforms

Differential Revision: D78695443


