### PR TITLE
Fix AdSim OSS build

### DIFF
--- a/packages/adsim/install_adsim.sh
+++ b/packages/adsim/install_adsim.sh
@@ -38,7 +38,7 @@ BENCHPRESS_ROOT="$(readlink -f "$BPKGS_ADSIM_ROOT/../..")"
 BENCHMARKS_DIR="${BENCHPRESS_ROOT}/benchmarks/adsim"
 
 # Temporary directory for intermediate build artifacts
-BUILD_DIR="${BENCHPRESS_ROOT}/build"
+BUILD_DIR="${BENCHMARKS_DIR}/build"
 
 ################################################################################
 # Setup Functions

--- a/packages/adsim/src/CMake/ThriftLibrary.cmake
+++ b/packages/adsim/src/CMake/ThriftLibrary.cmake
@@ -229,9 +229,8 @@ macro(thrift_generate
     ${output_path}/gen-${language}/${source_file_name}_constants.cpp
     ${output_path}/gen-${language}/${source_file_name}_data.cpp
     ${output_path}/gen-${language}/${source_file_name}_types.cpp
-    ${output_path}/gen-${language}/${source_file_name}_types_binary.cpp
     ${output_path}/gen-${language}/${source_file_name}_types_compact.cpp
-    ${output_path}/gen-${language}/${source_file_name}_types_serialization.cpp
+    ${output_path}/gen-${language}/${source_file_name}_types_binary.cpp
   )
   if("${options}" MATCHES "layouts")
     set("${target_file_name}-${language}-SOURCES"


### PR DESCRIPTION
Summary:
Fix AdSim's OSS build:
- Keep AdSim build artifacts in benchmarks/adsim/build folder
- Prevent fb303 from building mvfst again (since it's already built in fbthrift)
- Update ThriftLibrary.cmake to match the current version of fbthrift codegen output

Differential Revision: D81974904


