### PR TITLE
Feedsim: removing randomness

### DIFF
--- a/benchpress/config/jobs.yml
+++ b/benchpress/config/jobs.yml
@@ -477,6 +477,9 @@
     - '-S {graph_store_path}'
     - '-L {graph_load_path}'
     - '-D {queue_drain_time}'
+    - '-R {node_rank_seed}'
+    - '-P {page_rank_seed}'
+    - '-C {pointer_chase_seed}'
     - '-N'
     - '{extra_args}'
   vars:
@@ -489,6 +492,9 @@
     - 'graph_store_path=default_do_not_store'
     - 'graph_load_path=default_do_not_load'
     - 'queue_drain_time=1'
+    - 'node_rank_seed=54321'
+    - 'page_rank_seed=12345'
+    - 'pointer_chase_seed=98765'
     - 'extra_args='
   hooks:
     - hook: copymove

--- a/packages/feedsim/run.sh
+++ b/packages/feedsim/run.sh
@@ -73,6 +73,9 @@ Usage: ${0##*/} [OPTION]...
     -x Maximum number of warmup iterations when using QPS threshold. Default: 10
     -N No retry mode. Skip sleep and PID checking in load test startup, break immediately without retrying.
     -D Drain time in seconds. Time to wait for queue to drain after experiments. Default: 5
+    -R Seed for LeafNodeRank random number generator. If not provided, current time will be used.
+    -P Seed for PageRank random number generator. If not provided, current time will be used.
+    -C Seed for PointerChase random number generator. If not provided, current time will be used.
 EOF
 }
 
@@ -152,6 +155,15 @@ main() {
     local queue_drain_time
     queue_drain_time="5"
 
+    local leafnoderank_seed
+    leafnoderank_seed=""
+
+    local pagerank_seed
+    pagerank_seed=""
+
+    local pointerchase_seed
+    pointerchase_seed=""
+
     if [ -z "$IS_AUTOSCALE_RUN" ]; then
        echo > $BREPS_LFILE
     fi
@@ -221,6 +233,15 @@ main() {
             -D)
                 queue_drain_time="$2"
                 ;;
+            -R)
+                leafnoderank_seed="--node_rank_seed=$2"
+                ;;
+            -P)
+                pagerank_seed="--page_rank_seed=$2"
+                ;;
+            -C)
+                pointerchase_seed="--pointer_chase_seed=$2"
+                ;;
             -h|--help)
                 show_help >&2
                 exit 1
@@ -231,7 +252,7 @@ main() {
         esac
 
         case $1 in
-            -t|-c|-s|-d|-p|-q|-o|-w|-i|-l|-S|-L|-r|-x|-D)
+            -t|-c|-s|-d|-p|-q|-o|-w|-i|-l|-S|-L|-r|-x|-D|-R|-P|-C)
                 if [ -z "$2" ]; then
                     echo "Invalid option: '$1' requires an argument" 1>&2
                     exit 1
@@ -270,7 +291,10 @@ main() {
         --min_icache_iterations="$icache_iterations" \
         "$store_graph" \
         "$load_graph" \
-        "$instrument_graph" >> $BREPS_LFILE 2>&1 &
+        "$instrument_graph" \
+        "$leafnoderank_seed" \
+        "$pagerank_seed" \
+        "$pointerchase_seed" >> $BREPS_LFILE 2>&1 &
 
     LEAF_PID=$!
 

--- a/packages/feedsim/third_party/src/workloads/ranking/LeafNodeRankCmdline.ggo
+++ b/packages/feedsim/third_party/src/workloads/ranking/LeafNodeRankCmdline.ggo
@@ -35,6 +35,9 @@ option "max_response_size" - "Maximum response size in bytes returned by the lea
 option "compression_data_size" - "Number of bytes to compress per request." int default="131072"
 option "rank_trials_per_thread" - "Number of iterations each CPU thread executes of rank work." int default="1"
 option "min_icache_iterations" - "At least this number of icache busting iteration will be executed." int default="0"
+option "node_rank_seed" - "Seed for random number generator. If not provided, current time will be used." long optional
+option "page_rank_seed" - "Seed for PageRank random number generator. If not provided, current time will be used." long optional
+option "pointer_chase_seed" - "Seed for PointerChase random number generator. If not provided, current time will be used." long optional
 option "chase_iterations" - "Number of chases to execute on handler thread." int default="5120"
 option "io_chase_iterations" - "Number of chases to execute on IO threads." int default="5120"
 option "io_time_ms" - "Milliseconds to sleep emualting I/O offcpu." int default="200"

--- a/packages/feedsim/third_party/src/workloads/ranking/dwarfs/pagerank.h
+++ b/packages/feedsim/third_party/src/workloads/ranking/dwarfs/pagerank.h
@@ -45,11 +45,10 @@ class PageRankParams {
   CSRGraph<int32_t> makeGraphCopy(const CSRGraph<int32_t>& original);
 
   void storeGraphToFile(
-    const CSRGraph<int32_t>& original,
-    const std::string& filePath);
+      const CSRGraph<int32_t>& original,
+      const std::string& filePath);
 
-  CSRGraph<int32_t> loadGraphFromFile(
-    const std::string& filePath);
+  CSRGraph<int32_t> loadGraphFromFile(const std::string& filePath);
 
  private:
   struct Impl;
@@ -63,7 +62,10 @@ class PageRank {
  public:
   constexpr static const float kDamp = 0.85;
 
-  explicit PageRank(CSRGraph<int32_t> graph, int num_pvectors_entries);
+  explicit PageRank(
+      CSRGraph<int32_t> graph,
+      int num_pvectors_entries,
+      unsigned seed = 0);
 
   int rank(
       int thread_id,
@@ -75,6 +77,7 @@ class PageRank {
  private:
   CSRGraph<int32_t> graph_;
   int num_pvectors_entries_;
+  unsigned seed_;
   folly::F14FastMap<int, pvector<float>> scores_pvectors_map_;
   folly::F14FastMap<int, pvector<float>> outgoing_pvectors_map_;
 };

--- a/packages/feedsim/third_party/src/workloads/search/LeafNodeCmdline.ggo
+++ b/packages/feedsim/third_party/src/workloads/search/LeafNodeCmdline.ggo
@@ -25,5 +25,6 @@ option "quiet" - "Disable log messages."
 option "threads" - "Number of threads to use for serving." int default="1"
 option "port" - "Port to run server on." int default="11222"
 option "monitor_port" - "Port to run monitoring server on." int default="8888"
+option "node_seed" - "Seed for random number generator. If not provided, current time will be used." long optional
 option "noaffinity" - "Specify to disable thread pinning"
 option "noloadbalance" - "Specify to disable thread load balancing"

--- a/packages/feedsim/third_party/src/workloads/search/PointerChase.cc
+++ b/packages/feedsim/third_party/src/workloads/search/PointerChase.cc
@@ -21,14 +21,18 @@
 
 namespace search {
 
-PointerChase::PointerChase(size_t num_elems)
+PointerChase::PointerChase(size_t num_elems, unsigned seed)
     : data_(num_elems), current_index_(0) {
   // Fill data with [0, num_elems)
   std::iota(data_.begin(), data_.end(), 0);
 
   // Make a random permutation over data
-  unsigned seed = std::chrono::system_clock::now().time_since_epoch().count();
-  std::shuffle(data_.begin(), data_.end(), std::default_random_engine(seed));
+  // Use provided seed, or fall back to time-based seed if seed is 0
+  unsigned actual_seed = seed != 0
+      ? seed
+      : std::chrono::system_clock::now().time_since_epoch().count();
+  std::shuffle(
+      data_.begin(), data_.end(), std::default_random_engine(actual_seed));
 }
 
 void PointerChase::Chase(size_t num_iterations) {
@@ -36,4 +40,4 @@ void PointerChase::Chase(size_t num_iterations) {
     current_index_ = data_[current_index_];
   }
 }
-}  // namespace search
+} // namespace search

--- a/packages/feedsim/third_party/src/workloads/search/PointerChase.h
+++ b/packages/feedsim/third_party/src/workloads/search/PointerChase.h
@@ -21,11 +21,11 @@ namespace search {
 
 class PointerChase {
  public:
-  explicit PointerChase(size_t num_elems);
+  explicit PointerChase(size_t num_elems, unsigned seed = 0);
   void Chase(size_t num_iterations);
 
  private:
   std::vector<uint64_t> data_;
   size_t current_index_;
 };
-}  // namespace search
+} // namespace search


### PR DESCRIPTION
Summary:
This diff reduce score variations in feedsim by controlling random number generation. This change is critical for ensuring fair and accurate hardware performance comparisons.

This is crucial for:

*   **Vendor Hardware Comparisons**: Eliminating noise from random variations when comparing different hardware platforms
*   **DCPerf Mini Reliability**: Short-duration benchmarks are especially sensitive to random variations that can skew results
*   **Fair Performance Evaluation**: Ensuring benchmark scores reflect true hardware performance characteristics
*   **Scientific Rigor**: Providing reproducible results for performance analysis and decision-making

This implementation provides **granular control** over all three sources of randomness in feedsim:

#### **1. NodeRank Random Number Generation (`--node_rank_seed`)**

*   Controls thread-local random number generators used in LeafNodeRank
*   Affects latency distribution sampling and general RNG operations
*   **Usage**: `-R {seed_value}` or `--node_rank_seed={seed_value}`

#### **2. PageRank Algorithm Randomness (`--page_rank_seed`)**

*   Controls PageRank graph traversal and subset selection randomness
*   Affects graph partitioning and algorithm initialization
*   **Usage**: `-P {seed_value}` or `--page_rank_seed={seed_value}`

#### **3. PointerChase Memory Access Patterns (`--pointer_chase_seed`)** _(New Feature)_

*   Controls memory access pattern randomization in PointerChase workload
*   Affects cache behavior simulation and memory stress patterns
*   **Usage**: `-C {seed_value}` or `--pointer_chase_seed={seed_value}`

Differential Revision: D83871667


