### PR TITLE
folly::init -> folly::Init in cea/chips/adsim/cpp2/client/AdSimClient.cpp +5

### DIFF
--- a/packages/adsim/patches/treadmill.patch
+++ b/packages/adsim/patches/treadmill.patch
@@ -7524,7 +7524,7 @@ diff -wbBdu -ruN '--exclude=.git' '--exclude=*.rej' '--exclude=*.orig' '--exclud
 +  // Set the usage information
 +  std::string usage("Treadmill loadtester");
 +  google::SetUsageMessage(usage);
-+  folly::init(&argc, &argv);
++  const folly::Init init(&argc, &argv);
 +}
 +
 +} // namespace treadmill

--- a/packages/adsim/src/cpp2/client/AdSimClient.cpp
+++ b/packages/adsim/src/cpp2/client/AdSimClient.cpp
@@ -39,7 +39,7 @@ using facebook::cea::chips::adsim::AdSimResponse;
 using facebook::cea::chips::adsim::FizzStopTLSConnector;
 
 int main(int argc, char* argv[]) {
-  folly::init(&argc, &argv);
+  const folly::Init init(&argc, &argv);
 
   // create eventbase first so no dangling stack refs on 'client' dealloc
   folly::EventBase evb;


### PR DESCRIPTION
Summary: `folly::init` has been deprecated in favor of `folly::Init` for over two years. Let's make this switch.

Differential Revision: D82664101


