### PR TITLE
DCPerf: Adding support for lower granularity to topdown monitors

### DIFF
--- a/benchpress/plugins/hooks/perf.py
+++ b/benchpress/plugins/hooks/perf.py
@@ -39,7 +39,7 @@ DEFAULT_OPTIONS = {
     "perfstat": {"interval": 5, "additional_events": []},
     "netstat": {"interval": 5, "additional_counters": []},
     "memstat": {"interval": 5, "additional_counters": []},
-    "topdown": {},
+    "topdown": {"interval": 5},
     "power": {"interval": 1},
 }
 

--- a/perfutils/generate_amd_perf_report.py
+++ b/perfutils/generate_amd_perf_report.py
@@ -649,6 +649,7 @@ def zen4_frontend_bound(grouped_df):
     return {"name": "Zen4 frontend Bound %", "series": frontend_bound_pct_series}
 
 
+@skip_if_missing
 def zen4_backend_bound(grouped_df):
     de_no_dispatch_per_slot_backend_stalls_series = grouped_df.get_group(
         "de_no_dispatch_per_slot.backend_stalls"
@@ -2580,6 +2581,13 @@ def main(
         metrics.append(zen4_backend_bound(grouped_df))
 
     filtered_metrics = list(itertools.filterfalse(lambda x: x is None, metrics))
+
+    if not filtered_metrics:
+        click.echo(
+            "No metrics could be calculated. All required counters are missing from the input data."
+        )
+        return
+
     shortest_series = max(filtered_metrics, key=lambda m: m["series"].size)
     df_metrics = concat_series(filtered_metrics, shortest_series)
     if series:


### PR DESCRIPTION
Summary:
This diff introduces support for specifying a lower granularity interval in Perfutil performance data collection, which is necessary for DCPerf mini, where the execution time is less than 45 seconds

Key changes include:
Added an interval parameter with a default of 5 seconds to various Perfutil classes (BasePerfUtil, AMDPerfUtil, ARMPerfUtil, NVPerfUtil).
Updated constructors and run methods to accept and use the interval parameter for controlling data collection frequency.
Modified configuration dictionaries to include interval values for the "topdown" monitor.
Enhanced subprocess command construction to pass the interval argument to the underlying perf collection scripts.

Differential Revision: D79523911


