### PR TITLE
Ensure siege uses the config file specifically for the benchmark

### DIFF
--- a/packages/django_workload/templates/run-siege
+++ b/packages/django_workload/templates/run-siege
@@ -137,6 +137,8 @@ def run_siege(options):
         cmd = cmd + " -r " + str(options.reps)
     else:
         cmd = cmd + " -t " + DURATION
+    if options.siege_rc:
+        cmd = cmd + f" -R {options.siege_rc}"
     cmd = cmd + " -f " + SOURCE + " --log=" + LOG + " &>> "
     iterations = options.iterations
     url_dict, url_target = parse_urls(URLS_TEMPLATE_FILE)
@@ -322,6 +324,8 @@ def main():
                       "repetitions instead of amount of time. This will " +
                       "override DURATION env variable if set to a positive " +
                       "integer.")
+    parser.add_option("-R", "--siege-rc", default="", type="str",
+                      help="Path to a custom siegerc config file.")
 
     (options, args) = parser.parse_args()
 

--- a/packages/django_workload/templates/run.sh
+++ b/packages/django_workload/templates/run.sh
@@ -114,7 +114,7 @@ run_benchmark() {
   DURATION="$_duration" \
   LOG="$_siege_logs_path" \
   SOURCE="$_urls_path" \
-  python3 ./run-siege -i "${iterations}" -r "${reps}"
+  python3 ./run-siege -i "${iterations}" -r "${reps}" -R "${BENCHPRESS_ROOT}/packages/django_workload/templates/siege.conf"
 }
 
 load_snapshot(){


### PR DESCRIPTION
Summary: As title. This is to fix the problem that when using automark to run DjangoBench its siege log format is not understood by the parser and resulting in empty metrics.

Reviewed By: charles-typ

Differential Revision: D83507795


