### PR TITLE
Only send final JSON benchmark result to stdout, move others to stderr

### DIFF
--- a/benchpress/cli/main.py
+++ b/benchpress/cli/main.py
@@ -240,7 +240,8 @@ def parse_override_job_args(override_job_args):
             (
                 "Could not properly parse --override_job_args flag. "
                 "Run ./automark exec -h to see an example of what to pass in."
-            )
+            ),
+            err=True,
         )
         raise
 

--- a/benchpress/lib/job.py
+++ b/benchpress/lib/job.py
@@ -205,7 +205,7 @@ class Job:
         """Dump the run command in a file and execute it."""
         logger.info('Starting "{}"'.format(self.name))
         cmd = self.dry_run(role, role_input)
-        click.echo("Job execution command: {}".format(cmd))
+        click.echo("Job execution command: {}".format(cmd), err=True)
         # add string to cmd so that it dumps the stdout and strerr to different files
         # cmd = cmd + " > benchpress_run_output.txt 2> benchpress_run_error.txt"
 
@@ -237,7 +237,7 @@ class Job:
                 )
             else:
                 cmd = get_safe_cmd([self.binary] + self.args)
-                click.echo("Job execution command: {}".format(cmd))
+                click.echo("Job execution command: {}".format(cmd), err=True)
                 process = subprocess.Popen(
                     cmd,
                     stdout=subprocess.PIPE,
@@ -343,7 +343,7 @@ class Job:
         if len(stderr) > TRIM_OUTPUT_LINES:
             output += f"\n[...trimmed to last {TRIM_OUTPUT_LINES} lines...]\n"
         output += "\t{}".format("\n\t".join(stderr[-TRIM_OUTPUT_LINES:]))
-        click.echo(output)
+        click.echo(output, err=True)
 
 
 class JobSuiteBuilder:

--- a/benchpress/plugins/hooks/perf_monitors/topdown.py
+++ b/benchpress/plugins/hooks/perf_monitors/topdown.py
@@ -457,12 +457,12 @@ class ARMPerfUtil(Monitor):
                 return False
             subprocess.run(["topdown-tool", "--help"], capture_output=True, check=True)
         except subprocess.CalledProcessError as e:
-            print(
+            logger.warning(
                 f"Failed to install topdown-tool. Command: {e.cmd}, exit code: {e.returncode}"
             )
             return False
         except OSError:
-            print("Unable to chdir telemetry-solution/tools/topdown_tool")
+            logger.warning("Unable to chdir telemetry-solution/tools/topdown_tool")
             return False
         return True
 

--- a/benchpress/plugins/parsers/clang.py
+++ b/benchpress/plugins/parsers/clang.py
@@ -4,9 +4,12 @@
 # LICENSE file in the root directory of this source tree.
 
 # pyre-unsafe
+import logging
 import re
 
 from benchpress.lib.parser import Parser
+
+logger = logging.getLogger(__name__)
 
 
 class ClangParser(Parser):
@@ -65,6 +68,6 @@ class ClangParser(Parser):
             minute = int(m.group(1))
             second = float(m.group(2))
         except ValueError:
-            print("Failed to parse clang build time")
+            logger.error("Failed to parse clang build time")
             return -1
         return minute * 60 + second

--- a/benchpress/plugins/parsers/multichase_pointer.py
+++ b/benchpress/plugins/parsers/multichase_pointer.py
@@ -60,5 +60,4 @@ class MultichasePointerParser(Parser):
                     key = key + " thread count " + thread_count
                 key = key + " latency (ns)"
                 metrics[key] = float(v.strip())
-        print("metrics", metrics)
         return metrics

--- a/benchpress/plugins/parsers/small_locks_bench.py
+++ b/benchpress/plugins/parsers/small_locks_bench.py
@@ -33,5 +33,4 @@ class SmallLocksParser(Parser):
                 metrics[lock_name + " stddev in us"] = float(stddev_val)
                 max_val = re.findall(REGEX_VAL_AFTER_MAX, line)[0]
                 metrics[lock_name + " max in us"] = float(max_val)
-        print(metrics)
         return metrics


### PR DESCRIPTION
Summary: In Benchpress's run command, let's only print the final benchmark result report (in JSON) to stdout and redirect all other messages to stderr and/or benchpress.log. This will enable other scripts to easily extract and parse the results.

Differential Revision: D84308887


