### PR TITLE
Allow fast_float to be skipped

### DIFF
--- a/packages/feedsim/install_feedsim_aarch64.sh
+++ b/packages/feedsim/install_feedsim_aarch64.sh
@@ -72,13 +72,17 @@ fi
 
 export PATH="${FEEDSIM_THIRD_PARTY_SRC}/cmake-4.0.3/staging/bin:${PATH}"
 
-git clone https://github.com/fastfloat/fast_float.git
-cd fast_float
-mkdir build && cd build
-cmake ..
-make
-make install
-cd ../
+if ! [ -d "fast_float" ]; then
+    git clone https://github.com/fastfloat/fast_float.git
+    cd fast_float
+    mkdir build && cd build
+    cmake ..
+    make
+    make install
+    cd ../
+else
+    msg "[SKIPPED] fast_float"
+fi
 
 # Installing gengetopt
 if ! [ -d "gengetopt-2.23" ]; then


### PR DESCRIPTION
Summary: The other dependencies get skipped when their directory already exists, but fast_float doesn't.  This causes an error when trying to re-install feedsim.

Reviewed By: YifanYuan3

Differential Revision: D85675532


