### PR TITLE
Switch gengetopt download source from ftp.gnu.org to ftpmirror.gnu.org

### DIFF
--- a/packages/feedsim/alternative_install_feedsim_aws.sh
+++ b/packages/feedsim/alternative_install_feedsim_aws.sh
@@ -60,7 +60,9 @@ cd "${FEEDSIM_THIRD_PARTY_SRC}"
 
 # Installing gengetopt
 if ! [ -d "gengetopt-2.23" ]; then
-    wget "https://ftp.gnu.org/gnu/gengetopt/gengetopt-2.23.tar.xz"
+    # Source the download retry function
+    source "${BENCHPRESS_ROOT}/scripts/download_with_retry.sh"
+    download_with_retry "https://ftpmirror.gnu.org/gnu/gengetopt/gengetopt-2.23.tar.xz"
     tar -xf "gengetopt-2.23.tar.xz"
     cd "gengetopt-2.23"
     ./configure

--- a/packages/feedsim/install_feedsim.sh
+++ b/packages/feedsim/install_feedsim.sh
@@ -93,7 +93,9 @@ cd ../
 
 # Installing gengetopt
 if ! [ -d "gengetopt-2.23" ]; then
-    wget "https://ftp.gnu.org/gnu/gengetopt/gengetopt-2.23.tar.xz"
+    # Source the download retry function
+    source "${BENCHPRESS_ROOT}/scripts/download_with_retry.sh"
+    download_with_retry "https://ftpmirror.gnu.org/gnu/gengetopt/gengetopt-2.23.tar.xz"
     tar -xf "gengetopt-2.23.tar.xz"
     cd "gengetopt-2.23"
     ./configure

--- a/packages/feedsim/install_feedsim_aarch64.sh
+++ b/packages/feedsim/install_feedsim_aarch64.sh
@@ -82,7 +82,9 @@ cd ../
 
 # Installing gengetopt
 if ! [ -d "gengetopt-2.23" ]; then
-    wget "https://ftp.gnu.org/gnu/gengetopt/gengetopt-2.23.tar.xz"
+    # Source the download retry function
+    source "${BENCHPRESS_ROOT}/scripts/download_with_retry.sh"
+    download_with_retry "https://ftpmirror.gnu.org/gnu/gengetopt/gengetopt-2.23.tar.xz"
     tar -xf "gengetopt-2.23.tar.xz"
     cd "gengetopt-2.23"
     ./configure

--- a/packages/feedsim/install_feedsim_aarch64_ubuntu.sh
+++ b/packages/feedsim/install_feedsim_aarch64_ubuntu.sh
@@ -58,7 +58,9 @@ cd "${FEEDSIM_THIRD_PARTY_SRC}"
 
 # Installing gengetopt
 if ! [ -d "gengetopt-2.23" ]; then
-    wget "https://ftp.gnu.org/gnu/gengetopt/gengetopt-2.23.tar.xz"
+    # Source the download retry function
+    source "${BENCHPRESS_ROOT}/scripts/download_with_retry.sh"
+    download_with_retry "https://ftpmirror.gnu.org/gnu/gengetopt/gengetopt-2.23.tar.xz"
     tar -xf "gengetopt-2.23.tar.xz"
     cd "gengetopt-2.23"
     ./configure

--- a/packages/feedsim/install_feedsim_ubuntu.sh
+++ b/packages/feedsim/install_feedsim_ubuntu.sh
@@ -88,7 +88,9 @@ cd ../
 
 # Installing gengetopt
 if ! [ -d "gengetopt-2.23" ]; then
-    wget "https://ftp.gnu.org/gnu/gengetopt/gengetopt-2.23.tar.xz"
+    # Source the download retry function
+    source "${BENCHPRESS_ROOT}/scripts/download_with_retry.sh"
+    download_with_retry "https://ftpmirror.gnu.org/gnu/gengetopt/gengetopt-2.23.tar.xz"
     tar -xf "gengetopt-2.23.tar.xz"
     cd "gengetopt-2.23"
     ./configure

--- a/packages/feedsim/third_party/src/scripts/install_centos8_deps.sh
+++ b/packages/feedsim/third_party/src/scripts/install_centos8_deps.sh
@@ -11,7 +11,11 @@ dnf install -y cmake ninja-build flex bison git texinfo \
 
 
 # gengetopt
-curl $(fwdproxy-config curl) -O https://ftp.gnu.org/gnu/gengetopt/gengetopt-2.23.tar.xz
+# Source the download retry function - assuming this script is in a subdirectory
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" &>/dev/null && pwd -P)"
+BENCHPRESS_ROOT="$(readlink -f "$SCRIPT_DIR/../../../../..")"
+source "${BENCHPRESS_ROOT}/scripts/download_with_retry.sh"
+curl_with_retry "https://ftpmirror.gnu.org/gnu/gengetopt/gengetopt-2.23.tar.xz"
 tar -xf gengetopt-2.23.tar.xz
 cd gengetopt-2.23
 ./configure

--- a/scripts/download_with_retry.sh
+++ b/scripts/download_with_retry.sh
@@ -1,0 +1,97 @@
+#!/bin/bash
+
+# Function to download a file with retry logic
+# Usage: download_with_retry <url> [output_filename] [max_retries]
+download_with_retry() {
+    local url="$1"
+    local output="${2:-}"
+    local max_retries="${3:-5}"
+    local retry_count=0
+    local success=false
+
+    echo "Downloading from: $url"
+
+    while [ $retry_count -lt "$max_retries" ] && [ "$success" = false ]; do
+        retry_count=$((retry_count + 1))
+        echo "Attempt $retry_count of $max_retries"
+
+        if [ -n "$output" ]; then
+            if wget -O "$output" "$url"; then
+                success=true
+                echo "Download successful on attempt $retry_count"
+            else
+                echo "Download failed on attempt $retry_count"
+                if [ $retry_count -lt "$max_retries" ]; then
+                    echo "Retrying in 5 seconds..."
+                    sleep 5
+                fi
+            fi
+        else
+            if wget "$url"; then
+                success=true
+                echo "Download successful on attempt $retry_count"
+            else
+                echo "Download failed on attempt $retry_count"
+                if [ $retry_count -lt "$max_retries" ]; then
+                    echo "Retrying in 5 seconds..."
+                    sleep 5
+                fi
+            fi
+        fi
+    done
+
+    if [ "$success" = false ]; then
+        echo "ERROR: Failed to download $url after $max_retries attempts"
+        return 1
+    fi
+
+    return 0
+}
+
+# Function to download with curl and retry logic
+# Usage: curl_with_retry <url> [output_filename] [max_retries]
+curl_with_retry() {
+    local url="$1"
+    local output="${2:-}"
+    local max_retries="${3:-5}"
+    local retry_count=0
+    local success=false
+
+    echo "Downloading from: $url"
+
+    while [ $retry_count -lt "$max_retries" ] && [ "$success" = false ]; do
+        retry_count=$((retry_count + 1))
+        echo "Attempt $retry_count of $max_retries"
+
+        if [ -n "$output" ]; then
+            if curl "$(fwdproxy-config curl)" -O "$output" "$url"; then
+                success=true
+                echo "Download successful on attempt $retry_count"
+            else
+                echo "Download failed on attempt $retry_count"
+                if [ $retry_count -lt "$max_retries" ]; then
+                    echo "Retrying in 5 seconds..."
+                    sleep 5
+                fi
+            fi
+        else
+            if curl "$(fwdproxy-config curl)" -O "$url"; then
+                success=true
+                echo "Download successful on attempt $retry_count"
+            else
+                echo "Download failed on attempt $retry_count"
+                if [ $retry_count -lt "$max_retries" ]; then
+                    echo "Retrying in 5 seconds..."
+                    sleep 5
+                fi
+            fi
+        fi
+    done
+
+    if [ "$success" = false ]; then
+        echo "ERROR: Failed to download $url after $max_retries attempts"
+        return 1
+    fi
+
+    return 0
+}


### PR DESCRIPTION
Summary: Download gengetopt tarball from ftpmirror.gnu.org instead of ftp.gnu.org since the latter is down. Also add retry mechanism in case the chosen mirror is not reliable.

Differential Revision: D83781224


