### PR TITLE
Add concurrent hashmap kernel into adsim

### DIFF
--- a/packages/adsim/patches/adsim.patch
+++ b/packages/adsim/patches/adsim.patch
@@ -1,6 +1,6 @@
-diff -wbBdu -ruN '--exclude=.git' /data/users/kaiweitu/fbsource/fbcode/cea/chips/benchpress/adsim_group/cpp2/client/AdSimClient.cpp adsim/cpp2/client/AdSimClient.cpp
---- /data/users/kaiweitu/fbsource/fbcode/cea/chips/benchpress/adsim_group/cpp2/client/AdSimClient.cpp	2025-07-23 15:19:51.993714475 -0700
-+++ adsim/cpp2/client/AdSimClient.cpp	2025-07-23 13:39:13.956165397 -0700
+diff -wbBdu -ruN '--exclude=.git' '--exclude=*.rej' '--exclude=*.orig' '--exclude=gen-cpp2' adsim/cpp2/client/AdSimClient.cpp build/adsim/cpp2/client/AdSimClient.cpp
+--- adsim/cpp2/client/AdSimClient.cpp	2025-07-28 12:08:37.404634728 -0700
++++ build/adsim/cpp2/client/AdSimClient.cpp	2025-07-25 15:55:10.007667247 -0700
 @@ -14,17 +14,15 @@
   * limitations under the License.
   */
@@ -22,9 +22,9 @@ diff -wbBdu -ruN '--exclude=.git' /data/users/kaiweitu/fbsource/fbcode/cea/chips
  
  DEFINE_string(host, "::1", "AdSimServer host");
  DEFINE_int32(port, 10086, "AdSimServer port");
-diff -wbBdu -ruN '--exclude=.git' /data/users/kaiweitu/fbsource/fbcode/cea/chips/benchpress/adsim_group/cpp2/client/CoWorker.h adsim/cpp2/client/CoWorker.h
---- /data/users/kaiweitu/fbsource/fbcode/cea/chips/benchpress/adsim_group/cpp2/client/CoWorker.h	2025-07-23 15:19:51.994339131 -0700
-+++ adsim/cpp2/client/CoWorker.h	2025-07-23 15:00:16.348672265 -0700
+diff -wbBdu -ruN '--exclude=.git' '--exclude=*.rej' '--exclude=*.orig' '--exclude=gen-cpp2' adsim/cpp2/client/CoWorker.h build/adsim/cpp2/client/CoWorker.h
+--- adsim/cpp2/client/CoWorker.h	2025-07-28 12:08:37.405599047 -0700
++++ build/adsim/cpp2/client/CoWorker.h	2025-07-25 15:55:10.009191271 -0700
 @@ -16,14 +16,16 @@
  
  #pragma once
@@ -43,9 +43,9 @@ diff -wbBdu -ruN '--exclude=.git' /data/users/kaiweitu/fbsource/fbcode/cea/chips
  
  namespace facebook::cea::chips::adsim {
  
-diff -wbBdu -ruN '--exclude=.git' /data/users/kaiweitu/fbsource/fbcode/cea/chips/benchpress/adsim_group/cpp2/server/AdSimServer.cpp adsim/cpp2/server/AdSimServer.cpp
---- /data/users/kaiweitu/fbsource/fbcode/cea/chips/benchpress/adsim_group/cpp2/server/AdSimServer.cpp	2025-07-23 15:19:52.003168110 -0700
-+++ adsim/cpp2/server/AdSimServer.cpp	2025-07-23 14:55:00.473453567 -0700
+diff -wbBdu -ruN '--exclude=.git' '--exclude=*.rej' '--exclude=*.orig' '--exclude=gen-cpp2' adsim/cpp2/server/AdSimServer.cpp build/adsim/cpp2/server/AdSimServer.cpp
+--- adsim/cpp2/server/AdSimServer.cpp	2025-07-28 12:08:37.420421287 -0700
++++ build/adsim/cpp2/server/AdSimServer.cpp	2025-07-25 15:55:10.010304364 -0700
 @@ -19,16 +19,17 @@
  #include <streambuf>
  #include <string>
@@ -67,9 +67,9 @@ diff -wbBdu -ruN '--exclude=.git' /data/users/kaiweitu/fbsource/fbcode/cea/chips
  
  DEFINE_string(config_file, "", "A json file of configurations");
  DEFINE_int32(port, -1, "Overwrite port in the config file");
-diff -wbBdu -ruN '--exclude=.git' /data/users/kaiweitu/fbsource/fbcode/cea/chips/benchpress/adsim_group/cpp2/server/AdSimService.cpp adsim/cpp2/server/AdSimService.cpp
---- /data/users/kaiweitu/fbsource/fbcode/cea/chips/benchpress/adsim_group/cpp2/server/AdSimService.cpp	2025-07-23 15:19:52.003580325 -0700
-+++ adsim/cpp2/server/AdSimService.cpp	2025-07-23 14:47:08.225335194 -0700
+diff -wbBdu -ruN '--exclude=.git' '--exclude=*.rej' '--exclude=*.orig' '--exclude=gen-cpp2' adsim/cpp2/server/AdSimService.cpp build/adsim/cpp2/server/AdSimService.cpp
+--- adsim/cpp2/server/AdSimService.cpp	2025-07-28 12:08:37.420848854 -0700
++++ build/adsim/cpp2/server/AdSimService.cpp	2025-07-25 15:55:10.011314962 -0700
 @@ -14,8 +14,8 @@
   * limitations under the License.
   */
@@ -81,9 +81,9 @@ diff -wbBdu -ruN '--exclude=.git' /data/users/kaiweitu/fbsource/fbcode/cea/chips
  
  #include <fb303/ThreadCachedServiceData.h>
  #include <folly/coro/Collect.h>
-diff -wbBdu -ruN '--exclude=.git' /data/users/kaiweitu/fbsource/fbcode/cea/chips/benchpress/adsim_group/cpp2/server/AdSimService.h adsim/cpp2/server/AdSimService.h
---- /data/users/kaiweitu/fbsource/fbcode/cea/chips/benchpress/adsim_group/cpp2/server/AdSimService.h	2025-07-23 15:19:52.003915422 -0700
-+++ adsim/cpp2/server/AdSimService.h	2025-07-23 14:32:46.911992520 -0700
+diff -wbBdu -ruN '--exclude=.git' '--exclude=*.rej' '--exclude=*.orig' '--exclude=gen-cpp2' adsim/cpp2/server/AdSimService.h build/adsim/cpp2/server/AdSimService.h
+--- adsim/cpp2/server/AdSimService.h	2025-07-28 12:08:37.421285043 -0700
++++ build/adsim/cpp2/server/AdSimService.h	2025-07-25 15:55:10.012430769 -0700
 @@ -22,10 +22,10 @@
  #include <folly/Executor.h>
  #include <folly/MapUtil.h>
@@ -98,9 +98,9 @@ diff -wbBdu -ruN '--exclude=.git' /data/users/kaiweitu/fbsource/fbcode/cea/chips
  
  namespace facebook::cea::chips::adsim {
  
-diff -wbBdu -ruN '--exclude=.git' /data/users/kaiweitu/fbsource/fbcode/cea/chips/benchpress/adsim_group/cpp2/server/DataObjects.cpp adsim/cpp2/server/DataObjects.cpp
---- /data/users/kaiweitu/fbsource/fbcode/cea/chips/benchpress/adsim_group/cpp2/server/DataObjects.cpp	2025-07-23 15:19:52.004556773 -0700
-+++ adsim/cpp2/server/DataObjects.cpp	2025-07-23 14:32:46.159464476 -0700
+diff -wbBdu -ruN '--exclude=.git' '--exclude=*.rej' '--exclude=*.orig' '--exclude=gen-cpp2' adsim/cpp2/server/DataObjects.cpp build/adsim/cpp2/server/DataObjects.cpp
+--- adsim/cpp2/server/DataObjects.cpp	2025-07-28 12:08:37.422131554 -0700
++++ build/adsim/cpp2/server/DataObjects.cpp	2025-07-25 15:55:10.013145970 -0700
 @@ -14,7 +14,7 @@
   * limitations under the License.
   */
@@ -110,9 +110,9 @@ diff -wbBdu -ruN '--exclude=.git' /data/users/kaiweitu/fbsource/fbcode/cea/chips
  #include <folly/Singleton.h>
  
  namespace facebook::cea::chips::adsim {
-diff -wbBdu -ruN '--exclude=.git' /data/users/kaiweitu/fbsource/fbcode/cea/chips/benchpress/adsim_group/cpp2/server/DataObjects.h adsim/cpp2/server/DataObjects.h
---- /data/users/kaiweitu/fbsource/fbcode/cea/chips/benchpress/adsim_group/cpp2/server/DataObjects.h	2025-07-23 15:19:52.004868304 -0700
-+++ adsim/cpp2/server/DataObjects.h	2025-07-23 14:32:48.398548460 -0700
+diff -wbBdu -ruN '--exclude=.git' '--exclude=*.rej' '--exclude=*.orig' '--exclude=gen-cpp2' adsim/cpp2/server/DataObjects.h build/adsim/cpp2/server/DataObjects.h
+--- adsim/cpp2/server/DataObjects.h	2025-07-28 12:08:37.422600023 -0700
++++ build/adsim/cpp2/server/DataObjects.h	2025-07-25 15:55:10.013816493 -0700
 @@ -27,7 +27,7 @@
  #include <thrift/lib/cpp2/protocol/CompactProtocol.h>
  #include <thrift/lib/cpp2/protocol/Serializer.h>
@@ -122,9 +122,9 @@ diff -wbBdu -ruN '--exclude=.git' /data/users/kaiweitu/fbsource/fbcode/cea/chips
  
  namespace facebook::cea::chips::adsim {
  
-diff -wbBdu -ruN '--exclude=.git' /data/users/kaiweitu/fbsource/fbcode/cea/chips/benchpress/adsim_group/cpp2/server/dwarfs/Compress.cc adsim/cpp2/server/dwarfs/Compress.cc
---- /data/users/kaiweitu/fbsource/fbcode/cea/chips/benchpress/adsim_group/cpp2/server/dwarfs/Compress.cc	2025-07-23 15:19:51.997508761 -0700
-+++ adsim/cpp2/server/dwarfs/Compress.cc	2025-07-23 14:51:56.542138687 -0700
+diff -wbBdu -ruN '--exclude=.git' '--exclude=*.rej' '--exclude=*.orig' '--exclude=gen-cpp2' adsim/cpp2/server/dwarfs/Compress.cc build/adsim/cpp2/server/dwarfs/Compress.cc
+--- adsim/cpp2/server/dwarfs/Compress.cc	2025-07-28 12:08:37.411753456 -0700
++++ build/adsim/cpp2/server/dwarfs/Compress.cc	2025-07-25 15:55:10.014647761 -0700
 @@ -18,10 +18,10 @@
  #include <util.h>
  
@@ -139,9 +139,9 @@ diff -wbBdu -ruN '--exclude=.git' /data/users/kaiweitu/fbsource/fbcode/cea/chips
  
  #include <fb303/ThreadCachedServiceData.h>
  #include <folly/coro/Task.h>
-diff -wbBdu -ruN '--exclude=.git' /data/users/kaiweitu/fbsource/fbcode/cea/chips/benchpress/adsim_group/cpp2/server/dwarfs/Compress.h adsim/cpp2/server/dwarfs/Compress.h
---- /data/users/kaiweitu/fbsource/fbcode/cea/chips/benchpress/adsim_group/cpp2/server/dwarfs/Compress.h	2025-07-23 15:19:51.997799340 -0700
-+++ adsim/cpp2/server/dwarfs/Compress.h	2025-07-23 14:32:45.338879764 -0700
+diff -wbBdu -ruN '--exclude=.git' '--exclude=*.rej' '--exclude=*.orig' '--exclude=gen-cpp2' adsim/cpp2/server/dwarfs/Compress.h build/adsim/cpp2/server/dwarfs/Compress.h
+--- adsim/cpp2/server/dwarfs/Compress.h	2025-07-28 12:08:37.412260183 -0700
++++ build/adsim/cpp2/server/dwarfs/Compress.h	2025-07-25 15:55:10.015383212 -0700
 @@ -21,8 +21,8 @@
  
  #include <string.h>
@@ -153,9 +153,35 @@ diff -wbBdu -ruN '--exclude=.git' /data/users/kaiweitu/fbsource/fbcode/cea/chips
  
  #include <folly/coro/Task.h>
  
-diff -wbBdu -ruN '--exclude=.git' /data/users/kaiweitu/fbsource/fbcode/cea/chips/benchpress/adsim_group/cpp2/server/dwarfs/DeepCopy.h adsim/cpp2/server/dwarfs/DeepCopy.h
---- /data/users/kaiweitu/fbsource/fbcode/cea/chips/benchpress/adsim_group/cpp2/server/dwarfs/DeepCopy.h	2025-07-23 15:19:51.998073196 -0700
-+++ adsim/cpp2/server/dwarfs/DeepCopy.h	2025-07-23 15:00:48.547103410 -0700
+diff -wbBdu -ruN '--exclude=.git' '--exclude=*.rej' '--exclude=*.orig' '--exclude=gen-cpp2' adsim/cpp2/server/dwarfs/ConcurrentHashMap.cc build/adsim/cpp2/server/dwarfs/ConcurrentHashMap.cc
+--- adsim/cpp2/server/dwarfs/ConcurrentHashMap.cc	2025-07-28 12:08:37.412914793 -0700
++++ build/adsim/cpp2/server/dwarfs/ConcurrentHashMap.cc	2025-07-28 11:49:52.560117703 -0700
+@@ -14,7 +14,7 @@
+  * limitations under the License.
+  */
+ 
+-#include <cea/chips/adsim/cpp2/server/dwarfs/ConcurrentHashMap.h>
++#include "ConcurrentHashMap.h"
+ 
+ #include <fb303/ThreadCachedServiceData.h>
+ #include <folly/executors/CPUThreadPoolExecutor.h>
+diff -wbBdu -ruN '--exclude=.git' '--exclude=*.rej' '--exclude=*.orig' '--exclude=gen-cpp2' adsim/cpp2/server/dwarfs/ConcurrentHashMap.h build/adsim/cpp2/server/dwarfs/ConcurrentHashMap.h
+--- adsim/cpp2/server/dwarfs/ConcurrentHashMap.h	2025-07-28 12:08:37.413367828 -0700
++++ build/adsim/cpp2/server/dwarfs/ConcurrentHashMap.h	2025-07-28 11:40:51.243521796 -0700
+@@ -30,8 +30,8 @@
+ #include <utility>
+ #include <vector>
+ 
+-#include <cea/chips/adsim/cpp2/server/DataObjects.h>
+-#include <cea/chips/adsim/cpp2/server/dwarfs/Kernel.h>
++#include "cpp2/server/DataObjects.h"
++#include "cpp2/server/dwarfs/Kernel.h"
+ 
+ #include <folly/Likely.h>
+ #include <folly/SharedMutex.h>
+diff -wbBdu -ruN '--exclude=.git' '--exclude=*.rej' '--exclude=*.orig' '--exclude=gen-cpp2' adsim/cpp2/server/dwarfs/DeepCopy.h build/adsim/cpp2/server/dwarfs/DeepCopy.h
+--- adsim/cpp2/server/dwarfs/DeepCopy.h	2025-07-28 12:08:37.413807904 -0700
++++ build/adsim/cpp2/server/dwarfs/DeepCopy.h	2025-07-25 15:55:10.016208450 -0700
 @@ -24,8 +24,8 @@
  #include <unordered_map>
  #include <vector>
@@ -167,9 +193,9 @@ diff -wbBdu -ruN '--exclude=.git' /data/users/kaiweitu/fbsource/fbcode/cea/chips
  
  #include <fb303/ThreadCachedServiceData.h>
  #include <folly/container/F14Map.h>
-diff -wbBdu -ruN '--exclude=.git' /data/users/kaiweitu/fbsource/fbcode/cea/chips/benchpress/adsim_group/cpp2/server/dwarfs/Delay.h adsim/cpp2/server/dwarfs/Delay.h
---- /data/users/kaiweitu/fbsource/fbcode/cea/chips/benchpress/adsim_group/cpp2/server/dwarfs/Delay.h	2025-07-23 15:19:51.998389434 -0700
-+++ adsim/cpp2/server/dwarfs/Delay.h	2025-07-23 14:57:50.393897193 -0700
+diff -wbBdu -ruN '--exclude=.git' '--exclude=*.rej' '--exclude=*.orig' '--exclude=gen-cpp2' adsim/cpp2/server/dwarfs/Delay.h build/adsim/cpp2/server/dwarfs/Delay.h
+--- adsim/cpp2/server/dwarfs/Delay.h	2025-07-28 12:08:37.414329413 -0700
++++ build/adsim/cpp2/server/dwarfs/Delay.h	2025-07-25 15:55:10.016889980 -0700
 @@ -18,8 +18,8 @@
  
  #include <unistd.h>
@@ -181,14 +207,15 @@ diff -wbBdu -ruN '--exclude=.git' /data/users/kaiweitu/fbsource/fbcode/cea/chips
  
  #include <fb303/ThreadCachedServiceData.h>
  #include <folly/coro/Task.h>
-diff -wbBdu -ruN '--exclude=.git' /data/users/kaiweitu/fbsource/fbcode/cea/chips/benchpress/adsim_group/cpp2/server/dwarfs/Dwarfs.cc adsim/cpp2/server/dwarfs/Dwarfs.cc
---- /data/users/kaiweitu/fbsource/fbcode/cea/chips/benchpress/adsim_group/cpp2/server/dwarfs/Dwarfs.cc	2025-07-23 15:19:51.998841899 -0700
-+++ adsim/cpp2/server/dwarfs/Dwarfs.cc	2025-07-23 14:32:44.439619934 -0700
-@@ -19,17 +19,17 @@
+diff -wbBdu -ruN '--exclude=.git' '--exclude=*.rej' '--exclude=*.orig' '--exclude=gen-cpp2' adsim/cpp2/server/dwarfs/Dwarfs.cc build/adsim/cpp2/server/dwarfs/Dwarfs.cc
+--- adsim/cpp2/server/dwarfs/Dwarfs.cc	2025-07-28 12:08:37.414788797 -0700
++++ build/adsim/cpp2/server/dwarfs/Dwarfs.cc	2025-07-25 15:57:48.883604643 -0700
+@@ -19,18 +19,18 @@
  #include <folly/MapUtil.h>
  #include <folly/dynamic.h>
  
 -#include <cea/chips/adsim/cpp2/server/dwarfs/Compress.h>
+-#include <cea/chips/adsim/cpp2/server/dwarfs/ConcurrentHashMap.h>
 -#include <cea/chips/adsim/cpp2/server/dwarfs/DeepCopy.h>
 -#include <cea/chips/adsim/cpp2/server/dwarfs/Delay.h>
 -#include <cea/chips/adsim/cpp2/server/dwarfs/Dwarfs.h>
@@ -200,6 +227,7 @@ diff -wbBdu -ruN '--exclude=.git' /data/users/kaiweitu/fbsource/fbcode/cea/chips
 -#include <cea/chips/adsim/cpp2/server/dwarfs/Serialize.h>
 -#include <cea/chips/adsim/cpp2/server/dwarfs/Shape.h>
 +#include "Compress.h"
++#include "ConcurrentHashMap.h"
 +#include "DeepCopy.h"
 +#include "Delay.h"
 +#include "Dwarfs.h"
@@ -213,9 +241,9 @@ diff -wbBdu -ruN '--exclude=.git' /data/users/kaiweitu/fbsource/fbcode/cea/chips
  
  namespace facebook::cea::chips::adsim {
  
-diff -wbBdu -ruN '--exclude=.git' /data/users/kaiweitu/fbsource/fbcode/cea/chips/benchpress/adsim_group/cpp2/server/dwarfs/Dwarfs.h adsim/cpp2/server/dwarfs/Dwarfs.h
---- /data/users/kaiweitu/fbsource/fbcode/cea/chips/benchpress/adsim_group/cpp2/server/dwarfs/Dwarfs.h	2025-07-23 15:19:51.999213011 -0700
-+++ adsim/cpp2/server/dwarfs/Dwarfs.h	2025-07-23 14:32:43.684428312 -0700
+diff -wbBdu -ruN '--exclude=.git' '--exclude=*.rej' '--exclude=*.orig' '--exclude=gen-cpp2' adsim/cpp2/server/dwarfs/Dwarfs.h build/adsim/cpp2/server/dwarfs/Dwarfs.h
+--- adsim/cpp2/server/dwarfs/Dwarfs.h	2025-07-28 12:08:37.415197876 -0700
++++ build/adsim/cpp2/server/dwarfs/Dwarfs.h	2025-07-25 15:55:10.019374336 -0700
 @@ -19,9 +19,9 @@
  #include <string>
  
@@ -228,9 +256,9 @@ diff -wbBdu -ruN '--exclude=.git' /data/users/kaiweitu/fbsource/fbcode/cea/chips
  
  namespace facebook::cea::chips::adsim {
  
-diff -wbBdu -ruN '--exclude=.git' /data/users/kaiweitu/fbsource/fbcode/cea/chips/benchpress/adsim_group/cpp2/server/dwarfs/FakeIO.h adsim/cpp2/server/dwarfs/FakeIO.h
---- /data/users/kaiweitu/fbsource/fbcode/cea/chips/benchpress/adsim_group/cpp2/server/dwarfs/FakeIO.h	2025-07-23 15:19:51.999497513 -0700
-+++ adsim/cpp2/server/dwarfs/FakeIO.h	2025-07-23 14:57:47.233954082 -0700
+diff -wbBdu -ruN '--exclude=.git' '--exclude=*.rej' '--exclude=*.orig' '--exclude=gen-cpp2' adsim/cpp2/server/dwarfs/FakeIO.h build/adsim/cpp2/server/dwarfs/FakeIO.h
+--- adsim/cpp2/server/dwarfs/FakeIO.h	2025-07-28 12:08:37.415633616 -0700
++++ build/adsim/cpp2/server/dwarfs/FakeIO.h	2025-07-25 15:55:10.020115056 -0700
 @@ -18,8 +18,8 @@
  
  #include <unistd.h>
@@ -242,9 +270,9 @@ diff -wbBdu -ruN '--exclude=.git' /data/users/kaiweitu/fbsource/fbcode/cea/chips
  
  #include <fb303/ThreadCachedServiceData.h>
  #include <folly/coro/Task.h>
-diff -wbBdu -ruN '--exclude=.git' /data/users/kaiweitu/fbsource/fbcode/cea/chips/benchpress/adsim_group/cpp2/server/dwarfs/GEMM.cc adsim/cpp2/server/dwarfs/GEMM.cc
---- /data/users/kaiweitu/fbsource/fbcode/cea/chips/benchpress/adsim_group/cpp2/server/dwarfs/GEMM.cc	2025-07-23 15:19:51.999786450 -0700
-+++ adsim/cpp2/server/dwarfs/GEMM.cc	2025-07-23 14:32:42.590841531 -0700
+diff -wbBdu -ruN '--exclude=.git' '--exclude=*.rej' '--exclude=*.orig' '--exclude=gen-cpp2' adsim/cpp2/server/dwarfs/GEMM.cc build/adsim/cpp2/server/dwarfs/GEMM.cc
+--- adsim/cpp2/server/dwarfs/GEMM.cc	2025-07-28 12:08:37.416049855 -0700
++++ build/adsim/cpp2/server/dwarfs/GEMM.cc	2025-07-25 15:55:10.020712910 -0700
 @@ -22,17 +22,21 @@
  #include <glog/logging.h>
  
@@ -269,9 +297,9 @@ diff -wbBdu -ruN '--exclude=.git' /data/users/kaiweitu/fbsource/fbcode/cea/chips
  
  using namespace std;
  using namespace fbgemm;
-diff -wbBdu -ruN '--exclude=.git' /data/users/kaiweitu/fbsource/fbcode/cea/chips/benchpress/adsim_group/cpp2/server/dwarfs/GEMM.h adsim/cpp2/server/dwarfs/GEMM.h
---- /data/users/kaiweitu/fbsource/fbcode/cea/chips/benchpress/adsim_group/cpp2/server/dwarfs/GEMM.h	2025-07-23 15:19:52.000049698 -0700
-+++ adsim/cpp2/server/dwarfs/GEMM.h	2025-07-23 14:59:13.484075005 -0700
+diff -wbBdu -ruN '--exclude=.git' '--exclude=*.rej' '--exclude=*.orig' '--exclude=gen-cpp2' adsim/cpp2/server/dwarfs/GEMM.h build/adsim/cpp2/server/dwarfs/GEMM.h
+--- adsim/cpp2/server/dwarfs/GEMM.h	2025-07-28 12:08:37.416462089 -0700
++++ build/adsim/cpp2/server/dwarfs/GEMM.h	2025-07-25 15:55:10.021362522 -0700
 @@ -22,8 +22,8 @@
  
  #include <assert.h>
@@ -283,9 +311,9 @@ diff -wbBdu -ruN '--exclude=.git' /data/users/kaiweitu/fbsource/fbcode/cea/chips
  
  #include <fb303/ThreadCachedServiceData.h>
  #include <folly/coro/Collect.h>
-diff -wbBdu -ruN '--exclude=.git' /data/users/kaiweitu/fbsource/fbcode/cea/chips/benchpress/adsim_group/cpp2/server/dwarfs/HashMap.cc adsim/cpp2/server/dwarfs/HashMap.cc
---- /data/users/kaiweitu/fbsource/fbcode/cea/chips/benchpress/adsim_group/cpp2/server/dwarfs/HashMap.cc	2025-07-23 15:19:52.000486870 -0700
-+++ adsim/cpp2/server/dwarfs/HashMap.cc	2025-07-23 14:57:01.001349999 -0700
+diff -wbBdu -ruN '--exclude=.git' '--exclude=*.rej' '--exclude=*.orig' '--exclude=gen-cpp2' adsim/cpp2/server/dwarfs/HashMap.cc build/adsim/cpp2/server/dwarfs/HashMap.cc
+--- adsim/cpp2/server/dwarfs/HashMap.cc	2025-07-28 12:08:37.416948243 -0700
++++ build/adsim/cpp2/server/dwarfs/HashMap.cc	2025-07-25 15:55:10.022044754 -0700
 @@ -14,7 +14,7 @@
   * limitations under the License.
   */
@@ -295,9 +323,9 @@ diff -wbBdu -ruN '--exclude=.git' /data/users/kaiweitu/fbsource/fbcode/cea/chips
  
  #include <fb303/ThreadCachedServiceData.h>
  
-diff -wbBdu -ruN '--exclude=.git' /data/users/kaiweitu/fbsource/fbcode/cea/chips/benchpress/adsim_group/cpp2/server/dwarfs/HashMap.h adsim/cpp2/server/dwarfs/HashMap.h
---- /data/users/kaiweitu/fbsource/fbcode/cea/chips/benchpress/adsim_group/cpp2/server/dwarfs/HashMap.h	2025-07-23 15:19:52.000859194 -0700
-+++ adsim/cpp2/server/dwarfs/HashMap.h	2025-07-23 14:59:41.446148261 -0700
+diff -wbBdu -ruN '--exclude=.git' '--exclude=*.rej' '--exclude=*.orig' '--exclude=gen-cpp2' adsim/cpp2/server/dwarfs/HashMap.h build/adsim/cpp2/server/dwarfs/HashMap.h
+--- adsim/cpp2/server/dwarfs/HashMap.h	2025-07-28 12:08:37.417373798 -0700
++++ build/adsim/cpp2/server/dwarfs/HashMap.h	2025-07-25 15:55:10.022653935 -0700
 @@ -24,8 +24,8 @@
  #include <unordered_map>
  #include <vector>
@@ -309,9 +337,9 @@ diff -wbBdu -ruN '--exclude=.git' /data/users/kaiweitu/fbsource/fbcode/cea/chips
  
  #include <folly/Synchronized.h>
  #include <folly/container/F14Map.h>
-diff -wbBdu -ruN '--exclude=.git' /data/users/kaiweitu/fbsource/fbcode/cea/chips/benchpress/adsim_group/cpp2/server/dwarfs/IBRun.h adsim/cpp2/server/dwarfs/IBRun.h
---- /data/users/kaiweitu/fbsource/fbcode/cea/chips/benchpress/adsim_group/cpp2/server/dwarfs/IBRun.h	2025-07-23 15:19:52.001212739 -0700
-+++ adsim/cpp2/server/dwarfs/IBRun.h	2025-07-23 14:57:56.288805943 -0700
+diff -wbBdu -ruN '--exclude=.git' '--exclude=*.rej' '--exclude=*.orig' '--exclude=gen-cpp2' adsim/cpp2/server/dwarfs/IBRun.h build/adsim/cpp2/server/dwarfs/IBRun.h
+--- adsim/cpp2/server/dwarfs/IBRun.h	2025-07-28 12:08:37.417779992 -0700
++++ build/adsim/cpp2/server/dwarfs/IBRun.h	2025-07-25 15:55:10.023200492 -0700
 @@ -16,9 +16,9 @@
  
  #pragma once
@@ -325,9 +353,9 @@ diff -wbBdu -ruN '--exclude=.git' /data/users/kaiweitu/fbsource/fbcode/cea/chips
  
  #include <folly/coro/Task.h>
  
-diff -wbBdu -ruN '--exclude=.git' /data/users/kaiweitu/fbsource/fbcode/cea/chips/benchpress/adsim_group/cpp2/server/dwarfs/icache_buster/gen_icache_buster.py adsim/cpp2/server/dwarfs/icache_buster/gen_icache_buster.py
---- /data/users/kaiweitu/fbsource/fbcode/cea/chips/benchpress/adsim_group/cpp2/server/dwarfs/icache_buster/gen_icache_buster.py	2025-07-23 15:19:51.996896003 -0700
-+++ adsim/cpp2/server/dwarfs/icache_buster/gen_icache_buster.py	2025-07-23 15:01:29.653006276 -0700
+diff -wbBdu -ruN '--exclude=.git' '--exclude=*.rej' '--exclude=*.orig' '--exclude=gen-cpp2' adsim/cpp2/server/dwarfs/icache_buster/gen_icache_buster.py build/adsim/cpp2/server/dwarfs/icache_buster/gen_icache_buster.py
+--- adsim/cpp2/server/dwarfs/icache_buster/gen_icache_buster.py	2025-07-28 12:08:37.410741445 -0700
++++ build/adsim/cpp2/server/dwarfs/icache_buster/gen_icache_buster.py	2025-07-25 15:55:10.023937655 -0700
 @@ -14,8 +14,6 @@
  # See the License for the specific language governing permissions and
  # limitations under the License.
@@ -337,9 +365,9 @@ diff -wbBdu -ruN '--exclude=.git' /data/users/kaiweitu/fbsource/fbcode/cea/chips
  """Module to split file into multiple segments."""
  
  import argparse
-diff -wbBdu -ruN '--exclude=.git' /data/users/kaiweitu/fbsource/fbcode/cea/chips/benchpress/adsim_group/cpp2/server/dwarfs/Kernel.cc adsim/cpp2/server/dwarfs/Kernel.cc
---- /data/users/kaiweitu/fbsource/fbcode/cea/chips/benchpress/adsim_group/cpp2/server/dwarfs/Kernel.cc	2025-07-23 15:19:52.001549950 -0700
-+++ adsim/cpp2/server/dwarfs/Kernel.cc	2025-07-23 14:32:38.528752069 -0700
+diff -wbBdu -ruN '--exclude=.git' '--exclude=*.rej' '--exclude=*.orig' '--exclude=gen-cpp2' adsim/cpp2/server/dwarfs/Kernel.cc build/adsim/cpp2/server/dwarfs/Kernel.cc
+--- adsim/cpp2/server/dwarfs/Kernel.cc	2025-07-28 12:08:37.418280539 -0700
++++ build/adsim/cpp2/server/dwarfs/Kernel.cc	2025-07-25 16:37:11.073788021 -0700
 @@ -20,7 +20,7 @@
  #include <fb303/ExportType.h>
  #include <fb303/ThreadCachedServiceData.h>
@@ -349,9 +377,9 @@ diff -wbBdu -ruN '--exclude=.git' /data/users/kaiweitu/fbsource/fbcode/cea/chips
  
  namespace facebook::cea::chips::adsim {
  
-diff -wbBdu -ruN '--exclude=.git' /data/users/kaiweitu/fbsource/fbcode/cea/chips/benchpress/adsim_group/cpp2/server/dwarfs/Kernel.h adsim/cpp2/server/dwarfs/Kernel.h
---- /data/users/kaiweitu/fbsource/fbcode/cea/chips/benchpress/adsim_group/cpp2/server/dwarfs/Kernel.h	2025-07-23 15:19:52.001884327 -0700
-+++ adsim/cpp2/server/dwarfs/Kernel.h	2025-07-23 14:32:37.709212437 -0700
+diff -wbBdu -ruN '--exclude=.git' '--exclude=*.rej' '--exclude=*.orig' '--exclude=gen-cpp2' adsim/cpp2/server/dwarfs/Kernel.h build/adsim/cpp2/server/dwarfs/Kernel.h
+--- adsim/cpp2/server/dwarfs/Kernel.h	2025-07-28 12:08:37.418808267 -0700
++++ build/adsim/cpp2/server/dwarfs/Kernel.h	2025-07-25 15:55:10.025158201 -0700
 @@ -21,10 +21,10 @@
  #include <unordered_map>
  #include <vector>
@@ -365,9 +393,9 @@ diff -wbBdu -ruN '--exclude=.git' /data/users/kaiweitu/fbsource/fbcode/cea/chips
  
  namespace facebook::cea::chips::adsim {
  
-diff -wbBdu -ruN '--exclude=.git' /data/users/kaiweitu/fbsource/fbcode/cea/chips/benchpress/adsim_group/cpp2/server/dwarfs/Serialize.h adsim/cpp2/server/dwarfs/Serialize.h
---- /data/users/kaiweitu/fbsource/fbcode/cea/chips/benchpress/adsim_group/cpp2/server/dwarfs/Serialize.h	2025-07-23 15:19:52.002356461 -0700
-+++ adsim/cpp2/server/dwarfs/Serialize.h	2025-07-23 14:58:01.779376886 -0700
+diff -wbBdu -ruN '--exclude=.git' '--exclude=*.rej' '--exclude=*.orig' '--exclude=gen-cpp2' adsim/cpp2/server/dwarfs/Serialize.h build/adsim/cpp2/server/dwarfs/Serialize.h
+--- adsim/cpp2/server/dwarfs/Serialize.h	2025-07-28 12:08:37.419346141 -0700
++++ build/adsim/cpp2/server/dwarfs/Serialize.h	2025-07-25 15:55:10.025830557 -0700
 @@ -20,15 +20,15 @@
  
  #include <algorithm>
@@ -387,9 +415,9 @@ diff -wbBdu -ruN '--exclude=.git' /data/users/kaiweitu/fbsource/fbcode/cea/chips
  
  namespace facebook::cea::chips::adsim {
  
-diff -wbBdu -ruN '--exclude=.git' /data/users/kaiweitu/fbsource/fbcode/cea/chips/benchpress/adsim_group/cpp2/server/dwarfs/Shape.h adsim/cpp2/server/dwarfs/Shape.h
---- /data/users/kaiweitu/fbsource/fbcode/cea/chips/benchpress/adsim_group/cpp2/server/dwarfs/Shape.h	2025-07-23 15:19:52.002781275 -0700
-+++ adsim/cpp2/server/dwarfs/Shape.h	2025-07-23 14:56:52.357330465 -0700
+diff -wbBdu -ruN '--exclude=.git' '--exclude=*.rej' '--exclude=*.orig' '--exclude=gen-cpp2' adsim/cpp2/server/dwarfs/Shape.h build/adsim/cpp2/server/dwarfs/Shape.h
+--- adsim/cpp2/server/dwarfs/Shape.h	2025-07-28 12:08:37.419914901 -0700
++++ build/adsim/cpp2/server/dwarfs/Shape.h	2025-07-25 15:55:10.026656306 -0700
 @@ -16,10 +16,10 @@
  
  #pragma once
@@ -405,18 +433,18 @@ diff -wbBdu -ruN '--exclude=.git' /data/users/kaiweitu/fbsource/fbcode/cea/chips
  
  #include <fb303/ThreadCachedServiceData.h>
  #include <folly/MoveWrapper.h>
-diff -wbBdu -ruN '--exclude=.git' /data/users/kaiweitu/fbsource/fbcode/cea/chips/benchpress/adsim_group/if/AdSim.thrift adsim/if/AdSim.thrift
---- /data/users/kaiweitu/fbsource/fbcode/cea/chips/benchpress/adsim_group/if/AdSim.thrift	2025-07-23 15:19:52.006032827 -0700
-+++ adsim/if/AdSim.thrift	2025-07-23 13:32:56.207818287 -0700
+diff -wbBdu -ruN '--exclude=.git' '--exclude=*.rej' '--exclude=*.orig' '--exclude=gen-cpp2' adsim/if/AdSim.thrift build/adsim/if/AdSim.thrift
+--- adsim/if/AdSim.thrift	2025-07-28 12:08:37.424502511 -0700
++++ build/adsim/if/AdSim.thrift	2025-07-25 15:55:10.027410947 -0700
 @@ -1,4 +1,4 @@
 -include "common/fb303/if/fb303.thrift"
 +include "fb303.thrift"
  
  namespace cpp2 facebook.cea.chips.adsim
  namespace py3 facebook.cea.chips.adsim
-diff -wbBdu -ruN '--exclude=.git' /data/users/kaiweitu/fbsource/fbcode/cea/chips/benchpress/adsim_group/if/Serialize.thrift adsim/if/Serialize.thrift
---- /data/users/kaiweitu/fbsource/fbcode/cea/chips/benchpress/adsim_group/if/Serialize.thrift	2025-07-23 15:19:52.006574358 -0700
-+++ adsim/if/Serialize.thrift	2025-07-23 13:32:56.208334838 -0700
+diff -wbBdu -ruN '--exclude=.git' '--exclude=*.rej' '--exclude=*.orig' '--exclude=gen-cpp2' adsim/if/Serialize.thrift build/adsim/if/Serialize.thrift
+--- adsim/if/Serialize.thrift	2025-07-28 12:08:37.425347058 -0700
++++ build/adsim/if/Serialize.thrift	2025-07-25 15:55:10.028022061 -0700
 @@ -3,20 +3,15 @@
  cpp_include "list"
  cpp_include "folly/container/F14Map.h"

--- a/packages/adsim/src/cpp2/server/dwarfs/CMakeLists.txt
+++ b/packages/adsim/src/cpp2/server/dwarfs/CMakeLists.txt
@@ -112,6 +112,11 @@ target_link_libraries(hashmap data_objects kernel)
 target_compile_options(hashmap PRIVATE ${COROUTINES_FLAG})
 
 
+add_library(concurrenthashmap ConcurrentHashMap.cc ConcurrentHashMap.h)
+target_link_libraries(concurrenthashmap data_objects kernel)
+target_compile_options(concurrenthashmap PRIVATE ${COROUTINES_FLAG})
+
+
 add_library(deepcopy DeepCopy.h)
 target_link_libraries(deepcopy data_objects kernel)
 target_compile_options(deepcopy PRIVATE ${COROUTINES_FLAG})
@@ -125,6 +130,7 @@ target_compile_options(shape PRIVATE ${COROUTINES_FLAG})
 add_library(dwarfs Dwarfs.cc Dwarfs.h)
 target_link_libraries(dwarfs
     compress
+    concurrenthashmap
     deepcopy
     delay
     fakeio

--- a/packages/adsim/src/cpp2/server/dwarfs/ConcurrentHashMap.cc
+++ b/packages/adsim/src/cpp2/server/dwarfs/ConcurrentHashMap.cc
@@ -1,0 +1,283 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <cea/chips/adsim/cpp2/server/dwarfs/ConcurrentHashMap.h>
+
+#include <fb303/ThreadCachedServiceData.h>
+#include <folly/executors/CPUThreadPoolExecutor.h>
+#include <folly/futures/Future.h>
+
+namespace facebook::cea::chips::adsim {
+
+DECLARE_timeseries(concurrent_hashmap_nfired);
+
+/* A closure to create a vector of keys of certain type
+ *
+ * @return  The reference to the vector of keys
+ */
+template <class K>
+std::vector<K>& ConcurrentHashMap::keyList() {
+  static std::vector<K> keys;
+  return keys;
+}
+
+/* A closure to provide the lock for keylist of certain type
+ *
+ * @return  The reference to the lock
+ */
+folly::Synchronized<int>& ConcurrentHashMap::keyListLock() {
+  static folly::Synchronized<int> key_list_lock;
+  return key_list_lock;
+}
+
+/* ConcurrentHashMap kernel constructor
+ *
+ * Initializes benchmark with frequency-based access patterns from distribution
+ * file. Creates large pregenerated request book for realistic workload
+ * simulation.
+ */
+ConcurrentHashMap::ConcurrentHashMap(
+    int requests_per_run,
+    int request_book_multiplier,
+    int num_threads,
+    std::string input_str,
+    std::string distribution_file)
+    : requests_per_run_(requests_per_run),
+      request_book_multiplier_(request_book_multiplier),
+      num_threads_(num_threads),
+      input_str_(std::move(input_str)),
+      distribution_file_(std::move(distribution_file)),
+      current_request_position_(0) {
+  LOG(INFO) << "ConcurrentHashMap initialized with params: "
+            << "requests_per_run=" << requests_per_run_
+            << ", request_book_multiplier=" << request_book_multiplier_
+            << ", num_threads=" << num_threads_
+            << ", distribution_file=" << distribution_file_;
+}
+
+/* Create and populate concurrent hash map in handler objects
+ *
+ * Instantiates sharded hash map and populates with key-value pairs.
+ * Values are AdData objects created with sequential AdId values.
+ */
+void ConcurrentHashMap::insert_map(AdSimHandleObjs* h_objs, size_t total_keys) {
+  auto m = std::make_shared<concurrent_map<AdId, AdDataPtr>>(total_keys);
+  for (size_t i = 0; i < total_keys; ++i) {
+    AdId adId = static_cast<AdId>(i);
+    m->put(adId, std::make_shared<AdData>(adId));
+  }
+  h_objs->set_shared_ptr(input_str_, m);
+}
+
+/* Generate large pregenerated request book based on frequency distribution
+ *
+ * Creates request book with (request_book_multiplier × dataset_size) entries.
+ * Uses frequency-weighted random sampling from distribution buckets.
+ */
+void ConcurrentHashMap::generatePregeneratedRequests(
+    const WorkloadGenerator& generator) {
+  size_t dataset_size = keyList<AdId>().size();
+  size_t request_book_size = request_book_multiplier_ * dataset_size;
+  pregenerated_requests_.clear();
+  pregenerated_requests_.reserve(request_book_size);
+
+  // Create frequency buckets and weighted access distribution
+  auto buckets = generator.createBuckets();
+  auto accessDistribution = generator.createAccessDistribution();
+
+  std::random_device rd;
+  std::mt19937 rng(rd());
+
+  // Generate request book with frequency-weighted random selection
+  for (size_t i = 0; i < request_book_size; ++i) {
+    // Select bucket based on frequency weights
+    if (accessDistribution.empty() || buckets.empty()) {
+      throw std::runtime_error("Empty access distribution or bucket vector");
+    }
+    size_t bucketIdx = accessDistribution[rng() % accessDistribution.size()];
+    const auto& bucket = buckets[bucketIdx];
+
+    // Select random key within the bucket
+    size_t keyOffset = rng() % bucket.numKeys;
+    size_t keyIndex = bucket.startIndex + keyOffset;
+    keyIndex =
+        std::min(keyIndex, static_cast<size_t>(keyList<AdId>().size() - 1));
+
+    pregenerated_requests_.push_back(static_cast<uint32_t>(keyIndex));
+  }
+
+  LOG(INFO) << "Generated request book: " << request_book_size
+            << " requests from " << dataset_size << " keys";
+}
+
+/* Initialize concurrent hash map with distribution-based workload
+ *
+ * Loads distribution from CSV, calculates dataset size, generates shuffled
+ * working set, creates request book, and populates hash map.
+ */
+std::string ConcurrentHashMap::init(
+    std::shared_ptr<AdSimHandleObjs> h_objs,
+    std::shared_ptr<AdSimRequestObjs> /*unused*/) {
+  size_t total_keys = 0;
+
+  keyListLock().withWLock([&](int& /*unused*/) {
+    // Parse distribution file (frequency,count CSV format)
+    DistributionReader reader(distribution_file_);
+    auto distributionOpt = reader.read();
+    if (distributionOpt && !distributionOpt->empty()) {
+      WorkloadGenerator generator(*distributionOpt);
+
+      // Calculate total keys by summing all count values from distribution
+      total_keys = generator.calculateWorkingSetSize();
+      // Populate key list with shuffled working set to avoid cache patterns
+      auto& keys = keyList<AdId>();
+      keys.clear();
+      keys.reserve(total_keys);
+      for (size_t i = 0; i < total_keys; ++i) {
+        keys.push_back(static_cast<AdId>(i));
+      }
+
+      // Generate large request book for benchmark execution
+      generatePregeneratedRequests(generator);
+
+      LOG(INFO) << "Distribution loaded: " << distributionOpt->size()
+                << " frequency buckets, " << total_keys << " total keys";
+    } else {
+      throw std::runtime_error(
+          "Failed to read distribution file: " + distribution_file_);
+    }
+  });
+
+  // Create and populate the concurrent hash map
+  insert_map(h_objs.get(), total_keys);
+
+  std::string info = folly::to<std::string>(
+      "ConcurrentHashMap: ", input_str_, " ", std::to_string(total_keys), "B");
+  info += " (distribution: " + distribution_file_ + ")";
+  info += " (pregenerated " + std::to_string(pregenerated_requests_.size()) +
+      " requests)";
+  return info;
+}
+
+/* Single-threaded lookup using pregenerated request sequence
+ *
+ * Executes requests_per_run_ lookups from request book with atomic position
+ * advancement and wrapping. XOR aggregation prevents compiler optimization.
+ */
+int ConcurrentHashMap::lookup_map(std::shared_ptr<AdSimHandleObjs> h_objs) {
+  auto m = h_objs->get_shared_ptr<concurrent_map<AdId, AdDataPtr>>(input_str_);
+  int x = 0;
+
+  // Atomically reserve request range and advance global position
+  uint32_t start_pos = current_request_position_.fetch_add(
+                           static_cast<uint32_t>(requests_per_run_)) %
+      pregenerated_requests_.size();
+
+  // Execute lookups with automatic wrapping around request book
+  for (uint32_t i = 0; i < requests_per_run_; ++i) {
+    uint32_t pos = (start_pos + i) % pregenerated_requests_.size();
+    uint32_t requestIdx = pregenerated_requests_[pos];
+    AdId adId = static_cast<AdId>(requestIdx);
+    auto result = m->getValue(adId);
+    if (result.second) {
+      x ^= static_cast<int>(
+          result.first->getId()); // XOR aggregation for validation
+    }
+  }
+
+  return x;
+}
+
+/* Multi-threaded concurrent lookup with work distribution
+ *
+ * Distributes requests_per_run_ lookups across worker threads. Each thread
+ * processes contiguous chunk from reserved request range. XOR aggregation.
+ */
+folly::coro::Task<int> ConcurrentHashMap::concurrent_lookup_map(
+    std::shared_ptr<AdSimHandleObjs> h_objs,
+    std::shared_ptr<folly::Executor> pool) {
+  auto m = h_objs->get_shared_ptr<concurrent_map<AdId, AdDataPtr>>(input_str_);
+
+  // Atomically reserve contiguous request range for this fire operation
+  uint32_t start_pos = current_request_position_.fetch_add(
+                           static_cast<uint32_t>(requests_per_run_)) %
+      pregenerated_requests_.size();
+
+  std::vector<folly::Future<int>> futures;
+  uint32_t requests_per_thread = static_cast<uint32_t>(requests_per_run_) /
+      static_cast<uint32_t>(num_threads_);
+
+  // Create worker tasks with balanced load distribution
+  for (int t = 0; t < num_threads_; ++t) {
+    uint32_t thread_start = t * requests_per_thread;
+    uint32_t thread_end = (t == num_threads_ - 1)
+        ? static_cast<uint32_t>(
+              requests_per_run_) // Last thread handles remainder
+        : (t + 1) * requests_per_thread;
+
+    auto future = folly::via(
+        pool.get(), [this, m, start_pos, thread_start, thread_end]() {
+          int x = 0;
+          // Process assigned chunk of requests with wrapping
+          for (uint32_t i = thread_start; i < thread_end; ++i) {
+            uint32_t pos = (start_pos + i) % pregenerated_requests_.size();
+            uint32_t requestIdx = pregenerated_requests_[pos];
+            AdId adId = static_cast<AdId>(requestIdx);
+            auto result = m->getValue(adId);
+            if (result.second) {
+              x ^= static_cast<int>(
+                  result.first->getId()); // XOR aggregation per thread
+            }
+          }
+          return x;
+        });
+    futures.push_back(std::move(future));
+  }
+
+  // Collect and aggregate results from all worker threads
+  auto results = co_await folly::collectAll(futures);
+  int final_result = 0;
+  for (auto& result : results) {
+    if (result.hasValue()) {
+      final_result ^= result.value();
+    }
+  }
+
+  co_return final_result;
+}
+
+/* Execute benchmark fire operation
+ *
+ * Performs single benchmark iteration with requests_per_run_ lookups.
+ * Selects single/multi-threaded execution based on configuration.
+ */
+folly::coro::Task<std::string> ConcurrentHashMap::fire(
+    std::shared_ptr<AdSimHandleObjs> h_objs,
+    std::shared_ptr<AdSimRequestObjs> r_objs,
+    std::shared_ptr<folly::Executor> pool) {
+  STATS_concurrent_hashmap_nfired.add(1);
+
+  // Select execution mode based on thread configuration and pool availability
+  if (num_threads_ > 1 && pool) {
+    co_await concurrent_lookup_map(h_objs, pool);
+  } else {
+    lookup_map(h_objs);
+  }
+
+  co_return "";
+}
+
+} // namespace facebook::cea::chips::adsim

--- a/packages/adsim/src/cpp2/server/dwarfs/ConcurrentHashMap.h
+++ b/packages/adsim/src/cpp2/server/dwarfs/ConcurrentHashMap.h
@@ -1,0 +1,361 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <unistd.h>
+
+#include <algorithm>
+#include <array>
+#include <atomic>
+#include <fstream>
+#include <memory>
+#include <optional>
+#include <random>
+#include <sstream>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include <cea/chips/adsim/cpp2/server/DataObjects.h>
+#include <cea/chips/adsim/cpp2/server/dwarfs/Kernel.h>
+
+#include <folly/Likely.h>
+#include <folly/SharedMutex.h>
+#include <folly/Synchronized.h>
+#include <folly/container/F14Map.h>
+#include <folly/coro/Task.h>
+#include <folly/lang/Aligned.h>
+#include <folly/synchronization/Lock.h>
+
+namespace facebook::cea::chips::adsim {
+
+using AdId = int64_t;
+
+// Mock advertisement data stored as values in the hash map
+class AdData {
+ public:
+  explicit AdData(AdId id) : id_(id), data_("AdData-" + std::to_string(id)) {}
+
+  AdId getId() const {
+    return id_;
+  }
+  const std::string& getData() const {
+    return data_;
+  }
+
+ private:
+  AdId id_;
+  std::string data_; // Simulated payload data
+};
+
+using AdDataPtr = std::shared_ptr<AdData>;
+
+/**
+ * Hash function for shard distribution
+ *
+ * @param key The input key to hash
+ * @return A well-distributed hash value for sharding
+ */
+inline int32_t shardingHashFromKey(int32_t key) {
+  constexpr const uint32_t kC = 0x27d4eb2d; // a prime and an odd constant
+  key ^= ((key >> 15) | (static_cast<uint32_t>(key) << 17));
+  return static_cast<int32_t>(key * kC);
+}
+
+/**
+ * Represents frequency distribution data from CSV input
+ */
+struct DistributionEntry {
+  uint64_t frequency; // Access frequency weight
+  uint64_t numKeys; // Number of keys in this frequency bucket
+};
+
+/**
+ * Parses distribution file in CSV format (frequency,numKeys)
+ */
+class DistributionReader {
+ public:
+  explicit DistributionReader(std::string_view filePath)
+      : filePath_(filePath) {}
+
+  std::optional<std::vector<DistributionEntry>> read() const {
+    std::vector<DistributionEntry> distribution;
+    std::ifstream file(filePath_);
+
+    if (!file.is_open()) {
+      return std::nullopt;
+    }
+
+    std::string line;
+    bool isFirstLine = true;
+    while (std::getline(file, line)) {
+      if (isFirstLine) {
+        isFirstLine = false;
+        continue;
+      }
+      if (auto entry = parseLine(line)) {
+        distribution.push_back(*entry);
+      }
+    }
+
+    return distribution;
+  }
+
+ private:
+  std::optional<DistributionEntry> parseLine(const std::string& line) const {
+    std::istringstream iss(line);
+    std::string freqStr, numKeysStr;
+
+    if (std::getline(iss, freqStr, ',') && std::getline(iss, numKeysStr)) {
+      try {
+        return DistributionEntry{
+            .frequency = static_cast<uint64_t>(std::stod(freqStr)),
+            .numKeys = static_cast<uint64_t>(std::stoll(numKeysStr))};
+      } catch (const std::exception&) {
+        // Skip invalid lines
+      }
+    }
+    return std::nullopt;
+  }
+
+  std::string filePath_;
+};
+
+/**
+ * Generates workloads based on frequency distribution patterns
+ */
+class WorkloadGenerator {
+ public:
+  struct Bucket {
+    size_t startIndex; // Start index in shuffled working set
+    uint64_t numKeys; // Number of keys in this bucket
+  };
+
+  explicit WorkloadGenerator(const std::vector<DistributionEntry>& distribution)
+      : distribution_(distribution) {}
+
+  uint64_t calculateWorkingSetSize() const {
+    uint64_t totalKeys = 0;
+    for (const auto& entry : distribution_) {
+      totalKeys += entry.numKeys;
+    }
+    return totalKeys;
+  }
+
+  std::vector<Bucket> createBuckets() const {
+    std::vector<Bucket> buckets;
+    buckets.reserve(distribution_.size());
+    size_t currentIndex = 0;
+
+    for (const auto& entry : distribution_) {
+      buckets.push_back({currentIndex, entry.numKeys});
+      currentIndex += entry.numKeys;
+    }
+
+    return buckets;
+  }
+
+  std::vector<size_t> createAccessDistribution() const {
+    constexpr uint64_t MAX_DISTRIBUTION_ENTRIES = 10000000;
+
+    uint64_t totalFrequency = 0;
+    for (const auto& entry : distribution_) {
+      totalFrequency += entry.frequency * entry.numKeys;
+    }
+
+    uint64_t totalEntries = std::min(totalFrequency, MAX_DISTRIBUTION_ENTRIES);
+    double scalingFactor = static_cast<double>(totalEntries) / totalFrequency;
+
+    std::vector<size_t> accessDistribution;
+    accessDistribution.reserve(totalEntries);
+
+    for (size_t i = 0; i < distribution_.size(); ++i) {
+      const auto& entry = distribution_[i];
+      uint64_t numAppearances = std::max(
+          static_cast<uint64_t>(
+              entry.frequency * entry.numKeys * scalingFactor),
+          uint64_t(1));
+
+      for (uint64_t j = 0; j < numAppearances; ++j) {
+        accessDistribution.push_back(i);
+      }
+    }
+
+    std::random_shuffle(accessDistribution.begin(), accessDistribution.end());
+
+    return accessDistribution;
+  }
+
+ private:
+  const std::vector<DistributionEntry>& distribution_;
+};
+
+/**
+ * ConcurrentHashMapImpl - Thread-safe hash map implementation using sharding
+ *
+ * This implementation divides the hash space into multiple shards, each with
+ * its own mutex and underlying hash map, to reduce lock contention in
+ * concurrent access.
+ */
+template <
+    typename KeyT,
+    typename RecordT,
+    size_t kShardBits = 8,
+    typename InternalHashMapType = folly::F14FastMap<KeyT, RecordT>,
+    typename MutexType = folly::SharedMutex>
+class ConcurrentHashMapImpl {
+  enum {
+    kNumShards = (1 << kShardBits),
+    kShardMask = kNumShards - 1,
+  };
+
+  using HashFunc = typename InternalHashMapType::hasher;
+
+ public:
+  using key_type = KeyT;
+  using data_type = RecordT;
+  using mapped_type = RecordT;
+  using value_type = std::pair<KeyT, RecordT>;
+
+  explicit ConcurrentHashMapImpl(int sizeHint = 0) {
+    size_t hint = sizeHint >> kShardBits;
+    for (int i = 0; i < kNumShards; ++i) {
+      maps_[i].reset(new InternalHashMapType(hint));
+    }
+  }
+
+  ~ConcurrentHashMapImpl() = default;
+
+  std::pair<data_type, bool> getValue(const key_type& key) const {
+    std::pair<data_type, bool> ret;
+    int32_t shard = keyToSubMapIndex(key);
+    {
+      std::shared_lock lock{*mutexes_[shard]};
+      auto iter = subMap(shard).find(key);
+      if (iter != subMap(shard).end()) {
+        ret.first = iter->second;
+        ret.second = true;
+      }
+    }
+    return ret;
+  }
+
+  std::pair<data_type, bool> put(const value_type& in) {
+    return put(in.first, in.second);
+  }
+
+  std::pair<data_type, bool> put(const key_type& key, const data_type& value) {
+    int32_t shard = keyToSubMapIndex(key);
+    std::unique_lock xlock{*mutexes_[shard]};
+    auto ret(subMap(shard).insert(value_type(key, value)));
+    return std::pair<data_type, bool>(ret.first->second, ret.second);
+  }
+
+ private:
+  static int32_t keyToSubMapIndex(const key_type& key) {
+    return shardingHashFromKey(static_cast<int32_t>(HashFunc()(key))) &
+        kShardMask;
+  }
+
+  const InternalHashMapType& subMap(size_t shard) const {
+    return *maps_[shard];
+  }
+
+  InternalHashMapType& subMap(size_t shard) {
+    return *maps_[shard];
+  }
+
+  mutable std::array<folly::cacheline_aligned<MutexType>, kNumShards> mutexes_;
+  std::unique_ptr<InternalHashMapType> maps_[kNumShards];
+};
+
+/* A kernel that performs concurrent hash map operations intensively */
+class ConcurrentHashMap : public Kernel {
+  template <class K, class V>
+  using concurrent_map = ConcurrentHashMapImpl<K, V>;
+
+ public:
+  explicit ConcurrentHashMap(
+      int requests_per_run,
+      int request_book_multiplier,
+      int num_threads,
+      std::string input_str,
+      std::string distribution_file);
+
+  std::string init(
+      std::shared_ptr<AdSimHandleObjs> h_objs,
+      std::shared_ptr<AdSimRequestObjs> r_objs = nullptr) override;
+
+  folly::coro::Task<std::string> fire(
+      std::shared_ptr<AdSimHandleObjs> h_objs,
+      std::shared_ptr<AdSimRequestObjs> r_objs,
+      std::shared_ptr<folly::Executor> pool) override;
+
+  static std::shared_ptr<Kernel> config(const folly::dynamic& config_d) {
+    int64_t requests_per_run =
+        static_cast<int64_t>(config_d["requests_per_run"].asInt());
+    int64_t request_book_multiplier = config_d.count("request_book_multiplier")
+        ? static_cast<int64_t>(config_d["request_book_multiplier"].asInt())
+        : 10;
+    int64_t num_threads = config_d.count("num_threads")
+        ? static_cast<int64_t>(config_d["num_threads"].asInt())
+        : 4;
+    std::string input_str = "ConcurrentHashMap";
+    if (config_d.count("input")) {
+      input_str = config_d["input"].asString();
+    }
+    std::string distribution_file = config_d["distribution_file"].asString();
+    return std::make_shared<ConcurrentHashMap>(
+        requests_per_run,
+        request_book_multiplier,
+        num_threads,
+        input_str,
+        distribution_file);
+  }
+
+ private:
+  int64_t requests_per_run_;
+  int64_t request_book_multiplier_;
+  int64_t num_threads_;
+  std::string input_str_;
+  std::string distribution_file_;
+  std::vector<uint32_t>
+      pregenerated_requests_; // Large pre-generated request book
+  mutable std::atomic<uint32_t>
+      current_request_position_; // Current position in request book
+
+  folly::Synchronized<int>& keyListLock();
+
+  void insert_map(AdSimHandleObjs* h_objs, size_t total_keys);
+  int lookup_map(std::shared_ptr<AdSimHandleObjs> h_objs);
+  folly::coro::Task<int> concurrent_lookup_map(
+      std::shared_ptr<AdSimHandleObjs> h_objs,
+      std::shared_ptr<folly::Executor> pool);
+
+  // Helper methods for pregenerated requests
+  void generatePregeneratedRequests(const WorkloadGenerator& generator);
+
+  template <class K>
+  std::vector<K>& keyList();
+
+  template <class K>
+  const K& key(size_t index) {
+    return keyList<K>()[index];
+  }
+};
+
+} // namespace facebook::cea::chips::adsim

--- a/packages/adsim/src/cpp2/server/dwarfs/Dwarfs.cc
+++ b/packages/adsim/src/cpp2/server/dwarfs/Dwarfs.cc
@@ -20,6 +20,7 @@
 #include <folly/dynamic.h>
 
 #include <cea/chips/adsim/cpp2/server/dwarfs/Compress.h>
+#include <cea/chips/adsim/cpp2/server/dwarfs/ConcurrentHashMap.h>
 #include <cea/chips/adsim/cpp2/server/dwarfs/DeepCopy.h>
 #include <cea/chips/adsim/cpp2/server/dwarfs/Delay.h>
 #include <cea/chips/adsim/cpp2/server/dwarfs/Dwarfs.h>
@@ -44,6 +45,7 @@ const folly::F14VectorMap<std::string, CONFIG_F> KERNEL_DICT = {
     {"Serialize", Serialize::config},
     {"Deserialize", Deserialize::config},
     {"HashMap", HashMap::config},
+    {"ConcurrentHashMap", ConcurrentHashMap::config},
     {"DeepCopy", DeepCopy::config},
     {"Delay", Delay::config},
     {"Shape", Shape::config},

--- a/packages/adsim/src/cpp2/server/dwarfs/Kernel.cc
+++ b/packages/adsim/src/cpp2/server/dwarfs/Kernel.cc
@@ -32,6 +32,10 @@ DEFINE_timeseries(decompress_nfired, "decompress_nfired", fb303::SUM);
 DEFINE_timeseries(serialize_nfired, "serialize_nfired", fb303::SUM);
 DEFINE_timeseries(deserialize_nfired, "serialize_nfired", fb303::SUM);
 DEFINE_timeseries(hashmap_nfired, "hashmap_nfired", fb303::SUM);
+DEFINE_timeseries(
+    concurrent_hashmap_nfired,
+    "concurrent_hashmap_nfired",
+    fb303::SUM);
 DEFINE_timeseries(deepcopy_nfired, "deepcopy_nfired", fb303::SUM);
 DEFINE_timeseries(delay_nfired, "delay_nfired", fb303::SUM);
 DEFINE_timeseries(shape_nfired, "shape_nfired", fb303::SUM);


### PR DESCRIPTION
Summary:
### Summary

This diff adds a concurrent hashmap kernel into adsim. The changes include adding new files `ConcurrentHashMap.cc` and `ConcurrentHashMap.h` to the `cea/chips/adsim/cpp2/server/dwarfs` directory, and modifying existing files `Dwarfs.cc`, `Kernel.cc`, and `BUCK` to incorporate the new kernel.

Reviewed By: excelle08

Differential Revision: D79110818


