### PR TITLE
Fbgemm embedding

### DIFF
--- a/benchpress/config/jobs_ai.yml
+++ b/benchpress/config/jobs_ai.yml
@@ -14,6 +14,7 @@
   name: fbgemm_embedding_a_single
   description: Performance benchmark for Model A workload using one single representative embedding table.
   args:
+    - tbe_inference_benchmark
     - nbit-cpu
     - '--num-embeddings={embeddings}'
     - '--bag-size={bag_size}'
@@ -40,6 +41,7 @@
   name: fbgemm_embedding_a_spec
   description: Performance benchmark for Model A workload using a representative set of embedding tables with different bag sizes.
   args:
+    - tbe_inference_benchmark
     - nbit-device-with-spec
     - '--num-embeddings-list={embeddings_list}'
     - '--bag-size-list={bag_size_list}'
@@ -66,6 +68,7 @@
   name: fbgemm_embedding_b_spec_int4
   description: Performance benchmark for Model B workload using a representative set of embedding tables with int4 precision.
   args:
+    - tbe_inference_benchmark
     - nbit-device-with-spec
     - '--num-embeddings-list={embeddings_list}'
     - '--bag-size-list={bag_size_list}'
@@ -92,6 +95,7 @@
   name: fbgemm_embedding_b_spec_int8
   description: Performance benchmark for Model B workload using a representative set of embedding tables with int8 precision.
   args:
+    - tbe_inference_benchmark
     - nbit-device-with-spec
     - '--num-embeddings-list={embeddings_list}'
     - '--bag-size-list={bag_size_list}'

--- a/packages/fbgemm/install_fbgemm_bench.sh
+++ b/packages/fbgemm/install_fbgemm_bench.sh
@@ -904,7 +904,8 @@ clone_fbgemm_repo() {
   # Clone the FBGEMM repository along with its submodules
   # We specify the version tag to ensure we get the correct version
   echo "[SETUP] Cloning repository with submodules..."
-  git clone --recursive -b ${FBGEMM_VERSION} https://github.com/pytorch/FBGEMM.git fbgemm_${FBGEMM_VERSION}
+  git clone --recursive https://github.com/pytorch/FBGEMM.git fbgemm_${FBGEMM_VERSION}
+  git -C fbgemm_${FBGEMM_VERSION} checkout ${FBGEMM_VERSION}
 
   # Disable the postbuild script to prevent race conditions during linking
   # This is a workaround for a known issue in the build process


### PR DESCRIPTION
Two patches to fix FBGEMM git clone failures and runtime errors:

The FBGEMM_VERSION=fd32631d837b41251311099c393af7d7be5cfbf variable points to a commit ID. Using it with git clone -b $FBGEMM_VERSION fails. This patch corrects that issue.

The fbgemm_embedding benchmarks are now run through run.sh, so the benchmark execution script has been updated accordingly.