### PR TITLE
Add rebatch kernel into Adsim

### DIFF
--- a/packages/adsim/patches/adsim.patch
+++ b/packages/adsim/patches/adsim.patch
@@ -1,10 +1,10 @@
-diff -wbBdu -ruN '--exclude=.git' '--exclude=*.rej' '--exclude=*.orig' '--exclude=gen-cpp2' adsim_group/cpp2/client/AdSimClient.cpp build/adsim/cpp2/client/AdSimClient.cpp
---- adsim_group/cpp2/client/AdSimClient.cpp	2025-07-29 14:17:29.771582057 -0700
-+++ build/adsim/cpp2/client/AdSimClient.cpp	2025-07-25 15:55:10.007667247 -0700
+diff -wbBdu -ruN '--exclude=.git' '--exclude=*.rej' '--exclude=*.orig' '--exclude=gen-cpp2' adsim/cpp2/client/AdSimClient.cpp build/adsim/cpp2/client/AdSimClient.cpp
+--- adsim/cpp2/client/AdSimClient.cpp	2025-07-29 17:20:23.627383965 -0700
++++ build/adsim/cpp2/client/AdSimClient.cpp	2025-07-29 17:16:49.241854626 -0700
 @@ -14,17 +14,15 @@
   * limitations under the License.
   */
- 
+
 -#include <cea/chips/adsim/cpp2/client/TLSConnect.h>
  #include <folly/SocketAddress.h>
  #include <folly/coro/BlockingWait.h>
@@ -19,16 +19,16 @@ diff -wbBdu -ruN '--exclude=.git' '--exclude=*.rej' '--exclude=*.orig' '--exclud
 +#include "CoWorker.h"
 +#include "TLSConnect.h"
 +#include "if/gen-cpp2/AdSim.h"
- 
+
  DEFINE_string(host, "::1", "AdSimServer host");
  DEFINE_int32(port, 10086, "AdSimServer port");
-diff -wbBdu -ruN '--exclude=.git' '--exclude=*.rej' '--exclude=*.orig' '--exclude=gen-cpp2' adsim_group/cpp2/client/CoWorker.h build/adsim/cpp2/client/CoWorker.h
---- adsim_group/cpp2/client/CoWorker.h	2025-07-29 14:17:29.772459085 -0700
-+++ build/adsim/cpp2/client/CoWorker.h	2025-07-25 15:55:10.009191271 -0700
+diff -wbBdu -ruN '--exclude=.git' '--exclude=*.rej' '--exclude=*.orig' '--exclude=gen-cpp2' adsim/cpp2/client/CoWorker.h build/adsim/cpp2/client/CoWorker.h
+--- adsim/cpp2/client/CoWorker.h	2025-07-29 17:20:23.628326019 -0700
++++ build/adsim/cpp2/client/CoWorker.h	2025-07-29 17:16:49.242970483 -0700
 @@ -16,14 +16,16 @@
- 
+
  #pragma once
- 
+
 -#include <cea/chips/adsim/if/gen-cpp2/AdSim.h>
  #include <fizz/client/AsyncFizzClient.h>
  #include <folly/MoveWrapper.h>
@@ -40,16 +40,16 @@ diff -wbBdu -ruN '--exclude=.git' '--exclude=*.rej' '--exclude=*.orig' '--exclud
  #include <thrift/lib/cpp2/security/extensions/ThriftParametersClientExtension.h>
 +#include "TLSConnect.h"
 +#include "if/gen-cpp2/AdSim.h"
- 
+
  namespace facebook::cea::chips::adsim {
- 
-diff -wbBdu -ruN '--exclude=.git' '--exclude=*.rej' '--exclude=*.orig' '--exclude=gen-cpp2' adsim_group/cpp2/server/AdSimServer.cpp build/adsim/cpp2/server/AdSimServer.cpp
---- adsim_group/cpp2/server/AdSimServer.cpp	2025-07-29 14:17:29.787921133 -0700
-+++ build/adsim/cpp2/server/AdSimServer.cpp	2025-07-25 15:55:10.010304364 -0700
+
+diff -wbBdu -ruN '--exclude=.git' '--exclude=*.rej' '--exclude=*.orig' '--exclude=gen-cpp2' adsim/cpp2/server/AdSimServer.cpp build/adsim/cpp2/server/AdSimServer.cpp
+--- adsim/cpp2/server/AdSimServer.cpp	2025-07-29 17:20:23.643578543 -0700
++++ build/adsim/cpp2/server/AdSimServer.cpp	2025-07-29 17:16:49.243912648 -0700
 @@ -19,16 +19,17 @@
  #include <streambuf>
  #include <string>
- 
+
 -#include <cea/chips/adsim/cpp2/server/AdSimService.h>
 -#include <cea/chips/adsim/cpp2/server/dwarfs/Dwarfs.h>
 +#include <folly/dynamic.h>
@@ -64,30 +64,30 @@ diff -wbBdu -ruN '--exclude=.git' '--exclude=*.rej' '--exclude=*.orig' '--exclud
  #include <thrift/lib/cpp2/server/ThriftServer.h>
 +#include "cpp2/server/AdSimService.h"
 +#include "cpp2/server/dwarfs/Dwarfs.h"
- 
+
  DEFINE_string(config_file, "", "A json file of configurations");
  DEFINE_int32(port, -1, "Overwrite port in the config file");
-diff -wbBdu -ruN '--exclude=.git' '--exclude=*.rej' '--exclude=*.orig' '--exclude=gen-cpp2' adsim_group/cpp2/server/AdSimService.cpp build/adsim/cpp2/server/AdSimService.cpp
---- adsim_group/cpp2/server/AdSimService.cpp	2025-07-29 14:17:29.788333958 -0700
-+++ build/adsim/cpp2/server/AdSimService.cpp	2025-07-25 15:55:10.011314962 -0700
+diff -wbBdu -ruN '--exclude=.git' '--exclude=*.rej' '--exclude=*.orig' '--exclude=gen-cpp2' adsim/cpp2/server/AdSimService.cpp build/adsim/cpp2/server/AdSimService.cpp
+--- adsim/cpp2/server/AdSimService.cpp	2025-07-29 17:20:23.644003896 -0700
++++ build/adsim/cpp2/server/AdSimService.cpp	2025-07-29 17:16:49.244776624 -0700
 @@ -14,8 +14,8 @@
   * limitations under the License.
   */
- 
+
 -#include <cea/chips/adsim/cpp2/server/AdSimService.h>
 -#include <cea/chips/adsim/cpp2/server/DataObjects.h>
 +#include "cpp2/server/AdSimService.h"
 +#include "cpp2/server/DataObjects.h"
- 
+
  #include <fb303/ThreadCachedServiceData.h>
  #include <folly/coro/Collect.h>
-diff -wbBdu -ruN '--exclude=.git' '--exclude=*.rej' '--exclude=*.orig' '--exclude=gen-cpp2' adsim_group/cpp2/server/AdSimService.h build/adsim/cpp2/server/AdSimService.h
---- adsim_group/cpp2/server/AdSimService.h	2025-07-29 14:17:29.788761875 -0700
-+++ build/adsim/cpp2/server/AdSimService.h	2025-07-25 15:55:10.012430769 -0700
+diff -wbBdu -ruN '--exclude=.git' '--exclude=*.rej' '--exclude=*.orig' '--exclude=gen-cpp2' adsim/cpp2/server/AdSimService.h build/adsim/cpp2/server/AdSimService.h
+--- adsim/cpp2/server/AdSimService.h	2025-07-29 17:20:23.644425113 -0700
++++ build/adsim/cpp2/server/AdSimService.h	2025-07-29 17:16:49.245431123 -0700
 @@ -22,10 +22,10 @@
  #include <folly/Executor.h>
  #include <folly/MapUtil.h>
- 
+
 -#include <cea/chips/adsim/cpp2/server/DataObjects.h>
 -#include <cea/chips/adsim/cpp2/server/dwarfs/Kernel.h>
 -#include <cea/chips/adsim/if/gen-cpp2/AdSim.h>
@@ -95,125 +95,125 @@ diff -wbBdu -ruN '--exclude=.git' '--exclude=*.rej' '--exclude=*.orig' '--exclud
 +#include "cpp2/server/DataObjects.h"
 +#include "cpp2/server/dwarfs/Kernel.h"
 +#include "if/gen-cpp2/AdSim.h"
- 
+
  namespace facebook::cea::chips::adsim {
- 
-diff -wbBdu -ruN '--exclude=.git' '--exclude=*.rej' '--exclude=*.orig' '--exclude=gen-cpp2' adsim_group/cpp2/server/DataObjects.cpp build/adsim/cpp2/server/DataObjects.cpp
---- adsim_group/cpp2/server/DataObjects.cpp	2025-07-29 14:17:29.789743832 -0700
-+++ build/adsim/cpp2/server/DataObjects.cpp	2025-07-25 15:55:10.013145970 -0700
+
+diff -wbBdu -ruN '--exclude=.git' '--exclude=*.rej' '--exclude=*.orig' '--exclude=gen-cpp2' adsim/cpp2/server/DataObjects.cpp build/adsim/cpp2/server/DataObjects.cpp
+--- adsim/cpp2/server/DataObjects.cpp	2025-07-29 17:20:23.645212253 -0700
++++ build/adsim/cpp2/server/DataObjects.cpp	2025-07-29 17:16:49.246001116 -0700
 @@ -14,7 +14,7 @@
   * limitations under the License.
   */
- 
+
 -#include <cea/chips/adsim/cpp2/server/DataObjects.h>
 +#include "cpp2/server/DataObjects.h"
  #include <folly/Singleton.h>
- 
+
  namespace facebook::cea::chips::adsim {
-diff -wbBdu -ruN '--exclude=.git' '--exclude=*.rej' '--exclude=*.orig' '--exclude=gen-cpp2' adsim_group/cpp2/server/DataObjects.h build/adsim/cpp2/server/DataObjects.h
---- adsim_group/cpp2/server/DataObjects.h	2025-07-29 14:17:29.790185910 -0700
-+++ build/adsim/cpp2/server/DataObjects.h	2025-07-25 15:55:10.013816493 -0700
+diff -wbBdu -ruN '--exclude=.git' '--exclude=*.rej' '--exclude=*.orig' '--exclude=gen-cpp2' adsim/cpp2/server/DataObjects.h build/adsim/cpp2/server/DataObjects.h
+--- adsim/cpp2/server/DataObjects.h	2025-07-29 17:20:23.645726110 -0700
++++ build/adsim/cpp2/server/DataObjects.h	2025-07-29 17:16:49.246827264 -0700
 @@ -27,7 +27,7 @@
  #include <thrift/lib/cpp2/protocol/CompactProtocol.h>
  #include <thrift/lib/cpp2/protocol/Serializer.h>
- 
+
 -#include <cea/chips/adsim/if/gen-cpp2/AdSim.h>
 +#include "if/gen-cpp2/AdSim.h"
- 
+
  namespace facebook::cea::chips::adsim {
- 
-diff -wbBdu -ruN '--exclude=.git' '--exclude=*.rej' '--exclude=*.orig' '--exclude=gen-cpp2' adsim_group/cpp2/server/dwarfs/Compress.cc build/adsim/cpp2/server/dwarfs/Compress.cc
---- adsim_group/cpp2/server/dwarfs/Compress.cc	2025-07-29 14:17:29.777879647 -0700
-+++ build/adsim/cpp2/server/dwarfs/Compress.cc	2025-07-25 15:55:10.014647761 -0700
+
+diff -wbBdu -ruN '--exclude=.git' '--exclude=*.rej' '--exclude=*.orig' '--exclude=gen-cpp2' adsim/cpp2/server/dwarfs/Compress.cc build/adsim/cpp2/server/dwarfs/Compress.cc
+--- adsim/cpp2/server/dwarfs/Compress.cc	2025-07-29 17:20:23.633573374 -0700
++++ build/adsim/cpp2/server/dwarfs/Compress.cc	2025-07-29 17:16:49.247596287 -0700
 @@ -18,10 +18,10 @@
  #include <util.h>
- 
+
  #include <glog/logging.h>
 -#include <cstring>
 +#include <string.h>
- 
+
 -#include <cea/chips/adsim/cpp2/server/dwarfs/Compress.h>
 -#include <cea/chips/adsim/cpp2/server/dwarfs/Kernel.h>
 +#include "Compress.h"
 +#include "Kernel.h"
- 
+
  #include <fb303/ThreadCachedServiceData.h>
  #include <folly/coro/Task.h>
-diff -wbBdu -ruN '--exclude=.git' '--exclude=*.rej' '--exclude=*.orig' '--exclude=gen-cpp2' adsim_group/cpp2/server/dwarfs/Compress.h build/adsim/cpp2/server/dwarfs/Compress.h
---- adsim_group/cpp2/server/dwarfs/Compress.h	2025-07-29 14:17:29.778403731 -0700
-+++ build/adsim/cpp2/server/dwarfs/Compress.h	2025-07-25 15:55:10.015383212 -0700
+diff -wbBdu -ruN '--exclude=.git' '--exclude=*.rej' '--exclude=*.orig' '--exclude=gen-cpp2' adsim/cpp2/server/dwarfs/Compress.h build/adsim/cpp2/server/dwarfs/Compress.h
+--- adsim/cpp2/server/dwarfs/Compress.h	2025-07-29 17:20:23.633936002 -0700
++++ build/adsim/cpp2/server/dwarfs/Compress.h	2025-07-29 17:16:49.248495447 -0700
 @@ -21,8 +21,8 @@
- 
+
  #include <string.h>
- 
+
 -#include <cea/chips/adsim/cpp2/server/DataObjects.h>
 -#include <cea/chips/adsim/cpp2/server/dwarfs/Kernel.h>
 +#include "cpp2/server/DataObjects.h"
 +#include "cpp2/server/dwarfs/Kernel.h"
- 
+
  #include <folly/coro/Task.h>
- 
-diff -wbBdu -ruN '--exclude=.git' '--exclude=*.rej' '--exclude=*.orig' '--exclude=gen-cpp2' adsim_group/cpp2/server/dwarfs/ConcurrentHashMap.cc build/adsim/cpp2/server/dwarfs/ConcurrentHashMap.cc
---- adsim_group/cpp2/server/dwarfs/ConcurrentHashMap.cc	2025-07-29 14:17:29.778881854 -0700
-+++ build/adsim/cpp2/server/dwarfs/ConcurrentHashMap.cc	2025-07-29 14:21:45.143901510 -0700
+
+diff -wbBdu -ruN '--exclude=.git' '--exclude=*.rej' '--exclude=*.orig' '--exclude=gen-cpp2' adsim/cpp2/server/dwarfs/ConcurrentHashMap.cc build/adsim/cpp2/server/dwarfs/ConcurrentHashMap.cc
+--- adsim/cpp2/server/dwarfs/ConcurrentHashMap.cc	2025-07-29 17:20:23.634329728 -0700
++++ build/adsim/cpp2/server/dwarfs/ConcurrentHashMap.cc	2025-07-29 17:16:49.249399593 -0700
 @@ -14,7 +14,7 @@
   * limitations under the License.
   */
- 
+
 -#include <cea/chips/adsim/cpp2/server/dwarfs/ConcurrentHashMap.h>
 +#include "ConcurrentHashMap.h"
- 
+
  #include <fb303/ThreadCachedServiceData.h>
  #include <folly/executors/CPUThreadPoolExecutor.h>
-diff -wbBdu -ruN '--exclude=.git' '--exclude=*.rej' '--exclude=*.orig' '--exclude=gen-cpp2' adsim_group/cpp2/server/dwarfs/ConcurrentHashMap.h build/adsim/cpp2/server/dwarfs/ConcurrentHashMap.h
---- adsim_group/cpp2/server/dwarfs/ConcurrentHashMap.h	2025-07-29 14:17:29.779299386 -0700
-+++ build/adsim/cpp2/server/dwarfs/ConcurrentHashMap.h	2025-07-29 14:20:53.562536690 -0700
+diff -wbBdu -ruN '--exclude=.git' '--exclude=*.rej' '--exclude=*.orig' '--exclude=gen-cpp2' adsim/cpp2/server/dwarfs/ConcurrentHashMap.h build/adsim/cpp2/server/dwarfs/ConcurrentHashMap.h
+--- adsim/cpp2/server/dwarfs/ConcurrentHashMap.h	2025-07-29 17:20:23.634768041 -0700
++++ build/adsim/cpp2/server/dwarfs/ConcurrentHashMap.h	2025-07-29 17:16:49.250087493 -0700
 @@ -30,8 +30,8 @@
  #include <utility>
  #include <vector>
- 
+
 -#include <cea/chips/adsim/cpp2/server/DataObjects.h>
 -#include <cea/chips/adsim/cpp2/server/dwarfs/Kernel.h>
 +#include "cpp2/server/DataObjects.h"
 +#include "cpp2/server/dwarfs/Kernel.h"
- 
+
  #include <folly/Likely.h>
  #include <folly/SharedMutex.h>
-diff -wbBdu -ruN '--exclude=.git' '--exclude=*.rej' '--exclude=*.orig' '--exclude=gen-cpp2' adsim_group/cpp2/server/dwarfs/DeepCopy.h build/adsim/cpp2/server/dwarfs/DeepCopy.h
---- adsim_group/cpp2/server/dwarfs/DeepCopy.h	2025-07-29 14:17:29.779765491 -0700
-+++ build/adsim/cpp2/server/dwarfs/DeepCopy.h	2025-07-25 15:55:10.016208450 -0700
+diff -wbBdu -ruN '--exclude=.git' '--exclude=*.rej' '--exclude=*.orig' '--exclude=gen-cpp2' adsim/cpp2/server/dwarfs/DeepCopy.h build/adsim/cpp2/server/dwarfs/DeepCopy.h
+--- adsim/cpp2/server/dwarfs/DeepCopy.h	2025-07-29 17:20:23.635358934 -0700
++++ build/adsim/cpp2/server/dwarfs/DeepCopy.h	2025-07-29 17:16:49.250840472 -0700
 @@ -24,8 +24,8 @@
  #include <unordered_map>
  #include <vector>
- 
+
 -#include <cea/chips/adsim/cpp2/server/DataObjects.h>
 -#include <cea/chips/adsim/cpp2/server/dwarfs/Kernel.h>
 +#include "cpp2/server/DataObjects.h"
 +#include "cpp2/server/dwarfs/Kernel.h"
- 
+
  #include <fb303/ThreadCachedServiceData.h>
  #include <folly/container/F14Map.h>
-diff -wbBdu -ruN '--exclude=.git' '--exclude=*.rej' '--exclude=*.orig' '--exclude=gen-cpp2' adsim_group/cpp2/server/dwarfs/Delay.h build/adsim/cpp2/server/dwarfs/Delay.h
---- adsim_group/cpp2/server/dwarfs/Delay.h	2025-07-29 14:17:29.780277646 -0700
-+++ build/adsim/cpp2/server/dwarfs/Delay.h	2025-07-25 15:55:10.016889980 -0700
+diff -wbBdu -ruN '--exclude=.git' '--exclude=*.rej' '--exclude=*.orig' '--exclude=gen-cpp2' adsim/cpp2/server/dwarfs/Delay.h build/adsim/cpp2/server/dwarfs/Delay.h
+--- adsim/cpp2/server/dwarfs/Delay.h	2025-07-29 17:20:23.635800691 -0700
++++ build/adsim/cpp2/server/dwarfs/Delay.h	2025-07-29 17:16:49.251605649 -0700
 @@ -18,8 +18,8 @@
- 
+
  #include <unistd.h>
- 
+
 -#include <cea/chips/adsim/cpp2/server/DataObjects.h>
 -#include <cea/chips/adsim/cpp2/server/dwarfs/Kernel.h>
 +#include "cpp2/server/DataObjects.h"
 +#include "cpp2/server/dwarfs/Kernel.h"
- 
+
  #include <fb303/ThreadCachedServiceData.h>
  #include <folly/coro/Task.h>
-diff -wbBdu -ruN '--exclude=.git' '--exclude=*.rej' '--exclude=*.orig' '--exclude=gen-cpp2' adsim_group/cpp2/server/dwarfs/Dwarfs.cc build/adsim/cpp2/server/dwarfs/Dwarfs.cc
---- adsim_group/cpp2/server/dwarfs/Dwarfs.cc	2025-07-29 14:17:29.780712845 -0700
-+++ build/adsim/cpp2/server/dwarfs/Dwarfs.cc	2025-07-29 03:22:28.989646826 -0700
-@@ -19,19 +19,19 @@
+diff -wbBdu -ruN '--exclude=.git' '--exclude=*.rej' '--exclude=*.orig' '--exclude=gen-cpp2' adsim/cpp2/server/dwarfs/Dwarfs.cc build/adsim/cpp2/server/dwarfs/Dwarfs.cc
+--- adsim/cpp2/server/dwarfs/Dwarfs.cc	2025-07-29 17:20:23.636282090 -0700
++++ build/adsim/cpp2/server/dwarfs/Dwarfs.cc	2025-07-29 17:16:49.252183522 -0700
+@@ -19,20 +19,20 @@
  #include <folly/MapUtil.h>
  #include <folly/dynamic.h>
- 
+
 -#include <cea/chips/adsim/cpp2/server/dwarfs/Compress.h>
 -#include <cea/chips/adsim/cpp2/server/dwarfs/ConcurrentHashMap.h>
 -#include <cea/chips/adsim/cpp2/server/dwarfs/DeepCopy.h>
@@ -224,6 +224,7 @@ diff -wbBdu -ruN '--exclude=.git' '--exclude=*.rej' '--exclude=*.orig' '--exclud
 -#include <cea/chips/adsim/cpp2/server/dwarfs/HashMap.h>
 -#include <cea/chips/adsim/cpp2/server/dwarfs/IBRun.h>
 -#include <cea/chips/adsim/cpp2/server/dwarfs/Kernel.h>
+-#include <cea/chips/adsim/cpp2/server/dwarfs/Rebatch.h>
 -#include <cea/chips/adsim/cpp2/server/dwarfs/Serialize.h>
 -#include <cea/chips/adsim/cpp2/server/dwarfs/Shape.h>
 -#include <cea/chips/adsim/cpp2/server/dwarfs/TensorDeser.h>
@@ -237,193 +238,220 @@ diff -wbBdu -ruN '--exclude=.git' '--exclude=*.rej' '--exclude=*.orig' '--exclud
 +#include "HashMap.h"
 +#include "IBRun.h"
 +#include "Kernel.h"
++#include "Rebatch.h"
 +#include "Serialize.h"
 +#include "Shape.h"
 +#include "TensorDeser.h"
- 
+
  namespace facebook::cea::chips::adsim {
- 
-diff -wbBdu -ruN '--exclude=.git' '--exclude=*.rej' '--exclude=*.orig' '--exclude=gen-cpp2' adsim_group/cpp2/server/dwarfs/Dwarfs.h build/adsim/cpp2/server/dwarfs/Dwarfs.h
---- adsim_group/cpp2/server/dwarfs/Dwarfs.h	2025-07-29 14:17:29.781173923 -0700
-+++ build/adsim/cpp2/server/dwarfs/Dwarfs.h	2025-07-25 15:55:10.019374336 -0700
+
+diff -wbBdu -ruN '--exclude=.git' '--exclude=*.rej' '--exclude=*.orig' '--exclude=gen-cpp2' adsim/cpp2/server/dwarfs/Dwarfs.h build/adsim/cpp2/server/dwarfs/Dwarfs.h
+--- adsim/cpp2/server/dwarfs/Dwarfs.h	2025-07-29 17:20:23.636723818 -0700
++++ build/adsim/cpp2/server/dwarfs/Dwarfs.h	2025-07-29 17:16:49.252762768 -0700
 @@ -19,9 +19,9 @@
  #include <string>
- 
+
  #include <folly/MapUtil.h>
 -#include <folly/json/dynamic.h>
 +#include <folly/dynamic.h>
- 
+
 -#include <cea/chips/adsim/cpp2/server/dwarfs/Kernel.h>
 +#include "cpp2/server/dwarfs/Kernel.h"
- 
+
  namespace facebook::cea::chips::adsim {
- 
-diff -wbBdu -ruN '--exclude=.git' '--exclude=*.rej' '--exclude=*.orig' '--exclude=gen-cpp2' adsim_group/cpp2/server/dwarfs/FakeIO.h build/adsim/cpp2/server/dwarfs/FakeIO.h
---- adsim_group/cpp2/server/dwarfs/FakeIO.h	2025-07-29 14:17:29.781695752 -0700
-+++ build/adsim/cpp2/server/dwarfs/FakeIO.h	2025-07-25 15:55:10.020115056 -0700
+
+diff -wbBdu -ruN '--exclude=.git' '--exclude=*.rej' '--exclude=*.orig' '--exclude=gen-cpp2' adsim/cpp2/server/dwarfs/FakeIO.h build/adsim/cpp2/server/dwarfs/FakeIO.h
+--- adsim/cpp2/server/dwarfs/FakeIO.h	2025-07-29 17:20:23.637152757 -0700
++++ build/adsim/cpp2/server/dwarfs/FakeIO.h	2025-07-29 17:16:49.253448384 -0700
 @@ -18,8 +18,8 @@
- 
+
  #include <unistd.h>
- 
+
 -#include <cea/chips/adsim/cpp2/server/DataObjects.h>
 -#include <cea/chips/adsim/cpp2/server/dwarfs/Kernel.h>
 +#include "cpp2/server/DataObjects.h"
 +#include "cpp2/server/dwarfs/Kernel.h"
- 
+
  #include <fb303/ThreadCachedServiceData.h>
  #include <folly/coro/Task.h>
-diff -wbBdu -ruN '--exclude=.git' '--exclude=*.rej' '--exclude=*.orig' '--exclude=gen-cpp2' adsim_group/cpp2/server/dwarfs/GEMM.cc build/adsim/cpp2/server/dwarfs/GEMM.cc
---- adsim_group/cpp2/server/dwarfs/GEMM.cc	2025-07-29 14:17:29.782197962 -0700
-+++ build/adsim/cpp2/server/dwarfs/GEMM.cc	2025-07-25 15:55:10.020712910 -0700
+diff -wbBdu -ruN '--exclude=.git' '--exclude=*.rej' '--exclude=*.orig' '--exclude=gen-cpp2' adsim/cpp2/server/dwarfs/GEMM.cc build/adsim/cpp2/server/dwarfs/GEMM.cc
+--- adsim/cpp2/server/dwarfs/GEMM.cc	2025-07-29 17:20:23.637529265 -0700
++++ build/adsim/cpp2/server/dwarfs/GEMM.cc	2025-07-29 17:16:49.254103194 -0700
 @@ -22,17 +22,21 @@
  #include <glog/logging.h>
- 
+
  #ifdef _OPENMP
 +#include <omp.h>
  #endif
- 
+
  #ifdef USE_MKL
 +#include <mkl.h>
  #endif
- 
+
  #include "bench/BenchUtils.h"
  #include "fbgemm/Fbgemm.h"
 +#include "src/RefImplementations.h"
  #include "test/QuantizationHelpers.h"
- 
+
 -#include <cea/chips/adsim/cpp2/server/dwarfs/GEMM.h>
 -#include <cea/chips/adsim/cpp2/server/dwarfs/Kernel.h>
 +#include <folly/coro/Task.h>
 +#include "GEMM.h"
 +#include "Kernel.h"
- 
+
  using namespace std;
  using namespace fbgemm;
-diff -wbBdu -ruN '--exclude=.git' '--exclude=*.rej' '--exclude=*.orig' '--exclude=gen-cpp2' adsim_group/cpp2/server/dwarfs/GEMM.h build/adsim/cpp2/server/dwarfs/GEMM.h
---- adsim_group/cpp2/server/dwarfs/GEMM.h	2025-07-29 14:17:29.782715055 -0700
-+++ build/adsim/cpp2/server/dwarfs/GEMM.h	2025-07-25 15:55:10.021362522 -0700
+diff -wbBdu -ruN '--exclude=.git' '--exclude=*.rej' '--exclude=*.orig' '--exclude=gen-cpp2' adsim/cpp2/server/dwarfs/GEMM.h build/adsim/cpp2/server/dwarfs/GEMM.h
+--- adsim/cpp2/server/dwarfs/GEMM.h	2025-07-29 17:20:23.637936802 -0700
++++ build/adsim/cpp2/server/dwarfs/GEMM.h	2025-07-29 17:16:49.254694429 -0700
 @@ -22,8 +22,8 @@
- 
+
  #include <assert.h>
- 
+
 -#include <cea/chips/adsim/cpp2/server/DataObjects.h>
 -#include <cea/chips/adsim/cpp2/server/dwarfs/Kernel.h>
 +#include "cpp2/server/DataObjects.h"
 +#include "cpp2/server/dwarfs/Kernel.h"
- 
+
  #include <fb303/ThreadCachedServiceData.h>
  #include <folly/coro/Collect.h>
-diff -wbBdu -ruN '--exclude=.git' '--exclude=*.rej' '--exclude=*.orig' '--exclude=gen-cpp2' adsim_group/cpp2/server/dwarfs/HashMap.cc build/adsim/cpp2/server/dwarfs/HashMap.cc
---- adsim_group/cpp2/server/dwarfs/HashMap.cc	2025-07-29 14:17:29.783274811 -0700
-+++ build/adsim/cpp2/server/dwarfs/HashMap.cc	2025-07-25 15:55:10.022044754 -0700
+diff -wbBdu -ruN '--exclude=.git' '--exclude=*.rej' '--exclude=*.orig' '--exclude=gen-cpp2' adsim/cpp2/server/dwarfs/HashMap.cc build/adsim/cpp2/server/dwarfs/HashMap.cc
+--- adsim/cpp2/server/dwarfs/HashMap.cc	2025-07-29 17:20:23.638293180 -0700
++++ build/adsim/cpp2/server/dwarfs/HashMap.cc	2025-07-29 17:16:49.255301296 -0700
 @@ -14,7 +14,7 @@
   * limitations under the License.
   */
- 
+
 -#include <cea/chips/adsim/cpp2/server/dwarfs/HashMap.h>
 +#include "HashMap.h"
- 
+
  #include <fb303/ThreadCachedServiceData.h>
- 
-diff -wbBdu -ruN '--exclude=.git' '--exclude=*.rej' '--exclude=*.orig' '--exclude=gen-cpp2' adsim_group/cpp2/server/dwarfs/HashMap.h build/adsim/cpp2/server/dwarfs/HashMap.h
---- adsim_group/cpp2/server/dwarfs/HashMap.h	2025-07-29 14:17:29.783789461 -0700
-+++ build/adsim/cpp2/server/dwarfs/HashMap.h	2025-07-25 15:55:10.022653935 -0700
+
+diff -wbBdu -ruN '--exclude=.git' '--exclude=*.rej' '--exclude=*.orig' '--exclude=gen-cpp2' adsim/cpp2/server/dwarfs/HashMap.h build/adsim/cpp2/server/dwarfs/HashMap.h
+--- adsim/cpp2/server/dwarfs/HashMap.h	2025-07-29 17:20:23.638793648 -0700
++++ build/adsim/cpp2/server/dwarfs/HashMap.h	2025-07-29 17:16:49.255902134 -0700
 @@ -24,8 +24,8 @@
  #include <unordered_map>
  #include <vector>
- 
+
 -#include <cea/chips/adsim/cpp2/server/DataObjects.h>
 -#include <cea/chips/adsim/cpp2/server/dwarfs/Kernel.h>
 +#include "cpp2/server/DataObjects.h"
 +#include "cpp2/server/dwarfs/Kernel.h"
- 
+
  #include <folly/Synchronized.h>
  #include <folly/container/F14Map.h>
-diff -wbBdu -ruN '--exclude=.git' '--exclude=*.rej' '--exclude=*.orig' '--exclude=gen-cpp2' adsim_group/cpp2/server/dwarfs/IBRun.h build/adsim/cpp2/server/dwarfs/IBRun.h
---- adsim_group/cpp2/server/dwarfs/IBRun.h	2025-07-29 14:17:29.784390450 -0700
-+++ build/adsim/cpp2/server/dwarfs/IBRun.h	2025-07-25 15:55:10.023200492 -0700
+diff -wbBdu -ruN '--exclude=.git' '--exclude=*.rej' '--exclude=*.orig' '--exclude=gen-cpp2' adsim/cpp2/server/dwarfs/IBRun.h build/adsim/cpp2/server/dwarfs/IBRun.h
+--- adsim/cpp2/server/dwarfs/IBRun.h	2025-07-29 17:20:23.639247133 -0700
++++ build/adsim/cpp2/server/dwarfs/IBRun.h	2025-07-29 17:16:49.256601132 -0700
 @@ -16,9 +16,9 @@
- 
+
  #pragma once
- 
+
 -#include <cea/chips/adsim/cpp2/server/DataObjects.h>
 -#include <cea/chips/adsim/cpp2/server/dwarfs/Kernel.h>
 -#include <cea/chips/adsim/cpp2/server/dwarfs/icache_buster/ICacheBuster.h> // @manual=//cea/chips/adsim/cpp2/server/dwarfs/icache_buster:libicachebuster
 +#include "cpp2/server/DataObjects.h"
 +#include "cpp2/server/dwarfs/Kernel.h"
 +#include "cpp2/server/dwarfs/icache_buster/ICacheBuster.h" // @manual=//cea/chips/adsim/cpp2/server/dwarfs/icache_buster:libicachebuster
- 
+
  #include <folly/coro/Task.h>
- 
-diff -wbBdu -ruN '--exclude=.git' '--exclude=*.rej' '--exclude=*.orig' '--exclude=gen-cpp2' adsim_group/cpp2/server/dwarfs/icache_buster/gen_icache_buster.py build/adsim/cpp2/server/dwarfs/icache_buster/gen_icache_buster.py
---- adsim_group/cpp2/server/dwarfs/icache_buster/gen_icache_buster.py	2025-07-29 14:17:29.776967347 -0700
-+++ build/adsim/cpp2/server/dwarfs/icache_buster/gen_icache_buster.py	2025-07-25 15:55:10.023937655 -0700
+
+diff -wbBdu -ruN '--exclude=.git' '--exclude=*.rej' '--exclude=*.orig' '--exclude=gen-cpp2' adsim/cpp2/server/dwarfs/icache_buster/gen_icache_buster.py build/adsim/cpp2/server/dwarfs/icache_buster/gen_icache_buster.py
+--- adsim/cpp2/server/dwarfs/icache_buster/gen_icache_buster.py	2025-07-29 17:20:23.632763309 -0700
++++ build/adsim/cpp2/server/dwarfs/icache_buster/gen_icache_buster.py	2025-07-29 17:16:49.257317114 -0700
 @@ -14,8 +14,6 @@
  # See the License for the specific language governing permissions and
  # limitations under the License.
- 
+
 -# pyre-unsafe
 -
  """Module to split file into multiple segments."""
- 
+
  import argparse
-diff -wbBdu -ruN '--exclude=.git' '--exclude=*.rej' '--exclude=*.orig' '--exclude=gen-cpp2' adsim_group/cpp2/server/dwarfs/Kernel.cc build/adsim/cpp2/server/dwarfs/Kernel.cc
---- adsim_group/cpp2/server/dwarfs/Kernel.cc	2025-07-29 14:17:29.784831819 -0700
-+++ build/adsim/cpp2/server/dwarfs/Kernel.cc	2025-07-25 16:37:11.073788021 -0700
+diff -wbBdu -ruN '--exclude=.git' '--exclude=*.rej' '--exclude=*.orig' '--exclude=gen-cpp2' adsim/cpp2/server/dwarfs/Kernel.cc build/adsim/cpp2/server/dwarfs/Kernel.cc
+--- adsim/cpp2/server/dwarfs/Kernel.cc	2025-07-29 17:20:23.639696623 -0700
++++ build/adsim/cpp2/server/dwarfs/Kernel.cc	2025-07-29 17:16:49.257887606 -0700
 @@ -20,7 +20,7 @@
  #include <fb303/ExportType.h>
  #include <fb303/ThreadCachedServiceData.h>
- 
+
 -#include "cea/chips/adsim/cpp2/server/dwarfs/Kernel.h"
 +#include "Kernel.h"
- 
+
  namespace facebook::cea::chips::adsim {
- 
-diff -wbBdu -ruN '--exclude=.git' '--exclude=*.rej' '--exclude=*.orig' '--exclude=gen-cpp2' adsim_group/cpp2/server/dwarfs/Kernel.h build/adsim/cpp2/server/dwarfs/Kernel.h
---- adsim_group/cpp2/server/dwarfs/Kernel.h	2025-07-29 14:17:29.785257753 -0700
-+++ build/adsim/cpp2/server/dwarfs/Kernel.h	2025-07-25 15:55:10.025158201 -0700
+
+diff -wbBdu -ruN '--exclude=.git' '--exclude=*.rej' '--exclude=*.orig' '--exclude=gen-cpp2' adsim/cpp2/server/dwarfs/Kernel.h build/adsim/cpp2/server/dwarfs/Kernel.h
+--- adsim/cpp2/server/dwarfs/Kernel.h	2025-07-29 17:20:23.640110499 -0700
++++ build/adsim/cpp2/server/dwarfs/Kernel.h	2025-07-29 17:16:49.258481745 -0700
 @@ -21,10 +21,10 @@
  #include <unordered_map>
  #include <vector>
- 
+
 -#include <cea/chips/adsim/cpp2/server/DataObjects.h>
  #include <folly/coro/Task.h>
 -#include <folly/json/dynamic.h>
 +#include <folly/dynamic.h>
  #include <glog/logging.h>
 +#include "cpp2/server/DataObjects.h"
- 
+
  namespace facebook::cea::chips::adsim {
- 
-diff -wbBdu -ruN '--exclude=.git' '--exclude=*.rej' '--exclude=*.orig' '--exclude=gen-cpp2' adsim_group/cpp2/server/dwarfs/Serialize.h build/adsim/cpp2/server/dwarfs/Serialize.h
---- adsim_group/cpp2/server/dwarfs/Serialize.h	2025-07-29 14:17:29.785666401 -0700
-+++ build/adsim/cpp2/server/dwarfs/Serialize.h	2025-07-25 15:55:10.025830557 -0700
-@@ -20,15 +20,15 @@
- 
- #include <algorithm>
- 
+
+diff -wbBdu -ruN '--exclude=.git' '--exclude=*.rej' '--exclude=*.orig' '--exclude=gen-cpp2' adsim/cpp2/server/dwarfs/Rebatch.cc build/adsim/cpp2/server/dwarfs/Rebatch.cc
+--- adsim/cpp2/server/dwarfs/Rebatch.cc	2025-07-29 17:20:23.640525797 -0700
++++ build/adsim/cpp2/server/dwarfs/Rebatch.cc	2025-07-29 17:16:49.259297848 -0700
+@@ -14,7 +14,7 @@
+  * limitations under the License.
+  */
+
+-#include <cea/chips/adsim/cpp2/server/dwarfs/Rebatch.h>
++#include "Rebatch.h"
+
+ #include <fb303/ThreadCachedServiceData.h>
+ #include <folly/futures/Future.h>
+diff -wbBdu -ruN '--exclude=.git' '--exclude=*.rej' '--exclude=*.orig' '--exclude=gen-cpp2' adsim/cpp2/server/dwarfs/Rebatch.h build/adsim/cpp2/server/dwarfs/Rebatch.h
+--- adsim/cpp2/server/dwarfs/Rebatch.h	2025-07-29 17:20:23.640920403 -0700
++++ build/adsim/cpp2/server/dwarfs/Rebatch.h	2025-07-29 17:16:49.260401117 -0700
+@@ -26,8 +26,8 @@
+ #include <string>
+ #include <vector>
+
 -#include <cea/chips/adsim/cpp2/server/DataObjects.h>
 -#include <cea/chips/adsim/cpp2/server/dwarfs/Kernel.h>
 +#include "cpp2/server/DataObjects.h"
 +#include "cpp2/server/dwarfs/Kernel.h"
- 
+
+ #include <folly/CppAttributes.h>
  #include <folly/coro/Task.h>
- 
+diff -wbBdu -ruN '--exclude=.git' '--exclude=*.rej' '--exclude=*.orig' '--exclude=gen-cpp2' adsim/cpp2/server/dwarfs/Serialize.h build/adsim/cpp2/server/dwarfs/Serialize.h
+--- adsim/cpp2/server/dwarfs/Serialize.h	2025-07-29 17:20:23.641344614 -0700
++++ build/adsim/cpp2/server/dwarfs/Serialize.h	2025-07-29 17:16:49.261456722 -0700
+@@ -20,15 +20,15 @@
+
+ #include <algorithm>
+
+-#include <cea/chips/adsim/cpp2/server/DataObjects.h>
+-#include <cea/chips/adsim/cpp2/server/dwarfs/Kernel.h>
++#include "cpp2/server/DataObjects.h"
++#include "cpp2/server/dwarfs/Kernel.h"
+
+ #include <folly/coro/Task.h>
+
  #include <thrift/lib/cpp2/protocol/CompactProtocol.h>
  #include <thrift/lib/cpp2/protocol/Serializer.h>
- 
+
 -#include <cea/chips/adsim/if/gen-cpp2/Serialize_types.h>
 +#include "if/gen-cpp2/Serialize_types.h"
- 
+
  namespace facebook::cea::chips::adsim {
- 
-diff -wbBdu -ruN '--exclude=.git' '--exclude=*.rej' '--exclude=*.orig' '--exclude=gen-cpp2' adsim_group/cpp2/server/dwarfs/Shape.h build/adsim/cpp2/server/dwarfs/Shape.h
---- adsim_group/cpp2/server/dwarfs/Shape.h	2025-07-29 14:17:29.786140568 -0700
-+++ build/adsim/cpp2/server/dwarfs/Shape.h	2025-07-25 15:55:10.026656306 -0700
+
+diff -wbBdu -ruN '--exclude=.git' '--exclude=*.rej' '--exclude=*.orig' '--exclude=gen-cpp2' adsim/cpp2/server/dwarfs/Shape.h build/adsim/cpp2/server/dwarfs/Shape.h
+--- adsim/cpp2/server/dwarfs/Shape.h	2025-07-29 17:20:23.641793763 -0700
++++ build/adsim/cpp2/server/dwarfs/Shape.h	2025-07-29 17:16:49.262466429 -0700
 @@ -16,10 +16,10 @@
- 
+
  #pragma once
- 
+
 -#include <cea/chips/adsim/cpp2/client/TLSConnect.h>
 -#include <cea/chips/adsim/cpp2/server/DataObjects.h>
 -#include <cea/chips/adsim/cpp2/server/dwarfs/Kernel.h>
@@ -432,51 +460,51 @@ diff -wbBdu -ruN '--exclude=.git' '--exclude=*.rej' '--exclude=*.orig' '--exclud
 +#include "cpp2/server/DataObjects.h"
 +#include "cpp2/server/dwarfs/Kernel.h"
 +#include "if/gen-cpp2/AdSim.h"
- 
+
  #include <fb303/ThreadCachedServiceData.h>
  #include <folly/MoveWrapper.h>
-diff -wbBdu -ruN '--exclude=.git' '--exclude=*.rej' '--exclude=*.orig' '--exclude=gen-cpp2' adsim_group/cpp2/server/dwarfs/TensorDeser.cc build/adsim/cpp2/server/dwarfs/TensorDeser.cc
---- adsim_group/cpp2/server/dwarfs/TensorDeser.cc	2025-07-29 14:17:29.786570039 -0700
-+++ build/adsim/cpp2/server/dwarfs/TensorDeser.cc	2025-07-29 03:10:24.727445630 -0700
+diff -wbBdu -ruN '--exclude=.git' '--exclude=*.rej' '--exclude=*.orig' '--exclude=gen-cpp2' adsim/cpp2/server/dwarfs/TensorDeser.cc build/adsim/cpp2/server/dwarfs/TensorDeser.cc
+--- adsim/cpp2/server/dwarfs/TensorDeser.cc	2025-07-29 17:20:23.642258066 -0700
++++ build/adsim/cpp2/server/dwarfs/TensorDeser.cc	2025-07-29 17:16:49.263334411 -0700
 @@ -14,7 +14,7 @@
   * limitations under the License.
   */
- 
+
 -#include <cea/chips/adsim/cpp2/server/dwarfs/TensorDeser.h>
 +#include "TensorDeser.h"
  #include <cstring>
  #include <iomanip>
  #include <iostream>
-diff -wbBdu -ruN '--exclude=.git' '--exclude=*.rej' '--exclude=*.orig' '--exclude=gen-cpp2' adsim_group/cpp2/server/dwarfs/TensorDeser.h build/adsim/cpp2/server/dwarfs/TensorDeser.h
---- adsim_group/cpp2/server/dwarfs/TensorDeser.h	2025-07-29 14:17:29.787024406 -0700
-+++ build/adsim/cpp2/server/dwarfs/TensorDeser.h	2025-07-29 03:10:09.858016018 -0700
+diff -wbBdu -ruN '--exclude=.git' '--exclude=*.rej' '--exclude=*.orig' '--exclude=gen-cpp2' adsim/cpp2/server/dwarfs/TensorDeser.h build/adsim/cpp2/server/dwarfs/TensorDeser.h
+--- adsim/cpp2/server/dwarfs/TensorDeser.h	2025-07-29 17:20:23.642707696 -0700
++++ build/adsim/cpp2/server/dwarfs/TensorDeser.h	2025-07-29 17:16:49.263899105 -0700
 @@ -30,8 +30,8 @@
  #include <tuple>
  #include <vector>
- 
+
 -#include <cea/chips/adsim/cpp2/server/DataObjects.h>
 -#include <cea/chips/adsim/cpp2/server/dwarfs/Kernel.h>
 +#include "cpp2/server/DataObjects.h"
 +#include "cpp2/server/dwarfs/Kernel.h"
- 
+
  #include <folly/FileUtil.h>
  #include <folly/Format.h>
-diff -wbBdu -ruN '--exclude=.git' '--exclude=*.rej' '--exclude=*.orig' '--exclude=gen-cpp2' adsim_group/if/AdSim.thrift build/adsim/if/AdSim.thrift
---- adsim_group/if/AdSim.thrift	2025-07-29 14:17:29.792097453 -0700
-+++ build/adsim/if/AdSim.thrift	2025-07-25 15:55:10.027410947 -0700
+diff -wbBdu -ruN '--exclude=.git' '--exclude=*.rej' '--exclude=*.orig' '--exclude=gen-cpp2' adsim/if/AdSim.thrift build/adsim/if/AdSim.thrift
+--- adsim/if/AdSim.thrift	2025-07-29 17:20:23.647469406 -0700
++++ build/adsim/if/AdSim.thrift	2025-07-29 17:16:49.264643370 -0700
 @@ -1,4 +1,4 @@
 -include "common/fb303/if/fb303.thrift"
 +include "fb303.thrift"
- 
+
  namespace cpp2 facebook.cea.chips.adsim
  namespace py3 facebook.cea.chips.adsim
-diff -wbBdu -ruN '--exclude=.git' '--exclude=*.rej' '--exclude=*.orig' '--exclude=gen-cpp2' adsim_group/if/Serialize.thrift build/adsim/if/Serialize.thrift
---- adsim_group/if/Serialize.thrift	2025-07-29 14:17:29.792879556 -0700
-+++ build/adsim/if/Serialize.thrift	2025-07-25 15:55:10.028022061 -0700
+diff -wbBdu -ruN '--exclude=.git' '--exclude=*.rej' '--exclude=*.orig' '--exclude=gen-cpp2' adsim/if/Serialize.thrift build/adsim/if/Serialize.thrift
+--- adsim/if/Serialize.thrift	2025-07-29 17:20:23.648161923 -0700
++++ build/adsim/if/Serialize.thrift	2025-07-29 17:16:49.265284350 -0700
 @@ -3,20 +3,15 @@
  cpp_include "list"
  cpp_include "folly/container/F14Map.h"
- 
+
 -include "thrift/annotation/cpp.thrift"
 -
  struct SerializableInfo {
@@ -484,7 +512,7 @@ diff -wbBdu -ruN '--exclude=.git' '--exclude=*.rej' '--exclude=*.orig' '--exclud
    2: i32 var_i32;
    3: double var_double;
  }
- 
+
 -@cpp.Type{template = "std::list"}
 -typedef list<i32> id_list_t
 -@cpp.Type{template = "folly::F14VectorMap"}
@@ -494,16 +522,16 @@ diff -wbBdu -ruN '--exclude=.git' '--exclude=*.rej' '--exclude=*.orig' '--exclud
 +typedef list<i32> (cpp.template = "std::list") id_list_t
 +typedef map<i32, id_list_t> (cpp.template = "folly::F14VectorMap") id_map_t
 +typedef list<SerializableInfo> (cpp.template = "std::list") info_list_t
- 
+
  struct SerializableUnit {
    1: id_map_t map_of_list;
 @@ -24,8 +19,7 @@
    3: id_list_t list_of_i32;
  }
- 
+
 -@cpp.Type{template = "std::list"}
 -typedef list<SerializableUnit> unit_list_t
 +typedef list<SerializableUnit> (cpp.template = "std::list") unit_list_t
- 
+
  struct SerializableReq {
    1: i64 var_i64;

--- a/packages/adsim/src/cpp2/server/dwarfs/CMakeLists.txt
+++ b/packages/adsim/src/cpp2/server/dwarfs/CMakeLists.txt
@@ -122,6 +122,9 @@ add_library(tensordeser TensorDeser.cc TensorDeser.h)
 target_link_libraries(tensordeser data_objects kernel ${JEMALLOC_LIB})
 target_compile_options(tensordeser PRIVATE ${COROUTINES_FLAG})
 
+add_library(rebatch Rebatch.cc Rebatch.h)
+target_link_libraries(rebatch data_objects kernel)
+target_compile_options(rebatch PRIVATE ${COROUTINES_FLAG})
 
 add_library(deepcopy DeepCopy.h)
 target_link_libraries(deepcopy data_objects kernel)
@@ -137,6 +140,7 @@ add_library(dwarfs Dwarfs.cc Dwarfs.h)
 target_link_libraries(dwarfs
     compress
     concurrenthashmap
+    rebatch
     deepcopy
     delay
     fakeio

--- a/packages/adsim/src/cpp2/server/dwarfs/Dwarfs.cc
+++ b/packages/adsim/src/cpp2/server/dwarfs/Dwarfs.cc
@@ -29,6 +29,7 @@
 #include <cea/chips/adsim/cpp2/server/dwarfs/HashMap.h>
 #include <cea/chips/adsim/cpp2/server/dwarfs/IBRun.h>
 #include <cea/chips/adsim/cpp2/server/dwarfs/Kernel.h>
+#include <cea/chips/adsim/cpp2/server/dwarfs/Rebatch.h>
 #include <cea/chips/adsim/cpp2/server/dwarfs/Serialize.h>
 #include <cea/chips/adsim/cpp2/server/dwarfs/Shape.h>
 #include <cea/chips/adsim/cpp2/server/dwarfs/TensorDeser.h>
@@ -47,6 +48,7 @@ const folly::F14VectorMap<std::string, CONFIG_F> KERNEL_DICT = {
     {"TensorDeser", TensorDeser::config},
     {"HashMap", HashMap::config},
     {"ConcurrentHashMap", ConcurrentHashMap::config},
+    {"Rebatch", Rebatch::config},
     {"DeepCopy", DeepCopy::config},
     {"Delay", Delay::config},
     {"Shape", Shape::config},

--- a/packages/adsim/src/cpp2/server/dwarfs/Kernel.cc
+++ b/packages/adsim/src/cpp2/server/dwarfs/Kernel.cc
@@ -36,6 +36,7 @@ DEFINE_timeseries(
     concurrent_hashmap_nfired,
     "concurrent_hashmap_nfired",
     fb303::SUM);
+DEFINE_timeseries(rebatch_nfired, "rebatch_nfired", fb303::SUM);
 DEFINE_timeseries(deepcopy_nfired, "deepcopy_nfired", fb303::SUM);
 DEFINE_timeseries(delay_nfired, "delay_nfired", fb303::SUM);
 DEFINE_timeseries(shape_nfired, "shape_nfired", fb303::SUM);

--- a/packages/adsim/src/cpp2/server/dwarfs/Rebatch.cc
+++ b/packages/adsim/src/cpp2/server/dwarfs/Rebatch.cc
@@ -1,0 +1,477 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <cea/chips/adsim/cpp2/server/dwarfs/Rebatch.h>
+
+#include <fb303/ThreadCachedServiceData.h>
+#include <folly/futures/Future.h>
+
+namespace facebook::cea::chips::adsim {
+
+DECLARE_timeseries(rebatch_nfired);
+
+/**
+ * Load size distribution from a CSV file
+ * Format: size,frequency where frequency is a percentage (0-100)
+ * Example: 24460,0.69
+ *
+ * Builds a cumulative distribution function (CDF) for efficient sampling
+ */
+bool SizeDistribution::loadFromFile(const std::string& filename) {
+  std::ifstream file(filename);
+  if (!file.is_open()) {
+    LOG(ERROR) << "Failed to open size distribution file: " << filename;
+    return false;
+  }
+
+  sizes.clear();
+  cum_probs.clear();
+  std::string line;
+  std::vector<std::pair<size_t, double>> sizeFreqPairs;
+
+  // Read size and frequency pairs from the file
+  while (std::getline(file, line)) {
+    std::istringstream iss(line);
+    std::string sizeStr, freqStr;
+
+    if (std::getline(iss, sizeStr, ',') && std::getline(iss, freqStr)) {
+      try {
+        size_t size = std::stoul(sizeStr);
+        double freq = std::stod(freqStr);
+        sizeFreqPairs.emplace_back(size, freq / 100.0);
+      } catch (const std::exception& e) {
+        LOG(ERROR) << "Error parsing line: " << line << " - " << e.what();
+      }
+    }
+  }
+
+  // Sort by size for binary search efficiency
+  std::sort(
+      sizeFreqPairs.begin(),
+      sizeFreqPairs.end(),
+      [](const auto& a, const auto& b) { return a.first < b.first; });
+
+  // Build cumulative distribution
+  double cumProb = 0.0;
+  for (const auto& pair : sizeFreqPairs) {
+    sizes.push_back(pair.first);
+    cumProb += pair.second;
+    cum_probs.push_back(cumProb);
+  }
+
+  // Ensure the last cumulative probability is exactly 1.0
+  if (!cum_probs.empty()) {
+    cum_probs.back() = 1.0;
+  }
+
+  LOG(INFO) << "Loaded " << sizes.size()
+            << " unique sizes with cumulative probability distribution";
+  return true;
+}
+
+/**
+ * Sample a random size using binary search on the CDF
+ * Time complexity: O(log n) where n is the number of unique sizes
+ * Uses thread-local RNG for better performance in multi-threaded scenarios
+ */
+size_t SizeDistribution::getRandomSize() const {
+  if (sizes.empty()) {
+    return 0;
+  }
+
+  // Initialize thread-local random generator
+  static thread_local std::mt19937 local_gen(std::random_device{}());
+
+  // Generate random value between 0 and 1
+  std::uniform_real_distribution<double> dist(0.0, 1.0);
+  double rand_val = dist(local_gen);
+
+  // Binary search to find the corresponding size
+  auto it = std::lower_bound(cum_probs.begin(), cum_probs.end(), rand_val);
+  size_t index = std::distance(cum_probs.begin(), it);
+
+  // Ensure index is within bounds
+  if (index >= sizes.size()) {
+    index = sizes.size() - 1;
+  }
+
+  return sizes[index];
+}
+
+/**
+ * InputMemoryPool constructor - Initialize with a large memory chunk (size in
+ * GB)
+ */
+InputMemoryPool::InputMemoryPool(size_t size_gb) {
+  // Convert GB to bytes
+  size_t size_bytes = size_gb * 1024ULL * 1024ULL * 1024ULL;
+
+  LOG(INFO) << "Allocating a large memory pool of " << size_gb << " GB ("
+            << size_bytes << " bytes) for input tensors";
+
+  // Allocate the memory chunk
+  memory_ = malloc(size_bytes);
+  if (!memory_) {
+    throw std::bad_alloc();
+  }
+
+  // Initialize with some pattern for validation if needed
+  memset(memory_, 0xAB, size_bytes);
+
+  size_ = size_bytes;
+}
+
+InputMemoryPool::~InputMemoryPool() {
+  if (memory_) {
+    free(memory_);
+    memory_ = nullptr;
+  }
+}
+
+void* FOLLY_NULLABLE InputMemoryPool::getPointerAtOffset(size_t offset) const {
+  if (offset < size_) {
+    return static_cast<char*>(memory_) + offset;
+  }
+  return nullptr;
+}
+
+size_t InputMemoryPool::getSize() const {
+  return size_;
+}
+
+/**
+ * TensorBatch constructor - Collection of tensors with random offsets in memory
+ * pool
+ *
+ * Creates a batch of tensors with:
+ * 1. Sizes sampled from the provided distribution
+ * 2. Random offsets within the large memory pool
+ * 3. Total size limited by max_total_size
+ */
+TensorBatch::TensorBatch(
+    size_t count,
+    const SizeDistribution& size_dist,
+    size_t max_total_size,
+    const InputMemoryPool& memory_pool) {
+  // Initialize random number generator for offsets
+  static thread_local std::mt19937 rng(std::random_device{}());
+
+  // Get the total size of the memory pool
+  size_t pool_size = memory_pool.getSize();
+
+  // Allocate memory for each tensor based on the size distribution
+  for (size_t i = 0; i < count; ++i) {
+    size_t size = size_dist.getRandomSize();
+    if (size == 0) {
+      continue;
+    }
+
+    // Check if adding this tensor would exceed the max total size
+    if (total_size + size > max_total_size) {
+      break;
+    }
+
+    // Calculate maximum possible offset to ensure we don't exceed the pool size
+    if (size > pool_size) {
+      continue; // Skip tensors that are larger than the entire pool
+    }
+    size_t max_offset = pool_size - size;
+
+    // Generate a random offset within the valid range
+    std::uniform_int_distribution<size_t> dist(0, max_offset);
+    size_t offset = dist(rng);
+
+    // Get a pointer at the random offset in the memory pool
+    void* tensor = memory_pool.getPointerAtOffset(offset);
+
+    if (tensor) {
+      tensors.push_back(tensor);
+      tensor_sizes.push_back(size);
+      total_size += size;
+    }
+  }
+}
+
+TensorBatch::~TensorBatch() {
+  // No need to free tensors - they're pre-allocated and managed by the memory
+  // pool
+  tensors.clear();
+  tensor_sizes.clear();
+}
+
+const std::vector<const void*>& TensorBatch::getTensors() const {
+  return reinterpret_cast<const std::vector<const void*>&>(tensors);
+}
+
+size_t TensorBatch::getTensorSize(size_t index) const {
+  if (index < tensor_sizes.size()) {
+    return tensor_sizes[index];
+  }
+  return 0;
+}
+
+size_t TensorBatch::getTensorCount() const {
+  return tensors.size();
+}
+
+size_t TensorBatch::getTotalSize() const {
+  return total_size;
+}
+
+/**
+ * Rebatch kernel constructor
+ *
+ * Initializes benchmark with tensor size distribution and memory pool
+ * configuration.
+ */
+Rebatch::Rebatch(
+    int tensors_per_batch,
+    int num_threads,
+    size_t output_tensor_size,
+    size_t memory_pool_size_gb,
+    int prefetch_dist,
+    std::string input_str,
+    std::string distribution_file)
+    : tensors_per_batch_(tensors_per_batch),
+      num_threads_(num_threads),
+      output_tensor_size_(output_tensor_size),
+      memory_pool_size_gb_(memory_pool_size_gb),
+      prefetch_dist_(prefetch_dist),
+      input_str_(std::move(input_str)),
+      distribution_file_(std::move(distribution_file)) {
+  LOG(INFO) << "Rebatch initialized with params: " << "tensors_per_batch="
+            << tensors_per_batch_ << ", num_threads=" << num_threads_
+            << ", output_tensor_size=" << output_tensor_size_
+            << ", memory_pool_size_gb=" << memory_pool_size_gb_
+            << ", prefetch_dist=" << prefetch_dist_
+            << ", distribution_file=" << distribution_file_;
+}
+
+/**
+ * Initialize rebatch kernel with distribution-based workload
+ *
+ * Loads tensor size distribution from CSV file and initializes memory pool.
+ */
+std::string Rebatch::init(
+    std::shared_ptr<AdSimHandleObjs> h_objs,
+    std::shared_ptr<AdSimRequestObjs> /*unused*/) {
+  // Load tensor size distribution from file
+  size_distribution_ = std::make_shared<SizeDistribution>();
+  if (!size_distribution_->loadFromFile(distribution_file_)) {
+    throw std::runtime_error(
+        "Failed to load size distribution file: " + distribution_file_);
+  }
+
+  // Initialize the large input memory pool for realistic memory access patterns
+  input_memory_pool_ = std::make_shared<InputMemoryPool>(memory_pool_size_gb_);
+
+  // Store references in handle objects for potential reuse
+  h_objs->set_shared_ptr(input_str_ + "_size_dist", size_distribution_);
+  h_objs->set_shared_ptr(input_str_ + "_memory_pool", input_memory_pool_);
+
+  std::string info = folly::to<std::string>(
+      "Rebatch: ", input_str_, " ", std::to_string(output_tensor_size_), "B");
+  info += " (distribution: " + distribution_file_ + ")";
+  info += " (memory_pool: " + std::to_string(memory_pool_size_gb_) + "GB)";
+  return info;
+}
+
+/**
+ * Single-threaded rebatch operation
+ *
+ * Creates a batch of tensors and performs sequential memory copy operations.
+ */
+int Rebatch::rebatch_single_thread() {
+  // Create a fresh batch of tensors for this operation
+  auto batch = std::make_unique<TensorBatch>(
+      tensors_per_batch_,
+      *size_distribution_,
+      output_tensor_size_,
+      *input_memory_pool_);
+
+  const auto& tensors = batch->getTensors();
+  const size_t numTensors = tensors.size();
+
+  if (numTensors == 0) {
+    return 0; // Skip empty batches
+  }
+
+  // Allocate a fresh output tensor for this batch
+  std::unique_ptr<char[]> output(new char[output_tensor_size_]);
+
+  // Process all tensors sequentially, copying each to the output buffer
+  size_t totalProcessedBytes = 0;
+  uint64_t checksum = 0; // Prevent compiler optimization
+
+  if (prefetch_dist_ > 0) {
+    // With prefetching - improves performance by loading data into cache
+    const int prefetchDist = static_cast<int>(prefetch_dist_);
+
+    // Prefetch initial tensors
+    for (int i = 1; i < prefetchDist && i < static_cast<int>(numTensors); i++) {
+      __builtin_prefetch(tensors[i]);
+    }
+
+    // Process all tensors with prefetching
+    for (size_t i = 0; i < numTensors; ++i) {
+      const auto srcPtr = tensors[i];
+      const auto inputNbytes = batch->getTensorSize(i);
+
+      // Prefetch ahead
+      if (i + prefetchDist < numTensors) {
+        __builtin_prefetch(tensors[i + prefetchDist]);
+      }
+
+      if (inputNbytes == 0) {
+        continue;
+      }
+
+      // Perform the memcpy operation
+      memcpy(output.get() + totalProcessedBytes, srcPtr, inputNbytes);
+      totalProcessedBytes += inputNbytes;
+
+      // Update checksum to prevent optimization
+      checksum ^= reinterpret_cast<uintptr_t>(srcPtr);
+    }
+  } else {
+    // Without prefetching - baseline implementation
+    for (size_t i = 0; i < numTensors; ++i) {
+      const auto srcPtr = tensors[i];
+      const auto inputNbytes = batch->getTensorSize(i);
+
+      if (inputNbytes == 0) {
+        continue;
+      }
+
+      // Perform the memcpy operation
+      memcpy(output.get() + totalProcessedBytes, srcPtr, inputNbytes);
+      totalProcessedBytes += inputNbytes;
+
+      // Update checksum to prevent optimization
+      checksum ^= reinterpret_cast<uintptr_t>(srcPtr);
+    }
+  }
+
+  return static_cast<int>(totalProcessedBytes ^ checksum);
+}
+
+/**
+ * Multi-threaded rebatch operation with work distribution
+ *
+ * Distributes rebatch work across worker threads. Each thread processes
+ * a portion of the tensors in the batch.
+ */
+folly::coro::Task<int> Rebatch::rebatch_multi_thread(
+    std::shared_ptr<folly::Executor> pool) {
+  // Create a fresh batch of tensors for this operation
+  auto batch = std::make_shared<TensorBatch>(
+      tensors_per_batch_,
+      *size_distribution_,
+      output_tensor_size_,
+      *input_memory_pool_);
+
+  const auto& tensors = batch->getTensors();
+  const size_t numTensors = tensors.size();
+
+  if (numTensors == 0) {
+    co_return 0; // Skip empty batches
+  }
+
+  // Allocate a fresh output tensor for this batch
+  auto output = std::make_shared<std::vector<char>>(output_tensor_size_);
+
+  std::vector<folly::Future<int>> futures;
+  size_t tensors_per_thread = numTensors / num_threads_;
+
+  // Create worker tasks with balanced load distribution
+  for (int t = 0; t < num_threads_; ++t) {
+    size_t thread_start = t * tensors_per_thread;
+    size_t thread_end = (t == num_threads_ - 1)
+        ? numTensors // Last thread handles remainder
+        : (t + 1) * tensors_per_thread;
+
+    auto future =
+        folly::via(pool.get(), [batch, output, thread_start, thread_end]() {
+          const auto& batch_tensors = batch->getTensors();
+          size_t totalProcessedBytes = 0;
+          uint64_t checksum = 0;
+
+          // Calculate starting offset for this thread's portion
+          size_t output_offset = 0;
+          for (size_t i = 0; i < thread_start; ++i) {
+            output_offset += batch->getTensorSize(i);
+          }
+
+          // Process assigned chunk of tensors
+          for (size_t i = thread_start; i < thread_end; ++i) {
+            const auto srcPtr = batch_tensors[i];
+            const auto inputNbytes = batch->getTensorSize(i);
+
+            if (inputNbytes == 0) {
+              continue;
+            }
+
+            // Perform the memcpy operation
+            memcpy(
+                output->data() + output_offset + totalProcessedBytes,
+                srcPtr,
+                inputNbytes);
+            totalProcessedBytes += inputNbytes;
+
+            // Update checksum to prevent optimization
+            checksum ^= reinterpret_cast<uintptr_t>(srcPtr);
+          }
+
+          return static_cast<int>(totalProcessedBytes ^ checksum);
+        });
+    futures.push_back(std::move(future));
+  }
+
+  // Collect and aggregate results from all worker threads
+  auto results = co_await folly::collectAll(futures);
+  int final_result = 0;
+  for (auto& result : results) {
+    if (result.hasValue()) {
+      final_result ^= result.value();
+    }
+  }
+
+  co_return final_result;
+}
+
+/**
+ * Execute benchmark fire operation
+ *
+ * Performs single benchmark iteration with rebatch operations.
+ * Selects single/multi-threaded execution based on configuration.
+ */
+folly::coro::Task<std::string> Rebatch::fire(
+    std::shared_ptr<AdSimHandleObjs> h_objs,
+    std::shared_ptr<AdSimRequestObjs> r_objs,
+    std::shared_ptr<folly::Executor> pool) {
+  STATS_rebatch_nfired.add(1);
+
+  // Select execution mode based on thread configuration and pool availability
+  if (num_threads_ > 1 && pool) {
+    co_await rebatch_multi_thread(std::move(pool));
+  } else {
+    rebatch_single_thread();
+  }
+
+  co_return "";
+}
+
+} // namespace facebook::cea::chips::adsim

--- a/packages/adsim/src/cpp2/server/dwarfs/Rebatch.h
+++ b/packages/adsim/src/cpp2/server/dwarfs/Rebatch.h
@@ -1,0 +1,206 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <algorithm>
+#include <atomic>
+#include <cstring>
+#include <fstream>
+#include <memory>
+#include <random>
+#include <sstream>
+#include <string>
+#include <vector>
+
+#include <cea/chips/adsim/cpp2/server/DataObjects.h>
+#include <cea/chips/adsim/cpp2/server/dwarfs/Kernel.h>
+
+#include <folly/CppAttributes.h>
+#include <folly/coro/Task.h>
+#include <folly/executors/CPUThreadPoolExecutor.h>
+#include <folly/futures/Future.h>
+
+namespace facebook::cea::chips::adsim {
+
+/**
+ * SizeDistribution - Efficient tensor size sampling using CDF approach
+ *
+ * Uses binary search on a cumulative distribution function (CDF) to efficiently
+ * sample tensor sizes according to a specified probability distribution.
+ */
+struct SizeDistribution {
+  std::vector<size_t> sizes; // Array of unique sizes
+  std::vector<double>
+      cum_probs; // Array of corresponding cumulative probabilities
+
+  /**
+   * Load size distribution from a CSV file
+   * Format: size,frequency where frequency is a percentage (0-100)
+   * Example: 24460,0.69
+   */
+  bool loadFromFile(const std::string& filename);
+
+  /**
+   * Sample a random size using binary search on the CDF
+   * Time complexity: O(log n) where n is the number of unique sizes
+   */
+  size_t getRandomSize() const;
+};
+
+/**
+ * InputMemoryPool - Large pre-allocated memory pool for input tensors
+ *
+ * Allocates a single large memory chunk to simulate realistic memory
+ * environment. Tensors are positioned at random offsets within this pool.
+ */
+class InputMemoryPool {
+ public:
+  explicit InputMemoryPool(size_t size_gb);
+  ~InputMemoryPool();
+
+  // Delete copy constructor and copy assignment operator
+  InputMemoryPool(const InputMemoryPool&) = delete;
+  InputMemoryPool& operator=(const InputMemoryPool&) = delete;
+
+  // Delete move constructor and move assignment operator
+  InputMemoryPool(InputMemoryPool&&) = delete;
+  InputMemoryPool& operator=(InputMemoryPool&&) = delete;
+
+  void* FOLLY_NULLABLE getPointerAtOffset(size_t offset) const;
+  size_t getSize() const;
+
+ private:
+  void* memory_ = nullptr;
+  size_t size_ = 0;
+};
+
+/**
+ * TensorBatch - Collection of tensors with random offsets in memory pool
+ *
+ * Creates a batch of tensors with:
+ * 1. Sizes sampled from the provided distribution
+ * 2. Random offsets within the large memory pool
+ * 3. Total size limited by output tensor size
+ */
+class TensorBatch {
+ public:
+  TensorBatch(
+      size_t count,
+      const SizeDistribution& size_dist,
+      size_t max_total_size,
+      const InputMemoryPool& memory_pool);
+  ~TensorBatch();
+
+  // Delete copy constructor and copy assignment operator
+  TensorBatch(const TensorBatch&) = delete;
+  TensorBatch& operator=(const TensorBatch&) = delete;
+
+  // Delete move constructor and move assignment operator
+  TensorBatch(TensorBatch&&) = delete;
+  TensorBatch& operator=(TensorBatch&&) = delete;
+
+  const std::vector<const void*>& getTensors() const;
+  size_t getTensorSize(size_t index) const;
+  size_t getTensorCount() const;
+  size_t getTotalSize() const;
+
+ private:
+  std::vector<void*> tensors;
+  std::vector<size_t> tensor_sizes;
+  size_t total_size = 0;
+};
+
+/**
+ * Rebatch kernel - Multi-threaded memory copy benchmark
+ *
+ * Performs rebatch operations (concatenating multiple tensors into a single
+ * output tensor) with configurable batch sizes, tensor size distributions, and
+ * threading.
+ */
+class Rebatch : public Kernel {
+ public:
+  explicit Rebatch(
+      int tensors_per_batch,
+      int num_threads,
+      size_t output_tensor_size,
+      size_t memory_pool_size_gb,
+      int prefetch_dist,
+      std::string input_str,
+      std::string distribution_file);
+
+  std::string init(
+      std::shared_ptr<AdSimHandleObjs> h_objs,
+      std::shared_ptr<AdSimRequestObjs> r_objs = nullptr) override;
+
+  folly::coro::Task<std::string> fire(
+      std::shared_ptr<AdSimHandleObjs> h_objs,
+      std::shared_ptr<AdSimRequestObjs> r_objs,
+      std::shared_ptr<folly::Executor> pool) override;
+
+  static std::shared_ptr<Kernel> config(const folly::dynamic& config_d) {
+    int64_t tensors_per_batch = config_d.count("tensors_per_batch")
+        ? static_cast<int64_t>(config_d["tensors_per_batch"].asInt())
+        : 100;
+    int64_t num_threads = config_d.count("num_threads")
+        ? static_cast<int64_t>(config_d["num_threads"].asInt())
+        : 4;
+    size_t output_tensor_size = config_d.count("output_tensor_size")
+        ? static_cast<size_t>(config_d["output_tensor_size"].asInt())
+        : 2421002;
+    size_t memory_pool_size_gb = config_d.count("memory_pool_size_gb")
+        ? static_cast<size_t>(config_d["memory_pool_size_gb"].asInt())
+        : 4;
+    int64_t prefetch_dist = config_d.count("prefetch_dist")
+        ? static_cast<int64_t>(config_d["prefetch_dist"].asInt())
+        : 0;
+    std::string input_str = "Rebatch";
+    if (config_d.count("input")) {
+      input_str = config_d["input"].asString();
+    }
+    std::string distribution_file = config_d["distribution_file"].asString();
+
+    return std::make_shared<Rebatch>(
+        tensors_per_batch,
+        num_threads,
+        output_tensor_size,
+        memory_pool_size_gb,
+        prefetch_dist,
+        input_str,
+        distribution_file);
+  }
+
+ private:
+  int64_t tensors_per_batch_;
+  int64_t num_threads_;
+  size_t output_tensor_size_;
+  size_t memory_pool_size_gb_;
+  int64_t prefetch_dist_;
+  std::string input_str_;
+  std::string distribution_file_;
+
+  std::shared_ptr<SizeDistribution> size_distribution_;
+  std::shared_ptr<InputMemoryPool> input_memory_pool_;
+
+  // Single-threaded rebatch operation
+  int rebatch_single_thread();
+
+  // Multi-threaded rebatch operation
+  folly::coro::Task<int> rebatch_multi_thread(
+      std::shared_ptr<folly::Executor> pool);
+};
+
+} // namespace facebook::cea::chips::adsim


### PR DESCRIPTION
Summary:
### Summary

This diff adds a new kernel called "Rebatch" into Adsim. The Rebatch kernel is implemented in the `Rebatch.h` and `Rebatch.cc` files, which are added to the `cea/chips/adsim/cpp2/server/dwarfs` directory. The kernel is also included in the `adsim` BUCK target.

The diff also updates the `CMakeLists.txt` file to include the Rebatch kernel in the build process.

### Changes

* Added `Rebatch.h` and `Rebatch.cc` files to `cea/chips/adsim/cpp2/server/dwarfs` directory
* Added Rebatch kernel to `adsim` BUCK target
* Updated `CMakeLists.txt` file to include Rebatch kernel in build process

### Files Changed

* `fbcode/cea/chips/adsim/cpp2/server/dwarfs/Rebatch.h`
* `fbcode/cea/chips/adsim/cpp2/server/dwarfs/Kernel.cc`
* `fbcode/cea/chips/adsim/cpp2/server/dwarfs/Dwarfs.cc`
* `fbcode/cea/chips/adsim/cpp2/server/dwarfs/Rebatch.cc`
* `fbcode/cea/chips/adsim/cpp2/server/dwarfs/BUCK`
* `fbcode/cea/chips/adsim/BUCK`
* `fbcode/cea/chips/adsim/cpp2/server/dwarfs/CMakeLists.txt`

Differential Revision: D79221719


