### PR TITLE
Handle empty CLIENT_THREADS

### DIFF
--- a/packages/mediawiki/run.sh
+++ b/packages/mediawiki/run.sh
@@ -187,7 +187,7 @@ function run_benchmark() {
     lg_params="--wrk ${_lg_path}"
     client_threads="${WRK_CLIENT_THREADS}"
   fi
-  if [ "${CLIENT_THREADS}" -gt 0 ]; then
+  if [[ "${CLIENT_THREADS}" -gt 0 ]]; then
     client_threads="${CLIENT_THREADS}"
   fi
 


### PR DESCRIPTION
Summary: With the single `[` I get some spew that includes `./packages/mediawiki/run.sh: line 190: [: : integer expression expected'`.  I'm not 100% sure this is correct because I'm still having some issues running Mediawiki today, but ta least the `[` eating empty strings is a pretty standard issue.

Reviewed By: charles-typ

Differential Revision: D85383775


