### PR TITLE
Add deserialize kernel back to Adsim

### DIFF
--- a/packages/adsim/src/cpp2/server/dwarfs/Dwarfs.cc
+++ b/packages/adsim/src/cpp2/server/dwarfs/Dwarfs.cc
@@ -45,6 +45,7 @@ const folly::F14VectorMap<std::string, CONFIG_F> KERNEL_DICT = {
     {"Compress", Compress::config},
     {"Decompress", Decompress::config},
     {"Serialize", Serialize::config},
+    {"Deserialize", Deserialize::config},
     {"TensorDeser", TensorDeser::config},
     {"HashMap", HashMap::config},
     {"ConcurrentHashMap", ConcurrentHashMap::config},


### PR DESCRIPTION
Summary:
Previous diff accidentally delete the deserialize kernel. This diff add the deserialize kernel back.

Rollback Plan:

Differential Revision: D79240892


