### PR TITLE
Update DjangoBench README with Cinder interpreter instructions

### DIFF
--- a/benchpress/config/jobs.yml
+++ b/benchpress/config/jobs.yml
@@ -187,11 +187,13 @@
         - '-l ./siege.log'
         - '-s urls.txt'
         - '-c {db_addr}'
+        - '-I {interpreter}'
       vars:
         - 'db_addr'
         - 'duration=5M'
         - 'iterations=7'
         - 'reps=0'
+        - 'interpreter=cpython'
     db:
       args:
         - '-r db'
@@ -207,10 +209,12 @@
         - '-l ./siege.log'
         - '-s urls.txt'
         - '-c 127.0.0.1'
+        - '-I {interpreter}'
       vars:
         - 'duration=5M'
         - 'iterations=7'
         - 'reps=0'
+        - 'interpreter=cpython'
   hooks:
     - hook: copymove
       options:
@@ -234,11 +238,13 @@
         - '-c {db_addr}'
         - '-m 50000'
         - '-M 100000'
+        - '-I {interpreter}'
       vars:
         - 'db_addr'
         - 'duration=5M'
         - 'iterations=7'
         - 'reps=0'
+        - 'interpreter=cpython'
     db:
       args:
         - '-r db'
@@ -256,10 +262,12 @@
         - '-c 127.0.0.1'
         - '-m 50000'
         - '-M 100000'
+        - '-I {interpreter}'
       vars:
         - 'duration=5M'
         - 'iterations=7'
         - 'reps=0'
+        - 'interpreter=cpython'
   hooks:
     - hook: copymove
       options:
@@ -284,10 +292,12 @@
         - '-m 50000'
         - '-M 100000'
         - '-S'
+        - '-I {interpreter}'
       vars:
         - 'duration=1M'
         - 'iterations=1'
         - 'reps=1000'
+        - 'interpreter=cpython'
   hooks:
     - hook: copymove
       options:
@@ -310,10 +320,12 @@
         - '-s urls.txt'
         - '-c 127.0.0.1'
         - '-S'
+        - '-I {interpreter}'
       vars:
         - 'duration=1M'
         - 'iterations=1'
         - 'reps=1000'
+        - 'interpreter=cpython'
   hooks:
     - hook: copymove
       options:
@@ -340,6 +352,7 @@
         - '-x {client_workers}'
         - '-m {ib_min}'
         - '-M {ib_max}'
+        - '-I {interpreter}'
       vars:
         - 'duration=5M'
         - 'iterations=7'
@@ -349,6 +362,7 @@
         - 'db_addr'
         - 'server_workers'
         - 'client_workers'
+        - 'interpreter=cpython'
     client:
       args:
         - '-r client'
@@ -372,11 +386,13 @@
         - '-w {server_workers}'
         - '-m {ib_min}'
         - '-M {ib_max}'
+        - '-I {interpreter}'
       vars:
         - 'db_addr'
         - 'server_workers'
         - 'ib_min=100000'
         - 'ib_max=200000'
+        - 'interpreter=cpython'
     db:
       args:
         - '-r db'

--- a/benchpress/plugins/parsers/django_workload.py
+++ b/benchpress/plugins/parsers/django_workload.py
@@ -110,6 +110,9 @@ class DjangoWorkloadParser(Parser):
             hit_percentage = round(hit_percentage, 3)
             url_key = "URL_hit_percentages_" + metric
             dw_metrics[url_key] = hit_percentage
+        elif metric == "Interpreter":
+            # Handle interpreter type as a string, not a float
+            dw_metrics[metric] = data.strip()
         else:
             """Determine if metrics are faulty or invalid; notify service that
             benchmark execution has failed"""

--- a/packages/django_workload/README.md
+++ b/packages/django_workload/README.md
@@ -78,6 +78,35 @@ If running on ARM platform, please use the job `django_workload_arm`:
 ./benchpress_cli.py run django_workload_arm -r standalone
 ```
 
+### Selecting Python Interpreter
+
+DjangoBench supports two Python interpreters:
+- **CPython** (default): The standard Python interpreter
+- **Cinder**: Meta's performance-oriented Python runtime
+
+To specify which interpreter to use, add the `interpreter` parameter to your command:
+
+```
+# Run with CPython (default)
+./benchpress_cli.py run django_workload_default -r standalone
+
+# Run with Cinder
+./benchpress_cli.py run django_workload_default -r standalone -i '{"interpreter": "cinder"}'
+```
+
+When running with a separate database server:
+
+```
+# Run with CPython (default)
+./benchpress_cli.py run django_workload_default -r clientserver -i '{"db_addr": "<db-server-ip>"}'
+
+# Run with Cinder
+./benchpress_cli.py run django_workload_default -r clientserver -i '{"db_addr": "<db-server-ip>", "interpreter": "cinder"}'
+```
+
+The interpreter type will be reported in the benchmark results, allowing for performance comparison
+between CPython and Cinder.
+
 ## Reporting
 
 Once the benchmark finishes on the django benchmarking machine, benchpress will
@@ -114,6 +143,7 @@ is the metric that measures performance.:
     "Data transferred_MB": 474.424,
     "Elapsed time_secs": 299.22400000000005,
     "Failed transactions": 0.0,
+    "Interpreter": "cpython",
     "Longest transaction": 0.244,
     "P50_secs": 0.07,
     "P90_secs": 0.11000000000000001,
@@ -136,6 +166,10 @@ is the metric that measures performance.:
   "timestamp": 1651108577
 }
 ```
+
+Note the `Interpreter` field in the metrics section, which indicates which Python interpreter
+was used for the benchmark.
+
 ## Troubleshooting
 
 ### Cassandra could not start
@@ -150,7 +184,8 @@ the environment variable `JAVA_HOME` setting it to the path to your JVM.
 
 
 You may also encounter the error message "The stack size specified is too small, Specify at least 456k".
-To resolve this issue, add the following configuration to the end of `benchmarks/django_workload/apache-cassandra/conf/cassandra-env.sh`:
+To resolve this issue, add the following configuration to the end of
+`benchmarks/django_workload/apache-cassandra/conf/cassandra-env.sh`:
 ```shell
 JVM_OPTS="$JVM_OPTS -Xss512k"
 ```
@@ -208,3 +243,19 @@ depend on the computation power of your CPU.
 If you have already run the default time-based Django benchmark once, you can
 make REPS to be `wc -l /tmp/siege_out_1` divided by the number of your logical
 CPU cores. That way the runtime of each iteration will be close to 5 minutes.
+
+### Cinder-specific issues
+
+If you encounter issues when running with the Cinder interpreter:
+
+1. **Cinder build failures**: If Cinder fails to build during installation, make
+sure you have all the necessary build dependencies installed. You may need to
+install additional development packages.
+
+2. **Virtual environment issues**: If there are problems with the Cinder virtual
+environment, you can manually check if it was created correctly by looking for
+the `venv_cinder` directory in the django-workload installation.
+
+3. **Performance differences**: Cinder may show different performance
+characteristics compared to CPython. This is expected and can be used to
+evaluate the performance benefits of Cinder for Django workloads.

--- a/packages/django_workload/install_django_workload_x86_64_centos9.sh
+++ b/packages/django_workload/install_django_workload_x86_64_centos9.sh
@@ -39,8 +39,7 @@ fi
 pushd "${DJANGO_WORKLOAD_DEPS}"
 # cassandra-driver-3.29.1_x86_64.whl
 wget "https://files.pythonhosted.org/packages/eb/d5/e437271aea182e33db32e0990703b4e0d7025e4fba67829c5fd65dba926a/cassandra_driver-3.29.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
-# Cython-0.29.tar.gz
-wget "https://files.pythonhosted.org/packages/6c/9f/f501ba9d178aeb1f5bf7da1ad5619b207c90ac235d9859961c11829d0160/Cython-0.29.21.tar.gz"
+# Removed Cython download as it's not needed
 # Django-5.2.tar.gz
 wget "https://files.pythonhosted.org/packages/1b/11/7aff961db37e1ea501a2bb663d27a8ce97f3683b9e5b83d3bfead8b86fa4/django-5.2.3-py3-none-any.whl"
 # django-cassandra-engine-1.6.2.tar.gz
@@ -185,12 +184,29 @@ if ! [ -d Python-3.10.2 ]; then
     cd ../
 fi
 
-# Create virtual env to run Python 3.10
-[ ! -d venv ] && Python-3.10.2/python -m venv venv
-# Allow unbound variables for active script
+# Download and build Cinder
+if ! [ -d "cinder" ]; then
+    git clone -b cinder/3.10 https://github.com/facebookincubator/cinder.git
+    pushd cinder
+    mkdir -p cinder-build
+    ./configure --prefix="$(pwd)/cinder-build" --enable-optimizations
+    make -j
+    make install
+    popd
+fi
+
+# Create virtual environments for both CPython and Cinder
+# Create CPython virtual env
+[ ! -d venv_cpython ] && Python-3.10.2/python -m venv venv_cpython
+
+# Create Cinder virtual env
+[ ! -d venv_cinder ] && "${DJANGO_SERVER_ROOT}/cinder/cinder-build/bin/python3" -m venv venv_cinder
+
+# Install packages in both virtual environments
+# First, CPython environment
 set +u
 # shellcheck disable=SC1091
-source venv/bin/activate
+source ./venv_cpython/bin/activate
 set -u
 if ! [ -f setup.py.bak ]; then
     #sed -i 's/django-cassandra-engine/django-cassandra-engine >= 1.6, < 1.9/' setup.py
@@ -202,7 +218,6 @@ fi
 cp setup.py.bak setup.py
 
 # Install dependencies using third_party pip dependencies
-pip3.10 install "Cython>=0.29.21,<=0.29.32" --no-index --find-links file://"${DJANGO_WORKLOAD_DEPS}"
 pip3.10 install "django-statsd-mozilla" --no-index --find-links file://"${DJANGO_WORKLOAD_DEPS}"
 pip3.10 install "numpy>=1.19" --no-index --find-links file://"${DJANGO_WORKLOAD_DEPS}"
 pip3.10 install -e . --no-index --find-links file://"${DJANGO_WORKLOAD_DEPS}"
@@ -265,7 +280,20 @@ git apply --check "${TEMPLATES_DIR}/0005-django_middleware_settings.patch" && gi
 popd
 
 deactivate
-popd
+
+# Now install packages in Cinder environment
+pushd "${DJANGO_SERVER_ROOT}"  # Make sure we're in the right directory
+export CPATH="${DJANGO_SERVER_ROOT}/cinder/cinder-build/include:${DJANGO_SERVER_ROOT}/cinder/Include"
+source ./venv_cinder/bin/activate
+set -u
+
+# Install dependencies using third_party pip dependencies
+pip3.10 install "django-statsd-mozilla" --no-index --find-links file://"${DJANGO_WORKLOAD_DEPS}"
+pip3.10 install "numpy>=1.19" --no-index --find-links file://"${DJANGO_WORKLOAD_DEPS}"
+pip3.10 install -e . --no-index --find-links file://"${DJANGO_WORKLOAD_DEPS}"
+
+deactivate
+popd  # ${DJANGO_SERVER_ROOT}
 
 # Install siege
 pushd "${DJANGO_PKG_ROOT}" || exit 1

--- a/packages/django_workload/install_django_workload_x86_64_ubuntu22.sh
+++ b/packages/django_workload/install_django_workload_x86_64_ubuntu22.sh
@@ -38,8 +38,6 @@ fi
 pushd "${DJANGO_WORKLOAD_DEPS}"
 # cassandra-driver-3.29.1_x86_64.whl
 wget "https://files.pythonhosted.org/packages/eb/d5/e437271aea182e33db32e0990703b4e0d7025e4fba67829c5fd65dba926a/cassandra_driver-3.29.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
-# Cython-0.29.tar.gz
-wget "https://files.pythonhosted.org/packages/6c/9f/f501ba9d178aeb1f5bf7da1ad5619b207c90ac235d9859961c11829d0160/Cython-0.29.21.tar.gz"
 # Django-4.1-py3-none-any.whl
 wget "https://files.pythonhosted.org/packages/9b/41/e1e7d6ecc3bc76681dfdc6b373566822bc2aab96fa3eceaaed70accc28b6/Django-4.1-py3-none-any.whl"
 # Dulwich 0.21.2.tar.gz
@@ -212,7 +210,6 @@ fi
 cp setup.py.bak setup.py
 
 # Install dependencies using third_party pip dependencies
-pip3 install "Cython>=0.29.21,<=0.29.32" --no-index --find-links file://"${DJANGO_WORKLOAD_DEPS}"
 pip3 install "django-statsd-mozilla" --no-index --find-links file://"${DJANGO_WORKLOAD_DEPS}"
 pip3 install "numpy>=1.19" --no-index --find-links file://"${DJANGO_WORKLOAD_DEPS}"
 pip3 install -e . --no-index --find-links file://"${DJANGO_WORKLOAD_DEPS}"
@@ -288,7 +285,7 @@ pip3 install "numpy>=1.19" --no-index --find-links file://"${DJANGO_WORKLOAD_DEP
 pip3 install -e . --no-index --find-links file://"${DJANGO_WORKLOAD_DEPS}"
 
 deactivate
-popd
+popd  # ${DJANGO_SERVER_ROOT}
 
 # Install siege
 pushd "${DJANGO_PKG_ROOT}" || exit 1


### PR DESCRIPTION
Summary:
- Added a new section explaining how to select between CPython and Cinder interpreters
- Updated the reporting section to mention the Interpreter field in metrics
- Added a new troubleshooting section for Cinder-specific issues
- Fixed formatting and added newline at the end of the file

Differential Revision: D78747116


