### PR TITLE
Add initializer for 'score' Reporter, so it doesn't throw when the set of jobs reported is empty

### DIFF
--- a/benchpress/lib/reporter.py
+++ b/benchpress/lib/reporter.py
@@ -88,9 +88,10 @@ class JSONFileReporter(Reporter):
 class ScoreReporter(Reporter):
     """Report scores of benchmarks as well as overall DCPerf score"""
 
+    def __init__(self) -> None:
+        self.scores = {}
+
     def report(self, job, metrics):
-        if not hasattr(self, "scores"):
-            self.scores = {}
         job_name = job.name.replace(" ", "_")
 
         if job_name not in baseline.JOB_TO_BM.keys():


### PR DESCRIPTION
Summary: Trying out benchpress submcommands, I saw that running "report score" causes an exception since no jobs have caused the Score reporter's `report()` method to have run, thus the `scores` dict attribute was non-existent.

Reviewed By: excelle08, charles-typ

Differential Revision: D83201105


