### PR TITLE
Django-Replace archive.apache.org with CDN and cassandra version to avoid throttling

### DIFF
--- a/packages/django_workload/alternative_install_django_workload_aws.sh
+++ b/packages/django_workload/alternative_install_django_workload_aws.sh
@@ -72,12 +72,12 @@ sudo yum install -y "${JDK_NAME}" || { echo "Could not install ${JDK_NAME} packa
 
 # 4. Install Cassandra
 # Download Cassandra from third-party source
-cassandra_version=3.11.10
+cassandra_version=3.11.19
 CASSANDRA_NAME="apache-cassandra-${cassandra_version}"
 if ! [ -d "${CASSANDRA_NAME}" ]; then
     CASSANDRA_TAR="${CASSANDRA_NAME}-bin.tar.gz"
     if ! [ -f "${CASSANDRA_TAR}" ]; then
-        wget "https://archive.apache.org/dist/cassandra/${cassandra_version}/${CASSANDRA_TAR}"
+        wget "https://dlcdn.apache.org/cassandra/${cassandra_version}/${CASSANDRA_TAR}"
     fi
     tar -xvf "${CASSANDRA_TAR}" -C "${DJANGO_WORKLOAD_ROOT}"
 else

--- a/packages/django_workload/install_django_workload.sh
+++ b/packages/django_workload/install_django_workload.sh
@@ -99,8 +99,8 @@ update-alternatives --set keytool /usr/local/jdk-8u60-64/bin/keytool
 # 4. Install Cassandra
 
 # Download Cassandra from third-party source
-cassandra_version=3.11.10
-wget "https://archive.apache.org/dist/cassandra/${cassandra_version}/apache-cassandra-${cassandra_version}-bin.tar.gz"
+cassandra_version=3.11.19
+wget "https://dlcdn.apache.org/cassandra/${cassandra_version}/apache-cassandra-${cassandra_version}-bin.tar.gz"
 tar -xvf "apache-cassandra-${cassandra_version}-bin.tar.gz" -C "$OUT"
 # Rename
 [ ! -d "$OUT/apache-cassandra" ] && mv "$OUT/apache-cassandra-${cassandra_version}" "$OUT/apache-cassandra"

--- a/packages/django_workload/install_django_workload_aarch64.sh
+++ b/packages/django_workload/install_django_workload_aarch64.sh
@@ -139,12 +139,12 @@ dnf install -y "${JDK_NAME}" || { echo "Could not install ${JDK_NAME} package"; 
 
 # 4. Install Cassandra
 # Download Cassandra from third-party source
-cassandra_version=3.11.10
+cassandra_version=3.11.19
 CASSANDRA_NAME="apache-cassandra-${cassandra_version}"
 if ! [ -d "${CASSANDRA_NAME}" ]; then
     CASSANDRA_TAR="${CASSANDRA_NAME}-bin.tar.gz"
     if ! [ -f "${CASSANDRA_TAR}" ]; then
-        wget "https://archive.apache.org/dist/cassandra/${cassandra_version}/${CASSANDRA_TAR}"
+        wget "https://dlcdn.apache.org/cassandra/${cassandra_version}/${CASSANDRA_TAR}"
     fi
     tar -xvf "${CASSANDRA_TAR}" -C "${DJANGO_WORKLOAD_ROOT}"
 else

--- a/packages/django_workload/install_django_workload_aarch64_ubuntu22.sh
+++ b/packages/django_workload/install_django_workload_aarch64_ubuntu22.sh
@@ -141,12 +141,12 @@ apt install -y "${JDK_NAME}" || { echo "Could not install ${JDK_NAME} package"; 
 
 # 4. Install Cassandra
 # Download Cassandra from third-party source
-cassandra_version=3.11.10
+cassandra_version=3.11.19
 CASSANDRA_NAME="apache-cassandra-${cassandra_version}"
 if ! [ -d "${CASSANDRA_NAME}" ]; then
     CASSANDRA_TAR="${CASSANDRA_NAME}-bin.tar.gz"
     if ! [ -f "${CASSANDRA_TAR}" ]; then
-        wget "https://archive.apache.org/dist/cassandra/${cassandra_version}/${CASSANDRA_TAR}"
+        wget "https://dlcdn.apache.org/cassandra/${cassandra_version}/${CASSANDRA_TAR}"
     fi
     tar -xvf "${CASSANDRA_TAR}" -C "${DJANGO_WORKLOAD_ROOT}"
 else

--- a/packages/django_workload/install_django_workload_x86_64_centos9.sh
+++ b/packages/django_workload/install_django_workload_x86_64_centos9.sh
@@ -141,12 +141,12 @@ dnf install -y "${JDK_NAME}" || { echo "Could not install ${JDK_NAME} package"; 
 
 # 4. Install Cassandra
 # Download Cassandra from third-party source
-cassandra_version=3.11.10
+cassandra_version=3.11.19
 CASSANDRA_NAME="apache-cassandra-${cassandra_version}"
 if ! [ -d "${CASSANDRA_NAME}" ]; then
     CASSANDRA_TAR="${CASSANDRA_NAME}-bin.tar.gz"
     if ! [ -f "${CASSANDRA_TAR}" ]; then
-        wget "https://archive.apache.org/dist/cassandra/${cassandra_version}/${CASSANDRA_TAR}"
+        wget "https://dlcdn.apache.org/cassandra/${cassandra_version}/${CASSANDRA_TAR}"
     fi
     tar -xvf "${CASSANDRA_TAR}" -C "${DJANGO_WORKLOAD_ROOT}"
 else

--- a/packages/django_workload/install_django_workload_x86_64_ubuntu22.sh
+++ b/packages/django_workload/install_django_workload_x86_64_ubuntu22.sh
@@ -140,12 +140,12 @@ apt install -y "${JDK_NAME}" || { echo "Could not install ${JDK_NAME} package"; 
 
 # 4. Install Cassandra
 # Download Cassandra from third-party source
-cassandra_version=3.11.10
+cassandra_version=3.11.19
 CASSANDRA_NAME="apache-cassandra-${cassandra_version}"
 if ! [ -d "${CASSANDRA_NAME}" ]; then
     CASSANDRA_TAR="${CASSANDRA_NAME}-bin.tar.gz"
     if ! [ -f "${CASSANDRA_TAR}" ]; then
-        wget "https://archive.apache.org/dist/cassandra/${cassandra_version}/${CASSANDRA_TAR}"
+        wget "https://dlcdn.apache.org/cassandra/${cassandra_version}/${CASSANDRA_TAR}"
     fi
     tar -xvf "${CASSANDRA_TAR}" -C "${DJANGO_WORKLOAD_ROOT}"
 else


### PR DESCRIPTION
Summary: Django-Replace archive.apache.org with CDN and cassandra version to 3.11.19 to avoid throttling

Differential Revision: D82354545


