### PR TITLE
Add embedding kernel into Adsim

### DIFF
--- a/packages/adsim/patches/adsim.patch
+++ b/packages/adsim/patches/adsim.patch
@@ -1,10 +1,10 @@
-diff -wbBdu -ruN '--exclude=.git' '--exclude=*.rej' '--exclude=*.orig' '--exclude=gen-cpp2' adsim/cpp2/client/AdSimClient.cpp build/adsim/cpp2/client/AdSimClient.cpp
---- adsim/cpp2/client/AdSimClient.cpp	2025-07-29 17:20:23.627383965 -0700
-+++ build/adsim/cpp2/client/AdSimClient.cpp	2025-07-29 17:16:49.241854626 -0700
+diff -wbBdu -ruN '--exclude=.git' '--exclude=*.rej' '--exclude=*.orig' '--exclude=gen-cpp2' '--exclude=build' '--exclude=third_party' adsim/cpp2/client/AdSimClient.cpp build/adsim/cpp2/client/AdSimClient.cpp
+--- adsim/cpp2/client/AdSimClient.cpp	2025-07-30 18:04:11.133782404 -0700
++++ build/adsim/cpp2/client/AdSimClient.cpp	2025-07-30 18:02:55.837258581 -0700
 @@ -14,17 +14,15 @@
   * limitations under the License.
   */
-
+ 
 -#include <cea/chips/adsim/cpp2/client/TLSConnect.h>
  #include <folly/SocketAddress.h>
  #include <folly/coro/BlockingWait.h>
@@ -19,16 +19,16 @@ diff -wbBdu -ruN '--exclude=.git' '--exclude=*.rej' '--exclude=*.orig' '--exclud
 +#include "CoWorker.h"
 +#include "TLSConnect.h"
 +#include "if/gen-cpp2/AdSim.h"
-
+ 
  DEFINE_string(host, "::1", "AdSimServer host");
  DEFINE_int32(port, 10086, "AdSimServer port");
-diff -wbBdu -ruN '--exclude=.git' '--exclude=*.rej' '--exclude=*.orig' '--exclude=gen-cpp2' adsim/cpp2/client/CoWorker.h build/adsim/cpp2/client/CoWorker.h
---- adsim/cpp2/client/CoWorker.h	2025-07-29 17:20:23.628326019 -0700
-+++ build/adsim/cpp2/client/CoWorker.h	2025-07-29 17:16:49.242970483 -0700
+diff -wbBdu -ruN '--exclude=.git' '--exclude=*.rej' '--exclude=*.orig' '--exclude=gen-cpp2' '--exclude=build' '--exclude=third_party' adsim/cpp2/client/CoWorker.h build/adsim/cpp2/client/CoWorker.h
+--- adsim/cpp2/client/CoWorker.h	2025-07-30 18:04:11.134473118 -0700
++++ build/adsim/cpp2/client/CoWorker.h	2025-07-30 18:02:55.838762046 -0700
 @@ -16,14 +16,16 @@
-
+ 
  #pragma once
-
+ 
 -#include <cea/chips/adsim/if/gen-cpp2/AdSim.h>
  #include <fizz/client/AsyncFizzClient.h>
  #include <folly/MoveWrapper.h>
@@ -40,16 +40,16 @@ diff -wbBdu -ruN '--exclude=.git' '--exclude=*.rej' '--exclude=*.orig' '--exclud
  #include <thrift/lib/cpp2/security/extensions/ThriftParametersClientExtension.h>
 +#include "TLSConnect.h"
 +#include "if/gen-cpp2/AdSim.h"
-
+ 
  namespace facebook::cea::chips::adsim {
-
-diff -wbBdu -ruN '--exclude=.git' '--exclude=*.rej' '--exclude=*.orig' '--exclude=gen-cpp2' adsim/cpp2/server/AdSimServer.cpp build/adsim/cpp2/server/AdSimServer.cpp
---- adsim/cpp2/server/AdSimServer.cpp	2025-07-29 17:20:23.643578543 -0700
-+++ build/adsim/cpp2/server/AdSimServer.cpp	2025-07-29 17:16:49.243912648 -0700
+ 
+diff -wbBdu -ruN '--exclude=.git' '--exclude=*.rej' '--exclude=*.orig' '--exclude=gen-cpp2' '--exclude=build' '--exclude=third_party' adsim/cpp2/server/AdSimServer.cpp build/adsim/cpp2/server/AdSimServer.cpp
+--- adsim/cpp2/server/AdSimServer.cpp	2025-07-30 18:04:11.148809063 -0700
++++ build/adsim/cpp2/server/AdSimServer.cpp	2025-07-30 18:02:55.840021850 -0700
 @@ -19,16 +19,17 @@
  #include <streambuf>
  #include <string>
-
+ 
 -#include <cea/chips/adsim/cpp2/server/AdSimService.h>
 -#include <cea/chips/adsim/cpp2/server/dwarfs/Dwarfs.h>
 +#include <folly/dynamic.h>
@@ -64,30 +64,30 @@ diff -wbBdu -ruN '--exclude=.git' '--exclude=*.rej' '--exclude=*.orig' '--exclud
  #include <thrift/lib/cpp2/server/ThriftServer.h>
 +#include "cpp2/server/AdSimService.h"
 +#include "cpp2/server/dwarfs/Dwarfs.h"
-
+ 
  DEFINE_string(config_file, "", "A json file of configurations");
  DEFINE_int32(port, -1, "Overwrite port in the config file");
-diff -wbBdu -ruN '--exclude=.git' '--exclude=*.rej' '--exclude=*.orig' '--exclude=gen-cpp2' adsim/cpp2/server/AdSimService.cpp build/adsim/cpp2/server/AdSimService.cpp
---- adsim/cpp2/server/AdSimService.cpp	2025-07-29 17:20:23.644003896 -0700
-+++ build/adsim/cpp2/server/AdSimService.cpp	2025-07-29 17:16:49.244776624 -0700
+diff -wbBdu -ruN '--exclude=.git' '--exclude=*.rej' '--exclude=*.orig' '--exclude=gen-cpp2' '--exclude=build' '--exclude=third_party' adsim/cpp2/server/AdSimService.cpp build/adsim/cpp2/server/AdSimService.cpp
+--- adsim/cpp2/server/AdSimService.cpp	2025-07-30 18:04:11.149213675 -0700
++++ build/adsim/cpp2/server/AdSimService.cpp	2025-07-30 18:02:55.840979149 -0700
 @@ -14,8 +14,8 @@
   * limitations under the License.
   */
-
+ 
 -#include <cea/chips/adsim/cpp2/server/AdSimService.h>
 -#include <cea/chips/adsim/cpp2/server/DataObjects.h>
 +#include "cpp2/server/AdSimService.h"
 +#include "cpp2/server/DataObjects.h"
-
+ 
  #include <fb303/ThreadCachedServiceData.h>
  #include <folly/coro/Collect.h>
-diff -wbBdu -ruN '--exclude=.git' '--exclude=*.rej' '--exclude=*.orig' '--exclude=gen-cpp2' adsim/cpp2/server/AdSimService.h build/adsim/cpp2/server/AdSimService.h
---- adsim/cpp2/server/AdSimService.h	2025-07-29 17:20:23.644425113 -0700
-+++ build/adsim/cpp2/server/AdSimService.h	2025-07-29 17:16:49.245431123 -0700
+diff -wbBdu -ruN '--exclude=.git' '--exclude=*.rej' '--exclude=*.orig' '--exclude=gen-cpp2' '--exclude=build' '--exclude=third_party' adsim/cpp2/server/AdSimService.h build/adsim/cpp2/server/AdSimService.h
+--- adsim/cpp2/server/AdSimService.h	2025-07-30 18:04:11.149718969 -0700
++++ build/adsim/cpp2/server/AdSimService.h	2025-07-30 18:02:55.841776274 -0700
 @@ -22,10 +22,10 @@
  #include <folly/Executor.h>
  #include <folly/MapUtil.h>
-
+ 
 -#include <cea/chips/adsim/cpp2/server/DataObjects.h>
 -#include <cea/chips/adsim/cpp2/server/dwarfs/Kernel.h>
 -#include <cea/chips/adsim/if/gen-cpp2/AdSim.h>
@@ -95,130 +95,131 @@ diff -wbBdu -ruN '--exclude=.git' '--exclude=*.rej' '--exclude=*.orig' '--exclud
 +#include "cpp2/server/DataObjects.h"
 +#include "cpp2/server/dwarfs/Kernel.h"
 +#include "if/gen-cpp2/AdSim.h"
-
+ 
  namespace facebook::cea::chips::adsim {
-
-diff -wbBdu -ruN '--exclude=.git' '--exclude=*.rej' '--exclude=*.orig' '--exclude=gen-cpp2' adsim/cpp2/server/DataObjects.cpp build/adsim/cpp2/server/DataObjects.cpp
---- adsim/cpp2/server/DataObjects.cpp	2025-07-29 17:20:23.645212253 -0700
-+++ build/adsim/cpp2/server/DataObjects.cpp	2025-07-29 17:16:49.246001116 -0700
+ 
+diff -wbBdu -ruN '--exclude=.git' '--exclude=*.rej' '--exclude=*.orig' '--exclude=gen-cpp2' '--exclude=build' '--exclude=third_party' adsim/cpp2/server/DataObjects.cpp build/adsim/cpp2/server/DataObjects.cpp
+--- adsim/cpp2/server/DataObjects.cpp	2025-07-30 18:04:11.150525429 -0700
++++ build/adsim/cpp2/server/DataObjects.cpp	2025-07-30 18:02:55.842535912 -0700
 @@ -14,7 +14,7 @@
   * limitations under the License.
   */
-
+ 
 -#include <cea/chips/adsim/cpp2/server/DataObjects.h>
 +#include "cpp2/server/DataObjects.h"
  #include <folly/Singleton.h>
-
+ 
  namespace facebook::cea::chips::adsim {
-diff -wbBdu -ruN '--exclude=.git' '--exclude=*.rej' '--exclude=*.orig' '--exclude=gen-cpp2' adsim/cpp2/server/DataObjects.h build/adsim/cpp2/server/DataObjects.h
---- adsim/cpp2/server/DataObjects.h	2025-07-29 17:20:23.645726110 -0700
-+++ build/adsim/cpp2/server/DataObjects.h	2025-07-29 17:16:49.246827264 -0700
+diff -wbBdu -ruN '--exclude=.git' '--exclude=*.rej' '--exclude=*.orig' '--exclude=gen-cpp2' '--exclude=build' '--exclude=third_party' adsim/cpp2/server/DataObjects.h build/adsim/cpp2/server/DataObjects.h
+--- adsim/cpp2/server/DataObjects.h	2025-07-30 18:04:11.150957342 -0700
++++ build/adsim/cpp2/server/DataObjects.h	2025-07-30 18:02:55.843400910 -0700
 @@ -27,7 +27,7 @@
  #include <thrift/lib/cpp2/protocol/CompactProtocol.h>
  #include <thrift/lib/cpp2/protocol/Serializer.h>
-
+ 
 -#include <cea/chips/adsim/if/gen-cpp2/AdSim.h>
 +#include "if/gen-cpp2/AdSim.h"
-
+ 
  namespace facebook::cea::chips::adsim {
-
-diff -wbBdu -ruN '--exclude=.git' '--exclude=*.rej' '--exclude=*.orig' '--exclude=gen-cpp2' adsim/cpp2/server/dwarfs/Compress.cc build/adsim/cpp2/server/dwarfs/Compress.cc
---- adsim/cpp2/server/dwarfs/Compress.cc	2025-07-29 17:20:23.633573374 -0700
-+++ build/adsim/cpp2/server/dwarfs/Compress.cc	2025-07-29 17:16:49.247596287 -0700
+ 
+diff -wbBdu -ruN '--exclude=.git' '--exclude=*.rej' '--exclude=*.orig' '--exclude=gen-cpp2' '--exclude=build' '--exclude=third_party' adsim/cpp2/server/dwarfs/Compress.cc build/adsim/cpp2/server/dwarfs/Compress.cc
+--- adsim/cpp2/server/dwarfs/Compress.cc	2025-07-30 18:04:11.138865162 -0700
++++ build/adsim/cpp2/server/dwarfs/Compress.cc	2025-07-30 18:02:55.844520865 -0700
 @@ -18,10 +18,10 @@
  #include <util.h>
-
+ 
  #include <glog/logging.h>
 -#include <cstring>
 +#include <string.h>
-
+ 
 -#include <cea/chips/adsim/cpp2/server/dwarfs/Compress.h>
 -#include <cea/chips/adsim/cpp2/server/dwarfs/Kernel.h>
 +#include "Compress.h"
 +#include "Kernel.h"
-
+ 
  #include <fb303/ThreadCachedServiceData.h>
  #include <folly/coro/Task.h>
-diff -wbBdu -ruN '--exclude=.git' '--exclude=*.rej' '--exclude=*.orig' '--exclude=gen-cpp2' adsim/cpp2/server/dwarfs/Compress.h build/adsim/cpp2/server/dwarfs/Compress.h
---- adsim/cpp2/server/dwarfs/Compress.h	2025-07-29 17:20:23.633936002 -0700
-+++ build/adsim/cpp2/server/dwarfs/Compress.h	2025-07-29 17:16:49.248495447 -0700
+diff -wbBdu -ruN '--exclude=.git' '--exclude=*.rej' '--exclude=*.orig' '--exclude=gen-cpp2' '--exclude=build' '--exclude=third_party' adsim/cpp2/server/dwarfs/Compress.h build/adsim/cpp2/server/dwarfs/Compress.h
+--- adsim/cpp2/server/dwarfs/Compress.h	2025-07-30 18:04:11.139220429 -0700
++++ build/adsim/cpp2/server/dwarfs/Compress.h	2025-07-30 18:02:55.845471943 -0700
 @@ -21,8 +21,8 @@
-
+ 
  #include <string.h>
-
+ 
 -#include <cea/chips/adsim/cpp2/server/DataObjects.h>
 -#include <cea/chips/adsim/cpp2/server/dwarfs/Kernel.h>
 +#include "cpp2/server/DataObjects.h"
 +#include "cpp2/server/dwarfs/Kernel.h"
-
+ 
  #include <folly/coro/Task.h>
-
-diff -wbBdu -ruN '--exclude=.git' '--exclude=*.rej' '--exclude=*.orig' '--exclude=gen-cpp2' adsim/cpp2/server/dwarfs/ConcurrentHashMap.cc build/adsim/cpp2/server/dwarfs/ConcurrentHashMap.cc
---- adsim/cpp2/server/dwarfs/ConcurrentHashMap.cc	2025-07-29 17:20:23.634329728 -0700
-+++ build/adsim/cpp2/server/dwarfs/ConcurrentHashMap.cc	2025-07-29 17:16:49.249399593 -0700
+ 
+diff -wbBdu -ruN '--exclude=.git' '--exclude=*.rej' '--exclude=*.orig' '--exclude=gen-cpp2' '--exclude=build' '--exclude=third_party' adsim/cpp2/server/dwarfs/ConcurrentHashMap.cc build/adsim/cpp2/server/dwarfs/ConcurrentHashMap.cc
+--- adsim/cpp2/server/dwarfs/ConcurrentHashMap.cc	2025-07-30 18:04:11.139601996 -0700
++++ build/adsim/cpp2/server/dwarfs/ConcurrentHashMap.cc	2025-07-30 18:02:55.846448299 -0700
 @@ -14,7 +14,7 @@
   * limitations under the License.
   */
-
+ 
 -#include <cea/chips/adsim/cpp2/server/dwarfs/ConcurrentHashMap.h>
 +#include "ConcurrentHashMap.h"
-
+ 
  #include <fb303/ThreadCachedServiceData.h>
  #include <folly/executors/CPUThreadPoolExecutor.h>
-diff -wbBdu -ruN '--exclude=.git' '--exclude=*.rej' '--exclude=*.orig' '--exclude=gen-cpp2' adsim/cpp2/server/dwarfs/ConcurrentHashMap.h build/adsim/cpp2/server/dwarfs/ConcurrentHashMap.h
---- adsim/cpp2/server/dwarfs/ConcurrentHashMap.h	2025-07-29 17:20:23.634768041 -0700
-+++ build/adsim/cpp2/server/dwarfs/ConcurrentHashMap.h	2025-07-29 17:16:49.250087493 -0700
+diff -wbBdu -ruN '--exclude=.git' '--exclude=*.rej' '--exclude=*.orig' '--exclude=gen-cpp2' '--exclude=build' '--exclude=third_party' adsim/cpp2/server/dwarfs/ConcurrentHashMap.h build/adsim/cpp2/server/dwarfs/ConcurrentHashMap.h
+--- adsim/cpp2/server/dwarfs/ConcurrentHashMap.h	2025-07-30 18:04:11.139940108 -0700
++++ build/adsim/cpp2/server/dwarfs/ConcurrentHashMap.h	2025-07-30 18:02:55.847458748 -0700
 @@ -30,8 +30,8 @@
  #include <utility>
  #include <vector>
-
+ 
 -#include <cea/chips/adsim/cpp2/server/DataObjects.h>
 -#include <cea/chips/adsim/cpp2/server/dwarfs/Kernel.h>
 +#include "cpp2/server/DataObjects.h"
 +#include "cpp2/server/dwarfs/Kernel.h"
-
+ 
  #include <folly/Likely.h>
  #include <folly/SharedMutex.h>
-diff -wbBdu -ruN '--exclude=.git' '--exclude=*.rej' '--exclude=*.orig' '--exclude=gen-cpp2' adsim/cpp2/server/dwarfs/DeepCopy.h build/adsim/cpp2/server/dwarfs/DeepCopy.h
---- adsim/cpp2/server/dwarfs/DeepCopy.h	2025-07-29 17:20:23.635358934 -0700
-+++ build/adsim/cpp2/server/dwarfs/DeepCopy.h	2025-07-29 17:16:49.250840472 -0700
+diff -wbBdu -ruN '--exclude=.git' '--exclude=*.rej' '--exclude=*.orig' '--exclude=gen-cpp2' '--exclude=build' '--exclude=third_party' adsim/cpp2/server/dwarfs/DeepCopy.h build/adsim/cpp2/server/dwarfs/DeepCopy.h
+--- adsim/cpp2/server/dwarfs/DeepCopy.h	2025-07-30 18:04:11.140293483 -0700
++++ build/adsim/cpp2/server/dwarfs/DeepCopy.h	2025-07-30 18:02:55.848317316 -0700
 @@ -24,8 +24,8 @@
  #include <unordered_map>
  #include <vector>
-
+ 
 -#include <cea/chips/adsim/cpp2/server/DataObjects.h>
 -#include <cea/chips/adsim/cpp2/server/dwarfs/Kernel.h>
 +#include "cpp2/server/DataObjects.h"
 +#include "cpp2/server/dwarfs/Kernel.h"
-
+ 
  #include <fb303/ThreadCachedServiceData.h>
  #include <folly/container/F14Map.h>
-diff -wbBdu -ruN '--exclude=.git' '--exclude=*.rej' '--exclude=*.orig' '--exclude=gen-cpp2' adsim/cpp2/server/dwarfs/Delay.h build/adsim/cpp2/server/dwarfs/Delay.h
---- adsim/cpp2/server/dwarfs/Delay.h	2025-07-29 17:20:23.635800691 -0700
-+++ build/adsim/cpp2/server/dwarfs/Delay.h	2025-07-29 17:16:49.251605649 -0700
+diff -wbBdu -ruN '--exclude=.git' '--exclude=*.rej' '--exclude=*.orig' '--exclude=gen-cpp2' '--exclude=build' '--exclude=third_party' adsim/cpp2/server/dwarfs/Delay.h build/adsim/cpp2/server/dwarfs/Delay.h
+--- adsim/cpp2/server/dwarfs/Delay.h	2025-07-30 18:04:11.140767379 -0700
++++ build/adsim/cpp2/server/dwarfs/Delay.h	2025-07-30 18:02:55.849096705 -0700
 @@ -18,8 +18,8 @@
-
+ 
  #include <unistd.h>
-
+ 
 -#include <cea/chips/adsim/cpp2/server/DataObjects.h>
 -#include <cea/chips/adsim/cpp2/server/dwarfs/Kernel.h>
 +#include "cpp2/server/DataObjects.h"
 +#include "cpp2/server/dwarfs/Kernel.h"
-
+ 
  #include <fb303/ThreadCachedServiceData.h>
  #include <folly/coro/Task.h>
-diff -wbBdu -ruN '--exclude=.git' '--exclude=*.rej' '--exclude=*.orig' '--exclude=gen-cpp2' adsim/cpp2/server/dwarfs/Dwarfs.cc build/adsim/cpp2/server/dwarfs/Dwarfs.cc
---- adsim/cpp2/server/dwarfs/Dwarfs.cc	2025-07-29 17:20:23.636282090 -0700
-+++ build/adsim/cpp2/server/dwarfs/Dwarfs.cc	2025-07-29 17:16:49.252183522 -0700
-@@ -19,20 +19,20 @@
+diff -wbBdu -ruN '--exclude=.git' '--exclude=*.rej' '--exclude=*.orig' '--exclude=gen-cpp2' '--exclude=build' '--exclude=third_party' adsim/cpp2/server/dwarfs/Dwarfs.cc build/adsim/cpp2/server/dwarfs/Dwarfs.cc
+--- adsim/cpp2/server/dwarfs/Dwarfs.cc	2025-07-30 18:04:11.141113643 -0700
++++ build/adsim/cpp2/server/dwarfs/Dwarfs.cc	2025-07-30 18:02:55.849857996 -0700
+@@ -19,21 +19,21 @@
  #include <folly/MapUtil.h>
  #include <folly/dynamic.h>
-
+ 
 -#include <cea/chips/adsim/cpp2/server/dwarfs/Compress.h>
 -#include <cea/chips/adsim/cpp2/server/dwarfs/ConcurrentHashMap.h>
 -#include <cea/chips/adsim/cpp2/server/dwarfs/DeepCopy.h>
 -#include <cea/chips/adsim/cpp2/server/dwarfs/Delay.h>
 -#include <cea/chips/adsim/cpp2/server/dwarfs/Dwarfs.h>
+-#include <cea/chips/adsim/cpp2/server/dwarfs/Embedding.h>
 -#include <cea/chips/adsim/cpp2/server/dwarfs/FakeIO.h>
 -#include <cea/chips/adsim/cpp2/server/dwarfs/GEMM.h>
 -#include <cea/chips/adsim/cpp2/server/dwarfs/HashMap.h>
@@ -233,6 +234,7 @@ diff -wbBdu -ruN '--exclude=.git' '--exclude=*.rej' '--exclude=*.orig' '--exclud
 +#include "DeepCopy.h"
 +#include "Delay.h"
 +#include "Dwarfs.h"
++#include "Embedding.h"
 +#include "FakeIO.h"
 +#include "GEMM.h"
 +#include "HashMap.h"
@@ -242,216 +244,251 @@ diff -wbBdu -ruN '--exclude=.git' '--exclude=*.rej' '--exclude=*.orig' '--exclud
 +#include "Serialize.h"
 +#include "Shape.h"
 +#include "TensorDeser.h"
-
+ 
  namespace facebook::cea::chips::adsim {
-
-diff -wbBdu -ruN '--exclude=.git' '--exclude=*.rej' '--exclude=*.orig' '--exclude=gen-cpp2' adsim/cpp2/server/dwarfs/Dwarfs.h build/adsim/cpp2/server/dwarfs/Dwarfs.h
---- adsim/cpp2/server/dwarfs/Dwarfs.h	2025-07-29 17:20:23.636723818 -0700
-+++ build/adsim/cpp2/server/dwarfs/Dwarfs.h	2025-07-29 17:16:49.252762768 -0700
+ 
+diff -wbBdu -ruN '--exclude=.git' '--exclude=*.rej' '--exclude=*.orig' '--exclude=gen-cpp2' '--exclude=build' '--exclude=third_party' adsim/cpp2/server/dwarfs/Dwarfs.h build/adsim/cpp2/server/dwarfs/Dwarfs.h
+--- adsim/cpp2/server/dwarfs/Dwarfs.h	2025-07-30 18:04:11.141414699 -0700
++++ build/adsim/cpp2/server/dwarfs/Dwarfs.h	2025-07-30 18:02:55.850684696 -0700
 @@ -19,9 +19,9 @@
  #include <string>
-
+ 
  #include <folly/MapUtil.h>
 -#include <folly/json/dynamic.h>
 +#include <folly/dynamic.h>
-
+ 
 -#include <cea/chips/adsim/cpp2/server/dwarfs/Kernel.h>
 +#include "cpp2/server/dwarfs/Kernel.h"
-
+ 
  namespace facebook::cea::chips::adsim {
-
-diff -wbBdu -ruN '--exclude=.git' '--exclude=*.rej' '--exclude=*.orig' '--exclude=gen-cpp2' adsim/cpp2/server/dwarfs/FakeIO.h build/adsim/cpp2/server/dwarfs/FakeIO.h
---- adsim/cpp2/server/dwarfs/FakeIO.h	2025-07-29 17:20:23.637152757 -0700
-+++ build/adsim/cpp2/server/dwarfs/FakeIO.h	2025-07-29 17:16:49.253448384 -0700
-@@ -18,8 +18,8 @@
-
- #include <unistd.h>
-
+ 
+diff -wbBdu -ruN '--exclude=.git' '--exclude=*.rej' '--exclude=*.orig' '--exclude=gen-cpp2' '--exclude=build' '--exclude=third_party' adsim/cpp2/server/dwarfs/Embedding.cc build/adsim/cpp2/server/dwarfs/Embedding.cc
+--- adsim/cpp2/server/dwarfs/Embedding.cc	2025-07-30 18:04:11.141906672 -0700
++++ build/adsim/cpp2/server/dwarfs/Embedding.cc	2025-07-30 18:02:55.851848546 -0700
+@@ -14,7 +14,7 @@
+  * limitations under the License.
+  */
+ 
+-#include <cea/chips/adsim/cpp2/server/dwarfs/Embedding.h>
++#include "Embedding.h"
+ 
+ #include <algorithm>
+ #include <chrono>
+diff -wbBdu -ruN '--exclude=.git' '--exclude=*.rej' '--exclude=*.orig' '--exclude=gen-cpp2' '--exclude=build' '--exclude=third_party' adsim/cpp2/server/dwarfs/Embedding.h build/adsim/cpp2/server/dwarfs/Embedding.h
+--- adsim/cpp2/server/dwarfs/Embedding.h	2025-07-30 18:04:11.142235560 -0700
++++ build/adsim/cpp2/server/dwarfs/Embedding.h	2025-07-30 18:02:55.852722488 -0700
+@@ -21,8 +21,8 @@
+ #include <random>
+ #include <vector>
+ 
 -#include <cea/chips/adsim/cpp2/server/DataObjects.h>
 -#include <cea/chips/adsim/cpp2/server/dwarfs/Kernel.h>
 +#include "cpp2/server/DataObjects.h"
 +#include "cpp2/server/dwarfs/Kernel.h"
-
+ 
  #include <fb303/ThreadCachedServiceData.h>
  #include <folly/coro/Task.h>
-diff -wbBdu -ruN '--exclude=.git' '--exclude=*.rej' '--exclude=*.orig' '--exclude=gen-cpp2' adsim/cpp2/server/dwarfs/GEMM.cc build/adsim/cpp2/server/dwarfs/GEMM.cc
---- adsim/cpp2/server/dwarfs/GEMM.cc	2025-07-29 17:20:23.637529265 -0700
-+++ build/adsim/cpp2/server/dwarfs/GEMM.cc	2025-07-29 17:16:49.254103194 -0700
+diff -wbBdu -ruN '--exclude=.git' '--exclude=*.rej' '--exclude=*.orig' '--exclude=gen-cpp2' '--exclude=build' '--exclude=third_party' adsim/cpp2/server/dwarfs/FakeIO.h build/adsim/cpp2/server/dwarfs/FakeIO.h
+--- adsim/cpp2/server/dwarfs/FakeIO.h	2025-07-30 18:04:11.142599490 -0700
++++ build/adsim/cpp2/server/dwarfs/FakeIO.h	2025-07-30 18:02:55.853740317 -0700
+@@ -18,8 +18,8 @@
+ 
+ #include <unistd.h>
+ 
+-#include <cea/chips/adsim/cpp2/server/DataObjects.h>
+-#include <cea/chips/adsim/cpp2/server/dwarfs/Kernel.h>
++#include "cpp2/server/DataObjects.h"
++#include "cpp2/server/dwarfs/Kernel.h"
+ 
+ #include <fb303/ThreadCachedServiceData.h>
+ #include <folly/coro/Task.h>
+diff -wbBdu -ruN '--exclude=.git' '--exclude=*.rej' '--exclude=*.orig' '--exclude=gen-cpp2' '--exclude=build' '--exclude=third_party' adsim/cpp2/server/dwarfs/GEMM.cc build/adsim/cpp2/server/dwarfs/GEMM.cc
+--- adsim/cpp2/server/dwarfs/GEMM.cc	2025-07-30 18:04:11.142949941 -0700
++++ build/adsim/cpp2/server/dwarfs/GEMM.cc	2025-07-30 18:02:55.854448439 -0700
 @@ -22,17 +22,21 @@
  #include <glog/logging.h>
-
+ 
  #ifdef _OPENMP
 +#include <omp.h>
  #endif
-
+ 
  #ifdef USE_MKL
 +#include <mkl.h>
  #endif
-
+ 
  #include "bench/BenchUtils.h"
  #include "fbgemm/Fbgemm.h"
 +#include "src/RefImplementations.h"
  #include "test/QuantizationHelpers.h"
-
+ 
 -#include <cea/chips/adsim/cpp2/server/dwarfs/GEMM.h>
 -#include <cea/chips/adsim/cpp2/server/dwarfs/Kernel.h>
 +#include <folly/coro/Task.h>
 +#include "GEMM.h"
 +#include "Kernel.h"
-
+ 
  using namespace std;
  using namespace fbgemm;
-diff -wbBdu -ruN '--exclude=.git' '--exclude=*.rej' '--exclude=*.orig' '--exclude=gen-cpp2' adsim/cpp2/server/dwarfs/GEMM.h build/adsim/cpp2/server/dwarfs/GEMM.h
---- adsim/cpp2/server/dwarfs/GEMM.h	2025-07-29 17:20:23.637936802 -0700
-+++ build/adsim/cpp2/server/dwarfs/GEMM.h	2025-07-29 17:16:49.254694429 -0700
+diff -wbBdu -ruN '--exclude=.git' '--exclude=*.rej' '--exclude=*.orig' '--exclude=gen-cpp2' '--exclude=build' '--exclude=third_party' adsim/cpp2/server/dwarfs/GEMM.h build/adsim/cpp2/server/dwarfs/GEMM.h
+--- adsim/cpp2/server/dwarfs/GEMM.h	2025-07-30 18:04:11.143269905 -0700
++++ build/adsim/cpp2/server/dwarfs/GEMM.h	2025-07-30 18:02:55.855270671 -0700
 @@ -22,8 +22,8 @@
-
+ 
  #include <assert.h>
-
+ 
 -#include <cea/chips/adsim/cpp2/server/DataObjects.h>
 -#include <cea/chips/adsim/cpp2/server/dwarfs/Kernel.h>
 +#include "cpp2/server/DataObjects.h"
 +#include "cpp2/server/dwarfs/Kernel.h"
-
+ 
  #include <fb303/ThreadCachedServiceData.h>
  #include <folly/coro/Collect.h>
-diff -wbBdu -ruN '--exclude=.git' '--exclude=*.rej' '--exclude=*.orig' '--exclude=gen-cpp2' adsim/cpp2/server/dwarfs/HashMap.cc build/adsim/cpp2/server/dwarfs/HashMap.cc
---- adsim/cpp2/server/dwarfs/HashMap.cc	2025-07-29 17:20:23.638293180 -0700
-+++ build/adsim/cpp2/server/dwarfs/HashMap.cc	2025-07-29 17:16:49.255301296 -0700
+diff -wbBdu -ruN '--exclude=.git' '--exclude=*.rej' '--exclude=*.orig' '--exclude=gen-cpp2' '--exclude=build' '--exclude=third_party' adsim/cpp2/server/dwarfs/HashMap.cc build/adsim/cpp2/server/dwarfs/HashMap.cc
+--- adsim/cpp2/server/dwarfs/HashMap.cc	2025-07-30 18:04:11.143716230 -0700
++++ build/adsim/cpp2/server/dwarfs/HashMap.cc	2025-07-30 18:02:55.856132245 -0700
 @@ -14,7 +14,7 @@
   * limitations under the License.
   */
-
+ 
 -#include <cea/chips/adsim/cpp2/server/dwarfs/HashMap.h>
 +#include "HashMap.h"
-
+ 
  #include <fb303/ThreadCachedServiceData.h>
-
-diff -wbBdu -ruN '--exclude=.git' '--exclude=*.rej' '--exclude=*.orig' '--exclude=gen-cpp2' adsim/cpp2/server/dwarfs/HashMap.h build/adsim/cpp2/server/dwarfs/HashMap.h
---- adsim/cpp2/server/dwarfs/HashMap.h	2025-07-29 17:20:23.638793648 -0700
-+++ build/adsim/cpp2/server/dwarfs/HashMap.h	2025-07-29 17:16:49.255902134 -0700
+ 
+diff -wbBdu -ruN '--exclude=.git' '--exclude=*.rej' '--exclude=*.orig' '--exclude=gen-cpp2' '--exclude=build' '--exclude=third_party' adsim/cpp2/server/dwarfs/HashMap.h build/adsim/cpp2/server/dwarfs/HashMap.h
+--- adsim/cpp2/server/dwarfs/HashMap.h	2025-07-30 18:04:11.144115293 -0700
++++ build/adsim/cpp2/server/dwarfs/HashMap.h	2025-07-30 18:02:55.857035250 -0700
 @@ -24,8 +24,8 @@
  #include <unordered_map>
  #include <vector>
-
+ 
 -#include <cea/chips/adsim/cpp2/server/DataObjects.h>
 -#include <cea/chips/adsim/cpp2/server/dwarfs/Kernel.h>
 +#include "cpp2/server/DataObjects.h"
 +#include "cpp2/server/dwarfs/Kernel.h"
-
+ 
  #include <folly/Synchronized.h>
  #include <folly/container/F14Map.h>
-diff -wbBdu -ruN '--exclude=.git' '--exclude=*.rej' '--exclude=*.orig' '--exclude=gen-cpp2' adsim/cpp2/server/dwarfs/IBRun.h build/adsim/cpp2/server/dwarfs/IBRun.h
---- adsim/cpp2/server/dwarfs/IBRun.h	2025-07-29 17:20:23.639247133 -0700
-+++ build/adsim/cpp2/server/dwarfs/IBRun.h	2025-07-29 17:16:49.256601132 -0700
+diff -wbBdu -ruN '--exclude=.git' '--exclude=*.rej' '--exclude=*.orig' '--exclude=gen-cpp2' '--exclude=build' '--exclude=third_party' adsim/cpp2/server/dwarfs/IBRun.h build/adsim/cpp2/server/dwarfs/IBRun.h
+--- adsim/cpp2/server/dwarfs/IBRun.h	2025-07-30 18:04:11.144454216 -0700
++++ build/adsim/cpp2/server/dwarfs/IBRun.h	2025-07-30 18:02:55.857865015 -0700
 @@ -16,9 +16,9 @@
-
+ 
  #pragma once
-
+ 
 -#include <cea/chips/adsim/cpp2/server/DataObjects.h>
 -#include <cea/chips/adsim/cpp2/server/dwarfs/Kernel.h>
 -#include <cea/chips/adsim/cpp2/server/dwarfs/icache_buster/ICacheBuster.h> // @manual=//cea/chips/adsim/cpp2/server/dwarfs/icache_buster:libicachebuster
 +#include "cpp2/server/DataObjects.h"
 +#include "cpp2/server/dwarfs/Kernel.h"
 +#include "cpp2/server/dwarfs/icache_buster/ICacheBuster.h" // @manual=//cea/chips/adsim/cpp2/server/dwarfs/icache_buster:libicachebuster
-
+ 
  #include <folly/coro/Task.h>
-
-diff -wbBdu -ruN '--exclude=.git' '--exclude=*.rej' '--exclude=*.orig' '--exclude=gen-cpp2' adsim/cpp2/server/dwarfs/icache_buster/gen_icache_buster.py build/adsim/cpp2/server/dwarfs/icache_buster/gen_icache_buster.py
---- adsim/cpp2/server/dwarfs/icache_buster/gen_icache_buster.py	2025-07-29 17:20:23.632763309 -0700
-+++ build/adsim/cpp2/server/dwarfs/icache_buster/gen_icache_buster.py	2025-07-29 17:16:49.257317114 -0700
+ 
+diff -wbBdu -ruN '--exclude=.git' '--exclude=*.rej' '--exclude=*.orig' '--exclude=gen-cpp2' '--exclude=build' '--exclude=third_party' adsim/cpp2/server/dwarfs/icache_buster/gen_icache_buster.py build/adsim/cpp2/server/dwarfs/icache_buster/gen_icache_buster.py
+--- adsim/cpp2/server/dwarfs/icache_buster/gen_icache_buster.py	2025-07-30 18:04:11.138092232 -0700
++++ build/adsim/cpp2/server/dwarfs/icache_buster/gen_icache_buster.py	2025-07-30 18:02:55.858934413 -0700
 @@ -14,8 +14,6 @@
  # See the License for the specific language governing permissions and
  # limitations under the License.
-
+ 
 -# pyre-unsafe
 -
  """Module to split file into multiple segments."""
-
+ 
  import argparse
-diff -wbBdu -ruN '--exclude=.git' '--exclude=*.rej' '--exclude=*.orig' '--exclude=gen-cpp2' adsim/cpp2/server/dwarfs/Kernel.cc build/adsim/cpp2/server/dwarfs/Kernel.cc
---- adsim/cpp2/server/dwarfs/Kernel.cc	2025-07-29 17:20:23.639696623 -0700
-+++ build/adsim/cpp2/server/dwarfs/Kernel.cc	2025-07-29 17:16:49.257887606 -0700
+diff -wbBdu -ruN '--exclude=.git' '--exclude=*.rej' '--exclude=*.orig' '--exclude=gen-cpp2' '--exclude=build' '--exclude=third_party' adsim/cpp2/server/dwarfs/Kernel.cc build/adsim/cpp2/server/dwarfs/Kernel.cc
+--- adsim/cpp2/server/dwarfs/Kernel.cc	2025-07-30 18:04:11.144934703 -0700
++++ build/adsim/cpp2/server/dwarfs/Kernel.cc	2025-07-30 18:02:55.859722524 -0700
 @@ -20,7 +20,7 @@
  #include <fb303/ExportType.h>
  #include <fb303/ThreadCachedServiceData.h>
-
+ 
 -#include "cea/chips/adsim/cpp2/server/dwarfs/Kernel.h"
 +#include "Kernel.h"
-
+ 
  namespace facebook::cea::chips::adsim {
-
-diff -wbBdu -ruN '--exclude=.git' '--exclude=*.rej' '--exclude=*.orig' '--exclude=gen-cpp2' adsim/cpp2/server/dwarfs/Kernel.h build/adsim/cpp2/server/dwarfs/Kernel.h
---- adsim/cpp2/server/dwarfs/Kernel.h	2025-07-29 17:20:23.640110499 -0700
-+++ build/adsim/cpp2/server/dwarfs/Kernel.h	2025-07-29 17:16:49.258481745 -0700
+ 
+diff -wbBdu -ruN '--exclude=.git' '--exclude=*.rej' '--exclude=*.orig' '--exclude=gen-cpp2' '--exclude=build' '--exclude=third_party' adsim/cpp2/server/dwarfs/Kernel.h build/adsim/cpp2/server/dwarfs/Kernel.h
+--- adsim/cpp2/server/dwarfs/Kernel.h	2025-07-30 18:04:11.145362400 -0700
++++ build/adsim/cpp2/server/dwarfs/Kernel.h	2025-07-30 18:02:55.860595826 -0700
 @@ -21,10 +21,10 @@
  #include <unordered_map>
  #include <vector>
-
+ 
 -#include <cea/chips/adsim/cpp2/server/DataObjects.h>
  #include <folly/coro/Task.h>
 -#include <folly/json/dynamic.h>
 +#include <folly/dynamic.h>
  #include <glog/logging.h>
 +#include "cpp2/server/DataObjects.h"
-
+ 
  namespace facebook::cea::chips::adsim {
-
-diff -wbBdu -ruN '--exclude=.git' '--exclude=*.rej' '--exclude=*.orig' '--exclude=gen-cpp2' adsim/cpp2/server/dwarfs/Rebatch.cc build/adsim/cpp2/server/dwarfs/Rebatch.cc
---- adsim/cpp2/server/dwarfs/Rebatch.cc	2025-07-29 17:20:23.640525797 -0700
-+++ build/adsim/cpp2/server/dwarfs/Rebatch.cc	2025-07-29 17:16:49.259297848 -0700
+ 
+diff -wbBdu -ruN '--exclude=.git' '--exclude=*.rej' '--exclude=*.orig' '--exclude=gen-cpp2' '--exclude=build' '--exclude=third_party' adsim/cpp2/server/dwarfs/Rebatch.cc build/adsim/cpp2/server/dwarfs/Rebatch.cc
+--- adsim/cpp2/server/dwarfs/Rebatch.cc	2025-07-30 18:04:11.145893793 -0700
++++ build/adsim/cpp2/server/dwarfs/Rebatch.cc	2025-07-30 18:02:55.861583369 -0700
 @@ -14,7 +14,7 @@
   * limitations under the License.
   */
-
+ 
 -#include <cea/chips/adsim/cpp2/server/dwarfs/Rebatch.h>
 +#include "Rebatch.h"
-
+ 
  #include <fb303/ThreadCachedServiceData.h>
  #include <folly/futures/Future.h>
-diff -wbBdu -ruN '--exclude=.git' '--exclude=*.rej' '--exclude=*.orig' '--exclude=gen-cpp2' adsim/cpp2/server/dwarfs/Rebatch.h build/adsim/cpp2/server/dwarfs/Rebatch.h
---- adsim/cpp2/server/dwarfs/Rebatch.h	2025-07-29 17:20:23.640920403 -0700
-+++ build/adsim/cpp2/server/dwarfs/Rebatch.h	2025-07-29 17:16:49.260401117 -0700
+@@ -466,7 +466,7 @@
+ 
+   // Select execution mode based on thread configuration and pool availability
+   if (num_threads_ > 1 && pool) {
+-    co_await rebatch_multi_thread(std::move(pool));
++    co_await rebatch_multi_thread(pool);
+   } else {
+     rebatch_single_thread();
+   }
+diff -wbBdu -ruN '--exclude=.git' '--exclude=*.rej' '--exclude=*.orig' '--exclude=gen-cpp2' '--exclude=build' '--exclude=third_party' adsim/cpp2/server/dwarfs/Rebatch.h build/adsim/cpp2/server/dwarfs/Rebatch.h
+--- adsim/cpp2/server/dwarfs/Rebatch.h	2025-07-30 18:04:11.146246907 -0700
++++ build/adsim/cpp2/server/dwarfs/Rebatch.h	2025-07-30 18:02:55.862389218 -0700
 @@ -26,8 +26,8 @@
  #include <string>
  #include <vector>
-
+ 
 -#include <cea/chips/adsim/cpp2/server/DataObjects.h>
 -#include <cea/chips/adsim/cpp2/server/dwarfs/Kernel.h>
 +#include "cpp2/server/DataObjects.h"
 +#include "cpp2/server/dwarfs/Kernel.h"
-
+ 
  #include <folly/CppAttributes.h>
  #include <folly/coro/Task.h>
-diff -wbBdu -ruN '--exclude=.git' '--exclude=*.rej' '--exclude=*.orig' '--exclude=gen-cpp2' adsim/cpp2/server/dwarfs/Serialize.h build/adsim/cpp2/server/dwarfs/Serialize.h
---- adsim/cpp2/server/dwarfs/Serialize.h	2025-07-29 17:20:23.641344614 -0700
-+++ build/adsim/cpp2/server/dwarfs/Serialize.h	2025-07-29 17:16:49.261456722 -0700
+diff -wbBdu -ruN '--exclude=.git' '--exclude=*.rej' '--exclude=*.orig' '--exclude=gen-cpp2' '--exclude=build' '--exclude=third_party' adsim/cpp2/server/dwarfs/Serialize.h build/adsim/cpp2/server/dwarfs/Serialize.h
+--- adsim/cpp2/server/dwarfs/Serialize.h	2025-07-30 18:04:11.146617057 -0700
++++ build/adsim/cpp2/server/dwarfs/Serialize.h	2025-07-30 18:02:55.863285563 -0700
 @@ -20,15 +20,15 @@
-
+ 
  #include <algorithm>
-
+ 
 -#include <cea/chips/adsim/cpp2/server/DataObjects.h>
 -#include <cea/chips/adsim/cpp2/server/dwarfs/Kernel.h>
 +#include "cpp2/server/DataObjects.h"
 +#include "cpp2/server/dwarfs/Kernel.h"
-
+ 
  #include <folly/coro/Task.h>
-
+ 
  #include <thrift/lib/cpp2/protocol/CompactProtocol.h>
  #include <thrift/lib/cpp2/protocol/Serializer.h>
-
+ 
 -#include <cea/chips/adsim/if/gen-cpp2/Serialize_types.h>
 +#include "if/gen-cpp2/Serialize_types.h"
-
+ 
  namespace facebook::cea::chips::adsim {
-
-diff -wbBdu -ruN '--exclude=.git' '--exclude=*.rej' '--exclude=*.orig' '--exclude=gen-cpp2' adsim/cpp2/server/dwarfs/Shape.h build/adsim/cpp2/server/dwarfs/Shape.h
---- adsim/cpp2/server/dwarfs/Shape.h	2025-07-29 17:20:23.641793763 -0700
-+++ build/adsim/cpp2/server/dwarfs/Shape.h	2025-07-29 17:16:49.262466429 -0700
+ 
+diff -wbBdu -ruN '--exclude=.git' '--exclude=*.rej' '--exclude=*.orig' '--exclude=gen-cpp2' '--exclude=build' '--exclude=third_party' adsim/cpp2/server/dwarfs/Shape.h build/adsim/cpp2/server/dwarfs/Shape.h
+--- adsim/cpp2/server/dwarfs/Shape.h	2025-07-30 18:04:11.147082081 -0700
++++ build/adsim/cpp2/server/dwarfs/Shape.h	2025-07-30 18:02:55.864396233 -0700
 @@ -16,10 +16,10 @@
-
+ 
  #pragma once
-
+ 
 -#include <cea/chips/adsim/cpp2/client/TLSConnect.h>
 -#include <cea/chips/adsim/cpp2/server/DataObjects.h>
 -#include <cea/chips/adsim/cpp2/server/dwarfs/Kernel.h>
@@ -460,51 +497,51 @@ diff -wbBdu -ruN '--exclude=.git' '--exclude=*.rej' '--exclude=*.orig' '--exclud
 +#include "cpp2/server/DataObjects.h"
 +#include "cpp2/server/dwarfs/Kernel.h"
 +#include "if/gen-cpp2/AdSim.h"
-
+ 
  #include <fb303/ThreadCachedServiceData.h>
  #include <folly/MoveWrapper.h>
-diff -wbBdu -ruN '--exclude=.git' '--exclude=*.rej' '--exclude=*.orig' '--exclude=gen-cpp2' adsim/cpp2/server/dwarfs/TensorDeser.cc build/adsim/cpp2/server/dwarfs/TensorDeser.cc
---- adsim/cpp2/server/dwarfs/TensorDeser.cc	2025-07-29 17:20:23.642258066 -0700
-+++ build/adsim/cpp2/server/dwarfs/TensorDeser.cc	2025-07-29 17:16:49.263334411 -0700
+diff -wbBdu -ruN '--exclude=.git' '--exclude=*.rej' '--exclude=*.orig' '--exclude=gen-cpp2' '--exclude=build' '--exclude=third_party' adsim/cpp2/server/dwarfs/TensorDeser.cc build/adsim/cpp2/server/dwarfs/TensorDeser.cc
+--- adsim/cpp2/server/dwarfs/TensorDeser.cc	2025-07-30 18:04:11.147497770 -0700
++++ build/adsim/cpp2/server/dwarfs/TensorDeser.cc	2025-07-30 18:02:55.865374372 -0700
 @@ -14,7 +14,7 @@
   * limitations under the License.
   */
-
+ 
 -#include <cea/chips/adsim/cpp2/server/dwarfs/TensorDeser.h>
 +#include "TensorDeser.h"
  #include <cstring>
  #include <iomanip>
  #include <iostream>
-diff -wbBdu -ruN '--exclude=.git' '--exclude=*.rej' '--exclude=*.orig' '--exclude=gen-cpp2' adsim/cpp2/server/dwarfs/TensorDeser.h build/adsim/cpp2/server/dwarfs/TensorDeser.h
---- adsim/cpp2/server/dwarfs/TensorDeser.h	2025-07-29 17:20:23.642707696 -0700
-+++ build/adsim/cpp2/server/dwarfs/TensorDeser.h	2025-07-29 17:16:49.263899105 -0700
+diff -wbBdu -ruN '--exclude=.git' '--exclude=*.rej' '--exclude=*.orig' '--exclude=gen-cpp2' '--exclude=build' '--exclude=third_party' adsim/cpp2/server/dwarfs/TensorDeser.h build/adsim/cpp2/server/dwarfs/TensorDeser.h
+--- adsim/cpp2/server/dwarfs/TensorDeser.h	2025-07-30 18:04:11.148046660 -0700
++++ build/adsim/cpp2/server/dwarfs/TensorDeser.h	2025-07-30 18:02:55.866207813 -0700
 @@ -30,8 +30,8 @@
  #include <tuple>
  #include <vector>
-
+ 
 -#include <cea/chips/adsim/cpp2/server/DataObjects.h>
 -#include <cea/chips/adsim/cpp2/server/dwarfs/Kernel.h>
 +#include "cpp2/server/DataObjects.h"
 +#include "cpp2/server/dwarfs/Kernel.h"
-
+ 
  #include <folly/FileUtil.h>
  #include <folly/Format.h>
-diff -wbBdu -ruN '--exclude=.git' '--exclude=*.rej' '--exclude=*.orig' '--exclude=gen-cpp2' adsim/if/AdSim.thrift build/adsim/if/AdSim.thrift
---- adsim/if/AdSim.thrift	2025-07-29 17:20:23.647469406 -0700
-+++ build/adsim/if/AdSim.thrift	2025-07-29 17:16:49.264643370 -0700
+diff -wbBdu -ruN '--exclude=.git' '--exclude=*.rej' '--exclude=*.orig' '--exclude=gen-cpp2' '--exclude=build' '--exclude=third_party' adsim/if/AdSim.thrift build/adsim/if/AdSim.thrift
+--- adsim/if/AdSim.thrift	2025-07-30 18:04:11.152609451 -0700
++++ build/adsim/if/AdSim.thrift	2025-07-30 18:02:55.866966771 -0700
 @@ -1,4 +1,4 @@
 -include "common/fb303/if/fb303.thrift"
 +include "fb303.thrift"
-
+ 
  namespace cpp2 facebook.cea.chips.adsim
  namespace py3 facebook.cea.chips.adsim
-diff -wbBdu -ruN '--exclude=.git' '--exclude=*.rej' '--exclude=*.orig' '--exclude=gen-cpp2' adsim/if/Serialize.thrift build/adsim/if/Serialize.thrift
---- adsim/if/Serialize.thrift	2025-07-29 17:20:23.648161923 -0700
-+++ build/adsim/if/Serialize.thrift	2025-07-29 17:16:49.265284350 -0700
+diff -wbBdu -ruN '--exclude=.git' '--exclude=*.rej' '--exclude=*.orig' '--exclude=gen-cpp2' '--exclude=build' '--exclude=third_party' adsim/if/Serialize.thrift build/adsim/if/Serialize.thrift
+--- adsim/if/Serialize.thrift	2025-07-30 18:04:11.153312996 -0700
++++ build/adsim/if/Serialize.thrift	2025-07-30 18:02:55.867664966 -0700
 @@ -3,20 +3,15 @@
  cpp_include "list"
  cpp_include "folly/container/F14Map.h"
-
+ 
 -include "thrift/annotation/cpp.thrift"
 -
  struct SerializableInfo {
@@ -512,7 +549,7 @@ diff -wbBdu -ruN '--exclude=.git' '--exclude=*.rej' '--exclude=*.orig' '--exclud
    2: i32 var_i32;
    3: double var_double;
  }
-
+ 
 -@cpp.Type{template = "std::list"}
 -typedef list<i32> id_list_t
 -@cpp.Type{template = "folly::F14VectorMap"}
@@ -522,16 +559,16 @@ diff -wbBdu -ruN '--exclude=.git' '--exclude=*.rej' '--exclude=*.orig' '--exclud
 +typedef list<i32> (cpp.template = "std::list") id_list_t
 +typedef map<i32, id_list_t> (cpp.template = "folly::F14VectorMap") id_map_t
 +typedef list<SerializableInfo> (cpp.template = "std::list") info_list_t
-
+ 
  struct SerializableUnit {
    1: id_map_t map_of_list;
 @@ -24,8 +19,7 @@
    3: id_list_t list_of_i32;
  }
-
+ 
 -@cpp.Type{template = "std::list"}
 -typedef list<SerializableUnit> unit_list_t
 +typedef list<SerializableUnit> (cpp.template = "std::list") unit_list_t
-
+ 
  struct SerializableReq {
    1: i64 var_i64;

--- a/packages/adsim/src/cpp2/server/dwarfs/CMakeLists.txt
+++ b/packages/adsim/src/cpp2/server/dwarfs/CMakeLists.txt
@@ -30,16 +30,33 @@ target_link_directories(gemm
     PUBLIC
         ${ADSIM_STAGING_DIR}/include
 )
-target_link_libraries(gemm data_objects kernel fbgemm ${MKL_LIBRARIES} omp)
-target_link_options(gemm PUBLIC "-Wl,--rpath=${MKL_ROOT}/lib/intel64")
+target_link_libraries(gemm data_objects kernel fbgemm)
 target_include_directories(gemm
     PRIVATE
         ${FBGEMM_SRC_DIR}
-        #${CPUINFO_SOURCE_DIR}/include
         ${ADSIM_STAGING_DIR}/include
 )
 add_dependencies(gemm fbgemm)
-#add_dependencies(gemm gtest fbgemm_avx2 fbgemm)
+
+add_library(embedding Embedding.cc Embedding.h)
+
+target_compile_options(embedding PRIVATE
+    ${COROUTINES_FLAG}
+    -m64
+    -mavx2
+    -mfma
+    -masm=intel)
+target_link_directories(embedding
+    PUBLIC
+        ${ADSIM_STAGING_DIR}/include
+)
+target_link_libraries(embedding data_objects kernel fbgemm)
+target_include_directories(embedding
+    PRIVATE
+        ${FBGEMM_SRC_DIR}
+        ${ADSIM_STAGING_DIR}/include
+)
+add_dependencies(embedding fbgemm)
 
 add_library(compress
     Compress.cc
@@ -143,6 +160,7 @@ target_link_libraries(dwarfs
     rebatch
     deepcopy
     delay
+    embedding
     fakeio
     gemm
     hashmap

--- a/packages/adsim/src/cpp2/server/dwarfs/Dwarfs.cc
+++ b/packages/adsim/src/cpp2/server/dwarfs/Dwarfs.cc
@@ -24,6 +24,7 @@
 #include <cea/chips/adsim/cpp2/server/dwarfs/DeepCopy.h>
 #include <cea/chips/adsim/cpp2/server/dwarfs/Delay.h>
 #include <cea/chips/adsim/cpp2/server/dwarfs/Dwarfs.h>
+#include <cea/chips/adsim/cpp2/server/dwarfs/Embedding.h>
 #include <cea/chips/adsim/cpp2/server/dwarfs/FakeIO.h>
 #include <cea/chips/adsim/cpp2/server/dwarfs/GEMM.h>
 #include <cea/chips/adsim/cpp2/server/dwarfs/HashMap.h>
@@ -42,6 +43,7 @@ const folly::F14VectorMap<std::string, CONFIG_F> KERNEL_DICT = {
     {"FakeIO", FakeIO::config},
     {"IBRun", IBRun::config},
     {"GEMM", GEMM::config},
+    {"Embedding", Embedding::config},
     {"Compress", Compress::config},
     {"Decompress", Decompress::config},
     {"Serialize", Serialize::config},

--- a/packages/adsim/src/cpp2/server/dwarfs/Embedding.cc
+++ b/packages/adsim/src/cpp2/server/dwarfs/Embedding.cc
@@ -1,0 +1,775 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <cea/chips/adsim/cpp2/server/dwarfs/Embedding.h>
+
+#include <algorithm>
+#include <chrono>
+#include <future>
+#include <sstream>
+#include <thread>
+
+#include <folly/coro/Collect.h>
+#include <glog/logging.h>
+#include "fbgemm/Fbgemm.h"
+
+using fbgemm::GenerateEmbeddingSpMDMNBitWithStrides;
+using fbgemm::GenerateEmbeddingSpMDMWithStrides;
+
+namespace facebook::cea::chips::adsim {
+
+DEFINE_timeseries(
+    embedding_nfired,
+    facebook::fb303::SUM,
+    facebook::fb303::RATE);
+
+// Single embedding table with quantized weights and FBGEMM kernel dispatch
+EmbeddingTable::EmbeddingTable(const EmbeddingTableSpec& spec)
+    : spec_(spec), generator_(42) {
+  init_table();
+}
+
+EmbeddingTable::~EmbeddingTable() = default;
+
+// Initialize table memory layout: quantized weights + scale/bias per row
+void EmbeddingTable::init_table() {
+  fused_embedding_dim_ = get_fused_embedding_dim();
+  fused_embedding_table_.resize(spec_.num_embeddings * fused_embedding_dim_);
+  fill_random_weights();
+}
+
+// Calculate fused row size: quantized weights + scale/bias floats
+size_t EmbeddingTable::get_fused_embedding_dim() const {
+  size_t base_dim = 0;
+
+  // Calculate bytes needed for quantized weights
+  switch (spec_.weights_precision) {
+    case WeightsPrecision::INT4:
+      base_dim = (spec_.embedding_dim + 1) / 2; // 4-bit packed
+      break;
+    case WeightsPrecision::INT8:
+      base_dim = spec_.embedding_dim; // 1 byte per element
+      break;
+    case WeightsPrecision::FP16:
+      base_dim = spec_.embedding_dim * 2; // 2 bytes per element
+      break;
+    case WeightsPrecision::FP32:
+      base_dim = spec_.embedding_dim * 4; // 4 bytes per element
+      break;
+  }
+
+  // Add space for scale and bias (2 floats = 8 bytes)
+  return base_dim + 2 * sizeof(float);
+}
+
+// Initialize embedding table with random quantized weights and scale/bias
+void EmbeddingTable::fill_random_weights() {
+  const size_t weights_size = fused_embedding_dim_ - 2 * sizeof(float);
+
+  // Parallel initialization for better performance
+  const int num_threads =
+      std::min(static_cast<int>(std::thread::hardware_concurrency()), 16);
+  const int rows_per_thread =
+      (spec_.num_embeddings + num_threads - 1) / num_threads;
+
+  std::vector<std::future<void>> futures;
+  futures.reserve(num_threads);
+
+  for (int t = 0; t < num_threads; ++t) {
+    int start_row = t * rows_per_thread;
+    int end_row = std::min(start_row + rows_per_thread, spec_.num_embeddings);
+
+    if (start_row >= end_row) {
+      break;
+    }
+
+    futures.emplace_back(std::async(
+        std::launch::async, [this, start_row, end_row, weights_size]() {
+          std::minstd_rand fast_gen(42 + start_row);
+          std::uniform_int_distribution<uint8_t> byte_dist(0, 255);
+
+          for (int i = start_row; i < end_row; ++i) {
+            uint8_t* row_ptr =
+                fused_embedding_table_.data() + i * fused_embedding_dim_;
+
+            // Fill quantized weights with random bytes
+            for (size_t j = 0; j < weights_size; ++j) {
+              row_ptr[j] = byte_dist(fast_gen);
+            }
+
+            // Set scale and bias for quantized weights
+            float* scale_bias =
+                reinterpret_cast<float*>(row_ptr + weights_size);
+            scale_bias[0] = 2.0f; // scale
+            scale_bias[1] = 1.0f; // bias
+          }
+        }));
+  }
+
+  for (auto& future : futures) {
+    future.wait();
+  }
+}
+
+void EmbeddingTable::forward(
+    const EmbeddingRequest& request,
+    float* output,
+    PoolingMode pooling_mode) {
+  embedding_lookup_and_pool(
+      request.indices,
+      request.offsets,
+      request.per_sample_weights,
+      output,
+      request.weighted,
+      pooling_mode);
+}
+
+// Perform embedding lookup and pooling using optimized FBGEMM kernels
+void EmbeddingTable::embedding_lookup_and_pool(
+    const std::vector<int64_t>& indices,
+    const std::vector<int32_t>& offsets,
+    const std::vector<float>& weights,
+    float* output,
+    bool weighted,
+    PoolingMode pooling_mode) const {
+  int batch_size = static_cast<int>(offsets.size()) - 1;
+  int lengths_sum = static_cast<int>(indices.size());
+
+  bool success = false;
+  const bool has_weight = weighted;
+  const bool normalize =
+      (pooling_mode == PoolingMode::MEAN); // MEAN pooling divides by bag length
+  const int prefetch = 16; // FBGEMM prefetch distance
+  const int output_stride = spec_.embedding_dim;
+  const int input_stride = static_cast<int>(fused_embedding_dim_);
+
+  // Dispatch to appropriate FBGEMM kernel based on quantization precision
+  switch (spec_.weights_precision) {
+    case WeightsPrecision::FP32: {
+      auto kernel = GenerateEmbeddingSpMDMWithStrides<
+          float,
+          int64_t,
+          int32_t,
+          float,
+          true>(
+          spec_.embedding_dim,
+          has_weight,
+          normalize,
+          prefetch,
+          false,
+          true,
+          output_stride,
+          input_stride / sizeof(float),
+          false,
+          false,
+          false);
+
+      success = kernel(
+          batch_size,
+          lengths_sum,
+          spec_.num_embeddings,
+          reinterpret_cast<const float*>(fused_embedding_table_.data()),
+          indices.data(),
+          offsets.data(),
+          weighted ? weights.data() : nullptr,
+          output);
+      break;
+    }
+
+    case WeightsPrecision::FP16: {
+      auto kernel = GenerateEmbeddingSpMDMWithStrides<
+          uint16_t,
+          int64_t,
+          int32_t,
+          float,
+          true>(
+          spec_.embedding_dim,
+          has_weight,
+          normalize,
+          prefetch,
+          false,
+          true,
+          output_stride,
+          input_stride / sizeof(uint16_t),
+          false,
+          false,
+          false);
+
+      success = kernel(
+          batch_size,
+          lengths_sum,
+          spec_.num_embeddings,
+          reinterpret_cast<const uint16_t*>(fused_embedding_table_.data()),
+          indices.data(),
+          offsets.data(),
+          weighted ? weights.data() : nullptr,
+          output);
+      break;
+    }
+
+    case WeightsPrecision::INT8: {
+      auto kernel = GenerateEmbeddingSpMDMWithStrides<
+          uint8_t,
+          int64_t,
+          int32_t,
+          float,
+          true>(
+          spec_.embedding_dim,
+          has_weight,
+          normalize,
+          prefetch,
+          false,
+          true,
+          output_stride,
+          input_stride,
+          true,
+          false,
+          false);
+
+      success = kernel(
+          batch_size,
+          lengths_sum,
+          spec_.num_embeddings,
+          fused_embedding_table_.data(),
+          indices.data(),
+          offsets.data(),
+          weighted ? weights.data() : nullptr,
+          output);
+      break;
+    }
+
+    case WeightsPrecision::INT4: {
+      const int bit_rate = 4;
+      auto kernel =
+          GenerateEmbeddingSpMDMNBitWithStrides<int64_t, int32_t, float, true>(
+              bit_rate,
+              spec_.embedding_dim,
+              has_weight,
+              normalize,
+              prefetch,
+              false,
+              true,
+              output_stride,
+              input_stride,
+              true,
+              false,
+              false,
+              32);
+
+      success = kernel(
+          batch_size,
+          lengths_sum,
+          spec_.num_embeddings,
+          fused_embedding_table_.data(),
+          indices.data(),
+          offsets.data(),
+          weighted ? weights.data() : nullptr,
+          output);
+      break;
+    }
+
+    default: {
+      LOG(ERROR) << "Unsupported weights precision: "
+                 << static_cast<int>(spec_.weights_precision);
+      success = false;
+      break;
+    }
+  }
+
+  if (!success) {
+    LOG(ERROR) << "FBGEMM embedding operation failed for precision: "
+               << static_cast<int>(spec_.weights_precision);
+  }
+}
+
+size_t EmbeddingTable::get_memory_usage() const {
+  return fused_embedding_table_.size();
+}
+
+// Multi-table embedding kernel with weighted selection and parallel
+// initialization
+Embedding::Embedding(
+    std::vector<EmbeddingTableSpec> table_specs,
+    int requests_per_fire,
+    int nthreads,
+    bool weighted,
+    PoolingMode pooling_mode,
+    int pregenerated_req_num)
+    : table_specs_(std::move(table_specs)),
+      requests_per_fire_(requests_per_fire),
+      nthreads_(nthreads),
+      weighted_(weighted),
+      pooling_mode_(pooling_mode),
+      pregenerated_req_num_(pregenerated_req_num),
+      generator_(42) {
+  // Build cumulative distribution for O(log n) weighted table selection
+  cumulative_weights_.resize(table_specs_.size());
+  float total_weight = 0.0f;
+  for (size_t i = 0; i < table_specs_.size(); ++i) {
+    total_weight += table_specs_[i].access_weight;
+    cumulative_weights_[i] = total_weight;
+  }
+
+  // Normalize to [0,1] for uniform random sampling
+  if (total_weight > 0.0f) {
+    for (auto& weight : cumulative_weights_) {
+      weight /= total_weight;
+    }
+  }
+
+  tables_.resize(table_specs_.size());
+
+  auto start_time = std::chrono::high_resolution_clock::now();
+
+  // Parallel table initialization to reduce startup latency
+  const int num_threads = std::min(
+      static_cast<int>(std::thread::hardware_concurrency()),
+      static_cast<int>(table_specs_.size()));
+
+  if (num_threads > 1 && table_specs_.size() > 1) {
+    std::vector<std::future<void>> futures;
+    futures.reserve(num_threads);
+
+    const int tables_per_thread =
+        static_cast<int>((table_specs_.size() + num_threads - 1) / num_threads);
+
+    for (int t = 0; t < num_threads; ++t) {
+      int start_idx = t * tables_per_thread;
+      int end_idx = std::min(
+          start_idx + tables_per_thread, static_cast<int>(table_specs_.size()));
+
+      if (start_idx >= end_idx) {
+        break;
+      }
+
+      futures.emplace_back(
+          std::async(std::launch::async, [this, start_idx, end_idx]() {
+            for (int i = start_idx; i < end_idx; ++i) {
+              tables_[i] = std::make_unique<EmbeddingTable>(table_specs_[i]);
+            }
+          }));
+    }
+
+    for (auto& future : futures) {
+      future.wait();
+    }
+  } else {
+    for (size_t i = 0; i < table_specs_.size(); ++i) {
+      tables_[i] = std::make_unique<EmbeddingTable>(table_specs_[i]);
+    }
+  }
+
+  auto end_time = std::chrono::high_resolution_clock::now();
+  auto duration = std::chrono::duration_cast<std::chrono::milliseconds>(
+      end_time - start_time);
+
+  LOG(INFO) << "Created " << table_specs_.size() << " embedding tables in "
+            << duration.count() << "ms using " << num_threads << " threads";
+
+  // Calculate maximum output buffer size needed
+  max_output_size_ = 0;
+  for (const auto& spec : table_specs_) {
+    size_t output_size = spec.batch_size * spec.embedding_dim;
+    max_output_size_ = std::max(max_output_size_, output_size);
+  }
+
+  // Allocate per-thread output buffers to avoid repeated allocations
+  size_t max_threads = std::max(nthreads_, 1);
+  thread_output_buffers_ =
+      std::make_unique<std::unique_ptr<float[]>[]>(max_threads);
+  for (size_t t = 0; t < max_threads; ++t) {
+    thread_output_buffers_[t] = std::make_unique<float[]>(max_output_size_);
+  }
+
+  // Pre-generate table selections and requests for runtime efficiency
+  pregenerate_pools();
+}
+
+// Pre-generate single pool of requests with table indices for simple
+// distribution
+void Embedding::pregenerate_pools() {
+  pregenerated_requests_.reserve(pregenerated_req_num_);
+  std::mt19937 gen(42);
+
+  for (int i = 0; i < pregenerated_req_num_; ++i) {
+    // Select table using weighted distribution
+    auto rand_bits = gen();
+    float random_value =
+        static_cast<float>(rand_bits) / static_cast<float>(std::mt19937::max());
+
+    auto it = std::lower_bound(
+        cumulative_weights_.begin(), cumulative_weights_.end(), random_value);
+    int table_idx = (it == cumulative_weights_.end())
+        ? static_cast<int>(cumulative_weights_.size() - 1)
+        : static_cast<int>(std::distance(cumulative_weights_.begin(), it));
+
+    const auto& spec = table_specs_[table_idx];
+
+    // Pre-compute offsets for this table
+    std::vector<int32_t> offsets(spec.batch_size + 1);
+    offsets[0] = 0;
+    for (int b = 0; b < spec.batch_size; ++b) {
+      offsets[b + 1] = offsets[b] + spec.bag_size;
+    }
+
+    const int total_indices = spec.batch_size * spec.bag_size;
+    std::vector<int64_t> indices(total_indices);
+    std::vector<float> weights;
+
+    // Fast index generation
+    for (int j = 0; j < total_indices; ++j) {
+      indices[j] = static_cast<int64_t>(gen() % spec.num_embeddings);
+    }
+
+    // Fast weight generation if needed
+    if (weighted_ && total_indices > 0) {
+      weights.resize(total_indices);
+      // Explicit check to satisfy clang-tidy array bounds warning
+      if (!weights.empty()) {
+        for (int j = 0; j < total_indices; ++j) {
+          auto weight_bits = gen();
+          weights[j] = 0.9f +
+              0.2f * (static_cast<float>(weight_bits & 0xFFFF) / 65535.0f);
+        }
+      }
+    }
+
+    // Create pre-generated request with table index
+    pregenerated_requests_.emplace_back(
+        table_idx,
+        EmbeddingRequest(
+            std::move(indices),
+            std::move(offsets),
+            weighted_ ? std::move(weights) : std::vector<float>{},
+            weighted_));
+  }
+
+  LOG(INFO) << "Pre-generated " << pregenerated_req_num_ << " requests across "
+            << table_specs_.size() << " tables";
+}
+
+std::string Embedding::init(
+    std::shared_ptr<AdSimHandleObjs> h_objs,
+    std::shared_ptr<AdSimRequestObjs> r_objs) {
+  Kernel::init(std::move(h_objs), std::move(r_objs));
+
+  // Log embedding table information
+  size_t total_memory = 0;
+  for (size_t i = 0; i < tables_.size(); ++i) {
+    const auto& spec = table_specs_[i];
+    size_t table_memory = tables_[i]->get_memory_usage();
+    total_memory += table_memory;
+
+    LOG(INFO) << "Embedding Table " << i << ": "
+              << "rows=" << spec.num_embeddings
+              << ", dim=" << spec.embedding_dim
+              << ", bag_size=" << spec.bag_size
+              << ", precision=" << static_cast<int>(spec.weights_precision)
+              << ", memory=" << (table_memory / 1e6) << " MB";
+  }
+
+  LOG(INFO) << "Total embedding memory: " << (total_memory / 1e9) << " GB";
+
+  return "";
+}
+
+// Execute benchmark fire operation with multi-threaded coroutine support
+folly::coro::Task<std::string> Embedding::fire(
+    std::shared_ptr<AdSimHandleObjs> h_objs,
+    std::shared_ptr<AdSimRequestObjs> r_objs,
+    std::shared_ptr<folly::Executor> pool) {
+  STATS_embedding_nfired.add(1);
+
+  if (nthreads_ == 0) {
+    // Single-threaded: use entire pool with thread 0's output buffer
+    run_embedding_operations(
+        h_objs,
+        0,
+        pregenerated_requests_.size(),
+        thread_output_buffers_[0].get());
+  } else {
+    // Multi-threaded: partition the request pool into ranges for each thread
+    const size_t pool_size = pregenerated_requests_.size();
+    const size_t requests_per_thread = pool_size / nthreads_;
+
+    std::vector<folly::Future<int>> futures;
+    futures.reserve(nthreads_);
+
+    for (int i = 0; i < nthreads_; ++i) {
+      // Calculate this thread's range
+      size_t start_idx = i * requests_per_thread;
+      size_t end_idx =
+          (i == nthreads_ - 1) ? pool_size : start_idx + requests_per_thread;
+
+      // Get this thread's output buffer
+      float* output_buffer = thread_output_buffers_[i].get();
+
+      auto future = folly::via(
+          pool.get(), [this, h_objs, start_idx, end_idx, output_buffer]() {
+            run_embedding_operations(h_objs, start_idx, end_idx, output_buffer);
+            return 1;
+          });
+      futures.push_back(std::move(future));
+    }
+
+    // Collect and aggregate results from all worker threads
+    auto results = co_await folly::collectAll(futures);
+    [[maybe_unused]] int total = 0;
+    for (auto& result : results) {
+      if (result.hasValue()) {
+        total += result.value();
+      }
+    }
+  }
+
+  co_return "";
+}
+
+// Execute requests_per_fire_ embedding operations using pre-generated pools for
+// efficiency
+void Embedding::run_embedding_operations(
+    const std::shared_ptr<AdSimHandleObjs>& /* h_objs */,
+    size_t start_idx,
+    size_t end_idx,
+    float* output_buffer) {
+  // Execute configurable number of requests per fire operation
+  size_t current_idx = start_idx;
+  for (int req = 0; req < requests_per_fire_; ++req) {
+    // Get pre-generated request from this thread's range
+    const auto& pregenerated_req = pregenerated_requests_[current_idx];
+
+    // Move to next request in this thread's range (wrap around if needed)
+    current_idx++;
+    if (current_idx >= end_idx) {
+      current_idx = start_idx;
+    }
+
+    // Execute request using pre-generated data and passed output buffer
+    tables_[pregenerated_req.table_idx]->forward(
+        pregenerated_req.request, output_buffer, pooling_mode_);
+  }
+}
+
+// Static parsing functions
+WeightsPrecision Embedding::parse_weights_precision(const std::string& str) {
+  if (str == "int4") {
+    return WeightsPrecision::INT4;
+  }
+  if (str == "int8") {
+    return WeightsPrecision::INT8;
+  }
+  if (str == "fp16") {
+    return WeightsPrecision::FP16;
+  }
+  if (str == "fp32") {
+    return WeightsPrecision::FP32;
+  }
+  return WeightsPrecision::INT4; // default
+}
+
+OutputDtype Embedding::parse_output_dtype(const std::string& str) {
+  if (str == "fp16") {
+    return OutputDtype::FP16;
+  }
+  if (str == "fp32") {
+    return OutputDtype::FP32;
+  }
+  return OutputDtype::FP32; // default
+}
+
+PoolingMode Embedding::parse_pooling_mode(const std::string& str) {
+  if (str == "sum") {
+    return PoolingMode::SUM;
+  }
+  if (str == "mean") {
+    return PoolingMode::MEAN;
+  }
+  if (str == "none") {
+    return PoolingMode::NONE;
+  }
+  return PoolingMode::SUM; // default
+}
+
+std::shared_ptr<Kernel> Embedding::config(const folly::dynamic& config_d) {
+  std::vector<EmbeddingTableSpec> table_specs;
+
+  // Parse global configuration
+  int requests_per_fire =
+      static_cast<int>(config_d.getDefault("requests_per_fire", 1).asInt());
+  int nthreads = static_cast<int>(config_d.getDefault("nthreads", 0).asInt());
+  bool weighted = config_d.getDefault("weighted", false).asBool();
+  int pregenerated_req_num = static_cast<int>(
+      config_d.getDefault("pregenerated_req_num", 10000).asInt());
+
+  auto weights_precision = parse_weights_precision(
+      config_d.getDefault("weights_precision", "int4").asString());
+  auto output_dtype = parse_output_dtype(
+      config_d.getDefault("output_dtype", "fp32").asString());
+  auto pooling_mode =
+      parse_pooling_mode(config_d.getDefault("pooling", "sum").asString());
+
+  // Parse comma-separated lists helper
+  auto parse_int_list = [](const std::string& str) {
+    std::vector<int> result;
+    std::stringstream ss(str);
+    std::string item;
+    while (std::getline(ss, item, ',')) {
+      result.push_back(std::stoi(item));
+    }
+    return result;
+  };
+
+  auto parse_float_list = [](const std::string& str) {
+    std::vector<float> result;
+    std::stringstream ss(str);
+    std::string item;
+    while (std::getline(ss, item, ',')) {
+      result.push_back(std::stof(item));
+    }
+    return result;
+  };
+
+  // Helper function to get parameter values (single or list)
+  auto get_int_values = [&](const std::string& single_key,
+                            const std::string& list_key,
+                            int default_val) {
+    std::vector<int> values;
+    if (config_d.count(list_key)) {
+      values = parse_int_list(config_d[list_key].asString());
+    } else if (config_d.count(single_key)) {
+      values.push_back(static_cast<int>(config_d[single_key].asInt()));
+    } else {
+      values.push_back(default_val);
+    }
+    return values;
+  };
+
+  auto get_float_values = [&](const std::string& single_key,
+                              const std::string& list_key,
+                              float default_val) {
+    std::vector<float> values;
+    if (config_d.count(list_key)) {
+      values = parse_float_list(config_d[list_key].asString());
+    } else if (config_d.count(single_key)) {
+      values.push_back(static_cast<float>(config_d[single_key].asDouble()));
+    } else {
+      values.push_back(default_val);
+    }
+    return values;
+  };
+
+  // Get parameter values
+  auto num_embeddings_values =
+      get_int_values("num_embeddings", "num_embeddings_list", 100000);
+  auto embedding_dim_values =
+      get_int_values("embedding_dim", "embedding_dim_list", 128);
+  auto bag_size_values = get_int_values("bag_size", "bag_size_list", 20);
+  auto batch_size_values = get_int_values("batch_size", "batch_size_list", 512);
+  auto access_weight_values =
+      get_float_values("access_weight", "access_weight_list", 1.0f);
+
+  // Determine number of tables
+  size_t max_size = std::max(
+      {num_embeddings_values.size(),
+       embedding_dim_values.size(),
+       bag_size_values.size(),
+       batch_size_values.size(),
+       access_weight_values.size()});
+
+  // Check for mismatched sizes
+  std::vector<size_t> sizes = {
+      num_embeddings_values.size(),
+      embedding_dim_values.size(),
+      bag_size_values.size(),
+      batch_size_values.size(),
+      access_weight_values.size()};
+
+  bool has_mismatch = false;
+  for (size_t size : sizes) {
+    if (size != 1 && size != max_size) {
+      has_mismatch = true;
+      break;
+    }
+  }
+
+  if (has_mismatch) {
+    LOG(ERROR)
+        << "Configuration error: Mismatched list sizes in embedding configuration.";
+    LOG(ERROR)
+        << "Help: All parameter lists must have the same size, or be single values.";
+    LOG(ERROR) << "  num_embeddings: " << num_embeddings_values.size()
+               << " values";
+    LOG(ERROR) << "  embedding_dim: " << embedding_dim_values.size()
+               << " values";
+    LOG(ERROR) << "  bag_size: " << bag_size_values.size() << " values";
+    LOG(ERROR) << "  batch_size: " << batch_size_values.size() << " values";
+    LOG(ERROR) << "  access_weight: " << access_weight_values.size()
+               << " values";
+    LOG(ERROR) << "Expected: All lists should have " << max_size
+               << " values or be single values.";
+    return nullptr;
+  }
+
+  // Handle special case for num_tables parameter (legacy support)
+  if (max_size == 1 && config_d.count("num_tables")) {
+    int num_tables = static_cast<int>(config_d["num_tables"].asInt());
+    max_size = static_cast<size_t>(num_tables);
+  }
+
+  // Expand single values to match max_size
+  auto expand_to_size = [](std::vector<int>& vec, size_t target_size) {
+    if (vec.size() == 1 && target_size > 1) {
+      int val = vec[0];
+      vec.resize(target_size, val);
+    }
+  };
+
+  auto expand_float_to_size = [](std::vector<float>& vec, size_t target_size) {
+    if (vec.size() == 1 && target_size > 1) {
+      float val = vec[0];
+      vec.resize(target_size, val);
+    }
+  };
+
+  expand_to_size(num_embeddings_values, max_size);
+  expand_to_size(embedding_dim_values, max_size);
+  expand_to_size(bag_size_values, max_size);
+  expand_to_size(batch_size_values, max_size);
+  expand_float_to_size(access_weight_values, max_size);
+
+  // Create table specs
+  table_specs.reserve(max_size);
+  for (size_t i = 0; i < max_size; ++i) {
+    table_specs.emplace_back(
+        num_embeddings_values[i],
+        embedding_dim_values[i],
+        bag_size_values[i],
+        batch_size_values[i],
+        access_weight_values[i],
+        weights_precision,
+        output_dtype);
+  }
+
+  return std::make_shared<Embedding>(
+      std::move(table_specs),
+      requests_per_fire,
+      nthreads,
+      weighted,
+      pooling_mode,
+      pregenerated_req_num);
+}
+
+} // namespace facebook::cea::chips::adsim

--- a/packages/adsim/src/cpp2/server/dwarfs/Embedding.h
+++ b/packages/adsim/src/cpp2/server/dwarfs/Embedding.h
@@ -1,0 +1,184 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <cstdint>
+#include <memory>
+#include <random>
+#include <vector>
+
+#include <cea/chips/adsim/cpp2/server/DataObjects.h>
+#include <cea/chips/adsim/cpp2/server/dwarfs/Kernel.h>
+
+#include <fb303/ThreadCachedServiceData.h>
+#include <folly/coro/Task.h>
+#include <folly/json/dynamic.h>
+
+namespace facebook::cea::chips::adsim {
+
+DECLARE_timeseries(embedding_nfired);
+
+// Quantization precision for embedding weights
+enum class WeightsPrecision { INT4 = 4, INT8 = 8, FP16 = 16, FP32 = 32 };
+// Output data type for embedding lookups
+enum class OutputDtype { FP16 = 16, FP32 = 32 };
+// Pooling aggregation mode for embedding bags
+enum class PoolingMode { SUM, MEAN, NONE };
+
+// Configuration for a single embedding table
+struct EmbeddingTableSpec {
+  int num_embeddings;
+  int embedding_dim;
+  int bag_size;
+  int batch_size;
+  float access_weight; // Probability weight for table access
+  WeightsPrecision weights_precision;
+  OutputDtype output_dtype;
+
+  EmbeddingTableSpec(
+      int ne,
+      int ed,
+      int bs,
+      int batch_sz = 512,
+      float weight = 1.0f,
+      WeightsPrecision wp = WeightsPrecision::INT4,
+      OutputDtype od = OutputDtype::FP32)
+      : num_embeddings(ne),
+        embedding_dim(ed),
+        bag_size(bs),
+        batch_size(batch_sz),
+        access_weight(weight),
+        weights_precision(wp),
+        output_dtype(od) {}
+};
+
+// Embedding lookup request with sparse indices and optional weights
+struct EmbeddingRequest {
+  std::vector<int64_t> indices;
+  std::vector<int32_t> offsets;
+  std::vector<float> per_sample_weights;
+  bool weighted;
+
+  EmbeddingRequest(
+      std::vector<int64_t> idx,
+      std::vector<int32_t> off,
+      std::vector<float> weights = {},
+      bool w = false)
+      : indices(std::move(idx)),
+        offsets(std::move(off)),
+        per_sample_weights(std::move(weights)),
+        weighted(w) {}
+};
+
+// Single embedding table with quantized weights and FBGEMM kernels
+class EmbeddingTable {
+ public:
+  explicit EmbeddingTable(const EmbeddingTableSpec& spec);
+  ~EmbeddingTable();
+
+  void fill_random_weights();
+  void forward(
+      const EmbeddingRequest& request,
+      float* output,
+      PoolingMode pooling_mode = PoolingMode::SUM);
+
+  size_t get_memory_usage() const;
+
+ private:
+  EmbeddingTableSpec spec_;
+  std::vector<uint8_t> fused_embedding_table_; // Quantized weights + scale/bias
+  size_t fused_embedding_dim_{};
+  std::mt19937 generator_;
+
+  void init_table();
+  size_t get_fused_embedding_dim() const;
+  void embedding_lookup_and_pool(
+      const std::vector<int64_t>& indices,
+      const std::vector<int32_t>& offsets,
+      const std::vector<float>& weights,
+      float* output,
+      bool weighted,
+      PoolingMode pooling_mode = PoolingMode::SUM) const;
+};
+
+// Multi-table embedding kernel for AdSim simulation
+class Embedding : public Kernel {
+ public:
+  explicit Embedding(
+      std::vector<EmbeddingTableSpec> table_specs,
+      int requests_per_fire,
+      int nthreads,
+      bool weighted = false,
+      PoolingMode pooling_mode = PoolingMode::SUM,
+      int pregenerated_req_num = 10000);
+
+  std::string init(
+      std::shared_ptr<AdSimHandleObjs> h_objs,
+      std::shared_ptr<AdSimRequestObjs> r_objs = nullptr) override;
+
+  folly::coro::Task<std::string> fire(
+      std::shared_ptr<AdSimHandleObjs> h_objs,
+      std::shared_ptr<AdSimRequestObjs> r_objs,
+      std::shared_ptr<folly::Executor> pool) override;
+
+  static std::shared_ptr<Kernel> config(const folly::dynamic& config_d);
+
+ private:
+  std::vector<EmbeddingTableSpec> table_specs_;
+  std::vector<std::unique_ptr<EmbeddingTable>> tables_;
+  std::vector<float>
+      cumulative_weights_; // Cumulative weights for weighted table selection
+  int requests_per_fire_; // Number of requests to execute per fire operation
+  int nthreads_;
+  bool weighted_;
+  PoolingMode pooling_mode_;
+  int pregenerated_req_num_; // Total number of pre-generated requests
+
+  // Simplified pre-generated request pool
+  struct PreGeneratedRequest {
+    int table_idx;
+    EmbeddingRequest request;
+
+    PreGeneratedRequest(int idx, EmbeddingRequest req)
+        : table_idx(idx), request(std::move(req)) {}
+  };
+
+  std::vector<PreGeneratedRequest>
+      pregenerated_requests_; // Single pool of all requests
+
+  // Per-thread output buffers to avoid repeated allocations
+  size_t max_output_size_; // Maximum output buffer size needed
+  mutable std::unique_ptr<std::unique_ptr<float[]>[]>
+      thread_output_buffers_; // Per-thread output buffers
+
+  std::mt19937 generator_;
+
+  void run_embedding_operations(
+      const std::shared_ptr<AdSimHandleObjs>& h_objs,
+      size_t start_idx,
+      size_t end_idx,
+      float* output_buffer);
+
+  // Pre-generation methods for runtime efficiency
+  void pregenerate_pools();
+
+  static WeightsPrecision parse_weights_precision(const std::string& str);
+  static OutputDtype parse_output_dtype(const std::string& str);
+  static PoolingMode parse_pooling_mode(const std::string& str);
+};
+
+} // namespace facebook::cea::chips::adsim


### PR DESCRIPTION
Summary:
### Overview

This diff adds an `embedding` kernel to Adsim, a simulation framework for advertising services.

### Key Changes

*   The diff updates the `BUCK` files in `fbcode/cea/chips/adsim` and `fbcode/cea/chips/adsim/cpp2/server/dwarfs` to include the new `libembedding` library. This library is built from the `Embedding.cc` and `Embedding.h` files.
*   The `Embedding.cc` and `Embedding.h` files are added to the `fbcode/cea/chips/adsim/cpp2/server/dwarfs` directory. These files contain the implementation and interface for the embedding kernel.
*   The `Dwarfs.cc` file is updated to include the `Embedding` kernel in the list of available kernels.

### Functionality

The kernel is built using the `fbgemm` library, which provides optimized implementations of embedding operations.

Differential Revision: D79230030


