### PR TITLE
Add tensor deserialization kernel into Adsim

### DIFF
--- a/packages/adsim/patches/adsim.patch
+++ b/packages/adsim/patches/adsim.patch
@@ -1,5 +1,5 @@
-diff -wbBdu -ruN '--exclude=.git' '--exclude=*.rej' '--exclude=*.orig' '--exclude=gen-cpp2' adsim/cpp2/client/AdSimClient.cpp build/adsim/cpp2/client/AdSimClient.cpp
---- adsim/cpp2/client/AdSimClient.cpp	2025-07-28 12:08:37.404634728 -0700
+diff -wbBdu -ruN '--exclude=.git' '--exclude=*.rej' '--exclude=*.orig' '--exclude=gen-cpp2' adsim_group/cpp2/client/AdSimClient.cpp build/adsim/cpp2/client/AdSimClient.cpp
+--- adsim_group/cpp2/client/AdSimClient.cpp	2025-07-29 14:17:29.771582057 -0700
 +++ build/adsim/cpp2/client/AdSimClient.cpp	2025-07-25 15:55:10.007667247 -0700
 @@ -14,17 +14,15 @@
   * limitations under the License.
@@ -22,8 +22,8 @@ diff -wbBdu -ruN '--exclude=.git' '--exclude=*.rej' '--exclude=*.orig' '--exclud
  
  DEFINE_string(host, "::1", "AdSimServer host");
  DEFINE_int32(port, 10086, "AdSimServer port");
-diff -wbBdu -ruN '--exclude=.git' '--exclude=*.rej' '--exclude=*.orig' '--exclude=gen-cpp2' adsim/cpp2/client/CoWorker.h build/adsim/cpp2/client/CoWorker.h
---- adsim/cpp2/client/CoWorker.h	2025-07-28 12:08:37.405599047 -0700
+diff -wbBdu -ruN '--exclude=.git' '--exclude=*.rej' '--exclude=*.orig' '--exclude=gen-cpp2' adsim_group/cpp2/client/CoWorker.h build/adsim/cpp2/client/CoWorker.h
+--- adsim_group/cpp2/client/CoWorker.h	2025-07-29 14:17:29.772459085 -0700
 +++ build/adsim/cpp2/client/CoWorker.h	2025-07-25 15:55:10.009191271 -0700
 @@ -16,14 +16,16 @@
  
@@ -43,8 +43,8 @@ diff -wbBdu -ruN '--exclude=.git' '--exclude=*.rej' '--exclude=*.orig' '--exclud
  
  namespace facebook::cea::chips::adsim {
  
-diff -wbBdu -ruN '--exclude=.git' '--exclude=*.rej' '--exclude=*.orig' '--exclude=gen-cpp2' adsim/cpp2/server/AdSimServer.cpp build/adsim/cpp2/server/AdSimServer.cpp
---- adsim/cpp2/server/AdSimServer.cpp	2025-07-28 12:08:37.420421287 -0700
+diff -wbBdu -ruN '--exclude=.git' '--exclude=*.rej' '--exclude=*.orig' '--exclude=gen-cpp2' adsim_group/cpp2/server/AdSimServer.cpp build/adsim/cpp2/server/AdSimServer.cpp
+--- adsim_group/cpp2/server/AdSimServer.cpp	2025-07-29 14:17:29.787921133 -0700
 +++ build/adsim/cpp2/server/AdSimServer.cpp	2025-07-25 15:55:10.010304364 -0700
 @@ -19,16 +19,17 @@
  #include <streambuf>
@@ -67,8 +67,8 @@ diff -wbBdu -ruN '--exclude=.git' '--exclude=*.rej' '--exclude=*.orig' '--exclud
  
  DEFINE_string(config_file, "", "A json file of configurations");
  DEFINE_int32(port, -1, "Overwrite port in the config file");
-diff -wbBdu -ruN '--exclude=.git' '--exclude=*.rej' '--exclude=*.orig' '--exclude=gen-cpp2' adsim/cpp2/server/AdSimService.cpp build/adsim/cpp2/server/AdSimService.cpp
---- adsim/cpp2/server/AdSimService.cpp	2025-07-28 12:08:37.420848854 -0700
+diff -wbBdu -ruN '--exclude=.git' '--exclude=*.rej' '--exclude=*.orig' '--exclude=gen-cpp2' adsim_group/cpp2/server/AdSimService.cpp build/adsim/cpp2/server/AdSimService.cpp
+--- adsim_group/cpp2/server/AdSimService.cpp	2025-07-29 14:17:29.788333958 -0700
 +++ build/adsim/cpp2/server/AdSimService.cpp	2025-07-25 15:55:10.011314962 -0700
 @@ -14,8 +14,8 @@
   * limitations under the License.
@@ -81,8 +81,8 @@ diff -wbBdu -ruN '--exclude=.git' '--exclude=*.rej' '--exclude=*.orig' '--exclud
  
  #include <fb303/ThreadCachedServiceData.h>
  #include <folly/coro/Collect.h>
-diff -wbBdu -ruN '--exclude=.git' '--exclude=*.rej' '--exclude=*.orig' '--exclude=gen-cpp2' adsim/cpp2/server/AdSimService.h build/adsim/cpp2/server/AdSimService.h
---- adsim/cpp2/server/AdSimService.h	2025-07-28 12:08:37.421285043 -0700
+diff -wbBdu -ruN '--exclude=.git' '--exclude=*.rej' '--exclude=*.orig' '--exclude=gen-cpp2' adsim_group/cpp2/server/AdSimService.h build/adsim/cpp2/server/AdSimService.h
+--- adsim_group/cpp2/server/AdSimService.h	2025-07-29 14:17:29.788761875 -0700
 +++ build/adsim/cpp2/server/AdSimService.h	2025-07-25 15:55:10.012430769 -0700
 @@ -22,10 +22,10 @@
  #include <folly/Executor.h>
@@ -98,8 +98,8 @@ diff -wbBdu -ruN '--exclude=.git' '--exclude=*.rej' '--exclude=*.orig' '--exclud
  
  namespace facebook::cea::chips::adsim {
  
-diff -wbBdu -ruN '--exclude=.git' '--exclude=*.rej' '--exclude=*.orig' '--exclude=gen-cpp2' adsim/cpp2/server/DataObjects.cpp build/adsim/cpp2/server/DataObjects.cpp
---- adsim/cpp2/server/DataObjects.cpp	2025-07-28 12:08:37.422131554 -0700
+diff -wbBdu -ruN '--exclude=.git' '--exclude=*.rej' '--exclude=*.orig' '--exclude=gen-cpp2' adsim_group/cpp2/server/DataObjects.cpp build/adsim/cpp2/server/DataObjects.cpp
+--- adsim_group/cpp2/server/DataObjects.cpp	2025-07-29 14:17:29.789743832 -0700
 +++ build/adsim/cpp2/server/DataObjects.cpp	2025-07-25 15:55:10.013145970 -0700
 @@ -14,7 +14,7 @@
   * limitations under the License.
@@ -110,8 +110,8 @@ diff -wbBdu -ruN '--exclude=.git' '--exclude=*.rej' '--exclude=*.orig' '--exclud
  #include <folly/Singleton.h>
  
  namespace facebook::cea::chips::adsim {
-diff -wbBdu -ruN '--exclude=.git' '--exclude=*.rej' '--exclude=*.orig' '--exclude=gen-cpp2' adsim/cpp2/server/DataObjects.h build/adsim/cpp2/server/DataObjects.h
---- adsim/cpp2/server/DataObjects.h	2025-07-28 12:08:37.422600023 -0700
+diff -wbBdu -ruN '--exclude=.git' '--exclude=*.rej' '--exclude=*.orig' '--exclude=gen-cpp2' adsim_group/cpp2/server/DataObjects.h build/adsim/cpp2/server/DataObjects.h
+--- adsim_group/cpp2/server/DataObjects.h	2025-07-29 14:17:29.790185910 -0700
 +++ build/adsim/cpp2/server/DataObjects.h	2025-07-25 15:55:10.013816493 -0700
 @@ -27,7 +27,7 @@
  #include <thrift/lib/cpp2/protocol/CompactProtocol.h>
@@ -122,8 +122,8 @@ diff -wbBdu -ruN '--exclude=.git' '--exclude=*.rej' '--exclude=*.orig' '--exclud
  
  namespace facebook::cea::chips::adsim {
  
-diff -wbBdu -ruN '--exclude=.git' '--exclude=*.rej' '--exclude=*.orig' '--exclude=gen-cpp2' adsim/cpp2/server/dwarfs/Compress.cc build/adsim/cpp2/server/dwarfs/Compress.cc
---- adsim/cpp2/server/dwarfs/Compress.cc	2025-07-28 12:08:37.411753456 -0700
+diff -wbBdu -ruN '--exclude=.git' '--exclude=*.rej' '--exclude=*.orig' '--exclude=gen-cpp2' adsim_group/cpp2/server/dwarfs/Compress.cc build/adsim/cpp2/server/dwarfs/Compress.cc
+--- adsim_group/cpp2/server/dwarfs/Compress.cc	2025-07-29 14:17:29.777879647 -0700
 +++ build/adsim/cpp2/server/dwarfs/Compress.cc	2025-07-25 15:55:10.014647761 -0700
 @@ -18,10 +18,10 @@
  #include <util.h>
@@ -139,8 +139,8 @@ diff -wbBdu -ruN '--exclude=.git' '--exclude=*.rej' '--exclude=*.orig' '--exclud
  
  #include <fb303/ThreadCachedServiceData.h>
  #include <folly/coro/Task.h>
-diff -wbBdu -ruN '--exclude=.git' '--exclude=*.rej' '--exclude=*.orig' '--exclude=gen-cpp2' adsim/cpp2/server/dwarfs/Compress.h build/adsim/cpp2/server/dwarfs/Compress.h
---- adsim/cpp2/server/dwarfs/Compress.h	2025-07-28 12:08:37.412260183 -0700
+diff -wbBdu -ruN '--exclude=.git' '--exclude=*.rej' '--exclude=*.orig' '--exclude=gen-cpp2' adsim_group/cpp2/server/dwarfs/Compress.h build/adsim/cpp2/server/dwarfs/Compress.h
+--- adsim_group/cpp2/server/dwarfs/Compress.h	2025-07-29 14:17:29.778403731 -0700
 +++ build/adsim/cpp2/server/dwarfs/Compress.h	2025-07-25 15:55:10.015383212 -0700
 @@ -21,8 +21,8 @@
  
@@ -153,9 +153,9 @@ diff -wbBdu -ruN '--exclude=.git' '--exclude=*.rej' '--exclude=*.orig' '--exclud
  
  #include <folly/coro/Task.h>
  
-diff -wbBdu -ruN '--exclude=.git' '--exclude=*.rej' '--exclude=*.orig' '--exclude=gen-cpp2' adsim/cpp2/server/dwarfs/ConcurrentHashMap.cc build/adsim/cpp2/server/dwarfs/ConcurrentHashMap.cc
---- adsim/cpp2/server/dwarfs/ConcurrentHashMap.cc	2025-07-28 12:08:37.412914793 -0700
-+++ build/adsim/cpp2/server/dwarfs/ConcurrentHashMap.cc	2025-07-28 11:49:52.560117703 -0700
+diff -wbBdu -ruN '--exclude=.git' '--exclude=*.rej' '--exclude=*.orig' '--exclude=gen-cpp2' adsim_group/cpp2/server/dwarfs/ConcurrentHashMap.cc build/adsim/cpp2/server/dwarfs/ConcurrentHashMap.cc
+--- adsim_group/cpp2/server/dwarfs/ConcurrentHashMap.cc	2025-07-29 14:17:29.778881854 -0700
++++ build/adsim/cpp2/server/dwarfs/ConcurrentHashMap.cc	2025-07-29 14:21:45.143901510 -0700
 @@ -14,7 +14,7 @@
   * limitations under the License.
   */
@@ -165,9 +165,9 @@ diff -wbBdu -ruN '--exclude=.git' '--exclude=*.rej' '--exclude=*.orig' '--exclud
  
  #include <fb303/ThreadCachedServiceData.h>
  #include <folly/executors/CPUThreadPoolExecutor.h>
-diff -wbBdu -ruN '--exclude=.git' '--exclude=*.rej' '--exclude=*.orig' '--exclude=gen-cpp2' adsim/cpp2/server/dwarfs/ConcurrentHashMap.h build/adsim/cpp2/server/dwarfs/ConcurrentHashMap.h
---- adsim/cpp2/server/dwarfs/ConcurrentHashMap.h	2025-07-28 12:08:37.413367828 -0700
-+++ build/adsim/cpp2/server/dwarfs/ConcurrentHashMap.h	2025-07-28 11:40:51.243521796 -0700
+diff -wbBdu -ruN '--exclude=.git' '--exclude=*.rej' '--exclude=*.orig' '--exclude=gen-cpp2' adsim_group/cpp2/server/dwarfs/ConcurrentHashMap.h build/adsim/cpp2/server/dwarfs/ConcurrentHashMap.h
+--- adsim_group/cpp2/server/dwarfs/ConcurrentHashMap.h	2025-07-29 14:17:29.779299386 -0700
++++ build/adsim/cpp2/server/dwarfs/ConcurrentHashMap.h	2025-07-29 14:20:53.562536690 -0700
 @@ -30,8 +30,8 @@
  #include <utility>
  #include <vector>
@@ -179,8 +179,8 @@ diff -wbBdu -ruN '--exclude=.git' '--exclude=*.rej' '--exclude=*.orig' '--exclud
  
  #include <folly/Likely.h>
  #include <folly/SharedMutex.h>
-diff -wbBdu -ruN '--exclude=.git' '--exclude=*.rej' '--exclude=*.orig' '--exclude=gen-cpp2' adsim/cpp2/server/dwarfs/DeepCopy.h build/adsim/cpp2/server/dwarfs/DeepCopy.h
---- adsim/cpp2/server/dwarfs/DeepCopy.h	2025-07-28 12:08:37.413807904 -0700
+diff -wbBdu -ruN '--exclude=.git' '--exclude=*.rej' '--exclude=*.orig' '--exclude=gen-cpp2' adsim_group/cpp2/server/dwarfs/DeepCopy.h build/adsim/cpp2/server/dwarfs/DeepCopy.h
+--- adsim_group/cpp2/server/dwarfs/DeepCopy.h	2025-07-29 14:17:29.779765491 -0700
 +++ build/adsim/cpp2/server/dwarfs/DeepCopy.h	2025-07-25 15:55:10.016208450 -0700
 @@ -24,8 +24,8 @@
  #include <unordered_map>
@@ -193,8 +193,8 @@ diff -wbBdu -ruN '--exclude=.git' '--exclude=*.rej' '--exclude=*.orig' '--exclud
  
  #include <fb303/ThreadCachedServiceData.h>
  #include <folly/container/F14Map.h>
-diff -wbBdu -ruN '--exclude=.git' '--exclude=*.rej' '--exclude=*.orig' '--exclude=gen-cpp2' adsim/cpp2/server/dwarfs/Delay.h build/adsim/cpp2/server/dwarfs/Delay.h
---- adsim/cpp2/server/dwarfs/Delay.h	2025-07-28 12:08:37.414329413 -0700
+diff -wbBdu -ruN '--exclude=.git' '--exclude=*.rej' '--exclude=*.orig' '--exclude=gen-cpp2' adsim_group/cpp2/server/dwarfs/Delay.h build/adsim/cpp2/server/dwarfs/Delay.h
+--- adsim_group/cpp2/server/dwarfs/Delay.h	2025-07-29 14:17:29.780277646 -0700
 +++ build/adsim/cpp2/server/dwarfs/Delay.h	2025-07-25 15:55:10.016889980 -0700
 @@ -18,8 +18,8 @@
  
@@ -207,10 +207,10 @@ diff -wbBdu -ruN '--exclude=.git' '--exclude=*.rej' '--exclude=*.orig' '--exclud
  
  #include <fb303/ThreadCachedServiceData.h>
  #include <folly/coro/Task.h>
-diff -wbBdu -ruN '--exclude=.git' '--exclude=*.rej' '--exclude=*.orig' '--exclude=gen-cpp2' adsim/cpp2/server/dwarfs/Dwarfs.cc build/adsim/cpp2/server/dwarfs/Dwarfs.cc
---- adsim/cpp2/server/dwarfs/Dwarfs.cc	2025-07-28 12:08:37.414788797 -0700
-+++ build/adsim/cpp2/server/dwarfs/Dwarfs.cc	2025-07-25 15:57:48.883604643 -0700
-@@ -19,18 +19,18 @@
+diff -wbBdu -ruN '--exclude=.git' '--exclude=*.rej' '--exclude=*.orig' '--exclude=gen-cpp2' adsim_group/cpp2/server/dwarfs/Dwarfs.cc build/adsim/cpp2/server/dwarfs/Dwarfs.cc
+--- adsim_group/cpp2/server/dwarfs/Dwarfs.cc	2025-07-29 14:17:29.780712845 -0700
++++ build/adsim/cpp2/server/dwarfs/Dwarfs.cc	2025-07-29 03:22:28.989646826 -0700
+@@ -19,19 +19,19 @@
  #include <folly/MapUtil.h>
  #include <folly/dynamic.h>
  
@@ -226,6 +226,7 @@ diff -wbBdu -ruN '--exclude=.git' '--exclude=*.rej' '--exclude=*.orig' '--exclud
 -#include <cea/chips/adsim/cpp2/server/dwarfs/Kernel.h>
 -#include <cea/chips/adsim/cpp2/server/dwarfs/Serialize.h>
 -#include <cea/chips/adsim/cpp2/server/dwarfs/Shape.h>
+-#include <cea/chips/adsim/cpp2/server/dwarfs/TensorDeser.h>
 +#include "Compress.h"
 +#include "ConcurrentHashMap.h"
 +#include "DeepCopy.h"
@@ -238,11 +239,12 @@ diff -wbBdu -ruN '--exclude=.git' '--exclude=*.rej' '--exclude=*.orig' '--exclud
 +#include "Kernel.h"
 +#include "Serialize.h"
 +#include "Shape.h"
++#include "TensorDeser.h"
  
  namespace facebook::cea::chips::adsim {
  
-diff -wbBdu -ruN '--exclude=.git' '--exclude=*.rej' '--exclude=*.orig' '--exclude=gen-cpp2' adsim/cpp2/server/dwarfs/Dwarfs.h build/adsim/cpp2/server/dwarfs/Dwarfs.h
---- adsim/cpp2/server/dwarfs/Dwarfs.h	2025-07-28 12:08:37.415197876 -0700
+diff -wbBdu -ruN '--exclude=.git' '--exclude=*.rej' '--exclude=*.orig' '--exclude=gen-cpp2' adsim_group/cpp2/server/dwarfs/Dwarfs.h build/adsim/cpp2/server/dwarfs/Dwarfs.h
+--- adsim_group/cpp2/server/dwarfs/Dwarfs.h	2025-07-29 14:17:29.781173923 -0700
 +++ build/adsim/cpp2/server/dwarfs/Dwarfs.h	2025-07-25 15:55:10.019374336 -0700
 @@ -19,9 +19,9 @@
  #include <string>
@@ -256,8 +258,8 @@ diff -wbBdu -ruN '--exclude=.git' '--exclude=*.rej' '--exclude=*.orig' '--exclud
  
  namespace facebook::cea::chips::adsim {
  
-diff -wbBdu -ruN '--exclude=.git' '--exclude=*.rej' '--exclude=*.orig' '--exclude=gen-cpp2' adsim/cpp2/server/dwarfs/FakeIO.h build/adsim/cpp2/server/dwarfs/FakeIO.h
---- adsim/cpp2/server/dwarfs/FakeIO.h	2025-07-28 12:08:37.415633616 -0700
+diff -wbBdu -ruN '--exclude=.git' '--exclude=*.rej' '--exclude=*.orig' '--exclude=gen-cpp2' adsim_group/cpp2/server/dwarfs/FakeIO.h build/adsim/cpp2/server/dwarfs/FakeIO.h
+--- adsim_group/cpp2/server/dwarfs/FakeIO.h	2025-07-29 14:17:29.781695752 -0700
 +++ build/adsim/cpp2/server/dwarfs/FakeIO.h	2025-07-25 15:55:10.020115056 -0700
 @@ -18,8 +18,8 @@
  
@@ -270,8 +272,8 @@ diff -wbBdu -ruN '--exclude=.git' '--exclude=*.rej' '--exclude=*.orig' '--exclud
  
  #include <fb303/ThreadCachedServiceData.h>
  #include <folly/coro/Task.h>
-diff -wbBdu -ruN '--exclude=.git' '--exclude=*.rej' '--exclude=*.orig' '--exclude=gen-cpp2' adsim/cpp2/server/dwarfs/GEMM.cc build/adsim/cpp2/server/dwarfs/GEMM.cc
---- adsim/cpp2/server/dwarfs/GEMM.cc	2025-07-28 12:08:37.416049855 -0700
+diff -wbBdu -ruN '--exclude=.git' '--exclude=*.rej' '--exclude=*.orig' '--exclude=gen-cpp2' adsim_group/cpp2/server/dwarfs/GEMM.cc build/adsim/cpp2/server/dwarfs/GEMM.cc
+--- adsim_group/cpp2/server/dwarfs/GEMM.cc	2025-07-29 14:17:29.782197962 -0700
 +++ build/adsim/cpp2/server/dwarfs/GEMM.cc	2025-07-25 15:55:10.020712910 -0700
 @@ -22,17 +22,21 @@
  #include <glog/logging.h>
@@ -297,8 +299,8 @@ diff -wbBdu -ruN '--exclude=.git' '--exclude=*.rej' '--exclude=*.orig' '--exclud
  
  using namespace std;
  using namespace fbgemm;
-diff -wbBdu -ruN '--exclude=.git' '--exclude=*.rej' '--exclude=*.orig' '--exclude=gen-cpp2' adsim/cpp2/server/dwarfs/GEMM.h build/adsim/cpp2/server/dwarfs/GEMM.h
---- adsim/cpp2/server/dwarfs/GEMM.h	2025-07-28 12:08:37.416462089 -0700
+diff -wbBdu -ruN '--exclude=.git' '--exclude=*.rej' '--exclude=*.orig' '--exclude=gen-cpp2' adsim_group/cpp2/server/dwarfs/GEMM.h build/adsim/cpp2/server/dwarfs/GEMM.h
+--- adsim_group/cpp2/server/dwarfs/GEMM.h	2025-07-29 14:17:29.782715055 -0700
 +++ build/adsim/cpp2/server/dwarfs/GEMM.h	2025-07-25 15:55:10.021362522 -0700
 @@ -22,8 +22,8 @@
  
@@ -311,8 +313,8 @@ diff -wbBdu -ruN '--exclude=.git' '--exclude=*.rej' '--exclude=*.orig' '--exclud
  
  #include <fb303/ThreadCachedServiceData.h>
  #include <folly/coro/Collect.h>
-diff -wbBdu -ruN '--exclude=.git' '--exclude=*.rej' '--exclude=*.orig' '--exclude=gen-cpp2' adsim/cpp2/server/dwarfs/HashMap.cc build/adsim/cpp2/server/dwarfs/HashMap.cc
---- adsim/cpp2/server/dwarfs/HashMap.cc	2025-07-28 12:08:37.416948243 -0700
+diff -wbBdu -ruN '--exclude=.git' '--exclude=*.rej' '--exclude=*.orig' '--exclude=gen-cpp2' adsim_group/cpp2/server/dwarfs/HashMap.cc build/adsim/cpp2/server/dwarfs/HashMap.cc
+--- adsim_group/cpp2/server/dwarfs/HashMap.cc	2025-07-29 14:17:29.783274811 -0700
 +++ build/adsim/cpp2/server/dwarfs/HashMap.cc	2025-07-25 15:55:10.022044754 -0700
 @@ -14,7 +14,7 @@
   * limitations under the License.
@@ -323,8 +325,8 @@ diff -wbBdu -ruN '--exclude=.git' '--exclude=*.rej' '--exclude=*.orig' '--exclud
  
  #include <fb303/ThreadCachedServiceData.h>
  
-diff -wbBdu -ruN '--exclude=.git' '--exclude=*.rej' '--exclude=*.orig' '--exclude=gen-cpp2' adsim/cpp2/server/dwarfs/HashMap.h build/adsim/cpp2/server/dwarfs/HashMap.h
---- adsim/cpp2/server/dwarfs/HashMap.h	2025-07-28 12:08:37.417373798 -0700
+diff -wbBdu -ruN '--exclude=.git' '--exclude=*.rej' '--exclude=*.orig' '--exclude=gen-cpp2' adsim_group/cpp2/server/dwarfs/HashMap.h build/adsim/cpp2/server/dwarfs/HashMap.h
+--- adsim_group/cpp2/server/dwarfs/HashMap.h	2025-07-29 14:17:29.783789461 -0700
 +++ build/adsim/cpp2/server/dwarfs/HashMap.h	2025-07-25 15:55:10.022653935 -0700
 @@ -24,8 +24,8 @@
  #include <unordered_map>
@@ -337,8 +339,8 @@ diff -wbBdu -ruN '--exclude=.git' '--exclude=*.rej' '--exclude=*.orig' '--exclud
  
  #include <folly/Synchronized.h>
  #include <folly/container/F14Map.h>
-diff -wbBdu -ruN '--exclude=.git' '--exclude=*.rej' '--exclude=*.orig' '--exclude=gen-cpp2' adsim/cpp2/server/dwarfs/IBRun.h build/adsim/cpp2/server/dwarfs/IBRun.h
---- adsim/cpp2/server/dwarfs/IBRun.h	2025-07-28 12:08:37.417779992 -0700
+diff -wbBdu -ruN '--exclude=.git' '--exclude=*.rej' '--exclude=*.orig' '--exclude=gen-cpp2' adsim_group/cpp2/server/dwarfs/IBRun.h build/adsim/cpp2/server/dwarfs/IBRun.h
+--- adsim_group/cpp2/server/dwarfs/IBRun.h	2025-07-29 14:17:29.784390450 -0700
 +++ build/adsim/cpp2/server/dwarfs/IBRun.h	2025-07-25 15:55:10.023200492 -0700
 @@ -16,9 +16,9 @@
  
@@ -353,8 +355,8 @@ diff -wbBdu -ruN '--exclude=.git' '--exclude=*.rej' '--exclude=*.orig' '--exclud
  
  #include <folly/coro/Task.h>
  
-diff -wbBdu -ruN '--exclude=.git' '--exclude=*.rej' '--exclude=*.orig' '--exclude=gen-cpp2' adsim/cpp2/server/dwarfs/icache_buster/gen_icache_buster.py build/adsim/cpp2/server/dwarfs/icache_buster/gen_icache_buster.py
---- adsim/cpp2/server/dwarfs/icache_buster/gen_icache_buster.py	2025-07-28 12:08:37.410741445 -0700
+diff -wbBdu -ruN '--exclude=.git' '--exclude=*.rej' '--exclude=*.orig' '--exclude=gen-cpp2' adsim_group/cpp2/server/dwarfs/icache_buster/gen_icache_buster.py build/adsim/cpp2/server/dwarfs/icache_buster/gen_icache_buster.py
+--- adsim_group/cpp2/server/dwarfs/icache_buster/gen_icache_buster.py	2025-07-29 14:17:29.776967347 -0700
 +++ build/adsim/cpp2/server/dwarfs/icache_buster/gen_icache_buster.py	2025-07-25 15:55:10.023937655 -0700
 @@ -14,8 +14,6 @@
  # See the License for the specific language governing permissions and
@@ -365,8 +367,8 @@ diff -wbBdu -ruN '--exclude=.git' '--exclude=*.rej' '--exclude=*.orig' '--exclud
  """Module to split file into multiple segments."""
  
  import argparse
-diff -wbBdu -ruN '--exclude=.git' '--exclude=*.rej' '--exclude=*.orig' '--exclude=gen-cpp2' adsim/cpp2/server/dwarfs/Kernel.cc build/adsim/cpp2/server/dwarfs/Kernel.cc
---- adsim/cpp2/server/dwarfs/Kernel.cc	2025-07-28 12:08:37.418280539 -0700
+diff -wbBdu -ruN '--exclude=.git' '--exclude=*.rej' '--exclude=*.orig' '--exclude=gen-cpp2' adsim_group/cpp2/server/dwarfs/Kernel.cc build/adsim/cpp2/server/dwarfs/Kernel.cc
+--- adsim_group/cpp2/server/dwarfs/Kernel.cc	2025-07-29 14:17:29.784831819 -0700
 +++ build/adsim/cpp2/server/dwarfs/Kernel.cc	2025-07-25 16:37:11.073788021 -0700
 @@ -20,7 +20,7 @@
  #include <fb303/ExportType.h>
@@ -377,8 +379,8 @@ diff -wbBdu -ruN '--exclude=.git' '--exclude=*.rej' '--exclude=*.orig' '--exclud
  
  namespace facebook::cea::chips::adsim {
  
-diff -wbBdu -ruN '--exclude=.git' '--exclude=*.rej' '--exclude=*.orig' '--exclude=gen-cpp2' adsim/cpp2/server/dwarfs/Kernel.h build/adsim/cpp2/server/dwarfs/Kernel.h
---- adsim/cpp2/server/dwarfs/Kernel.h	2025-07-28 12:08:37.418808267 -0700
+diff -wbBdu -ruN '--exclude=.git' '--exclude=*.rej' '--exclude=*.orig' '--exclude=gen-cpp2' adsim_group/cpp2/server/dwarfs/Kernel.h build/adsim/cpp2/server/dwarfs/Kernel.h
+--- adsim_group/cpp2/server/dwarfs/Kernel.h	2025-07-29 14:17:29.785257753 -0700
 +++ build/adsim/cpp2/server/dwarfs/Kernel.h	2025-07-25 15:55:10.025158201 -0700
 @@ -21,10 +21,10 @@
  #include <unordered_map>
@@ -393,8 +395,8 @@ diff -wbBdu -ruN '--exclude=.git' '--exclude=*.rej' '--exclude=*.orig' '--exclud
  
  namespace facebook::cea::chips::adsim {
  
-diff -wbBdu -ruN '--exclude=.git' '--exclude=*.rej' '--exclude=*.orig' '--exclude=gen-cpp2' adsim/cpp2/server/dwarfs/Serialize.h build/adsim/cpp2/server/dwarfs/Serialize.h
---- adsim/cpp2/server/dwarfs/Serialize.h	2025-07-28 12:08:37.419346141 -0700
+diff -wbBdu -ruN '--exclude=.git' '--exclude=*.rej' '--exclude=*.orig' '--exclude=gen-cpp2' adsim_group/cpp2/server/dwarfs/Serialize.h build/adsim/cpp2/server/dwarfs/Serialize.h
+--- adsim_group/cpp2/server/dwarfs/Serialize.h	2025-07-29 14:17:29.785666401 -0700
 +++ build/adsim/cpp2/server/dwarfs/Serialize.h	2025-07-25 15:55:10.025830557 -0700
 @@ -20,15 +20,15 @@
  
@@ -415,8 +417,8 @@ diff -wbBdu -ruN '--exclude=.git' '--exclude=*.rej' '--exclude=*.orig' '--exclud
  
  namespace facebook::cea::chips::adsim {
  
-diff -wbBdu -ruN '--exclude=.git' '--exclude=*.rej' '--exclude=*.orig' '--exclude=gen-cpp2' adsim/cpp2/server/dwarfs/Shape.h build/adsim/cpp2/server/dwarfs/Shape.h
---- adsim/cpp2/server/dwarfs/Shape.h	2025-07-28 12:08:37.419914901 -0700
+diff -wbBdu -ruN '--exclude=.git' '--exclude=*.rej' '--exclude=*.orig' '--exclude=gen-cpp2' adsim_group/cpp2/server/dwarfs/Shape.h build/adsim/cpp2/server/dwarfs/Shape.h
+--- adsim_group/cpp2/server/dwarfs/Shape.h	2025-07-29 14:17:29.786140568 -0700
 +++ build/adsim/cpp2/server/dwarfs/Shape.h	2025-07-25 15:55:10.026656306 -0700
 @@ -16,10 +16,10 @@
  
@@ -433,8 +435,34 @@ diff -wbBdu -ruN '--exclude=.git' '--exclude=*.rej' '--exclude=*.orig' '--exclud
  
  #include <fb303/ThreadCachedServiceData.h>
  #include <folly/MoveWrapper.h>
-diff -wbBdu -ruN '--exclude=.git' '--exclude=*.rej' '--exclude=*.orig' '--exclude=gen-cpp2' adsim/if/AdSim.thrift build/adsim/if/AdSim.thrift
---- adsim/if/AdSim.thrift	2025-07-28 12:08:37.424502511 -0700
+diff -wbBdu -ruN '--exclude=.git' '--exclude=*.rej' '--exclude=*.orig' '--exclude=gen-cpp2' adsim_group/cpp2/server/dwarfs/TensorDeser.cc build/adsim/cpp2/server/dwarfs/TensorDeser.cc
+--- adsim_group/cpp2/server/dwarfs/TensorDeser.cc	2025-07-29 14:17:29.786570039 -0700
++++ build/adsim/cpp2/server/dwarfs/TensorDeser.cc	2025-07-29 03:10:24.727445630 -0700
+@@ -14,7 +14,7 @@
+  * limitations under the License.
+  */
+ 
+-#include <cea/chips/adsim/cpp2/server/dwarfs/TensorDeser.h>
++#include "TensorDeser.h"
+ #include <cstring>
+ #include <iomanip>
+ #include <iostream>
+diff -wbBdu -ruN '--exclude=.git' '--exclude=*.rej' '--exclude=*.orig' '--exclude=gen-cpp2' adsim_group/cpp2/server/dwarfs/TensorDeser.h build/adsim/cpp2/server/dwarfs/TensorDeser.h
+--- adsim_group/cpp2/server/dwarfs/TensorDeser.h	2025-07-29 14:17:29.787024406 -0700
++++ build/adsim/cpp2/server/dwarfs/TensorDeser.h	2025-07-29 03:10:09.858016018 -0700
+@@ -30,8 +30,8 @@
+ #include <tuple>
+ #include <vector>
+ 
+-#include <cea/chips/adsim/cpp2/server/DataObjects.h>
+-#include <cea/chips/adsim/cpp2/server/dwarfs/Kernel.h>
++#include "cpp2/server/DataObjects.h"
++#include "cpp2/server/dwarfs/Kernel.h"
+ 
+ #include <folly/FileUtil.h>
+ #include <folly/Format.h>
+diff -wbBdu -ruN '--exclude=.git' '--exclude=*.rej' '--exclude=*.orig' '--exclude=gen-cpp2' adsim_group/if/AdSim.thrift build/adsim/if/AdSim.thrift
+--- adsim_group/if/AdSim.thrift	2025-07-29 14:17:29.792097453 -0700
 +++ build/adsim/if/AdSim.thrift	2025-07-25 15:55:10.027410947 -0700
 @@ -1,4 +1,4 @@
 -include "common/fb303/if/fb303.thrift"
@@ -442,8 +470,8 @@ diff -wbBdu -ruN '--exclude=.git' '--exclude=*.rej' '--exclude=*.orig' '--exclud
  
  namespace cpp2 facebook.cea.chips.adsim
  namespace py3 facebook.cea.chips.adsim
-diff -wbBdu -ruN '--exclude=.git' '--exclude=*.rej' '--exclude=*.orig' '--exclude=gen-cpp2' adsim/if/Serialize.thrift build/adsim/if/Serialize.thrift
---- adsim/if/Serialize.thrift	2025-07-28 12:08:37.425347058 -0700
+diff -wbBdu -ruN '--exclude=.git' '--exclude=*.rej' '--exclude=*.orig' '--exclude=gen-cpp2' adsim_group/if/Serialize.thrift build/adsim/if/Serialize.thrift
+--- adsim_group/if/Serialize.thrift	2025-07-29 14:17:29.792879556 -0700
 +++ build/adsim/if/Serialize.thrift	2025-07-25 15:55:10.028022061 -0700
 @@ -3,20 +3,15 @@
  cpp_include "list"

--- a/packages/adsim/src/CMake/FindAtomic.cmake
+++ b/packages/adsim/src/CMake/FindAtomic.cmake
@@ -1,0 +1,80 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# Find libatomic library.
+# libatomic provides runtime support for atomic operations that cannot be
+# implemented directly by the processor (e.g., 64-bit atomics on 32-bit systems).
+#
+# This module defines the following variables:
+#  ATOMIC_FOUND       - True if libatomic found.
+#  ATOMIC_LIBRARY     - Path to the libatomic library.
+#  ATOMIC_LIBRARIES   - List of libraries when using libatomic.
+#
+# This module also defines the following imported target:
+#  Atomic::Atomic     - The libatomic library target.
+
+# Detect target architecture
+if(CMAKE_SYSTEM_PROCESSOR MATCHES "^(aarch64|arm64)")
+    set(_ATOMIC_ARCH "aarch64")
+    set(_ATOMIC_MULTIARCH "aarch64-linux-gnu")
+elseif(CMAKE_SYSTEM_PROCESSOR MATCHES "^(x86_64|amd64)")
+    set(_ATOMIC_ARCH "x86_64")
+    set(_ATOMIC_MULTIARCH "x86_64-linux-gnu")
+else()
+    set(_ATOMIC_ARCH ${CMAKE_SYSTEM_PROCESSOR})
+    set(_ATOMIC_MULTIARCH "${CMAKE_SYSTEM_PROCESSOR}-linux-gnu")
+endif()
+
+# Look for the library in standard locations
+find_library(ATOMIC_LIBRARY
+    NAMES atomic
+    HINTS
+        # GCC toolset paths (architecture-specific)
+        /opt/rh/gcc-toolset-14/root/usr/lib/gcc/${_ATOMIC_ARCH}-redhat-linux/14
+        /opt/rh/gcc-toolset-13/root/usr/lib/gcc/${_ATOMIC_ARCH}-redhat-linux/13
+        /opt/rh/gcc-toolset-12/root/usr/lib/gcc/${_ATOMIC_ARCH}-redhat-linux/12
+        # System GCC paths
+        /usr/lib/gcc/${_ATOMIC_ARCH}-redhat-linux/14
+        /usr/lib/gcc/${_ATOMIC_ARCH}-redhat-linux/13
+        /usr/lib/gcc/${_ATOMIC_ARCH}-redhat-linux/12
+        /usr/lib/gcc/${_ATOMIC_ARCH}-redhat-linux/11
+        # Standard system library paths
+        /usr/lib64
+        /usr/lib
+        /usr/lib/${_ATOMIC_MULTIARCH}
+        /lib64
+        /lib
+    PATH_SUFFIXES
+        # Additional suffixes for different distributions
+        gcc/${_ATOMIC_ARCH}-linux-gnu/11
+        gcc/${_ATOMIC_ARCH}-linux-gnu/12
+        gcc/${_ATOMIC_ARCH}-linux-gnu/13
+        gcc/${_ATOMIC_ARCH}-linux-gnu/14
+    DOC "Path to libatomic library"
+)
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(Atomic
+    REQUIRED_VARS ATOMIC_LIBRARY
+    FAIL_MESSAGE "Could NOT find libatomic (missing: ATOMIC_LIBRARY)"
+)
+
+if(ATOMIC_FOUND)
+    set(ATOMIC_LIBRARIES ${ATOMIC_LIBRARY})
+
+    if(NOT TARGET Atomic::Atomic)
+        add_library(Atomic::Atomic UNKNOWN IMPORTED)
+        set_target_properties(Atomic::Atomic PROPERTIES
+            IMPORTED_LOCATION "${ATOMIC_LIBRARY}"
+        )
+    endif()
+
+    if(NOT Atomic_FIND_QUIETLY)
+        message(STATUS "Found libatomic: ${ATOMIC_LIBRARY}")
+    endif()
+else()
+    if(Atomic_FIND_REQUIRED)
+        message(FATAL_ERROR "Could NOT find required libatomic library")
+    endif()
+endif()
+
+mark_as_advanced(ATOMIC_LIBRARY)

--- a/packages/adsim/src/CMakeLists.txt
+++ b/packages/adsim/src/CMakeLists.txt
@@ -25,6 +25,7 @@ find_package(Threads REQUIRED)
 find_package(LibEvent REQUIRED)
 find_package(LibIberty REQUIRED)
 find_library(JEMALLOC_LIB NAMES jemalloc REQUIRED)
+find_package(Atomic REQUIRED)
 find_package(Boost 1.83.0
     COMPONENTS
         context

--- a/packages/adsim/src/cpp2/server/CMakeLists.txt
+++ b/packages/adsim/src/cpp2/server/CMakeLists.txt
@@ -24,8 +24,8 @@ target_link_libraries(server_handlers
         FBThrift::thriftcpp2
         Folly::folly)
 
-set(ATOMIC_LIB /usr/lib64/libatomic.so.1)
-add_executable(adsim_server AdSimServer.cpp)
+add_executable(adsim_server AdSimServer.cpp dwarfs/memwrap.cc)
+target_link_options(adsim_server PRIVATE "-Wl,--wrap=memcpy")
 target_link_libraries(adsim_server
     PUBLIC
         server_handlers
@@ -37,5 +37,6 @@ target_link_libraries(adsim_server
         fb303::fb303_thrift_cpp
         FBThrift::thriftcpp2
         Folly::folly
-        ${ATOMIC_LIB}
-        ${FMT_LIBRARIES})
+        Atomic::Atomic
+        ${FMT_LIBRARIES}
+        ${JEMALLOC_LIB})

--- a/packages/adsim/src/cpp2/server/dwarfs/CMakeLists.txt
+++ b/packages/adsim/src/cpp2/server/dwarfs/CMakeLists.txt
@@ -117,6 +117,12 @@ target_link_libraries(concurrenthashmap data_objects kernel)
 target_compile_options(concurrenthashmap PRIVATE ${COROUTINES_FLAG})
 
 
+
+add_library(tensordeser TensorDeser.cc TensorDeser.h)
+target_link_libraries(tensordeser data_objects kernel ${JEMALLOC_LIB})
+target_compile_options(tensordeser PRIVATE ${COROUTINES_FLAG})
+
+
 add_library(deepcopy DeepCopy.h)
 target_link_libraries(deepcopy data_objects kernel)
 target_compile_options(deepcopy PRIVATE ${COROUTINES_FLAG})
@@ -138,5 +144,6 @@ target_link_libraries(dwarfs
     hashmap
     ibrun
     serialize
-    shape)
+    shape
+    tensordeser)
 target_compile_options(dwarfs PRIVATE ${COROUTINES_FLAG})

--- a/packages/adsim/src/cpp2/server/dwarfs/Dwarfs.cc
+++ b/packages/adsim/src/cpp2/server/dwarfs/Dwarfs.cc
@@ -31,6 +31,7 @@
 #include <cea/chips/adsim/cpp2/server/dwarfs/Kernel.h>
 #include <cea/chips/adsim/cpp2/server/dwarfs/Serialize.h>
 #include <cea/chips/adsim/cpp2/server/dwarfs/Shape.h>
+#include <cea/chips/adsim/cpp2/server/dwarfs/TensorDeser.h>
 
 namespace facebook::cea::chips::adsim {
 
@@ -43,7 +44,7 @@ const folly::F14VectorMap<std::string, CONFIG_F> KERNEL_DICT = {
     {"Compress", Compress::config},
     {"Decompress", Decompress::config},
     {"Serialize", Serialize::config},
-    {"Deserialize", Deserialize::config},
+    {"TensorDeser", TensorDeser::config},
     {"HashMap", HashMap::config},
     {"ConcurrentHashMap", ConcurrentHashMap::config},
     {"DeepCopy", DeepCopy::config},

--- a/packages/adsim/src/cpp2/server/dwarfs/TensorDeser.cc
+++ b/packages/adsim/src/cpp2/server/dwarfs/TensorDeser.cc
@@ -1,0 +1,545 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <cea/chips/adsim/cpp2/server/dwarfs/TensorDeser.h>
+#include <cstring>
+#include <iomanip>
+#include <iostream>
+
+#include <fb303/ThreadCachedServiceData.h>
+#include <folly/executors/CPUThreadPoolExecutor.h>
+#include <folly/futures/Future.h>
+
+namespace facebook::cea::chips::adsim {
+
+DECLARE_timeseries(deserialize_nfired);
+
+/**
+ * Function to mimic loadTensor which takes an IOBuf as input
+ * Copies the IOBuf and calls coalesceWithHeadroomTailroom
+ */
+folly::IOBuf
+loadTensor(const folly::IOBuf& input, size_t headroom, size_t tailroom) {
+  folly::IOBuf data = input;
+  data.coalesceWithHeadroomTailroom(headroom, tailroom);
+  return data;
+}
+
+/**
+ * Utility functions
+ */
+namespace util {
+
+std::string formatByteSize(size_t bytes) {
+  constexpr double KB = 1024.0;
+  constexpr double MB = KB * 1024.0;
+  constexpr double GB = MB * 1024.0;
+
+  std::ostringstream oss;
+  oss << std::fixed << std::setprecision(2);
+
+  if (bytes < KB) {
+    oss << bytes << " bytes";
+  } else if (bytes < MB) {
+    oss << (bytes / KB) << " KB";
+  } else if (bytes < GB) {
+    oss << (bytes / MB) << " MB";
+  } else {
+    oss << (bytes / GB) << " GB";
+  }
+
+  return oss.str();
+}
+
+} // namespace util
+
+// DeserDistributionReader implementation
+std::optional<std::vector<IOBufChainDesc>> DeserDistributionReader::read()
+    const {
+  std::vector<IOBufChainDesc> distribution;
+  std::string content;
+
+  if (!folly::readFile(filePath_.data(), content)) {
+    std::cerr << "Error: Could not open distribution file: " << filePath_
+              << std::endl;
+    return std::nullopt;
+  }
+
+  std::vector<folly::StringPiece> lines;
+  folly::split('\n', content, lines);
+
+  for (const auto& line : lines) {
+    if (line.empty()) {
+      continue;
+    }
+
+    auto desc = parseLine(line);
+    if (desc) {
+      distribution.push_back(*desc);
+    }
+  }
+
+  return distribution;
+}
+
+std::optional<IOBufChainDesc> DeserDistributionReader::parseLine(
+    const folly::StringPiece line) const {
+  std::vector<folly::StringPiece> columns;
+  folly::split(',', line, columns);
+
+  if (columns.size() != 4) {
+    std::cerr << "Warning: Skipping invalid line (expected 4 columns): " << line
+              << std::endl;
+    return std::nullopt;
+  }
+
+  try {
+    IOBufChainDesc desc;
+    desc.frequency = folly::to<int>(columns[0]);
+    desc.headroom = folly::to<size_t>(columns[1]);
+    desc.tailroom = folly::to<size_t>(columns[2]);
+
+    if (!parseChainDescription(columns[3].str(), desc.chains)) {
+      std::cerr << "Warning: No valid chains found in line: " << line
+                << std::endl;
+      return std::nullopt;
+    }
+
+    return desc;
+  } catch (const std::exception& e) {
+    std::cerr << "Error parsing line: " << line << " - " << e.what()
+              << std::endl;
+    return std::nullopt;
+  }
+}
+
+bool DeserDistributionReader::parseChainDescription(
+    const std::string& chainStr,
+    std::vector<std::tuple<size_t, size_t, size_t>>& chains) const {
+  // Parse chain description format: {h:123|d:456|t:789}
+  size_t pos = 0;
+  while (pos < chainStr.length()) {
+    // Find opening brace
+    size_t start = chainStr.find('{', pos);
+    if (start == std::string::npos) {
+      break;
+    }
+
+    // Find closing brace
+    size_t end = chainStr.find('}', start);
+    if (end == std::string::npos) {
+      break;
+    }
+
+    // Extract the content between braces
+    std::string content = chainStr.substr(start + 1, end - start - 1);
+
+    // Parse h:value|d:value|t:value format
+    size_t h = 0, d = 0, t = 0;
+    std::vector<folly::StringPiece> parts;
+    folly::split('|', content, parts);
+
+    if (parts.size() == 3) {
+      try {
+        for (const auto& part : parts) {
+          std::vector<folly::StringPiece> keyValue;
+          folly::split(':', part, keyValue);
+          if (keyValue.size() == 2) {
+            if (keyValue[0] == "h") {
+              h = folly::to<size_t>(keyValue[1]);
+            } else if (keyValue[0] == "d") {
+              d = folly::to<size_t>(keyValue[1]);
+            } else if (keyValue[0] == "t") {
+              t = folly::to<size_t>(keyValue[1]);
+            }
+          }
+        }
+        chains.emplace_back(h, d, t);
+      } catch (const std::exception&) {
+        // Skip invalid entries
+      }
+    }
+
+    pos = end + 1;
+  }
+
+  return !chains.empty();
+}
+
+// DeserWorkloadGenerator::IOBufSampler implementation
+DeserWorkloadGenerator::IOBufSampler::IOBufSampler(
+    const std::vector<IOBufChainDesc>& distribution) {
+  if (distribution.empty()) {
+    return;
+  }
+
+  uint64_t totalFrequency = 0;
+  for (const auto& entry : distribution) {
+    totalFrequency += entry.frequency;
+  }
+
+  constexpr uint64_t maxEntries = 10000000;
+  uint64_t distributionSize = std::min(totalFrequency, maxEntries);
+
+  double scalingFactor = static_cast<double>(distributionSize) / totalFrequency;
+
+  accessDistribution_.reserve(distributionSize);
+
+  for (size_t i = 0; i < distribution.size(); ++i) {
+    const auto& entry = distribution[i];
+
+    uint64_t appearances =
+        static_cast<uint64_t>(entry.frequency * scalingFactor);
+
+    if (entry.frequency > 0 && appearances == 0) {
+      appearances = 1;
+    }
+
+    for (uint64_t j = 0; j < appearances; ++j) {
+      accessDistribution_.push_back(i);
+    }
+  }
+  std::random_shuffle(accessDistribution_.begin(), accessDistribution_.end());
+
+  distribution_ = distribution;
+
+  if (accessDistribution_.empty()) {
+    std::cerr << "Warning: Generated empty access distribution" << std::endl;
+  }
+}
+
+size_t DeserWorkloadGenerator::IOBufSampler::getRandomIOBufIndex(
+    std::mt19937& rng) const {
+  if (distribution_.empty() || accessDistribution_.empty()) {
+    return 0;
+  }
+
+  return getRandomIndex(rng);
+}
+
+size_t DeserWorkloadGenerator::IOBufSampler::numDescriptions() const {
+  return distribution_.size();
+}
+
+size_t DeserWorkloadGenerator::IOBufSampler::distributionSize() const {
+  return accessDistribution_.size();
+}
+
+size_t DeserWorkloadGenerator::IOBufSampler::getRandomIndex(
+    std::mt19937& rng) const {
+  size_t randomIdx = rng() % accessDistribution_.size();
+  return accessDistribution_[randomIdx];
+}
+
+// DeserWorkloadGenerator implementation
+DeserWorkloadGenerator::IOBufSampler
+DeserWorkloadGenerator::createIOBufSampler() const {
+  return IOBufSampler(distribution_);
+}
+
+std::unique_ptr<folly::IOBuf> DeserWorkloadGenerator::generateIOBufChain(
+    const IOBufChainDesc& desc) {
+  std::unique_ptr<folly::IOBuf> head;
+  folly::IOBuf* current = nullptr;
+
+  for (const auto& chain : desc.chains) {
+    size_t h = std::get<0>(chain);
+    size_t d = std::get<1>(chain);
+    size_t t = std::get<2>(chain);
+
+    auto buf = folly::IOBuf::create(h + d + t);
+    buf->reserve(0, h);
+    buf->append(d);
+
+    memset(buf->writableData(), 'A', d);
+
+    if (!head) {
+      head = std::move(buf);
+      current = head.get();
+    } else {
+      CHECK_NOTNULL(current)->appendChain(std::move(buf));
+      current = CHECK_NOTNULL(current->next());
+    }
+  }
+
+  return head;
+}
+
+std::vector<std::vector<IOBufInstance>>
+DeserWorkloadGenerator::pregenerateIOBufs(int numCopiesPerConfig) const {
+  if (distribution_.empty() || numCopiesPerConfig <= 0) {
+    std::cerr << "Warning: Empty distribution or invalid copy count"
+              << std::endl;
+    return {};
+  }
+
+  std::vector<std::vector<IOBufInstance>> result;
+  result.reserve(distribution_.size());
+
+  std::cout << "Pregenerating IOBufs for " << distribution_.size()
+            << " unique configurations..." << std::endl;
+
+  PregenerationStats stats = generateIOBufInstances(result, numCopiesPerConfig);
+  printPregenerationStats(stats, numCopiesPerConfig);
+
+  return result;
+}
+
+size_t DeserWorkloadGenerator::calculateIOBufSize(const folly::IOBuf& buf) {
+  size_t totalSize = 0;
+  const folly::IOBuf* current = &buf;
+
+  do {
+    totalSize += current->capacity();
+    current = current->next();
+  } while (current != &buf);
+
+  return totalSize;
+}
+
+DeserWorkloadGenerator::PregenerationStats
+DeserWorkloadGenerator::generateIOBufInstances(
+    std::vector<std::vector<IOBufInstance>>& result,
+    int numCopiesPerConfig) const {
+  PregenerationStats stats;
+
+  for (const auto& desc : distribution_) {
+    std::vector<IOBufInstance> instances;
+    instances.reserve(numCopiesPerConfig);
+    stats.totalConfigurations++;
+
+    for (int i = 0; i < numCopiesPerConfig; ++i) {
+      IOBufInstance instance;
+      instance.buf = generateIOBufChain(desc);
+      instance.headroom = desc.headroom;
+      instance.tailroom = desc.tailroom;
+
+      stats.totalMemoryBytes += calculateIOBufSize(*instance.buf);
+      stats.totalInstances++;
+
+      instances.push_back(std::move(instance));
+    }
+
+    result.push_back(std::move(instances));
+  }
+
+  return stats;
+}
+
+void DeserWorkloadGenerator::printPregenerationStats(
+    const PregenerationStats& stats,
+    int numCopiesPerConfig) const {
+  std::cout << "Pregeneration complete:" << std::endl;
+  std::cout << "- " << stats.totalConfigurations << " unique configurations"
+            << std::endl;
+  std::cout << "- " << stats.totalInstances << " total IOBuf instances ("
+            << numCopiesPerConfig << " copies each)" << std::endl;
+  std::cout << "- " << util::formatByteSize(stats.totalMemoryBytes)
+            << " total memory usage" << std::endl;
+}
+
+// TensorDeser kernel implementation
+TensorDeser::TensorDeser(
+    int requests_per_run,
+    int request_book_multiplier,
+    int num_threads,
+    std::string input_str,
+    std::string distribution_file)
+    : requests_per_run_(requests_per_run),
+      request_book_multiplier_(request_book_multiplier),
+      num_threads_(num_threads),
+      input_str_(std::move(input_str)),
+      distribution_file_(std::move(distribution_file)),
+      current_request_position_(0) {
+  LOG(INFO) << "TensorDeser initialized with params: " << "requests_per_run="
+            << requests_per_run_
+            << ", request_book_multiplier=" << request_book_multiplier_
+            << ", num_threads=" << num_threads_
+            << ", distribution_file=" << distribution_file_;
+}
+
+void TensorDeser::generatePregeneratedRequests(
+    const DeserWorkloadGenerator& generator,
+    const std::vector<IOBufChainDesc>& distribution) {
+  uint32_t dataset_size = static_cast<uint32_t>(distribution.size());
+  uint32_t request_book_size = request_book_multiplier_ * dataset_size;
+  pregenerated_requests_.clear();
+  pregenerated_requests_.reserve(request_book_size);
+
+  auto accessDistribution = generator.createIOBufSampler();
+
+  std::random_device rd;
+  std::mt19937 rng(rd());
+
+  for (uint32_t i = 0; i < request_book_size; ++i) {
+    size_t configIdx = accessDistribution.getRandomIOBufIndex(rng);
+    configIdx = std::min(configIdx, static_cast<size_t>(dataset_size - 1));
+    pregenerated_requests_.push_back(static_cast<uint32_t>(configIdx));
+  }
+
+  LOG(INFO) << "Generated request book: " << request_book_size
+            << " requests from " << dataset_size << " configurations";
+}
+
+std::string TensorDeser::init(
+    std::shared_ptr<AdSimHandleObjs> h_objs,
+    std::shared_ptr<AdSimRequestObjs> /*unused*/) {
+  size_t total_configs = 0;
+
+  DeserDistributionReader reader(distribution_file_);
+  auto distributionOpt = reader.read();
+  if (!distributionOpt || distributionOpt->empty()) {
+    throw std::runtime_error(
+        "Failed to read distribution file: " + distribution_file_);
+  }
+
+  DeserWorkloadGenerator generator(*distributionOpt);
+  total_configs = distributionOpt->size();
+
+  auto pregeneratedIOBufs =
+      generator.pregenerateIOBufs(request_book_multiplier_);
+  h_objs->set_shared_ptr(
+      input_str_,
+      std::make_shared<std::vector<std::vector<IOBufInstance>>>(
+          std::move(pregeneratedIOBufs)));
+
+  generatePregeneratedRequests(generator, *distributionOpt);
+
+  LOG(INFO) << "Distribution loaded: " << distributionOpt->size()
+            << " configurations";
+
+  std::string info = folly::to<std::string>(
+      "TensorDeser: ",
+      input_str_,
+      " ",
+      std::to_string(total_configs),
+      " configs");
+  info += " (distribution: " + distribution_file_ + ")";
+  info += " (pregenerated " + std::to_string(pregenerated_requests_.size()) +
+      " requests)";
+  return info;
+}
+
+int TensorDeser::deserialize_operation(
+    std::shared_ptr<AdSimHandleObjs> h_objs) {
+  auto pregeneratedIOBufs =
+      h_objs->get_shared_ptr<std::vector<std::vector<IOBufInstance>>>(
+          input_str_);
+  int x = 0;
+
+  uint32_t start_pos = current_request_position_.fetch_add(requests_per_run_) %
+      pregenerated_requests_.size();
+
+  for (uint32_t i = 0; i < requests_per_run_; ++i) {
+    uint32_t pos = (start_pos + i) % pregenerated_requests_.size();
+    uint32_t configIdx = pregenerated_requests_[pos];
+
+    if (configIdx >= pregeneratedIOBufs->size()) {
+      continue;
+    }
+
+    const auto& instances = (*pregeneratedIOBufs)[configIdx];
+    if (instances.empty()) {
+      continue;
+    }
+
+    size_t instanceIdx = i % instances.size();
+    const auto& instance = instances[instanceIdx];
+
+    auto result =
+        loadTensor(*instance.buf, instance.headroom, instance.tailroom);
+    x ^= static_cast<int>(result.length());
+  }
+
+  return x;
+}
+
+folly::coro::Task<int> TensorDeser::concurrent_deserialize_operation(
+    std::shared_ptr<AdSimHandleObjs> h_objs,
+    std::shared_ptr<folly::Executor> pool) {
+  auto pregeneratedIOBufs =
+      h_objs->get_shared_ptr<std::vector<std::vector<IOBufInstance>>>(
+          input_str_);
+
+  uint32_t start_pos = current_request_position_.fetch_add(requests_per_run_) %
+      pregenerated_requests_.size();
+
+  std::vector<folly::Future<int>> futures;
+  uint32_t requests_per_thread = requests_per_run_ / num_threads_;
+
+  for (int t = 0; t < num_threads_; ++t) {
+    uint32_t thread_start = t * requests_per_thread;
+    uint32_t thread_end = (t == num_threads_ - 1)
+        ? requests_per_run_
+        : (t + 1) * requests_per_thread;
+
+    auto future = folly::via(
+        pool.get(),
+        [this, pregeneratedIOBufs, start_pos, thread_start, thread_end]() {
+          int x = 0;
+          for (uint32_t i = thread_start; i < thread_end; ++i) {
+            uint32_t pos = (start_pos + i) % pregenerated_requests_.size();
+            uint32_t configIdx = pregenerated_requests_[pos];
+
+            if (configIdx >= pregeneratedIOBufs->size()) {
+              continue;
+            }
+
+            const auto& instances = (*pregeneratedIOBufs)[configIdx];
+            if (instances.empty()) {
+              continue;
+            }
+
+            size_t instanceIdx = i % instances.size();
+            const auto& instance = instances[instanceIdx];
+
+            auto result =
+                loadTensor(*instance.buf, instance.headroom, instance.tailroom);
+            x ^= static_cast<int>(result.length());
+          }
+          return x;
+        });
+    futures.push_back(std::move(future));
+  }
+
+  auto results = co_await folly::collectAll(futures);
+  int final_result = 0;
+  for (auto& result : results) {
+    if (result.hasValue()) {
+      final_result ^= result.value();
+    }
+  }
+
+  co_return final_result;
+}
+
+folly::coro::Task<std::string> TensorDeser::fire(
+    std::shared_ptr<AdSimHandleObjs> h_objs,
+    std::shared_ptr<AdSimRequestObjs> /*r_objs*/,
+    std::shared_ptr<folly::Executor> pool) {
+  STATS_deserialize_nfired.add(1);
+
+  if (num_threads_ > 1 && pool) {
+    co_await concurrent_deserialize_operation(
+        std::move(h_objs), std::move(pool));
+  } else {
+    deserialize_operation(std::move(h_objs));
+  }
+
+  co_return "";
+}
+
+} // namespace facebook::cea::chips::adsim

--- a/packages/adsim/src/cpp2/server/dwarfs/TensorDeser.h
+++ b/packages/adsim/src/cpp2/server/dwarfs/TensorDeser.h
@@ -1,0 +1,206 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <unistd.h>
+
+#include <algorithm>
+#include <array>
+#include <atomic>
+#include <fstream>
+#include <memory>
+#include <optional>
+#include <random>
+#include <sstream>
+#include <string>
+#include <tuple>
+#include <vector>
+
+#include <cea/chips/adsim/cpp2/server/DataObjects.h>
+#include <cea/chips/adsim/cpp2/server/dwarfs/Kernel.h>
+
+#include <folly/FileUtil.h>
+#include <folly/Format.h>
+#include <folly/Portability.h>
+#include <folly/Range.h>
+#include <folly/String.h>
+#include <folly/coro/Task.h>
+#include <folly/io/IOBuf.h>
+
+namespace facebook::cea::chips::adsim {
+
+/**
+ * Structure to hold IOBuf chain description from the distribution file
+ */
+struct IOBufChainDesc {
+  int frequency{};
+  size_t headroom{};
+  size_t tailroom{};
+  std::vector<std::tuple<size_t, size_t, size_t>> chains; // (h, d, t)
+};
+
+/**
+ * Structure to hold a pregenerated IOBuf and its associated parameters
+ */
+struct IOBufInstance {
+  std::unique_ptr<folly::IOBuf> buf;
+  size_t headroom{};
+  size_t tailroom{};
+};
+
+/**
+ * DistributionReader: Parses the distribution file into IOBufChainDesc objects
+ * Format: frequency,headroom,tailroom,chain_description
+ */
+class DeserDistributionReader {
+ public:
+  explicit DeserDistributionReader(std::string_view filePath)
+      : filePath_(filePath) {}
+
+  std::optional<std::vector<IOBufChainDesc>> read() const;
+
+ private:
+  std::optional<IOBufChainDesc> parseLine(const folly::StringPiece line) const;
+
+  bool parseChainDescription(
+      const std::string& chainStr,
+      std::vector<std::tuple<size_t, size_t, size_t>>& chains) const;
+
+  std::string_view filePath_;
+};
+
+/**
+ * Workload generator class for deserialization
+ * Responsible for creating IOBuf instances based on the distribution
+ */
+class DeserWorkloadGenerator {
+ public:
+  /**
+   * IOBufSampler: Fast sampler for frequency-based random IOBuf selection
+   * Uses O(1) lookup for maximum performance at the cost of higher memory usage
+   */
+  class IOBufSampler {
+   public:
+    explicit IOBufSampler(const std::vector<IOBufChainDesc>& distribution);
+
+    size_t getRandomIOBufIndex(std::mt19937& rng) const;
+    size_t numDescriptions() const;
+    size_t distributionSize() const;
+
+   private:
+    size_t getRandomIndex(std::mt19937& rng) const;
+
+    std::vector<size_t> accessDistribution_;
+    std::vector<IOBufChainDesc> distribution_;
+  };
+
+  explicit DeserWorkloadGenerator(
+      const std::vector<IOBufChainDesc>& distribution)
+      : distribution_(distribution) {}
+
+  IOBufSampler createIOBufSampler() const;
+  static std::unique_ptr<folly::IOBuf> generateIOBufChain(
+      const IOBufChainDesc& desc);
+  std::vector<std::vector<IOBufInstance>> pregenerateIOBufs(
+      int numCopiesPerConfig) const;
+
+ private:
+  struct PregenerationStats {
+    size_t totalConfigurations{0};
+    size_t totalInstances{0};
+    size_t totalMemoryBytes{0};
+  };
+
+  static size_t calculateIOBufSize(const folly::IOBuf& buf);
+  PregenerationStats generateIOBufInstances(
+      std::vector<std::vector<IOBufInstance>>& result,
+      int numCopiesPerConfig) const;
+  void printPregenerationStats(
+      const PregenerationStats& stats,
+      int numCopiesPerConfig) const;
+
+  const std::vector<IOBufChainDesc>& distribution_;
+};
+
+/**
+ * Function to mimic loadTensor which takes an IOBuf as input
+ * Copies the IOBuf and calls coalesceWithHeadroomTailroom
+ */
+folly::IOBuf
+loadTensor(const folly::IOBuf& input, size_t headroom, size_t tailroom);
+
+/* A kernel that performs tensor deserialization operations intensively */
+class TensorDeser : public Kernel {
+ public:
+  explicit TensorDeser(
+      int requests_per_run,
+      int request_book_multiplier,
+      int num_threads,
+      std::string input_str,
+      std::string distribution_file);
+
+  std::string init(
+      std::shared_ptr<AdSimHandleObjs> h_objs,
+      std::shared_ptr<AdSimRequestObjs> r_objs = nullptr) override;
+
+  folly::coro::Task<std::string> fire(
+      std::shared_ptr<AdSimHandleObjs> h_objs,
+      std::shared_ptr<AdSimRequestObjs> r_objs,
+      std::shared_ptr<folly::Executor> pool) override;
+
+  static std::shared_ptr<Kernel> config(const folly::dynamic& config_d) {
+    int requests_per_run =
+        static_cast<int>(config_d["requests_per_run"].asInt());
+    int request_book_multiplier = config_d.count("request_book_multiplier")
+        ? static_cast<int>(config_d["request_book_multiplier"].asInt())
+        : 10;
+    int num_threads = config_d.count("num_threads")
+        ? static_cast<int>(config_d["num_threads"].asInt())
+        : 4;
+    std::string input_str = "TensorDeser";
+    if (config_d.count("input")) {
+      input_str = config_d["input"].asString();
+    }
+    std::string distribution_file = config_d["distribution_file"].asString();
+    return std::make_shared<TensorDeser>(
+        requests_per_run,
+        request_book_multiplier,
+        num_threads,
+        input_str,
+        distribution_file);
+  }
+
+ private:
+  int requests_per_run_;
+  int request_book_multiplier_;
+  int num_threads_;
+  std::string input_str_;
+  std::string distribution_file_;
+  std::vector<uint32_t> pregenerated_requests_;
+  mutable std::atomic<uint32_t> current_request_position_;
+
+  void generatePregeneratedRequests(
+      const DeserWorkloadGenerator& generator,
+      const std::vector<IOBufChainDesc>& distribution);
+
+  int deserialize_operation(std::shared_ptr<AdSimHandleObjs> h_objs);
+  folly::coro::Task<int> concurrent_deserialize_operation(
+      std::shared_ptr<AdSimHandleObjs> h_objs,
+      std::shared_ptr<folly::Executor> pool);
+};
+
+} // namespace facebook::cea::chips::adsim

--- a/packages/adsim/src/cpp2/server/dwarfs/memwrap.cc
+++ b/packages/adsim/src/cpp2/server/dwarfs/memwrap.cc
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <cstddef>
+
+extern "C" void* __folly_memcpy(void* dest, const void* src, size_t n);
+
+extern "C" void* __wrap_memcpy(void* dest, const void* src, size_t n) {
+  return __folly_memcpy(dest, src, n);
+}


### PR DESCRIPTION
Summary:
### Summary

#### Add tensor deserialization kernel into Adsim

This diff adds a new tensor deserialization kernel into the Adsim system. The changes include:

*   Adding a new library `tensordeser` to the `dwarfs` directory, which includes the `TensorDeser.cc` and `TensorDeser.h` files.
*   Updating the `CMakeLists.txt` files in the `dwarfs` and `server` directories to include the new library and link it to the `adsim_server` executable.
*   Adding a new library `libtensordeser` to the `BUCK` file in the `dwarfs` directory, which includes the `TensorDeser.cc` and `TensorDeser.h` files.

The new tensor deserialization kernel is designed to deserialize tensors from a wire message.

#### Changes

*   Added new library `tensordeser` to `dwarfs/CMakeLists.txt`
*   Updated `server/CMakeLists.txt` to include `tensordeser` library
*   Added new library `libtensordeser` to `dwarfs/BUCK`
*   Implemented tensor deserialization kernel in `TensorDeser.cc`

Reviewed By: excelle08

Differential Revision: D79207582


