### PR TITLE
Improve finally clause when benchmark/job/toolchain spec given as argument doesn't exist

### DIFF
--- a/benchpress/cli/main.py
+++ b/benchpress/cli/main.py
@@ -253,6 +253,10 @@ def load_config(args) -> config.BenchpressConfig:
     """
     try:
         override_benchmark = False
+        benchmarks_specs = None
+        jobs_specs = None
+        toolchain_specs = None
+
         if args.benchmarks and args.benchmarks in config.ALT_BENCHMARKS_CONFIGS:
             logger.info(f"Using alternative benchmark suite {args.benchmarks}.")
             bm_config_path = config.ALT_BENCHMARKS_CONFIGS[args.benchmarks]
@@ -311,6 +315,14 @@ def load_config(args) -> config.BenchpressConfig:
             toolchain_specs = toolchain_path.open()
             if args.toolchain_file:
                 toolchain_specs_path = os.path.abspath(args.toolchain_file)
+                if not os.path.exists(toolchain_specs_path):
+                    logger.error(
+                        'toolchain file with name "{}" not found'.format(
+                            toolchain_specs_path
+                        )
+                    )
+                    exit(1)
+
                 logger.warning("Overriding default toolchain config!")
                 logger.info(
                     'Loading toolchain config from "{}"'.format(toolchain_specs_path)


### PR DESCRIPTION
Summary: When inadvertently providing a bad benchmark/job/toolchain spec name, the logger error message correctly says it doesn't exist, but it's buried behind the other exception that occurs in the "finally" clause. This just adds a fix so we don't throw an exception, so the original error is easier to see.

Differential Revision: D83190156


