### PR TITLE
Fix spark standalone mini

### DIFF
--- a/benchpress/config/jobs.yml
+++ b/benchpress/config/jobs.yml
@@ -643,7 +643,6 @@
     - 'sanity=0'
     - 'dataset_name=bpc_t93586_s2_synthetic_5GB'
     - 'local_hostname='
-    - 'dataset_name=bpc_t93586_s2_synthetic_1GB'
     - 'shuffle_partitions=20'
   hooks:
     - hook: copymove


### PR DESCRIPTION
Summary:
Since there are two `dataset_name` in jobs.yml, specifying it in the CLI doesn't work. Benchpress always tries to use 1GB dataset:

```
./benchpress run spark_standalone_remote_mini -i '{"dataset_name":"bpc_t93586_s2_synthetic_5GB"}'
```

```
[..]
        StorageException(
            canRetry=False,
            message=('Path not found -- tree/spark_standalone/dataset/bpc_t93586_s2_synthetic_1GB '
             'See https://fburl.com/mf_404_not_found to troubleshoot.'),
            httpCode=404,
            httpResponseHeaders={},
            retryAfterMsec=0,
            category='Path not found',
            exceptionDetail=ExceptionDetail(
                objectAccessError=ObjectAccessError(
                    pathInfo=[ObjectPathInfo(
                        originalPath='tree/spark_standalone/dataset/bpc_t93586_s2_synthetic_1GB',
                        shortestInvalidPath='',
                        canonicalPath='nodes/9410efe7-fb22-4a11-832a-cd76a889ec69/bpc_t93586_s2_synthetic_1GB')],
[..]
```

Reviewed By: marziehlenjaniMeta

Differential Revision: D85675714


