### PR TITLE
Chm: Add auto-scaled benchmark

### DIFF
--- a/benchpress/config/jobs_ai.yml
+++ b/benchpress/config/jobs_ai.yml
@@ -199,6 +199,43 @@
     - 'num_batch_threads=4'
     - 'worker_loop_count=10'
 
+- benchmark: chm
+  name: chm_autoscale_a
+  description: Concurrent hash map benchmark for Model A with all available cpu threads.
+  args:
+    - '--distribution_file={distribution_file}'
+    - '--duration_seconds={duration_seconds}'
+    - '--batch_size={batch_size}'
+    - '--num_batch_threads={num_batch_threads}'
+    - '--worker_loop_count={worker_loop_count}'
+    - '--autoscale={autoscale}'
+
+  vars:
+    - 'distribution_file=benchmarks/ai_wdl/chm/model_a.dist'
+    - 'duration_seconds=360'
+    - 'batch_size=10000000'
+    - 'num_batch_threads=4'
+    - 'worker_loop_count=10'
+    - 'autoscale=true'
+
+- benchmark: chm
+  name: chm_autoscale_b
+  description: Concurrent hash map benchmark for Model B with all available cpu threads.
+  args:
+    - '--distribution_file={distribution_file}'
+    - '--duration_seconds={duration_seconds}'
+    - '--batch_size={batch_size}'
+    - '--num_batch_threads={num_batch_threads}'
+    - '--worker_loop_count={worker_loop_count}'
+    - '--autoscale={autoscale}'
+
+  vars:
+    - 'distribution_file=benchmarks/ai_wdl/chm/model_b.dist'
+    - 'duration_seconds=360'
+    - 'batch_size=10000000'
+    - 'num_batch_threads=4'
+    - 'worker_loop_count=10'
+    - 'autoscale=true'
 
 - benchmark: deser
   name: deser_a

--- a/packages/ai_wdl/chm/ChmBenchmark.cpp
+++ b/packages/ai_wdl/chm/ChmBenchmark.cpp
@@ -37,6 +37,7 @@
 DEFINE_string(distribution_file, "", "Path to the distribution CSV file");
 DEFINE_int32(num_threads, 4, "Number of worker threads per batch");
 DEFINE_int32(num_batch_threads, 2, "Number of parallel batch threads");
+DEFINE_bool(autoscale, false, "Use all available cpu threads");
 DEFINE_int32(duration_seconds, 10, "Benchmark duration in seconds");
 DEFINE_int32(initial_capacity, 0, "Initial hash map capacity hint");
 DEFINE_int32(batch_size, 1000, "Operations per batch");
@@ -634,6 +635,30 @@ class ChmBenchmark {
 int main(int argc, char* argv[]) {
   // Parse command line flags
   gflags::ParseCommandLineFlags(&argc, &argv, true);
+
+  // Check autoscale
+  if(FLAGS_autoscale){
+    cpu_set_t mask;
+    CPU_ZERO(&mask);
+
+    if (sched_getaffinity(0, sizeof(mask), &mask) == -1) {
+        std::cerr << "sched_getaffinity error!";
+        return 1;
+    }
+    int num_threads = 0;
+    for (int i = 0; i < CPU_SETSIZE; i++) {
+        if (CPU_ISSET(i, &mask)) {
+            num_threads++;
+        }
+    }
+
+    if (0 >= num_threads) {
+      std::cerr << "Failed to get available cpu threads!\n";
+      return 1;
+    }
+    FLAGS_num_threads = num_threads;
+    std::cout << "Autoscaled: " << FLAGS_num_threads << std::endl;
+  }
 
   if (FLAGS_distribution_file.empty()) {
     std::cerr

--- a/packages/ai_wdl/chm/README.md
+++ b/packages/ai_wdl/chm/README.md
@@ -11,11 +11,14 @@ To install `chm`, execute the following command:
 ## Run `chm`
 ### Job - `chm_a` and `chm_b`
 `chm_a` and `chm_b` correspondingly simuate the workload for Model A and Model B.
+`chm_autoscale_a` and `chm_autoscale_b` sets num_threads to the number of all available cpu threads.
 
 To run `chm` benchmark, please use following command
 ```bash
 ./benchpress -b ai run chm_a
 ./benchpress -b ai run chm_b
+./benchpress -b ai run chm_autoscale_a
+./benchpress -b ai run chm_autoscale_b
 ```
 
 ## Reporting and Measurement


### PR DESCRIPTION
By default, the worker thread count for the CHM benchmark is set to 80.
This patch introduces an auto-scaled benchmark configuration that sets
the thread count to the number of all cpu threads. User can use
`numactl` or `taskset` to limit the cpus to use, and this benchmark will
use the specified cpu number as the worker threads count.