### PR TITLE
setup entry for edge hardware on dc perf

### DIFF
--- a/benchpress/config/__init__.py
+++ b/benchpress/config/__init__.py
@@ -70,6 +70,7 @@ if not open_source:
     register_benchmark_suite("internal")
     register_benchmark_suite("wdl_v1")
     register_benchmark_suite("v1")
+    register_benchmark_suite("ehw")
 
 register_benchmark_suite("wdl")
 register_benchmark_suite("system")

--- a/benchpress/plugins/parsers/__init__.py
+++ b/benchpress/plugins/parsers/__init__.py
@@ -6,12 +6,11 @@
 
 # pyre-unsafe
 
-from benchpress.lib import open_source
-
 from .adsim import AdSimParser
 
 from .benchdnn import BenchdnnParser
 from .cachebench import CacheBenchParser
+from .cdn_bench import CDNBenchParser
 from .checkmark import CheckmarkParser
 from .chm import ChmParser
 from .clang import ClangParser
@@ -108,6 +107,7 @@ def register_parsers(factory):
     factory.register("chm", ChmParser)
     factory.register("deser", DeserParser)
     factory.register("adsim", AdSimParser)
+    factory.register("cdn_bench", CDNBenchParser)
 
     # if not open_source:
     #     factory.register("adsim", AdSimParser)

--- a/benchpress/plugins/parsers/cdn_bench.py
+++ b/benchpress/plugins/parsers/cdn_bench.py
@@ -1,0 +1,18 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-unsafe
+
+from benchpress.lib.parser import Parser
+
+
+class CDNBenchParser(Parser):
+    """The Parser returns a dictionary of metrics mapping name → value."""
+
+    def parse(self, stdout, stderr, returncode):
+        return {
+            "exit_code": returncode,
+        }

--- a/packages/cdn_bench/cleanup_cdn_bench.sh
+++ b/packages/cdn_bench/cleanup_cdn_bench.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+set -Eeuo pipefail
+
+echo "Goodbye, World!"

--- a/packages/cdn_bench/install_cdn_bench.sh
+++ b/packages/cdn_bench/install_cdn_bench.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+set -Eeuo pipefail
+
+echo "Hello, World!"

--- a/packages/cdn_bench/run.sh
+++ b/packages/cdn_bench/run.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+set -Eeuo pipefail
+
+echo "Run, World!"


### PR DESCRIPTION
Summary:
Trying to set up an entry for edge hardware in DC perf so we can start iterating.

The only test is sleep which is copied from default. Will start including the benchmarks once they are developed.

Following this guide to add the entries
 https://www.internalfb.com/wiki/Capacity_Engineering/CHiPs/DCPerf/Development_Guide/how-to-add-benchmark/

Differential Revision: D82576323


