### PR TITLE
Changing ftpmirror.gnu.org to mirrors.ocf.berkeley.edu

### DIFF
--- a/packages/feedsim/alternative_install_feedsim_aws.sh
+++ b/packages/feedsim/alternative_install_feedsim_aws.sh
@@ -62,7 +62,7 @@ cd "${FEEDSIM_THIRD_PARTY_SRC}"
 if ! [ -d "gengetopt-2.23" ]; then
     # Source the download retry function
     source "${BENCHPRESS_ROOT}/scripts/download_with_retry.sh"
-    download_with_retry "https://ftpmirror.gnu.org/gnu/gengetopt/gengetopt-2.23.tar.xz"
+    download_with_retry "https://mirrors.ocf.berkeley.edu/gnu/gengetopt/gengetopt-2.23.tar.xz"
     tar -xf "gengetopt-2.23.tar.xz"
     cd "gengetopt-2.23"
     ./configure

--- a/packages/feedsim/install_feedsim.sh
+++ b/packages/feedsim/install_feedsim.sh
@@ -95,7 +95,7 @@ cd ../
 if ! [ -d "gengetopt-2.23" ]; then
     # Source the download retry function
     source "${BENCHPRESS_ROOT}/scripts/download_with_retry.sh"
-    download_with_retry "https://ftpmirror.gnu.org/gnu/gengetopt/gengetopt-2.23.tar.xz"
+    download_with_retry "https://mirrors.ocf.berkeley.edu/gnu/gengetopt/gengetopt-2.23.tar.xz"
     tar -xf "gengetopt-2.23.tar.xz"
     cd "gengetopt-2.23"
     ./configure

--- a/packages/feedsim/install_feedsim_aarch64.sh
+++ b/packages/feedsim/install_feedsim_aarch64.sh
@@ -84,7 +84,7 @@ cd ../
 if ! [ -d "gengetopt-2.23" ]; then
     # Source the download retry function
     source "${BENCHPRESS_ROOT}/scripts/download_with_retry.sh"
-    download_with_retry "https://ftpmirror.gnu.org/gnu/gengetopt/gengetopt-2.23.tar.xz"
+    download_with_retry "https://mirrors.ocf.berkeley.edu/gnu/gengetopt/gengetopt-2.23.tar.xz"
     tar -xf "gengetopt-2.23.tar.xz"
     cd "gengetopt-2.23"
     ./configure

--- a/packages/feedsim/install_feedsim_aarch64_ubuntu.sh
+++ b/packages/feedsim/install_feedsim_aarch64_ubuntu.sh
@@ -60,7 +60,7 @@ cd "${FEEDSIM_THIRD_PARTY_SRC}"
 if ! [ -d "gengetopt-2.23" ]; then
     # Source the download retry function
     source "${BENCHPRESS_ROOT}/scripts/download_with_retry.sh"
-    download_with_retry "https://ftpmirror.gnu.org/gnu/gengetopt/gengetopt-2.23.tar.xz"
+    download_with_retry "https://mirrors.ocf.berkeley.edu/gnu/gengetopt/gengetopt-2.23.tar.xz"
     tar -xf "gengetopt-2.23.tar.xz"
     cd "gengetopt-2.23"
     ./configure

--- a/packages/feedsim/install_feedsim_ubuntu.sh
+++ b/packages/feedsim/install_feedsim_ubuntu.sh
@@ -90,7 +90,7 @@ cd ../
 if ! [ -d "gengetopt-2.23" ]; then
     # Source the download retry function
     source "${BENCHPRESS_ROOT}/scripts/download_with_retry.sh"
-    download_with_retry "https://ftpmirror.gnu.org/gnu/gengetopt/gengetopt-2.23.tar.xz"
+    download_with_retry "https://mirrors.ocf.berkeley.edu/gnu/gengetopt/gengetopt-2.23.tar.xz"
     tar -xf "gengetopt-2.23.tar.xz"
     cd "gengetopt-2.23"
     ./configure

--- a/packages/feedsim/third_party/src/scripts/install_centos8_deps.sh
+++ b/packages/feedsim/third_party/src/scripts/install_centos8_deps.sh
@@ -15,7 +15,7 @@ dnf install -y cmake ninja-build flex bison git texinfo \
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" &>/dev/null && pwd -P)"
 BENCHPRESS_ROOT="$(readlink -f "$SCRIPT_DIR/../../../../..")"
 source "${BENCHPRESS_ROOT}/scripts/download_with_retry.sh"
-curl_with_retry "https://ftpmirror.gnu.org/gnu/gengetopt/gengetopt-2.23.tar.xz"
+curl_with_retry "https://mirrors.ocf.berkeley.edu/gnu/gengetopt/gengetopt-2.23.tar.xz"
 tar -xf gengetopt-2.23.tar.xz
 cd gengetopt-2.23
 ./configure

--- a/packages/tao_bench/install_tao_bench_aarch64.sh
+++ b/packages/tao_bench/install_tao_bench_aarch64.sh
@@ -87,7 +87,7 @@ fi
 
 # Download binutils
 BINUTILS_TARBALL_PATH="${FOLLY_BUILD_ROOT}/downloads/libiberty-binutils-2.42.tar.xz"
-BINUTILS_TARBALL_URL="https://ftpmirror.gnu.org/gnu/binutils/binutils-2.42.tar.xz"
+BINUTILS_TARBALL_URL="https://mirrors.ocf.berkeley.edu/gnu/binutils/binutils-2.42.tar.xz"
 if ! [ -f "${BINUTILS_TARBALL_PATH}" ]; then
     echo "Downloading libiberty-binutils-2.42.tar.xz..."
     source "${BENCHPRESS_ROOT}/scripts/download_with_retry.sh"

--- a/packages/tao_bench/install_tao_bench_x86_64.sh
+++ b/packages/tao_bench/install_tao_bench_x86_64.sh
@@ -83,7 +83,7 @@ fi
 
 # Download binutils
 BINUTILS_TARBALL_PATH="${FOLLY_BUILD_ROOT}/downloads/libiberty-binutils-2.42.tar.xz"
-BINUTILS_TARBALL_URL="https://ftpmirror.gnu.org/gnu/binutils/binutils-2.42.tar.xz"
+BINUTILS_TARBALL_URL="https://mirrors.ocf.berkeley.edu/gnu/binutils/binutils-2.42.tar.xz"
 if ! [ -f "${BINUTILS_TARBALL_PATH}" ]; then
     echo "Downloading libiberty-binutils-2.42.tar.xz..."
     source "${BENCHPRESS_ROOT}/scripts/download_with_retry.sh"


### PR DESCRIPTION
Summary:
Changing ftpmirror.gnu.org to mirrors.ocf.berkeley.edu
Add DCPerf's download sources to sandcastle fwdproxy allowlist

Differential Revision: D85070055


