### PR TITLE
Fix FBGEMM Embedding Benchmark runtime errors

### DIFF
--- a/packages/fbgemm/install_fbgemm_bench.sh
+++ b/packages/fbgemm/install_fbgemm_bench.sh
@@ -21,7 +21,7 @@ MINICONDA_PREFIX=$(pwd)/build/miniconda
 FBGEMM_VERSION=fd32631d837b41251311099c393af7d7be5cfbf5
 
 # Version of PyTorch to install
-PYTORCH_VERSION=2.7.0
+PYTORCH_VERSION=2.8.0
 
 # Version of GCC to use for building
 export GCC_VERSION=14.1.0


### PR DESCRIPTION
Update PyTorch from 2.7.0 to 2.8.0 to resolve runtime issues observed during the FBGEMM Embedding Benchmark run.

Error log:

./benchpress_cli.py -b ai run fbgemm_embedding_a_single stderr:
    Traceback (most recent call last):
      File "tbe_inference_benchmark.py", line 26, in <module>
    ModuleNotFoundError: No module named
'fbgemm_gpu.split_embedding_configs'
    [PYI-265070:ERROR] Failed to execute script
'tbe_inference_benchmark' due to unhandled exception!