### PR TITLE
Update folly and fbthrift versions

### DIFF
--- a/packages/spark_standalone/install_spark_standalone.sh
+++ b/packages/spark_standalone/install_spark_standalone.sh
@@ -42,10 +42,10 @@ fi
 
 # download spark
 pushd "${OUT}" || exit 1
-if [ ! -f spark-4.0.0-bin-hadoop3.tgz ]; then
-  wget https://dlcdn.apache.org/spark/spark-4.0.0/spark-4.0.0-bin-hadoop3.tgz
+if [ ! -f spark-4.0.1-bin-hadoop3.tgz ]; then
+  wget https://dlcdn.apache.org/spark/spark-4.0.1/spark-4.0.1-bin-hadoop3.tgz
 fi
-tar xzf spark-4.0.0-bin-hadoop3.tgz
+tar xzf spark-4.0.1-bin-hadoop3.tgz
 popd || exit 1
 
 # create sub directories

--- a/packages/wdl_bench/install_wdl_bench.sh
+++ b/packages/wdl_bench/install_wdl_bench.sh
@@ -16,8 +16,8 @@ declare -A REPOS=(
 )
 
 declare -A TAGS=(
-    ['folly']='v2025.09.15.00'
-    ['fbthrift']='v2025.09.15.00'
+    ['folly']='v2025.09.22.00'
+    ['fbthrift']='v2025.09.22.00'
     ['lzbench']='v2.1'
     ['openssl']='openssl-3.3.1'
     ['vdso']='main'


### PR DESCRIPTION
Summary: CI is failing ([link](https://github.com/facebookresearch/DCPerf/actions/runs/17990450091/job/51179095789?fbclid=IwY2xjawNBywJleHRuA2FlbQIxMQBicmlkETE1cjM0TE15VEhpSEtGVHBuAR7VlZcEX1Zl2FeYpp8mWgzyQV1dZ8lRMcY2lJZxMDTle48pgtvQMow4nDQqMg_aem_ItATH7rHjfxPjVev4fp-Hw)) because the folly version doesn't include D82676673.

Differential Revision: D83225390


