### PR TITLE
Copied Dcperf (Feedsim) : Add graph storage/loading optimization and eliminate per-thread graph building

### DIFF
--- a/benchpress/config/jobs.yml
+++ b/benchpress/config/jobs.yml
@@ -461,6 +461,36 @@
           - 'benchmarks/feedsim/feedsim-multi-inst-*.log'
           - 'benchmarks/feedsim/src/perf.data'
 
+- name: feedsim_autoscale_mini
+  benchmark: feedsim_autoscale
+  description: >
+    Aggregator like workload. Latency sensitive.
+    The feedsim_autoscale mini benchmark jobs
+    are configured with a fixed QPS.
+  args:
+    - '-n {num_instances}'
+    - '-q {fixed_qps}'
+    - '-d {fixed_qps_duration}'
+    - '-w {warmup_time}'
+    - '-S {graph_store_path}'
+    - '-L {graph_load_path}'
+    - '{extra_args}'
+  vars:
+    - 'num_instances=-1'
+    - 'fixed_qps=100'
+    - 'fixed_qps_duration=300'
+    - 'warmup_time=120'
+    - 'graph_store_path=default_do_not_store'
+    - 'graph_load_path=default_do_not_load'
+    - 'extra_args='
+  hooks:
+    - hook: copymove
+      options:
+        is_move: true
+        after:
+          - 'benchmarks/feedsim/feedsim_results*.txt'
+          - 'benchmarks/feedsim/feedsim-multi-inst-*.log'
+          - 'benchmarks/feedsim/src/perf.data'
 
 - name: feedsim_autoscale_arm
   benchmark: feedsim_autoscale
@@ -484,6 +514,38 @@
         args:
           - '-u'   # utilization
           - '1'    # second interval
+    - hook: copymove
+      options:
+        is_move: true
+        after:
+          - 'benchmarks/feedsim/feedsim_results*.txt'
+          - 'benchmarks/feedsim/feedsim-multi-inst-*.log'
+          - 'benchmarks/feedsim/src/perf.data'
+
+- name: feedsim_autoscale_arm_mini
+  benchmark: feedsim_autoscale
+  description: >
+    Aggregator like workload. Latency sensitive.
+    The feedsim_autoscale mini benchmark jobs
+     are configured with a fixed QPS.
+    Parameters tuned for arm.
+  args:
+    - '-n {num_instances}'
+    - '-i {icache_iterations}'
+    - '-q {fixed_qps}'
+    - '-d {fixed_qps_duration}'
+    - '-w {warmup_time}'
+    - '{extra_args}'
+  vars:
+    - 'num_instances=-1'
+    - 'icache_iterations=400000'
+    - 'fixed_qps=100'
+    - 'fixed_qps_duration=300'
+    - 'warmup_time=120'
+    - 'graph_store_path=default_do_not_store'
+    - 'graph_load_path=default_do_not_load'
+    - 'extra_args='
+  hooks:
     - hook: copymove
       options:
         is_move: true

--- a/packages/feedsim/run-feedsim-multi.sh
+++ b/packages/feedsim/run-feedsim-multi.sh
@@ -21,8 +21,29 @@ NUM_INSTANCES="$(( ( NCPU + 99 ) / 100 ))"
 
 NUM_ICACHE_ITERATIONS="1600000"
 
+show_help() {
+cat <<EOF
+Usage: ${0##*/} [OPTION]...
+
+    -h Display this help and exit
+    -n Number of parallel instances to run. Default: $(( ( NCPU + 99 ) / 100 ))
+    -i Number of icache iterations to use. Default: 1600000
+    -S Store the generated graph to a file (requires a file path)
+    -L Load a graph from a file instead of generating one (requires a file path)
+    -I Enable timing instrumentation for graph operations (build, store, load)
+
+Any remaining arguments are passed to run.sh
+
+EOF
+}
+
 SCRIPT_NAME="$(basename "$0")"
 echo "${SCRIPT_NAME}: DCPERF_PERF_RECORD=${DCPERF_PERF_RECORD}"
+
+# Initialize variables for graph storage and loading
+STORE_GRAPH=""
+LOAD_GRAPH=""
+INSTRUMENT_GRAPH=""
 
 while [ $# -ne 0 ]; do
     case $1 in
@@ -34,6 +55,15 @@ while [ $# -ne 0 ]; do
         -i)
             NUM_ICACHE_ITERATIONS="$2"
             ;;
+        -S)
+            STORE_GRAPH="-S $2"
+            ;;
+        -L)
+            LOAD_GRAPH="-L $2"
+            ;;
+        -I)
+            INSTRUMENT_GRAPH="-I"
+            ;;
         -h|--help)
             show_help >&2
             exit 1
@@ -43,7 +73,7 @@ while [ $# -ne 0 ]; do
     esac
 
     case $1 in
-        -n|-i)
+        -n|-i|-S|-L)
             if [ -z "$2" ]; then
                 echo "Invalid option: '$1' requires an argument" 1>&2
                 exit 1
@@ -99,10 +129,10 @@ echo > $BREPS_LFILE
 # shellcheck disable=SC2086
 for i in $(seq 1 ${NUM_INSTANCES}); do
     CORE_RANGE="$(get_cpu_range "${NUM_INSTANCES}" "$((i - 1))")"
-    CMD="IS_AUTOSCALE_RUN=${NUM_INSTANCES} taskset --cpu-list ${CORE_RANGE} ${FEEDSIM_ROOT}/run.sh -p ${PORT} -i ${NUM_ICACHE_ITERATIONS} -o feedsim_results_${FIXQPS_SUFFIX}${i}.txt $*"
+    CMD="IS_AUTOSCALE_RUN=${NUM_INSTANCES} taskset --cpu-list ${CORE_RANGE} ${FEEDSIM_ROOT}/run.sh -p ${PORT} -i ${NUM_ICACHE_ITERATIONS} -o feedsim_results_${FIXQPS_SUFFIX}${i}.txt ${STORE_GRAPH} ${LOAD_GRAPH} ${INSTRUMENT_GRAPH} $*"
     echo "$CMD" > "${FEEDSIM_LOG_PREFIX}${i}.log"
     # shellcheck disable=SC2068,SC2069
-    IS_AUTOSCALE_RUN=${NUM_INSTANCES} stdbuf -i0 -o0 -e0 taskset --cpu-list "${CORE_RANGE}" "${FEEDSIM_ROOT}"/run.sh -p "${PORT}" -i "${NUM_ICACHE_ITERATIONS}" -o "feedsim_results_${FIXQPS_SUFFIX}${i}.txt" $@ 2>&1 > "${FEEDSIM_LOG_PREFIX}${i}.log" &
+    IS_AUTOSCALE_RUN=${NUM_INSTANCES} stdbuf -i0 -o0 -e0 taskset --cpu-list "${CORE_RANGE}" "${FEEDSIM_ROOT}"/run.sh -p "${PORT}" -i "${NUM_ICACHE_ITERATIONS}" -o "feedsim_results_${FIXQPS_SUFFIX}${i}.txt" ${STORE_GRAPH} ${LOAD_GRAPH} ${INSTRUMENT_GRAPH} $@ 2>&1 > "${FEEDSIM_LOG_PREFIX}${i}.log" &
     PIDS+=("$!")
     PHY_CORE_ID=$((PHY_CORE_ID + CORES_PER_INST))
     SMT_ID=$((SMT_ID + CORES_PER_INST))

--- a/packages/feedsim/third_party/src/workloads/ranking/LeafNodeRankCmdline.ggo
+++ b/packages/feedsim/third_party/src/workloads/ranking/LeafNodeRankCmdline.ggo
@@ -28,6 +28,9 @@ option "graph_max_iters" - "Perform at most 'graph_max_iters' iterations during 
 option "graph_subset" - "Perform partial PageRank over these numbers of nodes. 0 indicates all nodes." int default="3145728"
 option "num_objects" - "Number of objects to serialize." int default="40"
 option "random_data_size" - "Number of bytes of string random data." int default="3145728"
+option "store_graph" - "Enable storing the generated graph to a file." string typestr="filename" optional
+option "load_graph" - "Enable loading a graph from a file instead of generating one." string typestr="filename" optional
+option "instrument_graph" - "Enable timing instrumentation for graph operations (build, store, load)."
 option "max_response_size" - "Maximum response size in bytes returned by the leaf server." int default="131072"
 option "compression_data_size" - "Number of bytes to compress per request." int default="131072"
 option "rank_trials_per_thread" - "Number of iterations each CPU thread executes of rank work." int default="1"

--- a/packages/feedsim/third_party/src/workloads/ranking/dwarfs/pagerank.h
+++ b/packages/feedsim/third_party/src/workloads/ranking/dwarfs/pagerank.h
@@ -42,6 +42,14 @@ class PageRankParams {
   ~PageRankParams();
 
   CSRGraph<int32_t> buildGraph();
+  CSRGraph<int32_t> makeGraphCopy(const CSRGraph<int32_t>& original);
+
+  void storeGraphToFile(
+    const CSRGraph<int32_t>& original,
+    const std::string& filePath);
+
+  CSRGraph<int32_t> loadGraphFromFile(
+    const std::string& filePath);
 
  private:
   struct Impl;


### PR DESCRIPTION
Summary:
This diff enhances the DCPerf Feedsim benchmark by adding graph storage and loading optimization capabilities. It also eliminates redundant graph building across multiple thread runs, improving performance and scalability.

**Key changes:**

1.  **Shell script enhancements** (`run-feedsim-multi.sh`, `run.sh`):

    *   Added `-S` flag to store generated graphs to a file for reuse across instances
    *   Added `-L` flag to load pre-generated graphs from a file instead of rebuilding per thread
    *   Enhanced help documentation to explain the new optimization options
    *   Updated command line parsing to handle the new flags and pass them through to the underlying executables
2.  **Command line options** (`LeafNodeRankCmdline.ggo`):

    *   Added `store_graph` option to enable saving generated graphs to a specified file
    *   Added `load_graph` option to enable loading graphs from a specified file instead of generating new ones

**Performance optimizations:**

*   **Eliminates per-thread graph building overhead**: Instead of each parallel instance building its own graph, one instance can build and store the graph while others load the pre-built version
*   Reduces benchmark initialization time by orders of magnitude for multi-instance runs
*   Enables consistent testing across runs by using identical graph structures
*   Improves reproducibility of benchmark results
*   Optimizes memory and CPU usage by avoiding redundant graph generation across parallel threads

This optimization is particularly impactful for ranking workloads in multi-threaded scenarios where graph generation was previously a significant bottleneck, with each thread duplicating expensive graph building work.

Rollback Plan:

Differential Revision: D80288337


