### PR TITLE
Replace archive.apache.org with CDN to avoid throttling

### DIFF
--- a/packages/spark_standalone/install_spark_standalone.sh
+++ b/packages/spark_standalone/install_spark_standalone.sh
@@ -43,7 +43,7 @@ fi
 # download spark
 pushd "${OUT}" || exit 1
 if [ ! -f spark-4.0.0-bin-hadoop3.tgz ]; then
-  wget https://archive.apache.org/dist/spark/spark-4.0.0/spark-4.0.0-bin-hadoop3.tgz
+  wget https://dlcdn.apache.org/spark/spark-4.0.0/spark-4.0.0-bin-hadoop3.tgz
 fi
 tar xzf spark-4.0.0-bin-hadoop3.tgz
 popd || exit 1


### PR DESCRIPTION
Summary:
archive.apache.org is for archiving and is not recommended for regular downloads
Switched this to the CDN recommended by the archive's page

Reviewed By: excelle08

Differential Revision: D82071107


