### PR TITLE
DjangoBench V2: Move relevant logs to benchmark_metrics folder to help debugging

### DIFF
--- a/benchpress/config/jobs.yml
+++ b/benchpress/config/jobs.yml
@@ -188,18 +188,30 @@
         - '-s urls.txt'
         - '-c {db_addr}'
         - '-I {interpreter}'
+        - '-A {use_async}'
       vars:
         - 'db_addr'
         - 'duration=5M'
         - 'iterations=7'
         - 'reps=0'
         - 'interpreter=cpython'
+        - 'use_async=1'
     db:
       args:
         - '-r db'
         - '-b {bind_ip}'
       vars:
         - 'bind_ip=default'
+    server:
+      args:
+        - '-r server'
+        - '-c {db_addr}'
+        - '-I {interpreter}'
+        - '-A {use_async}'
+      vars:
+        - 'db_addr'
+        - 'interpreter=cpython'
+        - 'use_async=1'
     standalone:
       args:
         - '-r standalone'
@@ -210,11 +222,13 @@
         - '-s urls.txt'
         - '-c 127.0.0.1'
         - '-I {interpreter}'
+        - '-A {use_async}'
       vars:
         - 'duration=5M'
         - 'iterations=7'
         - 'reps=0'
         - 'interpreter=cpython'
+        - 'use_async=1'
   hooks:
     - hook: copymove
       options:
@@ -239,18 +253,32 @@
         - '-m 50000'
         - '-M 100000'
         - '-I {interpreter}'
+        - '-A {use_async}'
       vars:
         - 'db_addr'
         - 'duration=5M'
         - 'iterations=7'
         - 'reps=0'
         - 'interpreter=cpython'
+        - 'use_async=1'
     db:
       args:
         - '-r db'
         - '-b {bind_ip}'
       vars:
         - 'bind_ip=default'
+    server:
+      args:
+        - '-r server'
+        - '-c {db_addr}'
+        - '-m 50000'
+        - '-M 100000'
+        - '-I {interpreter}'
+        - '-A {use_async}'
+      vars:
+        - 'db_addr'
+        - 'interpreter=cpython'
+        - 'use_async=1'
     standalone:
       args:
         - '-r standalone'
@@ -263,11 +291,13 @@
         - '-m 50000'
         - '-M 100000'
         - '-I {interpreter}'
+        - '-A {use_async}'
       vars:
         - 'duration=5M'
         - 'iterations=7'
         - 'reps=0'
         - 'interpreter=cpython'
+        - 'use_async=1'
   hooks:
     - hook: copymove
       options:
@@ -293,11 +323,13 @@
         - '-M 100000'
         - '-S'
         - '-I {interpreter}'
+        - '-A {use_async}'
       vars:
         - 'duration=1M'
         - 'iterations=1'
         - 'reps=1000'
         - 'interpreter=cpython'
+        - 'use_async=1'
   hooks:
     - hook: copymove
       options:
@@ -321,11 +353,13 @@
         - '-c 127.0.0.1'
         - '-S'
         - '-I {interpreter}'
+        - '-A {use_async}'
       vars:
         - 'duration=1M'
         - 'iterations=1'
         - 'reps=1000'
         - 'interpreter=cpython'
+        - 'use_async=1'
   hooks:
     - hook: copymove
       options:
@@ -353,6 +387,7 @@
         - '-m {ib_min}'
         - '-M {ib_max}'
         - '-I {interpreter}'
+        - '-A {use_async}'
       vars:
         - 'duration=5M'
         - 'iterations=7'
@@ -363,6 +398,7 @@
         - 'server_workers'
         - 'client_workers'
         - 'interpreter=cpython'
+        - 'use_async=1'
     client:
       args:
         - '-r client'
@@ -387,12 +423,14 @@
         - '-m {ib_min}'
         - '-M {ib_max}'
         - '-I {interpreter}'
+        - '-A {use_async}'
       vars:
         - 'db_addr'
         - 'server_workers'
         - 'ib_min=100000'
         - 'ib_max=200000'
         - 'interpreter=cpython'
+        - 'use_async=1'
     db:
       args:
         - '-r db'

--- a/benchpress/config/jobs.yml
+++ b/benchpress/config/jobs.yml
@@ -235,6 +235,11 @@
         is_move: true
         after:
           - 'benchmarks/django_workload/django-workload/client/perf.data'
+          - 'benchmarks/django_workload/django-workload/django-workload/*.log'
+          - 'benchmarks/django_workload/django-workload/django-workload/log_load_balancer'
+          - 'benchmarks/django_workload/django-workload/client/*.log'
+          - 'benchmarks/django_workload/*.log'
+          - '/tmp/siege_out_*'
 
 - benchmark: django_workload
   name: django_workload_arm
@@ -304,6 +309,11 @@
         is_move: true
         after:
           - 'benchmarks/django_workload/django-workload/client/perf.data'
+          - 'benchmarks/django_workload/django-workload/django-workload/*.log'
+          - 'benchmarks/django_workload/django-workload/django-workload/log_load_balancer'
+          - 'benchmarks/django_workload/django-workload/client/*.log'
+          - 'benchmarks/django_workload/*.log'
+          - '/tmp/siege_out_*'
 
 - benchmark: django_workload
   name: django_workload_arm_mini
@@ -336,6 +346,11 @@
         is_move: true
         after:
           - 'benchmarks/django_workload/django-workload/client/perf.data'
+          - 'benchmarks/django_workload/django-workload/django-workload/*.log'
+          - 'benchmarks/django_workload/django-workload/django-workload/log_load_balancer'
+          - 'benchmarks/django_workload/django-workload/client/*.log'
+          - 'benchmarks/django_workload/*.log'
+          - '/tmp/siege_out_*'
 
 - benchmark: django_workload
   name: django_workload_mini
@@ -366,6 +381,11 @@
         is_move: true
         after:
           - 'benchmarks/django_workload/django-workload/client/perf.data'
+          - 'benchmarks/django_workload/django-workload/django-workload/*.log'
+          - 'benchmarks/django_workload/django-workload/django-workload/log_load_balancer'
+          - 'benchmarks/django_workload/django-workload/client/*.log'
+          - 'benchmarks/django_workload/*.log'
+          - '/tmp/siege_out_*'
 
 
 - benchmark: django_workload
@@ -445,6 +465,11 @@
         is_move: true
         after:
           - 'benchmarks/django_workload/django-workload/client/perf.data'
+          - 'benchmarks/django_workload/django-workload/django-workload/*.log'
+          - 'benchmarks/django_workload/django-workload/django-workload/log_load_balancer'
+          - 'benchmarks/django_workload/django-workload/client/*.log'
+          - 'benchmarks/django_workload/*.log'
+          - '/tmp/siege_out_*'
 
 - name: feedsim_default
   benchmark: feedsim

--- a/packages/django_workload/install_django_workload.sh
+++ b/packages/django_workload/install_django_workload.sh
@@ -41,7 +41,7 @@ cd "$BP_TMP" || exit 1
 
 # Install system dependencies
 dnf install -y git memcached libmemcached-devel zlib-devel screen python36 \
-    python36-devel python3-numpy
+    python36-devel python3-numpy haproxy
 
 # Copy django-workload from srcs directory instead of cloning from GitHub
 mkdir -p "${OUT}/django-workload"

--- a/packages/django_workload/install_django_workload_aarch64.sh
+++ b/packages/django_workload/install_django_workload_aarch64.sh
@@ -14,11 +14,20 @@ DJANGO_REPO_ROOT="${DJANGO_WORKLOAD_ROOT}/django-workload"
 DJANGO_SERVER_ROOT="${DJANGO_REPO_ROOT}/django-workload"
 DJANGO_WORKLOAD_DEPS="${DJANGO_SERVER_ROOT}/third_party"
 
-# Install system dependencies
+# =====================================================================
+# Step 1: Install System Dependencies
+# =====================================================================
+echo ""
+echo "====================================================================="
+echo "Step 1: Installing System Dependencies"
+echo "====================================================================="
+
 dnf groupinstall "Development Tools" -y --exclude="texlive*"
 dnf install -y memcached libmemcached-awesome-devel zlib-devel screen \
-    openssl-devel bzip2-devel libffi-devel wget make xz-devel
-#s
+    openssl-devel bzip2-devel libffi-devel wget make xz-devel haproxy
+
+echo "System dependencies installed successfully"
+
 # Copy django-workload from srcs directory instead of cloning from GitHub
 mkdir -p "${DJANGO_WORKLOAD_ROOT}"
 pushd "${DJANGO_WORKLOAD_ROOT}"
@@ -28,6 +37,14 @@ if ! [ -d "django-workload" ]; then
 else
     echo "[SKIPPED] copying django-workload"
 fi
+
+# =====================================================================
+# Step 2: Download pip third-party dependencies for django-workload
+# =====================================================================
+echo ""
+echo "====================================================================="
+echo "Step 2: Downloading pip third-party dependencies"
+echo "====================================================================="
 
 # Download pip third-party dependencies for django-workload
 if ! [ -d "${DJANGO_WORKLOAD_DEPS}" ]; then
@@ -136,11 +153,22 @@ mkdir -p "${DJANGO_WORKLOAD_ROOT}/bin"
 cp -r "${DJANGO_PKG_ROOT}/srcs/bin/"* "${DJANGO_WORKLOAD_ROOT}/bin/"
 chmod +x "${DJANGO_WORKLOAD_ROOT}/bin/"*.sh
 
-# 2. Install JDK
+echo "Pip dependencies downloaded successfully"
+
+# =====================================================================
+# Step 3: Install JDK and Cassandra
+# =====================================================================
+echo ""
+echo "====================================================================="
+echo "Step 3: Installing JDK and Cassandra"
+echo "====================================================================="
+
+# Install JDK
 JDK_NAME=java-1.8.0-openjdk-devel
 dnf install -y "${JDK_NAME}" || { echo "Could not install ${JDK_NAME} package"; exit 1;}
+echo "JDK installed successfully"
 
-# 4. Install Cassandra
+# Install Cassandra
 # Download Cassandra from third-party source
 cassandra_version=3.11.19
 CASSANDRA_NAME="apache-cassandra-${cassandra_version}"
@@ -172,7 +200,16 @@ chmod -R 0700 /data/cassandra
 cp "${TEMPLATES_DIR}/cassandra.yaml" "${CASSANDRA_ROOT}/conf/cassandra.yaml.template" || exit 1
 popd
 
-# 5. Install Django and its dependencies
+echo "JDK and Cassandra installed successfully"
+
+# =====================================================================
+# Step 4: Build CPython 3.10
+# =====================================================================
+echo ""
+echo "====================================================================="
+echo "Step 4: Building CPython 3.10"
+echo "====================================================================="
+
 pushd "${DJANGO_SERVER_ROOT}"
 
 # Install python3.10
@@ -185,6 +222,19 @@ if ! [ -d Python-3.10.2 ]; then
     cd ../
 fi
 
+CPYTHON_INSTALL_PREFIX="${DJANGO_SERVER_ROOT}/Python-3.10.2/python-build"
+export LD_LIBRARY_PATH="${CPYTHON_INSTALL_PREFIX}/lib"
+
+echo "CPython 3.10 built successfully"
+
+# =====================================================================
+# Step 5: Build Cinder 3.10
+# =====================================================================
+echo ""
+echo "====================================================================="
+echo "Step 5: Building Cinder 3.10"
+echo "====================================================================="
+
 # Download and build Cinder
 if ! [ -d "cinder" ]; then
     git clone -b cinder/3.10 https://github.com/facebookincubator/cinder.git
@@ -196,19 +246,27 @@ if ! [ -d "cinder" ]; then
     popd
 fi
 
+CINDER_INSTALL_PREFIX="${DJANGO_SERVER_ROOT}/cinder/cinder-build"
+export LD_LIBRARY_PATH="${CINDER_INSTALL_PREFIX}/lib"
+
+echo "Cinder 3.10 built successfully"
+
+# =====================================================================
+# Step 6: Install Python dependencies in virtual environments
+# =====================================================================
+echo ""
+echo "====================================================================="
+echo "Step 6: Installing Python dependencies in virtual environments"
+echo "====================================================================="
+
 # Create virtual environments for both CPython and Cinder
-# Create CPython virtual env
-CPYTHON_INSTALL_PREFIX="${DJANGO_SERVER_ROOT}/Python-3.10.2/python-build"
 export LD_LIBRARY_PATH="${CPYTHON_INSTALL_PREFIX}/lib"
 [ ! -d venv_cpython ] && "${CPYTHON_INSTALL_PREFIX}/bin/python3.10" -m venv venv_cpython
 
-# Create Cinder virtual env
-CINDER_INSTALL_PREFIX="${DJANGO_SERVER_ROOT}/cinder/cinder-build"
 export LD_LIBRARY_PATH="${CINDER_INSTALL_PREFIX}/lib"
 [ ! -d venv_cinder ] && "${CINDER_INSTALL_PREFIX}/bin/python3" -m venv venv_cinder
 
-# Install packages in both virtual environments
-# First, CPython environment
+# Install packages in CPython environment
 set +u
 # shellcheck disable=SC1091
 source ./venv_cpython/bin/activate
@@ -217,14 +275,13 @@ set -u
 export LD_LIBRARY_PATH="${CPYTHON_INSTALL_PREFIX}/lib"
 export CMAKE_LIBRARY_PATH="${CPYTHON_INSTALL_PREFIX}/lib"
 export CPATH="${DJANGO_SERVER_ROOT}/Python-3.10.2/python-build/include:${DJANGO_SERVER_ROOT}/Python-3.10.2/Include"
+
 # Install dependencies using third_party pip dependencies
 pip3.10 install "django-statsd-mozilla" --no-index --find-links file://"${DJANGO_WORKLOAD_DEPS}"
 pip3.10 install "numpy>=1.19" --no-index --find-links file://"${DJANGO_WORKLOAD_DEPS}"
 pip3.10 install -e . --no-index --find-links file://"${DJANGO_WORKLOAD_DEPS}"
 
-# No need to copy configuration files as they are already in the srcs directory
-
-# No need to apply patches as the code in srcs already has the desired changes
+echo "Dependencies installed in CPython venv"
 
 # Build oldisim icache buster library
 set +u
@@ -249,15 +306,13 @@ fi
 # shellcheck disable=SC2016
 echo 'JVM_OPTS="$JVM_OPTS -Xss512k"' >> "${DJANGO_WORKLOAD_ROOT}/apache-cassandra/conf/cassandra-env.sh"
 
-# No need to copy template files as they are already in the srcs directory
-
 deactivate
 
-# Now install packages in Cinder environment
-pushd "${DJANGO_SERVER_ROOT}"  # Make sure we're in the right directory
+# Install packages in Cinder environment
+pushd "${DJANGO_SERVER_ROOT}"
+export CPATH="${DJANGO_SERVER_ROOT}/cinder/cinder-build/include:${DJANGO_SERVER_ROOT}/cinder/Include"
 export LD_LIBRARY_PATH="${CINDER_INSTALL_PREFIX}/lib"
 export CMAKE_LIBRARY_PATH="${CINDER_INSTALL_PREFIX}/lib"
-export CPATH="${DJANGO_SERVER_ROOT}/cinder/cinder-build/include:${DJANGO_SERVER_ROOT}/cinder/Include"
 source ./venv_cinder/bin/activate
 set -u
 
@@ -266,10 +321,111 @@ pip3.10 install "django-statsd-mozilla" --no-index --find-links file://"${DJANGO
 pip3.10 install "numpy>=1.19" --no-index --find-links file://"${DJANGO_WORKLOAD_DEPS}"
 pip3.10 install -e . --no-index --find-links file://"${DJANGO_WORKLOAD_DEPS}"
 
+echo "Dependencies installed in Cinder venv"
+
 deactivate
 popd  # ${DJANGO_SERVER_ROOT}
+
+echo "Python dependencies installation completed"
 
 # Install siege
 pushd "${DJANGO_PKG_ROOT}" || exit 1
 bash -x install_siege.sh
 popd
+
+echo "Siege installed successfully"
+
+# =====================================================================
+# Step 7: Build and Install Proxygen (for DjangoBench V2)
+# =====================================================================
+echo ""
+echo "====================================================================="
+echo "Step 7: Building and Installing Proxygen"
+echo "====================================================================="
+
+# Clone Proxygen if not already present
+PROXYGEN_VERSION="v2025.10.13.00"
+if [ ! -d "${DJANGO_WORKLOAD_ROOT}/proxygen" ]; then
+    echo "Cloning Proxygen from GitHub..."
+    cd "${DJANGO_WORKLOAD_ROOT}"
+    git clone https://github.com/facebook/proxygen.git
+    cd proxygen
+    git checkout "${PROXYGEN_VERSION}"
+    echo "Proxygen cloned successfully"
+else
+    echo "Proxygen directory already exists at ${DJANGO_WORKLOAD_ROOT}/proxygen"
+    cd "${DJANGO_WORKLOAD_ROOT}/proxygen"
+fi
+
+# Overwrite build script with custom version
+echo "Installing custom build script with -fPIC support..."
+cp "${TEMPLATES_DIR}/build_proxygen.sh" "${DJANGO_WORKLOAD_ROOT}/proxygen/proxygen/build_proxygen.sh"
+chmod +x "${DJANGO_WORKLOAD_ROOT}/proxygen/proxygen/build_proxygen.sh"
+
+# Build Proxygen
+echo "Building Proxygen (this may take 10-20 minutes)..."
+cd "${DJANGO_WORKLOAD_ROOT}/proxygen/proxygen"
+bash -x ./build_proxygen.sh --prefix "${DJANGO_WORKLOAD_ROOT}/proxygen/staging" -j "$(nproc)"
+bash -x ./install.sh
+
+echo "Proxygen built and installed at ${DJANGO_WORKLOAD_ROOT}/proxygen/staging"
+
+# =====================================================================
+# Step 8: Build and Install proxygen_binding (for DjangoBench V2)
+# =====================================================================
+echo ""
+echo "====================================================================="
+echo "Step 8: Building and Installing proxygen_binding"
+echo "====================================================================="
+
+# Copy proxygen_binding to django_workload root
+if [ ! -d "${DJANGO_WORKLOAD_ROOT}/proxygen_binding" ]; then
+    echo "Copying proxygen_binding module..."
+    cp -r "${DJANGO_PKG_ROOT}/srcs/proxygen_binding" "${DJANGO_WORKLOAD_ROOT}/"
+    echo "proxygen_binding copied to ${DJANGO_WORKLOAD_ROOT}/proxygen_binding"
+else
+    echo "proxygen_binding directory already exists, updating..."
+    rm -rf "${DJANGO_WORKLOAD_ROOT}/proxygen_binding"
+    cp -r "${DJANGO_PKG_ROOT}/srcs/proxygen_binding" "${DJANGO_WORKLOAD_ROOT}/proxygen_binding"
+fi
+
+# Set Proxygen installation directory for building proxygen_binding
+export PROXYGEN_INSTALL_DIR="${DJANGO_WORKLOAD_ROOT}/proxygen/staging"
+
+# Build and install in venv_cpython
+echo ""
+echo "Installing proxygen_binding in venv_cpython..."
+cd "${DJANGO_WORKLOAD_ROOT}/proxygen_binding"
+"${DJANGO_SERVER_ROOT}/venv_cpython/bin/python" -m pip install pybind11
+"${DJANGO_SERVER_ROOT}/venv_cpython/bin/python" -m pip install -e .
+echo "proxygen_binding installed in venv_cpython"
+
+# Build and install in venv_cinder
+echo ""
+echo "Installing proxygen_binding in venv_cinder..."
+cd "${DJANGO_WORKLOAD_ROOT}/proxygen_binding"
+"${DJANGO_SERVER_ROOT}/venv_cinder/bin/python" -m pip install pybind11
+"${DJANGO_SERVER_ROOT}/venv_cinder/bin/python" -m pip install -e .
+echo "proxygen_binding installed in venv_cinder"
+
+echo ""
+echo "====================================================================="
+echo "DjangoBench installation completed successfully!"
+echo "====================================================================="
+echo ""
+echo "Installation directory: ${DJANGO_WORKLOAD_ROOT}"
+echo ""
+echo "DjangoBench V2 Components (Async HTTP with Proxygen):"
+echo "  - Proxygen: ${DJANGO_WORKLOAD_ROOT}/proxygen/staging"
+echo "  - proxygen_binding: ${DJANGO_WORKLOAD_ROOT}/proxygen_binding"
+echo "  - Django workload: ${DJANGO_WORKLOAD_ROOT}/django-workload/django-workload"
+echo ""
+echo "To run DjangoBench V2 with Proxygen (asynchronous HTTP):"
+echo "  cd ${DJANGO_WORKLOAD_ROOT}/django-workload/django-workload"
+echo "  ./run_proxygen.sh"
+echo ""
+echo "To run DjangoBench V1 with uWSGI (traditional):"
+echo "  cd ${DJANGO_WORKLOAD_ROOT}/django-workload/django-workload"
+echo "  ./run.sh"
+echo ""
+echo "====================================================================="

--- a/packages/django_workload/install_django_workload_x86_64_centos9.sh
+++ b/packages/django_workload/install_django_workload_x86_64_centos9.sh
@@ -14,12 +14,20 @@ DJANGO_REPO_ROOT="${DJANGO_WORKLOAD_ROOT}/django-workload"
 DJANGO_SERVER_ROOT="${DJANGO_REPO_ROOT}/django-workload"
 DJANGO_WORKLOAD_DEPS="${DJANGO_SERVER_ROOT}/third_party"
 
-# Install system dependencies
+# =====================================================================
+# Step 1: Install System Dependencies
+# =====================================================================
+echo ""
+echo "====================================================================="
+echo "Step 1: Installing System Dependencies"
+echo "====================================================================="
+
 dnf groupinstall "Development Tools" -y --exclude="texlive*"
 dnf install -y memcached libmemcached-awesome-devel zlib-devel screen \
-    openssl-devel bzip2-devel libffi-devel wget make
+    openssl-devel bzip2-devel libffi-devel wget make haproxy
 
-#s
+echo "System dependencies installed successfully"
+
 # Copy django-workload from srcs directory instead of cloning from GitHub
 mkdir -p "${DJANGO_WORKLOAD_ROOT}"
 pushd "${DJANGO_WORKLOAD_ROOT}"
@@ -30,7 +38,13 @@ else
     echo "[SKIPPED] copying django-workload"
 fi
 
-# Download pip third-party dependencies for django-workload
+# =====================================================================
+# Step 2: Download pip third-party dependencies for django-workload
+# =====================================================================
+echo ""
+echo "====================================================================="
+echo "Step 2: Downloading pip third-party dependencies"
+echo "====================================================================="
 if ! [ -d "${DJANGO_WORKLOAD_DEPS}" ]; then
     mkdir -p "${DJANGO_WORKLOAD_DEPS}"
 else
@@ -138,11 +152,22 @@ mkdir -p "${DJANGO_WORKLOAD_ROOT}/bin"
 cp -r "${DJANGO_PKG_ROOT}/srcs/bin/"* "${DJANGO_WORKLOAD_ROOT}/bin/"
 chmod +x "${DJANGO_WORKLOAD_ROOT}/bin/"*.sh
 
-# 2. Install JDK
+echo "Pip dependencies downloaded successfully"
+
+# =====================================================================
+# Step 3: Install JDK and Cassandra
+# =====================================================================
+echo ""
+echo "====================================================================="
+echo "Step 3: Installing JDK and Cassandra"
+echo "====================================================================="
+
+# Install JDK
 JDK_NAME=java-1.8.0-openjdk-devel
 dnf install -y "${JDK_NAME}" || { echo "Could not install ${JDK_NAME} package"; exit 1;}
+echo "JDK installed successfully"
 
-# 4. Install Cassandra
+# Install Cassandra
 # Download Cassandra from third-party source
 cassandra_version=3.11.19
 CASSANDRA_NAME="apache-cassandra-${cassandra_version}"
@@ -174,7 +199,16 @@ chmod -R 0700 /data/cassandra
 cp "${TEMPLATES_DIR}/cassandra.yaml" "${CASSANDRA_ROOT}/conf/cassandra.yaml.template" || exit 1
 popd
 
-# 5. Install Django and its dependencies
+echo "JDK and Cassandra installed successfully"
+
+# =====================================================================
+# Step 4: Build CPython 3.10
+# =====================================================================
+echo ""
+echo "====================================================================="
+echo "Step 4: Building CPython 3.10"
+echo "====================================================================="
+
 pushd "${DJANGO_SERVER_ROOT}"
 
 # Install python3.10
@@ -187,6 +221,19 @@ if ! [ -d Python-3.10.2 ]; then
     cd ../
 fi
 
+CPYTHON_INSTALL_PREFIX="${DJANGO_SERVER_ROOT}/Python-3.10.2/python-build"
+export LD_LIBRARY_PATH="${CPYTHON_INSTALL_PREFIX}/lib"
+
+echo "CPython 3.10 built successfully"
+
+# =====================================================================
+# Step 5: Build Cinder 3.10
+# =====================================================================
+echo ""
+echo "====================================================================="
+echo "Step 5: Building Cinder 3.10"
+echo "====================================================================="
+
 # Download and build Cinder
 if ! [ -d "cinder" ]; then
     git clone -b cinder/3.10 https://github.com/facebookincubator/cinder.git
@@ -198,19 +245,27 @@ if ! [ -d "cinder" ]; then
     popd
 fi
 
+CINDER_INSTALL_PREFIX="${DJANGO_SERVER_ROOT}/cinder/cinder-build"
+export LD_LIBRARY_PATH="${CINDER_INSTALL_PREFIX}/lib"
+
+echo "Cinder 3.10 built successfully"
+
+# =====================================================================
+# Step 6: Install Python dependencies in virtual environments
+# =====================================================================
+echo ""
+echo "====================================================================="
+echo "Step 6: Installing Python dependencies in virtual environments"
+echo "====================================================================="
+
 # Create virtual environments for both CPython and Cinder
-# Create CPython virtual env
-CPYTHON_INSTALL_PREFIX="${DJANGO_SERVER_ROOT}/Python-3.10.2/python-build"
 export LD_LIBRARY_PATH="${CPYTHON_INSTALL_PREFIX}/lib"
 [ ! -d venv_cpython ] && "${CPYTHON_INSTALL_PREFIX}/bin/python3.10" -m venv venv_cpython
 
-# Create Cinder virtual env
-CINDER_INSTALL_PREFIX="${DJANGO_SERVER_ROOT}/cinder/cinder-build"
 export LD_LIBRARY_PATH="${CINDER_INSTALL_PREFIX}/lib"
 [ ! -d venv_cinder ] && "${CINDER_INSTALL_PREFIX}/bin/python3" -m venv venv_cinder
 
-# Install packages in both virtual environments
-# First, CPython environment
+# Install packages in CPython environment
 set +u
 # shellcheck disable=SC1091
 source ./venv_cpython/bin/activate
@@ -219,14 +274,13 @@ set -u
 export LD_LIBRARY_PATH="${CPYTHON_INSTALL_PREFIX}/lib"
 export CMAKE_LIBRARY_PATH="${CPYTHON_INSTALL_PREFIX}/lib"
 export CPATH="${DJANGO_SERVER_ROOT}/Python-3.10.2/python-build/include:${DJANGO_SERVER_ROOT}/Python-3.10.2/Include"
+
 # Install dependencies using third_party pip dependencies
 pip3.10 install "django-statsd-mozilla" --no-index --find-links file://"${DJANGO_WORKLOAD_DEPS}"
 pip3.10 install "numpy>=1.19" --no-index --find-links file://"${DJANGO_WORKLOAD_DEPS}"
 pip3.10 install -e . --no-index --find-links file://"${DJANGO_WORKLOAD_DEPS}"
 
-# No need to copy configuration files as they are already in the srcs directory
-
-# No need to apply patches as the code in srcs already has the desired changes
+echo "Dependencies installed in CPython venv"
 
 # Build oldisim icache buster library
 set +u
@@ -251,12 +305,10 @@ fi
 # shellcheck disable=SC2016
 echo 'JVM_OPTS="$JVM_OPTS -Xss512k"' >> "${DJANGO_WORKLOAD_ROOT}/apache-cassandra/conf/cassandra-env.sh"
 
-# No need to copy template files as they are already in the srcs directory
-
 deactivate
 
-# Now install packages in Cinder environment
-pushd "${DJANGO_SERVER_ROOT}"  # Make sure we're in the right directory
+# Install packages in Cinder environment
+pushd "${DJANGO_SERVER_ROOT}"
 export CPATH="${DJANGO_SERVER_ROOT}/cinder/cinder-build/include:${DJANGO_SERVER_ROOT}/cinder/Include"
 export LD_LIBRARY_PATH="${CINDER_INSTALL_PREFIX}/lib"
 export CMAKE_LIBRARY_PATH="${CINDER_INSTALL_PREFIX}/lib"
@@ -268,10 +320,111 @@ pip3.10 install "django-statsd-mozilla" --no-index --find-links file://"${DJANGO
 pip3.10 install "numpy>=1.19" --no-index --find-links file://"${DJANGO_WORKLOAD_DEPS}"
 pip3.10 install -e . --no-index --find-links file://"${DJANGO_WORKLOAD_DEPS}"
 
+echo "Dependencies installed in Cinder venv"
+
 deactivate
 popd  # ${DJANGO_SERVER_ROOT}
+
+echo "Python dependencies installation completed"
 
 # Install siege
 pushd "${DJANGO_PKG_ROOT}" || exit 1
 bash -x install_siege.sh
 popd
+
+echo "Siege installed successfully"
+
+# =====================================================================
+# Step 7: Build and Install Proxygen (for DjangoBench V2)
+# =====================================================================
+echo ""
+echo "====================================================================="
+echo "Step 7: Building and Installing Proxygen"
+echo "====================================================================="
+
+# Clone Proxygen if not already present
+PROXYGEN_VERSION="v2025.10.13.00"
+if [ ! -d "${DJANGO_WORKLOAD_ROOT}/proxygen" ]; then
+    echo "Cloning Proxygen from GitHub..."
+    cd "${DJANGO_WORKLOAD_ROOT}"
+    git clone https://github.com/facebook/proxygen.git
+    cd proxygen
+    git checkout "${PROXYGEN_VERSION}"
+    echo "Proxygen cloned successfully"
+else
+    echo "Proxygen directory already exists at ${DJANGO_WORKLOAD_ROOT}/proxygen"
+    cd "${DJANGO_WORKLOAD_ROOT}/proxygen"
+fi
+
+# Overwrite build script with custom version
+echo "Installing custom build script with -fPIC support..."
+cp "${TEMPLATES_DIR}/build_proxygen.sh" "${DJANGO_WORKLOAD_ROOT}/proxygen/proxygen/build_proxygen.sh"
+chmod +x "${DJANGO_WORKLOAD_ROOT}/proxygen/proxygen/build_proxygen.sh"
+
+# Build Proxygen
+echo "Building Proxygen (this may take 10-20 minutes)..."
+cd "${DJANGO_WORKLOAD_ROOT}/proxygen/proxygen"
+bash -x ./build_proxygen.sh --prefix "${DJANGO_WORKLOAD_ROOT}/proxygen/staging" -j "$(nproc)"
+bash -x ./install.sh
+
+echo "Proxygen built and installed at ${DJANGO_WORKLOAD_ROOT}/proxygen/staging"
+
+# =====================================================================
+# Step 8: Build and Install proxygen_binding (for DjangoBench V2)
+# =====================================================================
+echo ""
+echo "====================================================================="
+echo "Step 8: Building and Installing proxygen_binding"
+echo "====================================================================="
+
+# Copy proxygen_binding to django_workload root
+if [ ! -d "${DJANGO_WORKLOAD_ROOT}/proxygen_binding" ]; then
+    echo "Copying proxygen_binding module..."
+    cp -r "${DJANGO_PKG_ROOT}/srcs/proxygen_binding" "${DJANGO_WORKLOAD_ROOT}/"
+    echo "proxygen_binding copied to ${DJANGO_WORKLOAD_ROOT}/proxygen_binding"
+else
+    echo "proxygen_binding directory already exists, updating..."
+    rm -rf "${DJANGO_WORKLOAD_ROOT}/proxygen_binding"
+    cp -r "${DJANGO_PKG_ROOT}/srcs/proxygen_binding" "${DJANGO_WORKLOAD_ROOT}/proxygen_binding"
+fi
+
+# Set Proxygen installation directory for building proxygen_binding
+export PROXYGEN_INSTALL_DIR="${DJANGO_WORKLOAD_ROOT}/proxygen/staging"
+
+# Build and install in venv_cpython
+echo ""
+echo "Installing proxygen_binding in venv_cpython..."
+cd "${DJANGO_WORKLOAD_ROOT}/proxygen_binding"
+"${DJANGO_SERVER_ROOT}/venv_cpython/bin/python" -m pip install pybind11
+"${DJANGO_SERVER_ROOT}/venv_cpython/bin/python" -m pip install -e .
+echo "proxygen_binding installed in venv_cpython"
+
+# Build and install in venv_cinder
+echo ""
+echo "Installing proxygen_binding in venv_cinder..."
+cd "${DJANGO_WORKLOAD_ROOT}/proxygen_binding"
+"${DJANGO_SERVER_ROOT}/venv_cinder/bin/python" -m pip install pybind11
+"${DJANGO_SERVER_ROOT}/venv_cinder/bin/python" -m pip install -e .
+echo "proxygen_binding installed in venv_cinder"
+
+echo ""
+echo "====================================================================="
+echo "DjangoBench installation completed successfully!"
+echo "====================================================================="
+echo ""
+echo "Installation directory: ${DJANGO_WORKLOAD_ROOT}"
+echo ""
+echo "DjangoBench V2 Components (Async HTTP with Proxygen):"
+echo "  - Proxygen: ${DJANGO_WORKLOAD_ROOT}/proxygen/staging"
+echo "  - proxygen_binding: ${DJANGO_WORKLOAD_ROOT}/proxygen_binding"
+echo "  - Django workload: ${DJANGO_WORKLOAD_ROOT}/django-workload/django-workload"
+echo ""
+echo "To run DjangoBench V2 with Proxygen (asynchronous HTTP):"
+echo "  cd ${DJANGO_WORKLOAD_ROOT}/django-workload/django-workload"
+echo "  ./run_proxygen.sh"
+echo ""
+echo "To run DjangoBench V1 with uWSGI (traditional):"
+echo "  cd ${DJANGO_WORKLOAD_ROOT}/django-workload/django-workload"
+echo "  ./run.sh"
+echo ""
+echo "====================================================================="

--- a/packages/django_workload/install_django_workload_x86_64_ubuntu22.sh
+++ b/packages/django_workload/install_django_workload_x86_64_ubuntu22.sh
@@ -14,10 +14,19 @@ DJANGO_REPO_ROOT="${DJANGO_WORKLOAD_ROOT}/django-workload"
 DJANGO_SERVER_ROOT="${DJANGO_REPO_ROOT}/django-workload"
 DJANGO_WORKLOAD_DEPS="${DJANGO_SERVER_ROOT}/third_party"
 
-# Install system dependencies
+# =====================================================================
+# Step 1: Install System Dependencies
+# =====================================================================
+echo ""
+echo "====================================================================="
+echo "Step 1: Installing System Dependencies"
+echo "====================================================================="
+
 apt install -y memcached libmemcached-dev zlib1g-dev screen \
     python3 python3.10-dev python3.10-venv rpm libffi-dev \
-    libssl-dev libcrypt-dev
+    libssl-dev libcrypt-dev haproxy
+
+echo "System dependencies installed successfully"
 
 # Copy django-workload from srcs directory instead of cloning from GitHub
 mkdir -p "${DJANGO_WORKLOAD_ROOT}"
@@ -28,6 +37,14 @@ if ! [ -d "django-workload" ]; then
 else
     echo "[SKIPPED] copying django-workload"
 fi
+
+# =====================================================================
+# Step 2: Download pip third-party dependencies for django-workload
+# =====================================================================
+echo ""
+echo "====================================================================="
+echo "Step 2: Downloading pip third-party dependencies"
+echo "====================================================================="
 
 # Download pip third-party dependencies for django-workload
 if ! [ -d "${DJANGO_WORKLOAD_DEPS}" ]; then
@@ -137,11 +154,20 @@ mkdir -p "${DJANGO_WORKLOAD_ROOT}/bin"
 cp -r "${DJANGO_PKG_ROOT}/srcs/bin/"* "${DJANGO_WORKLOAD_ROOT}/bin/"
 chmod +x "${DJANGO_WORKLOAD_ROOT}/bin/"*.sh
 
-# 2. Install JDK
+# =====================================================================
+# Step 3: Install JDK and Cassandra
+# =====================================================================
+echo ""
+echo "====================================================================="
+echo "Step 3: Installing JDK and Cassandra"
+echo "====================================================================="
+
+# Install JDK
 JDK_NAME=openjdk-11-jdk
 apt install -y "${JDK_NAME}" || { echo "Could not install ${JDK_NAME} package"; exit 1;}
+echo "JDK installed successfully"
 
-# 4. Install Cassandra
+# Install Cassandra
 # Download Cassandra from third-party source
 cassandra_version=3.11.19
 CASSANDRA_NAME="apache-cassandra-${cassandra_version}"
@@ -173,11 +199,32 @@ chmod -R 0700 /data/cassandra
 cp "${TEMPLATES_DIR}/cassandra.yaml" "${CASSANDRA_ROOT}/conf/cassandra.yaml.template" || exit 1
 popd
 
-# 5. Install Django and its dependencies
+echo "JDK and Cassandra installed successfully"
+
+# =====================================================================
+# Step 4: Build CPython 3.10
+# =====================================================================
+echo ""
+echo "====================================================================="
+echo "Step 4: Building CPython 3.10"
+echo "====================================================================="
+
 pushd "${DJANGO_SERVER_ROOT}"
 
+# Ubuntu 22 comes with python3.10, so we use system python
+echo "Using system Python 3.10"
+
+echo "CPython 3.10 ready"
+
+# =====================================================================
+# Step 5: Build Cinder 3.10
+# =====================================================================
+echo ""
+echo "====================================================================="
+echo "Step 5: Building Cinder 3.10"
+echo "====================================================================="
+
 # Download and build Cinder
-pushd "${DJANGO_SERVER_ROOT}"
 if ! [ -d "cinder" ]; then
     git clone -b cinder/3.10 https://github.com/facebookincubator/cinder.git
     pushd cinder
@@ -187,20 +234,29 @@ if ! [ -d "cinder" ]; then
     make install
     popd
 fi
-popd
+
+CINDER_INSTALL_PREFIX="${DJANGO_SERVER_ROOT}/cinder/cinder-build"
+export LD_LIBRARY_PATH="${CINDER_INSTALL_PREFIX}/lib"
+
+echo "Cinder 3.10 built successfully"
+
+# =====================================================================
+# Step 6: Install Python dependencies in virtual environments
+# =====================================================================
+echo ""
+echo "====================================================================="
+echo "Step 6: Installing Python dependencies in virtual environments"
+echo "====================================================================="
 
 # Create virtual environments for both CPython and Cinder
-pushd "${DJANGO_SERVER_ROOT}"
 # Create CPython virtual env
 python3.10 -m venv venv_cpython
 
 # Create Cinder virtual env
-CINDER_INSTALL_PREFIX="${DJANGO_SERVER_ROOT}/cinder/cinder-build"
 export LD_LIBRARY_PATH="${CINDER_INSTALL_PREFIX}/lib"
 [ ! -d venv_cinder ] && "${CINDER_INSTALL_PREFIX}/bin/python3" -m venv venv_cinder
 
-# Install packages in both virtual environments
-# First, CPython environment
+# Install packages in CPython environment
 set +u
 # shellcheck disable=SC1091
 source ./venv_cpython/bin/activate
@@ -210,9 +266,8 @@ set -u
 pip3 install "django-statsd-mozilla" --no-index --find-links file://"${DJANGO_WORKLOAD_DEPS}"
 pip3 install "numpy>=1.19" --no-index --find-links file://"${DJANGO_WORKLOAD_DEPS}"
 pip3 install -e . --no-index --find-links file://"${DJANGO_WORKLOAD_DEPS}"
-# No need to copy configuration files as they are already in the srcs directory
 
-# No need to apply patches as the code in srcs already has the desired changes
+echo "Dependencies installed in CPython venv"
 
 # Build oldisim icache buster library
 set +u
@@ -238,12 +293,10 @@ fi
 # shellcheck disable=SC2016
 echo 'JVM_OPTS="$JVM_OPTS -Xss512k"' >> "${DJANGO_WORKLOAD_ROOT}/apache-cassandra/conf/cassandra-env.sh"
 
-# No need to copy template files as they are already in the srcs directory
-
 deactivate
 
-# Now install packages in Cinder environment
-pushd "${DJANGO_SERVER_ROOT}"  # Make sure we're in the right directory
+# Install packages in Cinder environment
+pushd "${DJANGO_SERVER_ROOT}"
 export CPATH="${DJANGO_SERVER_ROOT}/cinder/cinder-build/include:${DJANGO_SERVER_ROOT}/cinder/Include"
 export LD_LIBRARY_PATH="${CINDER_INSTALL_PREFIX}/lib"
 export CMAKE_LIBRARY_PATH="${CINDER_INSTALL_PREFIX}/lib"
@@ -255,10 +308,111 @@ pip3 install "django-statsd-mozilla" --no-index --find-links file://"${DJANGO_WO
 pip3 install "numpy>=1.19" --no-index --find-links file://"${DJANGO_WORKLOAD_DEPS}"
 pip3 install -e . --no-index --find-links file://"${DJANGO_WORKLOAD_DEPS}"
 
+echo "Dependencies installed in Cinder venv"
+
 deactivate
 popd  # ${DJANGO_SERVER_ROOT}
+
+echo "Python dependencies installation completed"
 
 # Install siege
 pushd "${DJANGO_PKG_ROOT}" || exit 1
 bash -x install_siege.sh
 popd
+
+echo "Siege installed successfully"
+
+# =====================================================================
+# Step 7: Build and Install Proxygen (for DjangoBench V2)
+# =====================================================================
+echo ""
+echo "====================================================================="
+echo "Step 7: Building and Installing Proxygen"
+echo "====================================================================="
+
+# Clone Proxygen if not already present
+PROXYGEN_VERSION="v2025.10.13.00"
+if [ ! -d "${DJANGO_WORKLOAD_ROOT}/proxygen" ]; then
+    echo "Cloning Proxygen from GitHub..."
+    cd "${DJANGO_WORKLOAD_ROOT}"
+    git clone https://github.com/facebook/proxygen.git
+    cd proxygen
+    git checkout "${PROXYGEN_VERSION}"
+    echo "Proxygen cloned successfully"
+else
+    echo "Proxygen directory already exists at ${DJANGO_WORKLOAD_ROOT}/proxygen"
+    cd "${DJANGO_WORKLOAD_ROOT}/proxygen"
+fi
+
+# Overwrite build script with custom version
+echo "Installing custom build script with -fPIC support..."
+cp "${TEMPLATES_DIR}/build_proxygen.sh" "${DJANGO_WORKLOAD_ROOT}/proxygen/proxygen/build_proxygen.sh"
+chmod +x "${DJANGO_WORKLOAD_ROOT}/proxygen/proxygen/build_proxygen.sh"
+
+# Build Proxygen
+echo "Building Proxygen (this may take 10-20 minutes)..."
+cd "${DJANGO_WORKLOAD_ROOT}/proxygen/proxygen"
+bash -x ./build_proxygen.sh --prefix "${DJANGO_WORKLOAD_ROOT}/proxygen/staging" -j "$(nproc)"
+bash -x ./install.sh
+
+echo "Proxygen built and installed at ${DJANGO_WORKLOAD_ROOT}/proxygen/staging"
+
+# =====================================================================
+# Step 8: Build and Install proxygen_binding (for DjangoBench V2)
+# =====================================================================
+echo ""
+echo "====================================================================="
+echo "Step 8: Building and Installing proxygen_binding"
+echo "====================================================================="
+
+# Copy proxygen_binding to django_workload root
+if [ ! -d "${DJANGO_WORKLOAD_ROOT}/proxygen_binding" ]; then
+    echo "Copying proxygen_binding module..."
+    cp -r "${DJANGO_PKG_ROOT}/srcs/proxygen_binding" "${DJANGO_WORKLOAD_ROOT}/"
+    echo "proxygen_binding copied to ${DJANGO_WORKLOAD_ROOT}/proxygen_binding"
+else
+    echo "proxygen_binding directory already exists, updating..."
+    rm -rf "${DJANGO_WORKLOAD_ROOT}/proxygen_binding"
+    cp -r "${DJANGO_PKG_ROOT}/srcs/proxygen_binding" "${DJANGO_WORKLOAD_ROOT}/proxygen_binding"
+fi
+
+# Set Proxygen installation directory for building proxygen_binding
+export PROXYGEN_INSTALL_DIR="${DJANGO_WORKLOAD_ROOT}/proxygen/staging"
+
+# Build and install in venv_cpython
+echo ""
+echo "Installing proxygen_binding in venv_cpython..."
+cd "${DJANGO_WORKLOAD_ROOT}/proxygen_binding"
+"${DJANGO_SERVER_ROOT}/venv_cpython/bin/python" -m pip install pybind11
+"${DJANGO_SERVER_ROOT}/venv_cpython/bin/python" -m pip install -e .
+echo "proxygen_binding installed in venv_cpython"
+
+# Build and install in venv_cinder
+echo ""
+echo "Installing proxygen_binding in venv_cinder..."
+cd "${DJANGO_WORKLOAD_ROOT}/proxygen_binding"
+"${DJANGO_SERVER_ROOT}/venv_cinder/bin/python" -m pip install pybind11
+"${DJANGO_SERVER_ROOT}/venv_cinder/bin/python" -m pip install -e .
+echo "proxygen_binding installed in venv_cinder"
+
+echo ""
+echo "====================================================================="
+echo "DjangoBench installation completed successfully!"
+echo "====================================================================="
+echo ""
+echo "Installation directory: ${DJANGO_WORKLOAD_ROOT}"
+echo ""
+echo "DjangoBench V2 Components (Async HTTP with Proxygen):"
+echo "  - Proxygen: ${DJANGO_WORKLOAD_ROOT}/proxygen/staging"
+echo "  - proxygen_binding: ${DJANGO_WORKLOAD_ROOT}/proxygen_binding"
+echo "  - Django workload: ${DJANGO_WORKLOAD_ROOT}/django-workload/django-workload"
+echo ""
+echo "To run DjangoBench V2 with Proxygen (asynchronous HTTP):"
+echo "  cd ${DJANGO_WORKLOAD_ROOT}/django-workload/django-workload"
+echo "  ./run_proxygen.sh"
+echo ""
+echo "To run DjangoBench V1 with uWSGI (traditional):"
+echo "  cd ${DJANGO_WORKLOAD_ROOT}/django-workload/django-workload"
+echo "  ./run.sh"
+echo ""
+echo "====================================================================="

--- a/packages/django_workload/srcs/django-workload/django-workload/cluster_settings.py
+++ b/packages/django_workload/srcs/django-workload/django-workload/cluster_settings.py
@@ -40,7 +40,7 @@ LOGGING = {
     "disable_existing_loggers": False,
     "formatters": {
         "verbose": {
-            "format": "[{asctime}] {levelname}: {name}.{message}",
+            "format": "[{asctime}] {filename}:{lineno} {name} {levelname}: {message}",
             "style": "{",
         },
     },

--- a/packages/django_workload/srcs/django-workload/django-workload/cluster_settings.py.template
+++ b/packages/django_workload/srcs/django-workload/django-workload/cluster_settings.py.template
@@ -40,7 +40,7 @@ LOGGING = {
     "disable_existing_loggers": False,
     "formatters": {
         "verbose": {
-            "format": "[{asctime}] {levelname}: {name}.{message}",
+            "format": "[{asctime}] {filename}:{lineno} {name} {levelname}: {message}",
             "style": "{",
         },
     },

--- a/packages/django_workload/srcs/django-workload/django-workload/proxygen_wsgi.py
+++ b/packages/django_workload/srcs/django-workload/django-workload/proxygen_wsgi.py
@@ -1,0 +1,209 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""
+Proxygen-based WSGI entry point for DjangoBench
+
+This module initializes Proxygen HTTP server within each uWSGI worker process.
+uWSGI handles:
+  - Worker process forking and management
+  - Memory leak cleanup (harakiri, reload-on-rss)
+  - Process monitoring
+
+Proxygen handles:
+  - Asynchronous HTTP request processing
+  - Multi-threaded request handling
+  - Connection management
+
+Architecture:
+  uWSGI (process manager)
+    └─> Worker Process (fork)
+        └─> Proxygen Server (async HTTP)
+            └─> Django ASGI App
+"""
+
+import logging
+import os
+import signal
+import sys
+import threading
+
+# Add proxygen_binding to path if not installed system-wide
+PROXYGEN_BINDING_PATH = os.path.join(
+    os.path.dirname(os.path.dirname(os.path.dirname(__file__))), "proxygen_binding"
+)
+if os.path.exists(PROXYGEN_BINDING_PATH) and PROXYGEN_BINDING_PATH not in sys.path:
+    sys.path.insert(0, PROXYGEN_BINDING_PATH)
+
+try:
+    from django_asgi_adapter import create_django_handler
+    from proxygen_binding import init_logging, ProxygenServer
+except ImportError as e:
+    print(f"ERROR: Failed to import proxygen_binding: {e}", file=sys.stderr)
+    print("Make sure proxygen_binding is built and available", file=sys.stderr)
+    print(f"Expected path: {PROXYGEN_BINDING_PATH}", file=sys.stderr)
+    sys.exit(1)
+
+# Configure Django settings
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "django_workload.settings")
+
+# Initialize logging
+logging.basicConfig(
+    level=logging.INFO,
+    format="[%(process)d] %(asctime)s - %(name)s - %(levelname)s - %(message)s",
+)
+logger = logging.getLogger(__name__)
+
+# Global server instance for this worker process
+_proxygen_server = None
+_server_thread = None
+_shutdown_event = threading.Event()
+
+
+def start_proxygen_server():
+    """
+    Start Proxygen server in this uWSGI worker process.
+
+    This function is called by uWSGI's postfork hook to start Proxygen
+    in each worker process after forking.
+
+    Architecture:
+        Proxygen RequestData
+            ↓
+        django_asgi_adapter.ASGIRequestHandler (converts to ASGI protocol)
+            ↓
+        django.core.asgi.get_asgi_application() (Django's ASGI app)
+            ↓
+        Django views/middleware
+    """
+    global _proxygen_server, _server_thread
+
+    # Get configuration from environment
+    ip = os.environ.get("PROXYGEN_IP", "0.0.0.0")
+    port = int(os.environ.get("PROXYGEN_PORT", "8000"))
+    threads = int(os.environ.get("PROXYGEN_THREADS", "0"))  # 0 = auto-detect
+
+    logger.info(
+        "Initializing Proxygen server in worker %d: %s:%d with %d threads",
+        os.getpid(),
+        ip,
+        port,
+        threads,
+    )
+
+    try:
+        # Initialize Proxygen logging
+        init_logging()
+
+        # Create Django ASGI handler
+        # This internally calls django.core.asgi.get_asgi_application()
+        # and wraps it with ASGIRequestHandler to convert between
+        # Proxygen's RequestData/ResponseData and Django's ASGI protocol
+        django_handler = create_django_handler()
+        logger.info(
+            "Django ASGI handler created (using django.core.asgi.get_asgi_application)"
+        )
+
+        # Create Proxygen server with async callback
+        # Using async_callback enables true concurrent request processing
+        # where multiple requests can be handled simultaneously per thread
+        _proxygen_server = ProxygenServer(
+            ip=ip,
+            port=port,
+            threads=threads,
+            async_callback=django_handler,
+            is_async=True,
+        )
+
+        # Start server
+        _proxygen_server.start()
+        logger.info(
+            "Proxygen server started in worker %d on %s:%d", os.getpid(), ip, port
+        )
+
+    except Exception as e:
+        logger.exception(
+            "Failed to start Proxygen server in worker %d: %s", os.getpid(), e
+        )
+        # Don't exit - let uWSGI handle worker failure
+        raise
+
+
+def stop_proxygen_server():
+    """
+    Stop Proxygen server gracefully.
+
+    This function is called when the worker is shutting down.
+    """
+    global _proxygen_server
+
+    if _proxygen_server:
+        logger.info("Stopping Proxygen server in worker %d", os.getpid())
+        try:
+            _proxygen_server.stop()
+            logger.info("Proxygen server stopped in worker %d", os.getpid())
+        except Exception as e:
+            logger.exception(
+                "Error stopping Proxygen server in worker %d: %s", os.getpid(), e
+            )
+        finally:
+            _proxygen_server = None
+
+
+def signal_handler(signum, frame):
+    """Handle shutdown signals"""
+    logger.info("Worker %d received signal %d, shutting down", os.getpid(), signum)
+    stop_proxygen_server()
+    sys.exit(0)
+
+
+# Initialize when module is loaded (works with lazy-apps)
+try:
+    import uwsgi
+
+    # Check if we're in a worker process (worker_id >= 1)
+    # In master process, worker_id is 0
+    if uwsgi.worker_id() > 0:
+        logger.info(
+            "Detected uWSGI worker %d, starting Proxygen server", uwsgi.worker_id()
+        )
+
+        # Register signal handlers
+        signal.signal(signal.SIGTERM, signal_handler)
+        signal.signal(signal.SIGINT, signal_handler)
+
+        # Start Proxygen server in this worker
+        start_proxygen_server()
+    else:
+        logger.info(
+            "Running in uWSGI master process (worker_id=0), Proxygen will start in workers"
+        )
+
+except (ImportError, AttributeError):
+    # Not running under uWSGI or uwsgi module not fully initialized
+    logger.warning("Not running under uWSGI - starting Proxygen directly for testing")
+
+    # Register signal handlers
+    signal.signal(signal.SIGTERM, signal_handler)
+    signal.signal(signal.SIGINT, signal_handler)
+
+    # Start server if running as main module
+    if __name__ == "__main__":
+        start_proxygen_server()
+        try:
+            # Keep process alive
+            _proxygen_server.wait()
+        except KeyboardInterrupt:
+            logger.info("Received Ctrl+C, shutting down")
+            stop_proxygen_server()
+
+
+# WSGI application for compatibility (not actually used by Proxygen)
+# This is here so uWSGI can load the module without errors
+from django.core.wsgi import get_wsgi_application
+
+application = get_wsgi_application()

--- a/packages/django_workload/srcs/django-workload/django-workload/run_proxygen.sh
+++ b/packages/django_workload/srcs/django-workload/django-workload/run_proxygen.sh
@@ -1,0 +1,127 @@
+#!/bin/bash
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$SCRIPT_DIR"
+
+echo "=========================================="
+echo "Starting DjangoBench V2 with Proxygen"
+echo "=========================================="
+echo ""
+echo "Architecture:"
+echo "  uWSGI: Process management + memory cleanup"
+echo "  Proxygen: Async HTTP server (in each worker)"
+echo "  Django: ASGI application"
+echo ""
+
+# ============================================
+# Configuration
+# ============================================
+
+# Proxygen settings
+export PROXYGEN_IP="${PROXYGEN_IP:-0.0.0.0}"
+export PROXYGEN_PORT="${PROXYGEN_PORT:-8000}"
+export PROXYGEN_THREADS="${PROXYGEN_THREADS:-0}"  # 0 = auto-detect CPU cores
+
+# Django settings
+export DJANGO_SETTINGS_MODULE="${DJANGO_SETTINGS_MODULE:-django_workload.settings}"
+
+# Add proxygen_binding to PYTHONPATH if not installed system-wide
+PROXYGEN_BINDING_DIR="${SCRIPT_DIR}/../../proxygen_binding"
+if [ -d "$PROXYGEN_BINDING_DIR" ]; then
+    # Check if any .so file matching the pattern exists
+    SO_FILE_FOUND=false
+    for file in "$PROXYGEN_BINDING_DIR"/proxygen_binding.cpython*.so; do
+        if [ -f "$file" ]; then
+            SO_FILE_FOUND=true
+            break
+        fi
+    done
+
+    if [ "$SO_FILE_FOUND" = true ]; then
+        export PYTHONPATH="${PROXYGEN_BINDING_DIR}:${PYTHONPATH}"
+        echo "Added proxygen_binding to PYTHONPATH: ${PROXYGEN_BINDING_DIR}"
+    fi
+fi
+
+# ============================================
+# Pre-flight Checks
+# ============================================
+
+echo "Configuration:"
+echo "  PROXYGEN_IP: ${PROXYGEN_IP}"
+echo "  PROXYGEN_PORT: ${PROXYGEN_PORT}"
+echo "  PROXYGEN_THREADS: ${PROXYGEN_THREADS} (0 = auto-detect)"
+echo "  DJANGO_SETTINGS_MODULE: ${DJANGO_SETTINGS_MODULE}"
+echo ""
+
+# Check if proxygen_binding is available
+if ! python3 << EOF
+import sys
+try:
+    from proxygen_binding import ProxygenServer
+    print("✓ proxygen_binding is available")
+except ImportError as e:
+    print("✗ ERROR: proxygen_binding not found!", file=sys.stderr)
+    print(f"  {e}", file=sys.stderr)
+    print("", file=sys.stderr)
+    print("Please build and install proxygen_binding first:", file=sys.stderr)
+    print("  cd ../../proxygen_binding", file=sys.stderr)
+    print("  ./build.sh", file=sys.stderr)
+    print("  pip install .", file=sys.stderr)
+    sys.exit(1)
+EOF
+then
+    exit 1
+fi
+
+# Check if Django is configured
+if ! python3 << EOF
+import sys
+import os
+try:
+    import django
+    django.setup()
+    print("✓ Django is configured")
+except Exception as e:
+    print("✗ ERROR: Django configuration failed!", file=sys.stderr)
+    print(f"  {e}", file=sys.stderr)
+    sys.exit(1)
+EOF
+then
+    exit 1
+fi
+
+# Check if uWSGI is available
+if ! command -v uwsgi &> /dev/null; then
+    echo "✗ ERROR: uWSGI not found!"
+    echo ""
+    echo "Please install uWSGI:"
+    echo "  pip install uwsgi"
+    exit 1
+fi
+
+echo "✓ uWSGI is available"
+echo ""
+
+# ============================================
+# Start Server
+# ============================================
+
+echo "Starting uWSGI + Proxygen server..."
+echo ""
+echo "Server will be available at: http://${PROXYGEN_IP}:${PROXYGEN_PORT}"
+echo "Press Ctrl+C to stop"
+echo ""
+echo "Logs will be written to: django-proxygen-uwsgi.log"
+echo "Stats available at: http://127.0.0.1:9191"
+echo ""
+
+# Start uWSGI with Proxygen configuration
+exec uwsgi --ini uwsgi_proxygen.ini

--- a/packages/django_workload/srcs/django-workload/django-workload/start_loadbalanced_server.py
+++ b/packages/django_workload/srcs/django-workload/django-workload/start_loadbalanced_server.py
@@ -40,6 +40,484 @@ logging.basicConfig(
 logger = logging.getLogger(__name__)
 
 
+class UWSGIManager:
+    """Manages uWSGI with Proxygen workers and HAProxy load balancer."""
+
+    def __init__(
+        self,
+        num_workers: int = 8,
+        base_port: int = 8001,
+        lb_port: int = 8000,
+        stats_port: int = 8080,
+        threads_per_worker: int = 14,
+        haproxy_config: Optional[str] = None,
+        uwsgi_config: Optional[str] = None,
+        log_dir: Optional[str] = None,
+    ):
+        """
+        Initialize uWSGI manager.
+
+        Args:
+            num_workers: Number of uWSGI worker processes
+            base_port: Starting port for workers (8001, 8002, ...)
+            lb_port: Load balancer frontend port
+            stats_port: HAProxy stats dashboard port
+            threads_per_worker: Threads per Proxygen worker
+            haproxy_config: Path to HAProxy config (auto-generated if None)
+            uwsgi_config: Path to uWSGI config (default: uwsgi_loadbalanced.ini)
+            log_dir: Directory for log files (None = logs to stdout only)
+        """
+        self.num_workers = num_workers
+        self.base_port = base_port
+        self.lb_port = lb_port
+        self.stats_port = stats_port
+        self.threads_per_worker = threads_per_worker
+        self.haproxy_config = haproxy_config
+        self.uwsgi_config = uwsgi_config
+        self.log_dir = Path(log_dir) if log_dir else None
+
+        # Process tracking
+        self.uwsgi_process: Optional[subprocess.Popen] = None
+        self.haproxy_process: Optional[subprocess.Popen] = None
+
+        # Log file handles
+        self.log_files: List[IO] = []
+
+        # Log streaming threads
+        self.log_threads: List[threading.Thread] = []
+        self.stop_logging = threading.Event()
+
+        # Directory setup
+        self.script_dir = Path(__file__).parent
+        self.default_uwsgi_config = self.script_dir / "uwsgi_loadbalanced.ini"
+
+        # Create log directory if specified
+        if self.log_dir:
+            self.log_dir.mkdir(parents=True, exist_ok=True)
+            logger.info(f"Logs will be saved to: {self.log_dir}")
+
+        # Validate prerequisites
+        self._validate_setup()
+
+    def start_uwsgi(self) -> None:
+        """Start uWSGI with workers."""
+        # Determine config path
+        if self.uwsgi_config:
+            config_path = Path(self.uwsgi_config)
+            if not config_path.exists():
+                raise FileNotFoundError(f"uWSGI config not found: {config_path}")
+        else:
+            config_path = self.default_uwsgi_config
+            if not config_path.exists():
+                raise FileNotFoundError(
+                    f"Default uWSGI config not found: {config_path}"
+                )
+
+        logger.info(f"Starting uWSGI with config: {config_path}")
+
+        # Prepare environment variables
+        env = os.environ.copy()
+        env["PROXYGEN_BASE_PORT"] = str(self.base_port)
+        env["PROXYGEN_THREADS"] = str(self.threads_per_worker)
+        env["PYTHONUNBUFFERED"] = "1"
+
+        # Start uWSGI with config overrides
+        # Use --set to override config variables (standard uWSGI way)
+        self.uwsgi_process = subprocess.Popen(
+            [
+                "uwsgi",
+                "--ini",
+                str(config_path),
+                "--set",
+                f"workers={self.num_workers}",
+            ],
+            env=env,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            text=True,
+            bufsize=1,
+        )
+
+        logger.info(
+            f"uWSGI started (PID: {self.uwsgi_process.pid})\n"
+            f"  Workers: {self.num_workers}\n"
+            f"  Ports: {self.base_port}-{self.base_port + self.num_workers - 1}\n"
+            f"  Threads per worker: {self.threads_per_worker}"
+        )
+
+        # Start log streaming thread for uWSGI
+        log_file = None
+        if self.log_dir:
+            log_file_path = self.log_dir / "uwsgi.log"
+            log_file = open(log_file_path, "w")
+            self.log_files.append(log_file)
+
+        log_thread = threading.Thread(
+            target=self._stream_logs,
+            args=(self.uwsgi_process, "[uWSGI]", log_file),
+            daemon=True,
+        )
+        log_thread.start()
+        self.log_threads.append(log_thread)
+
+    def stop(self) -> None:
+        """Stop all processes (uWSGI + HAProxy)."""
+        logger.info("Shutting down...")
+
+        # Signal log threads to stop
+        self.stop_logging.set()
+
+        # Stop HAProxy
+        if self.haproxy_process:
+            logger.info("Stopping HAProxy...")
+            self.haproxy_process.terminate()
+            try:
+                self.haproxy_process.wait(timeout=5)
+            except subprocess.TimeoutExpired:
+                self.haproxy_process.kill()
+
+        # Stop uWSGI
+        if self.uwsgi_process:
+            logger.info("Stopping uWSGI (will wait for workers to finish)...")
+            self.uwsgi_process.terminate()
+            try:
+                self.uwsgi_process.wait(timeout=30)  # Longer timeout for uWSGI
+            except subprocess.TimeoutExpired:
+                logger.warning("uWSGI did not stop gracefully, killing...")
+                self.uwsgi_process.kill()
+
+        # Wait for log threads to finish
+        for thread in self.log_threads:
+            thread.join(timeout=2)
+
+        # Close log files
+        for log_file in self.log_files:
+            try:
+                log_file.close()
+            except Exception as e:
+                logger.warning(f"Error closing log file: {e}")
+
+        logger.info("All processes stopped")
+
+        if self.log_dir:
+            logger.info(f"Logs saved to: {self.log_dir}")
+
+    def _stream_logs(
+        self, process: subprocess.Popen, prefix: str, log_file: Optional[IO] = None
+    ) -> None:
+        """Stream logs from a process to stdout and optionally to a file."""
+        try:
+            for line in iter(process.stdout.readline, ""):
+                if self.stop_logging.is_set():
+                    break
+                if line:
+                    line = line.rstrip()
+                    print(f"{prefix} {line}", flush=True)
+                    if log_file:
+                        log_file.write(f"{prefix} {line}\n")
+                        log_file.flush()
+        except Exception as e:
+            logger.error(f"Error streaming logs for {prefix}: {e}")
+
+    def _check_port_available(self, port: int) -> bool:
+        """Check if a port is available for binding."""
+        import socket
+
+        sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        try:
+            sock.bind(("0.0.0.0", port))
+            sock.close()
+            return True
+        except OSError:
+            return False
+
+    def _find_process_on_port(self, port: int) -> Optional[str]:
+        """Find what process is using a port."""
+        try:
+            result = subprocess.run(
+                ["lsof", "-i", f":{port}", "-t"],
+                capture_output=True,
+                text=True,
+            )
+            if result.returncode == 0 and result.stdout.strip():
+                pid = result.stdout.strip().split()[0]
+                proc_result = subprocess.run(
+                    ["ps", "-p", pid, "-o", "comm="],
+                    capture_output=True,
+                    text=True,
+                )
+                if proc_result.returncode == 0:
+                    return f"PID {pid} ({proc_result.stdout.strip()})"
+            return None
+        except Exception:
+            return None
+
+    def _validate_setup(self) -> None:
+        """Validate that required files and commands exist."""
+        # Check for uWSGI
+        if (
+            subprocess.run(
+                ["which", "uwsgi"],
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+            ).returncode
+            != 0
+        ):
+            logger.warning(
+                "uWSGI not found in PATH. Install with:\n" "  pip install uwsgi"
+            )
+            raise RuntimeError("uWSGI not installed")
+
+        # Check for HAProxy
+        if (
+            subprocess.run(
+                ["which", "haproxy"],
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+            ).returncode
+            != 0
+        ):
+            logger.warning(
+                "HAProxy not found in PATH. Install with:\n"
+                "  Ubuntu/Debian: sudo apt-get install haproxy\n"
+                "  CentOS/RHEL: sudo yum install haproxy\n"
+                "  macOS: brew install haproxy"
+            )
+            raise RuntimeError("HAProxy not installed")
+
+        # Check port availability
+        ports_to_check = [self.lb_port, self.stats_port] + [
+            self.base_port + i for i in range(self.num_workers)
+        ]
+
+        unavailable_ports = []
+        for port in ports_to_check:
+            if not self._check_port_available(port):
+                process_info = self._find_process_on_port(port)
+                if process_info:
+                    unavailable_ports.append(f"  Port {port}: {process_info}")
+                else:
+                    unavailable_ports.append(f"  Port {port}: unknown process")
+
+        if unavailable_ports:
+            logger.error("The following ports are already in use:")
+            for info in unavailable_ports:
+                logger.error(info)
+            logger.error("\nTo fix this:")
+            logger.error("1. Kill the processes: pkill -f haproxy; pkill -f uwsgi")
+            logger.error(
+                "2. Or use different ports: --lb-port 9000 --base-port 9001 --stats-port 9080"
+            )
+            raise RuntimeError("Required ports are not available")
+
+    def generate_haproxy_config(self) -> Path:
+        """Generate HAProxy configuration dynamically."""
+        config_path = self.script_dir / "haproxy_generated.cfg"
+
+        # Generate server entries for all workers
+        server_lines = []
+        for i in range(1, self.num_workers + 1):
+            port = self.base_port + (i - 1)
+            server_lines.append(
+                f"    server worker{i} 127.0.0.1:{port} "
+                f"check weight 1 maxconn 10000 inter 2s fall 3 rise 2"
+            )
+
+        servers_config = "\n".join(server_lines)
+
+        # HAProxy configuration template
+        config_content = f"""global
+    log stdout format raw local0 info
+    maxconn 100000
+    nbthread 4
+    tune.bufsize 32768
+    tune.maxrewrite 1024
+
+defaults
+    log global
+    mode http
+    option httplog
+    option dontlognull
+    option http-server-close
+    option forwardfor except 127.0.0.0/8
+    option redispatch
+    retries 3
+    timeout connect 5000ms
+    timeout client 50000ms
+    timeout server 50000ms
+    timeout http-keep-alive 10s
+    timeout check 2000ms
+
+frontend django_frontend
+    bind *:{self.lb_port}
+    maxconn 50000
+    default_backend django_workers
+    option dontlog-normal
+
+backend django_workers
+    balance leastconn
+    option httpchk GET /
+    http-check expect status 200
+    timeout connect 3000ms
+    timeout server 30000ms
+
+{servers_config}
+
+listen stats
+    bind *:{self.stats_port}
+    stats enable
+    stats uri /stats
+    stats refresh 5s
+    stats show-legends
+    stats show-node
+    stats admin if TRUE
+"""
+
+        # Write configuration
+        with open(config_path, "w") as f:
+            f.write(config_content)
+
+        logger.info(f"Generated HAProxy config: {config_path}")
+        return config_path
+
+    def wait_for_workers_ready(self, timeout: int = 30) -> bool:
+        """Wait for all workers to be ready to accept connections."""
+        import socket
+
+        logger.info("Waiting for workers to be ready...")
+        start_time = time.time()
+
+        while time.time() - start_time < timeout:
+            all_ready = True
+
+            for i in range(self.num_workers):
+                port = self.base_port + i
+                sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+                sock.settimeout(0.5)
+
+                try:
+                    result = sock.connect_ex(("127.0.0.1", port))
+                    if result != 0:
+                        all_ready = False
+                except Exception:
+                    all_ready = False
+                finally:
+                    sock.close()
+
+            if all_ready:
+                logger.info("All workers are ready!")
+                return True
+
+            time.sleep(1)
+
+        logger.warning(f"Timeout waiting for workers (waited {timeout}s)")
+        return False
+
+    def start_haproxy(self) -> None:
+        """Start HAProxy load balancer."""
+        # Generate or use provided config
+        if self.haproxy_config:
+            config_path = Path(self.haproxy_config)
+            if not config_path.exists():
+                raise FileNotFoundError(f"HAProxy config not found: {config_path}")
+        else:
+            config_path = self.generate_haproxy_config()
+
+        logger.info(f"Starting HAProxy with config: {config_path}")
+
+        # Start HAProxy
+        self.haproxy_process = subprocess.Popen(
+            ["haproxy", "-f", str(config_path)],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            text=True,
+            bufsize=1,
+        )
+
+        logger.info(
+            f"HAProxy started (PID: {self.haproxy_process.pid})\n"
+            f"  Frontend: http://127.0.0.1:{self.lb_port}\n"
+            f"  Stats: http://127.0.0.1:{self.stats_port}/stats"
+        )
+
+        # Start log streaming thread for HAProxy
+        log_file = None
+        if self.log_dir:
+            log_file_path = self.log_dir / "haproxy.log"
+            log_file = open(log_file_path, "w")
+            self.log_files.append(log_file)
+
+        log_thread = threading.Thread(
+            target=self._stream_logs,
+            args=(self.haproxy_process, "[HAProxy]", log_file),
+            daemon=True,
+        )
+        log_thread.start()
+        self.log_threads.append(log_thread)
+
+    def start(self) -> None:
+        """Start all components (uWSGI + HAProxy)."""
+        try:
+            # Start uWSGI
+            self.start_uwsgi()
+
+            # Wait for workers to be ready
+            if not self.wait_for_workers_ready():
+                logger.warning("Some workers may not be ready yet, continuing anyway")
+
+            # Start HAProxy
+            self.start_haproxy()
+
+            logger.info(
+                "\n" + "=" * 60 + "\n"
+                f"Load-balanced Django server with uWSGI is running!\n"
+                f"  Access via: http://127.0.0.1:{self.lb_port}\n"
+                f"  uWSGI workers: {self.num_workers} (ports {self.base_port}-{self.base_port + self.num_workers - 1})\n"
+                f"  Stats UI: http://127.0.0.1:{self.stats_port}/stats\n"
+                f"  Threads per worker: {self.threads_per_worker}\n"
+                "\n"
+                f"Press Ctrl+C to stop all processes\n" + "=" * 60
+            )
+
+        except Exception as e:
+            logger.error(f"Failed to start server: {e}")
+            self.stop()
+            raise
+
+    def run(self) -> None:
+        """Start server and block until interrupted."""
+
+        # Setup signal handlers
+        def signal_handler(signum, frame):
+            logger.info(f"\nReceived signal {signum}")
+            self.stop()
+            sys.exit(0)
+
+        signal.signal(signal.SIGINT, signal_handler)
+        signal.signal(signal.SIGTERM, signal_handler)
+
+        # Start everything
+        self.start()
+
+        # Monitor processes
+        try:
+            while True:
+                # Check if any process died
+                if self.haproxy_process and self.haproxy_process.poll() is not None:
+                    logger.error("HAProxy died unexpectedly!")
+                    break
+
+                if self.uwsgi_process and self.uwsgi_process.poll() is not None:
+                    logger.error("uWSGI died unexpectedly!")
+                    break
+
+                time.sleep(1)
+        except KeyboardInterrupt:
+            pass
+        finally:
+            self.stop()
+
+
 class ServerManager:
     """Manages Proxygen worker processes and HAProxy load balancer."""
 
@@ -49,7 +527,7 @@ class ServerManager:
         base_port: int = 8001,
         lb_port: int = 8000,
         stats_port: int = 8080,
-        threads_per_worker: int = 14,
+        threads_per_worker: int = 8,
         haproxy_config: Optional[str] = None,
         log_dir: Optional[str] = None,
     ):
@@ -443,24 +921,26 @@ listen stats
             self.stop()
             raise
 
-    def stop(self) -> None:
-        """Stop all processes (workers + load balancer)."""
-        logger.info("Shutting down...")
+    def _stop_haproxy(self) -> None:
+        """Stop HAProxy process gracefully."""
+        if not self.haproxy_process:
+            return
 
-        # Signal log threads to stop
-        self.stop_logging.set()
+        logger.info("Stopping HAProxy...")
+        self.haproxy_process.terminate()
+        try:
+            self.haproxy_process.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            self.haproxy_process.kill()
 
-        # Stop HAProxy
-        if self.haproxy_process:
-            logger.info("Stopping HAProxy...")
-            self.haproxy_process.terminate()
-            try:
-                self.haproxy_process.wait(timeout=5)
-            except subprocess.TimeoutExpired:
-                self.haproxy_process.kill()
+    def _stop_workers(self) -> None:
+        """Stop all worker processes gracefully."""
+        if not self.worker_processes:
+            return
 
-        # Stop all workers
         logger.info(f"Stopping {len(self.worker_processes)} workers...")
+
+        # Terminate all workers
         for i, process in enumerate(self.worker_processes, 1):
             logger.info(f"Stopping worker {i} (PID: {process.pid})...")
             process.terminate()
@@ -472,16 +952,31 @@ listen stats
             except subprocess.TimeoutExpired:
                 process.kill()
 
-        # Wait for log threads to finish
+    def _stop_log_threads(self) -> None:
+        """Stop all log streaming threads."""
         for thread in self.log_threads:
             thread.join(timeout=2)
 
-        # Close log files
+    def _close_log_files(self) -> None:
+        """Close all open log files."""
         for log_file in self.log_files:
             try:
                 log_file.close()
             except Exception as e:
                 logger.warning(f"Error closing log file: {e}")
+
+    def stop(self) -> None:
+        """Stop all processes (workers + load balancer)."""
+        logger.info("Shutting down...")
+
+        # Signal log threads to stop
+        self.stop_logging.set()
+
+        # Stop components
+        self._stop_haproxy()
+        self._stop_workers()
+        self._stop_log_threads()
+        self._close_log_files()
 
         logger.info("All processes stopped")
 
@@ -560,7 +1055,7 @@ def main():
     parser.add_argument(
         "--threads-per-worker",
         type=int,
-        default=14,
+        default=8,
         help="Number of threads per Proxygen worker",
     )
 
@@ -578,18 +1073,45 @@ def main():
         help="Directory to save log files (default: logs only to stdout)",
     )
 
+    parser.add_argument(
+        "--use-uwsgi",
+        action="store_true",
+        help="Use uWSGI to manage workers (instead of direct Python processes)",
+    )
+
+    parser.add_argument(
+        "--uwsgi-config",
+        type=str,
+        default=None,
+        help="Path to uWSGI config file (default: uwsgi_loadbalanced.ini)",
+    )
+
     args = parser.parse_args()
 
-    # Create and run server manager
-    manager = ServerManager(
-        num_workers=args.workers,
-        base_port=args.base_port,
-        lb_port=args.lb_port,
-        stats_port=args.stats_port,
-        threads_per_worker=args.threads_per_worker,
-        haproxy_config=args.haproxy_config,
-        log_dir=args.log_dir,
-    )
+    # Choose between uWSGI mode or direct worker mode
+    if args.use_uwsgi:
+        # Use uWSGI to manage workers
+        manager = UWSGIManager(
+            num_workers=args.workers,
+            base_port=args.base_port,
+            lb_port=args.lb_port,
+            stats_port=args.stats_port,
+            threads_per_worker=args.threads_per_worker,
+            haproxy_config=args.haproxy_config,
+            uwsgi_config=args.uwsgi_config,
+            log_dir=args.log_dir,
+        )
+    else:
+        # Direct Python worker processes
+        manager = ServerManager(
+            num_workers=args.workers,
+            base_port=args.base_port,
+            lb_port=args.lb_port,
+            stats_port=args.stats_port,
+            threads_per_worker=args.threads_per_worker,
+            haproxy_config=args.haproxy_config,
+            log_dir=args.log_dir,
+        )
 
     manager.run()
 

--- a/packages/django_workload/srcs/django-workload/django-workload/start_loadbalanced_server.py
+++ b/packages/django_workload/srcs/django-workload/django-workload/start_loadbalanced_server.py
@@ -1,0 +1,598 @@
+#!/usr/bin/env python3
+"""
+Start Django server with HAProxy load balancer and multiple Proxygen workers.
+
+This script orchestrates the startup of:
+1. Multiple Proxygen worker processes on different ports
+2. HAProxy load balancer distributing traffic across workers
+
+Usage:
+    python start_loadbalanced_server.py [options]
+
+Example:
+    # Start with 8 workers (default)
+    python start_loadbalanced_server.py
+
+    # Start with 16 workers
+    python start_loadbalanced_server.py --workers 16
+
+    # Custom HAProxy config
+    python start_loadbalanced_server.py --haproxy-config custom_haproxy.cfg
+"""
+
+import argparse
+import logging
+import os
+import signal
+import subprocess
+import sys
+import threading
+import time
+from pathlib import Path
+from typing import IO, List, Optional
+
+# Configure logging
+logging.basicConfig(
+    level=logging.INFO,
+    format="[%(asctime)s] [%(levelname)s] %(message)s",
+    datefmt="%H:%M:%S",
+)
+logger = logging.getLogger(__name__)
+
+
+class ServerManager:
+    """Manages Proxygen worker processes and HAProxy load balancer."""
+
+    def __init__(
+        self,
+        num_workers: int = 8,
+        base_port: int = 8001,
+        lb_port: int = 8000,
+        stats_port: int = 8080,
+        threads_per_worker: int = 14,
+        haproxy_config: Optional[str] = None,
+        log_dir: Optional[str] = None,
+    ):
+        """
+        Initialize server manager.
+
+        Args:
+            num_workers: Number of Proxygen worker processes
+            base_port: Starting port for workers (8001, 8002, ...)
+            lb_port: Load balancer frontend port
+            stats_port: HAProxy stats dashboard port
+            threads_per_worker: Threads per Proxygen worker
+            haproxy_config: Path to HAProxy config (auto-generated if None)
+            log_dir: Directory for log files (None = logs to stdout only)
+        """
+        self.num_workers = num_workers
+        self.base_port = base_port
+        self.lb_port = lb_port
+        self.stats_port = stats_port
+        self.threads_per_worker = threads_per_worker
+        self.haproxy_config = haproxy_config
+        self.log_dir = Path(log_dir) if log_dir else None
+
+        # Process tracking
+        self.worker_processes: List[subprocess.Popen] = []
+        self.haproxy_process: Optional[subprocess.Popen] = None
+
+        # Log file handles
+        self.log_files: List[IO] = []
+
+        # Log streaming threads
+        self.log_threads: List[threading.Thread] = []
+        self.stop_logging = threading.Event()
+
+        # Directory setup
+        self.script_dir = Path(__file__).parent
+        self.worker_script = self.script_dir / "proxygen_wsgi.py"
+
+        # Create log directory if specified
+        if self.log_dir:
+            self.log_dir.mkdir(parents=True, exist_ok=True)
+            logger.info(f"Logs will be saved to: {self.log_dir}")
+
+        # Validate prerequisites
+        self._validate_setup()
+
+    def _check_port_available(self, port: int) -> bool:
+        """Check if a port is available for binding."""
+        import socket
+
+        sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        try:
+            sock.bind(("0.0.0.0", port))
+            sock.close()
+            return True
+        except OSError:
+            return False
+
+    def _find_process_on_port(self, port: int) -> Optional[str]:
+        """Find what process is using a port."""
+        try:
+            result = subprocess.run(
+                ["lsof", "-i", f":{port}", "-t"],
+                capture_output=True,
+                text=True,
+            )
+            if result.returncode == 0 and result.stdout.strip():
+                pid = result.stdout.strip().split()[0]
+                # Get process name
+                proc_result = subprocess.run(
+                    ["ps", "-p", pid, "-o", "comm="],
+                    capture_output=True,
+                    text=True,
+                )
+                if proc_result.returncode == 0:
+                    return f"PID {pid} ({proc_result.stdout.strip()})"
+            return None
+        except Exception:
+            return None
+
+    def _validate_setup(self) -> None:
+        """Validate that required files and commands exist."""
+        if not self.worker_script.exists():
+            raise FileNotFoundError(
+                f"Worker script not found: {self.worker_script}\n"
+                f"Expected: {self.script_dir}/proxygen_wsgi.py"
+            )
+
+        # Check for HAProxy
+        if (
+            subprocess.run(
+                ["which", "haproxy"],
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+            ).returncode
+            != 0
+        ):
+            logger.warning(
+                "HAProxy not found in PATH. Install with:\n"
+                "  Ubuntu/Debian: sudo apt-get install haproxy\n"
+                "  CentOS/RHEL: sudo yum install haproxy\n"
+                "  macOS: brew install haproxy"
+            )
+            raise RuntimeError("HAProxy not installed")
+
+        # Check port availability
+        ports_to_check = [self.lb_port, self.stats_port] + [
+            self.base_port + i for i in range(self.num_workers)
+        ]
+
+        unavailable_ports = []
+        for port in ports_to_check:
+            if not self._check_port_available(port):
+                process_info = self._find_process_on_port(port)
+                if process_info:
+                    unavailable_ports.append(f"  Port {port}: {process_info}")
+                else:
+                    unavailable_ports.append(f"  Port {port}: unknown process")
+
+        if unavailable_ports:
+            logger.error("The following ports are already in use:")
+            for info in unavailable_ports:
+                logger.error(info)
+            logger.error("\nTo fix this:")
+            logger.error(
+                "1. Kill the processes: pkill -f haproxy; pkill -f proxygen_wsgi"
+            )
+            logger.error(
+                "2. Or use different ports: --lb-port 9000 --base-port 9001 --stats-port 9080"
+            )
+            raise RuntimeError("Required ports are not available")
+
+    def generate_haproxy_config(self) -> Path:
+        """Generate HAProxy configuration dynamically."""
+        config_path = self.script_dir / "haproxy_generated.cfg"
+
+        # Generate server entries for all workers
+        server_lines = []
+        for i in range(1, self.num_workers + 1):
+            port = self.base_port + (i - 1)
+            server_lines.append(
+                f"    server worker{i} 127.0.0.1:{port} "
+                f"check weight 1 maxconn 10000 inter 2s fall 3 rise 2"
+            )
+
+        servers_config = "\n".join(server_lines)
+
+        # HAProxy configuration template
+        config_content = f"""global
+    log stdout format raw local0 info
+    maxconn 100000
+    nbthread 4
+    tune.bufsize 32768
+    tune.maxrewrite 1024
+
+defaults
+    log global
+    mode http
+    option httplog
+    option dontlognull
+    option http-server-close
+    option forwardfor except 127.0.0.0/8
+    option redispatch
+    retries 3
+    timeout connect 5000ms
+    timeout client 50000ms
+    timeout server 50000ms
+    timeout http-keep-alive 10s
+    timeout check 2000ms
+
+frontend django_frontend
+    bind *:{self.lb_port}
+    maxconn 50000
+    default_backend django_workers
+    option dontlog-normal
+
+backend django_workers
+    balance leastconn
+    option httpchk GET /
+    http-check expect status 200
+    timeout connect 3000ms
+    timeout server 30000ms
+
+{servers_config}
+
+listen stats
+    bind *:{self.stats_port}
+    stats enable
+    stats uri /stats
+    stats refresh 5s
+    stats show-legends
+    stats show-node
+    stats admin if TRUE
+"""
+
+        # Write configuration
+        with open(config_path, "w") as f:
+            f.write(config_content)
+
+        logger.info(f"Generated HAProxy config: {config_path}")
+        return config_path
+
+    def _stream_logs(
+        self, process: subprocess.Popen, prefix: str, log_file: Optional[IO] = None
+    ) -> None:
+        """
+        Stream logs from a process to stdout and optionally to a file.
+
+        Args:
+            process: Process to stream logs from
+            prefix: Prefix for log lines (e.g., "[Worker-1]")
+            log_file: Optional file handle to write logs to
+        """
+        try:
+            for line in iter(process.stdout.readline, ""):
+                if self.stop_logging.is_set():
+                    break
+
+                if line:
+                    # Remove trailing newline
+                    line = line.rstrip()
+
+                    # Print to stdout
+                    print(f"{prefix} {line}", flush=True)
+
+                    # Write to log file if provided
+                    if log_file:
+                        log_file.write(f"{prefix} {line}\n")
+                        log_file.flush()
+        except Exception as e:
+            logger.error(f"Error streaming logs for {prefix}: {e}")
+
+    def start_worker(self, worker_id: int, port: int) -> subprocess.Popen:
+        """Start a single Proxygen worker process."""
+        logger.info(f"Starting worker {worker_id} on port {port}...")
+
+        env = os.environ.copy()
+        env["PYTHONUNBUFFERED"] = "1"  # Disable output buffering
+
+        # Start worker process
+        process = subprocess.Popen(
+            [
+                sys.executable,
+                str(self.worker_script),
+                "--port",
+                str(port),
+                "--threads",
+                str(self.threads_per_worker),
+            ],
+            env=env,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            text=True,
+            bufsize=1,  # Line buffered
+        )
+
+        logger.info(f"Worker {worker_id} started (PID: {process.pid})")
+
+        # Start log streaming thread
+        log_file = None
+        if self.log_dir:
+            log_file_path = self.log_dir / f"worker_{worker_id}.log"
+            log_file = open(log_file_path, "w")
+            self.log_files.append(log_file)
+
+        log_thread = threading.Thread(
+            target=self._stream_logs,
+            args=(process, f"[Worker-{worker_id}]", log_file),
+            daemon=True,
+        )
+        log_thread.start()
+        self.log_threads.append(log_thread)
+
+        return process
+
+    def start_workers(self) -> None:
+        """Start all Proxygen worker processes."""
+        logger.info(f"Starting {self.num_workers} Proxygen workers...")
+
+        for i in range(1, self.num_workers + 1):
+            port = self.base_port + (i - 1)
+            process = self.start_worker(i, port)
+            self.worker_processes.append(process)
+
+            # Brief delay to avoid port conflicts
+            time.sleep(0.2)
+
+        logger.info(f"All {self.num_workers} workers started")
+
+    def wait_for_workers_ready(self, timeout: int = 30) -> bool:
+        """Wait for all workers to be ready to accept connections."""
+        import socket
+
+        logger.info("Waiting for workers to be ready...")
+        start_time = time.time()
+
+        while time.time() - start_time < timeout:
+            all_ready = True
+
+            for i in range(self.num_workers):
+                port = self.base_port + i
+                sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+                sock.settimeout(0.5)
+
+                try:
+                    result = sock.connect_ex(("127.0.0.1", port))
+                    if result != 0:
+                        all_ready = False
+                except Exception:
+                    all_ready = False
+                finally:
+                    sock.close()
+
+            if all_ready:
+                logger.info("All workers are ready!")
+                return True
+
+            time.sleep(1)
+
+        logger.warning(f"Timeout waiting for workers (waited {timeout}s)")
+        return False
+
+    def start_haproxy(self) -> None:
+        """Start HAProxy load balancer."""
+        # Generate or use provided config
+        if self.haproxy_config:
+            config_path = Path(self.haproxy_config)
+            if not config_path.exists():
+                raise FileNotFoundError(f"HAProxy config not found: {config_path}")
+        else:
+            config_path = self.generate_haproxy_config()
+
+        logger.info(f"Starting HAProxy with config: {config_path}")
+
+        # Start HAProxy
+        self.haproxy_process = subprocess.Popen(
+            ["haproxy", "-f", str(config_path)],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            text=True,
+            bufsize=1,
+        )
+
+        logger.info(
+            f"HAProxy started (PID: {self.haproxy_process.pid})\n"
+            f"  Frontend: http://127.0.0.1:{self.lb_port}\n"
+            f"  Stats: http://127.0.0.1:8080/stats"
+        )
+
+        # Start log streaming thread for HAProxy
+        log_file = None
+        if self.log_dir:
+            log_file_path = self.log_dir / "haproxy.log"
+            log_file = open(log_file_path, "w")
+            self.log_files.append(log_file)
+
+        log_thread = threading.Thread(
+            target=self._stream_logs,
+            args=(self.haproxy_process, "[HAProxy]", log_file),
+            daemon=True,
+        )
+        log_thread.start()
+        self.log_threads.append(log_thread)
+
+    def start(self) -> None:
+        """Start all components (workers + load balancer)."""
+        try:
+            # Start workers
+            self.start_workers()
+
+            # Wait for workers to be ready
+            if not self.wait_for_workers_ready():
+                logger.warning("Some workers may not be ready yet, continuing anyway")
+
+            # Start HAProxy
+            self.start_haproxy()
+
+            logger.info(
+                "\n" + "=" * 60 + "\n"
+                f"Load-balanced Django server is running!\n"
+                f"  Access via: http://127.0.0.1:{self.lb_port}\n"
+                f"  Workers: {self.num_workers} (ports {self.base_port}-{self.base_port + self.num_workers - 1})\n"
+                f"  Stats UI: http://127.0.0.1:8080/stats\n"
+                f"  Threads per worker: {self.threads_per_worker}\n"
+                "\n"
+                f"Press Ctrl+C to stop all processes\n" + "=" * 60
+            )
+
+        except Exception as e:
+            logger.error(f"Failed to start server: {e}")
+            self.stop()
+            raise
+
+    def stop(self) -> None:
+        """Stop all processes (workers + load balancer)."""
+        logger.info("Shutting down...")
+
+        # Signal log threads to stop
+        self.stop_logging.set()
+
+        # Stop HAProxy
+        if self.haproxy_process:
+            logger.info("Stopping HAProxy...")
+            self.haproxy_process.terminate()
+            try:
+                self.haproxy_process.wait(timeout=5)
+            except subprocess.TimeoutExpired:
+                self.haproxy_process.kill()
+
+        # Stop all workers
+        logger.info(f"Stopping {len(self.worker_processes)} workers...")
+        for i, process in enumerate(self.worker_processes, 1):
+            logger.info(f"Stopping worker {i} (PID: {process.pid})...")
+            process.terminate()
+
+        # Wait for graceful shutdown
+        for process in self.worker_processes:
+            try:
+                process.wait(timeout=5)
+            except subprocess.TimeoutExpired:
+                process.kill()
+
+        # Wait for log threads to finish
+        for thread in self.log_threads:
+            thread.join(timeout=2)
+
+        # Close log files
+        for log_file in self.log_files:
+            try:
+                log_file.close()
+            except Exception as e:
+                logger.warning(f"Error closing log file: {e}")
+
+        logger.info("All processes stopped")
+
+        if self.log_dir:
+            logger.info(f"Logs saved to: {self.log_dir}")
+
+    def run(self) -> None:
+        """Start server and block until interrupted."""
+
+        # Setup signal handlers
+        def signal_handler(signum, frame):
+            logger.info(f"\nReceived signal {signum}")
+            self.stop()
+            sys.exit(0)
+
+        signal.signal(signal.SIGINT, signal_handler)
+        signal.signal(signal.SIGTERM, signal_handler)
+
+        # Start everything
+        self.start()
+
+        # Monitor processes
+        try:
+            while True:
+                # Check if any process died
+                if self.haproxy_process and self.haproxy_process.poll() is not None:
+                    logger.error("HAProxy died unexpectedly!")
+                    break
+
+                for i, process in enumerate(self.worker_processes, 1):
+                    if process.poll() is not None:
+                        logger.error(f"Worker {i} died unexpectedly!")
+                        break
+
+                time.sleep(1)
+        except KeyboardInterrupt:
+            pass
+        finally:
+            self.stop()
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Start load-balanced Django server with HAProxy and Proxygen workers",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
+
+    parser.add_argument(
+        "--workers",
+        type=int,
+        default=8,
+        help="Number of Proxygen worker processes",
+    )
+
+    parser.add_argument(
+        "--base-port",
+        type=int,
+        default=8001,
+        help="Starting port for workers (workers use base_port, base_port+1, ...)",
+    )
+
+    parser.add_argument(
+        "--lb-port",
+        type=int,
+        default=8000,
+        help="Load balancer frontend port",
+    )
+
+    parser.add_argument(
+        "--stats-port",
+        type=int,
+        default=8080,
+        help="HAProxy stats dashboard port",
+    )
+
+    parser.add_argument(
+        "--threads-per-worker",
+        type=int,
+        default=14,
+        help="Number of threads per Proxygen worker",
+    )
+
+    parser.add_argument(
+        "--haproxy-config",
+        type=str,
+        default=None,
+        help="Path to custom HAProxy config (auto-generated if not provided)",
+    )
+
+    parser.add_argument(
+        "--log-dir",
+        type=str,
+        default=None,
+        help="Directory to save log files (default: logs only to stdout)",
+    )
+
+    args = parser.parse_args()
+
+    # Create and run server manager
+    manager = ServerManager(
+        num_workers=args.workers,
+        base_port=args.base_port,
+        lb_port=args.lb_port,
+        stats_port=args.stats_port,
+        threads_per_worker=args.threads_per_worker,
+        haproxy_config=args.haproxy_config,
+        log_dir=args.log_dir,
+    )
+
+    manager.run()
+
+
+if __name__ == "__main__":
+    main()

--- a/packages/django_workload/srcs/django-workload/django-workload/uwsgi_loadbalanced.ini
+++ b/packages/django_workload/srcs/django-workload/django-workload/uwsgi_loadbalanced.ini
@@ -1,0 +1,177 @@
+[uwsgi]
+# uWSGI + HAProxy Load Balanced Configuration
+# This config starts N uWSGI workers, each running a Proxygen server on a unique port
+# HAProxy load balances requests across all workers
+
+# =============================================================================
+# Core Settings
+# =============================================================================
+
+# Load proxygen_wsgi to register postfork hooks
+# Use wsgi-file to directly load the Python file
+wsgi-file = proxygen_wsgi.py
+
+# Master process (manages workers)
+master = true
+
+# Number of worker processes
+# Override with --set workers=N or environment variable UWSGI_WORKERS
+# Default to 8 if not specified
+processes = %(workers)
+workers = 8
+
+# Enable lazy-apps mode (load application after worker fork)
+# This is CRITICAL for Proxygen to work correctly
+# Without this, Proxygen server would start in master process before fork
+lazy-apps = true
+
+# Enable threads for Python (needed for Proxygen's threading)
+enable-threads = true
+
+# =============================================================================
+# Socket Configuration
+# =============================================================================
+
+# uWSGI requires a socket to start, even if not actively used
+# We use a Unix socket for uWSGI master communication
+# Proxygen handles all actual HTTP traffic on its own port
+socket = /tmp/uwsgi-loadbalanced.sock
+chmod-socket = 666
+
+# Keep socket for graceful reloads
+vacuum = true
+
+# =============================================================================
+# Port Configuration
+# =============================================================================
+
+# Environment variables are set by start_loadbalanced_server.py:
+#   PROXYGEN_BASE_PORT - Starting port for workers (default: 8001)
+#   PROXYGEN_THREADS - Number of threads per worker (default: 14)
+#
+# These are passed via the Python subprocess environment and should NOT be
+# redefined here using "env =" directives, as that would override the values.
+#
+# Port calculation in proxygen_wsgi.py:
+#   Worker 1 port = PROXYGEN_BASE_PORT + 1 - 1 = base_port
+#   Worker 2 port = PROXYGEN_BASE_PORT + 2 - 1 = base_port + 1
+#   Worker N port = PROXYGEN_BASE_PORT + N - 1
+
+# =============================================================================
+# Process Management
+# =============================================================================
+
+# Reload workers after serving N requests (detect memory leaks)
+max-requests = 10000
+
+# Add jitter to max-requests to avoid thundering herd
+max-requests-delta = 1000
+
+# Reload worker if memory exceeds 2GB
+reload-on-rss = 2048
+
+# Kill worker if request takes longer than 60 seconds (harakiri)
+harakiri = 60
+
+# Reload workers gracefully on SIGHUP
+die-on-term = true
+
+# Graceful reload timeout
+worker-reload-mercy = 30
+
+# =============================================================================
+# Logging
+# =============================================================================
+
+# Don't specify logto - let uWSGI log naturally to stdout
+# (Python orchestration script captures stdout via subprocess.PIPE)
+
+# Log format with timestamps
+log-date = true
+
+# Disable request logging (Proxygen handles this)
+disable-logging = true
+
+# But log important events (worker spawn, reload, etc.)
+log-master = true
+
+# =============================================================================
+# Performance Tuning
+# =============================================================================
+
+# Listen queue size
+listen = 1024
+
+# Enable thunder lock (prevent thundering herd)
+thunder-lock = true
+
+# Cheaper subsystem (dynamic worker scaling)
+# Disabled for load balanced setup (we want all workers running)
+# cheaper-algo = spare
+# cheaper = 2
+# cheaper-initial = 4
+# cheaper-step = 1
+
+# =============================================================================
+# Health & Monitoring
+# =============================================================================
+
+# Stats server (optional - for monitoring)
+# Uncomment to enable:
+# stats = 127.0.0.1:9191
+# stats-http = true
+
+# Memory report (log memory usage)
+memory-report = true
+
+# =============================================================================
+# Vacuum & Cleanup
+# =============================================================================
+
+# Clean up on exit
+vacuum = true
+
+# =============================================================================
+# Python Environment
+# =============================================================================
+
+# Disable buffering for real-time logs
+env = PYTHONUNBUFFERED=1
+
+# Django settings module
+# Set via environment variable: DJANGO_SETTINGS_MODULE
+# env = DJANGO_SETTINGS_MODULE=django_workload.settings
+
+# =============================================================================
+# Notes
+# =============================================================================
+#
+# Usage:
+#   1. Start uWSGI with this config:
+#      UWSGI_WORKERS=8 PROXYGEN_BASE_PORT=8001 uwsgi --ini uwsgi_loadbalanced.ini
+#
+#   2. Each worker will automatically:
+#      - Calculate its port: PROXYGEN_BASE_PORT + worker_id - 1
+#      - Start Proxygen server on that port
+#      - Handle requests asynchronously via Proxygen
+#
+#   3. HAProxy load balances across all worker ports (8001-8008)
+#
+# Architecture:
+#   Client → HAProxy:8000
+#              ↓
+#       [Load Balancer]
+#              ↓
+#   ┌──────┬──────┬──────┐
+#   ↓      ↓      ↓      ↓
+#  uWSGI  uWSGI  uWSGI  uWSGI
+#  Worker Worker Worker Worker
+#    1      2      3      4
+#    ↓      ↓      ↓      ↓
+# Proxygen Proxygen Proxygen Proxygen
+#  :8001   :8002   :8003   :8004
+#
+# Benefits:
+#   - uWSGI process management (harakiri, memory limits, graceful reload)
+#   - Proxygen async HTTP (high performance, concurrent requests)
+#   - HAProxy load balancing (even distribution, health checks)

--- a/packages/django_workload/srcs/django-workload/django-workload/uwsgi_proxygen.ini
+++ b/packages/django_workload/srcs/django-workload/django-workload/uwsgi_proxygen.ini
@@ -1,0 +1,104 @@
+[uwsgi]
+# Proxygen + uWSGI Configuration for DjangoBench V2
+#
+# Architecture:
+#   uWSGI: Process management, memory cleanup, monitoring
+#   Proxygen: Async HTTP server (started in each worker via postfork hook)
+#   Django: ASGI application
+#
+# Each uWSGI worker process starts its own Proxygen server instance
+# that handles HTTP requests asynchronously using multiple threads.
+
+# ============================================
+# Process Management
+# ============================================
+master = True
+processes = %(workers)
+workers = %k
+lazy-apps = True
+
+# Load proxygen_wsgi to register postfork hooks
+# Use wsgi-file to directly load the Python file
+wsgi-file = proxygen_wsgi.py
+
+# Enable threads for Python (needed for Proxygen's threading)
+enable-threads = True
+
+# ============================================
+# Socket Configuration
+# ============================================
+# uWSGI requires a socket to start, even if not actively used
+# We use a Unix socket for uWSGI master communication
+# Proxygen handles all actual HTTP traffic on its own port
+socket = /tmp/uwsgi-proxygen.sock
+chmod-socket = 666
+
+# Keep socket for graceful reloads
+vacuum-socket = true
+
+# ============================================
+# Memory Management and Cleanup
+# ============================================
+# Reload worker if RSS memory exceeds 1GB
+reload-on-rss = 1000
+
+# Force reload if RSS memory exceeds 1.5GB
+evil-reload-on-rss = 1500
+
+# Maximum request execution time (seconds)
+harakiri = 75
+
+# Time to wait for graceful shutdown
+reload-mercy = 15
+worker-reload-mercy = 15
+
+# Clean up on exit
+vacuum = True
+
+# ============================================
+# Concurrency and Threading
+# ============================================
+# Lock engine for thread safety
+lock-engine = ipcsem
+persistent-ipcsem = 1
+
+# Note: Proxygen handles threading internally
+# Each worker process runs one Proxygen server with multiple threads
+
+# ============================================
+# Python Optimization
+# ============================================
+# Disable Python garbage collection for performance
+# (Django and Proxygen manage memory efficiently)
+disable-gc = True
+
+# NUMA-aware forking
+numa-fork = True
+
+# Call os.fork hooks after forking
+py-call-osafterfork = True
+
+# Python optimization level
+optimize = 2
+
+# ============================================
+# Logging and Monitoring
+# ============================================
+# Stats server for monitoring
+stats = 127.0.0.1:9191
+
+# Log to file
+logger = file:django-proxygen-uwsgi.log
+
+# Log worker lifecycle events
+log-master = True
+
+# ============================================
+# Environment Variables (Examples)
+# ============================================
+# Set these in your environment or override here:
+#   PROXYGEN_IP=0.0.0.0
+#   PROXYGEN_PORT=8000
+#   PROXYGEN_THREADS=0  (0 = auto-detect CPU cores)
+#   DJANGO_SETTINGS_MODULE=django_workload.settings
+env= DJANGO_SETTINGS_MODULE=cluster_settings

--- a/packages/django_workload/srcs/proxygen_binding/CMakeLists.txt
+++ b/packages/django_workload/srcs/proxygen_binding/CMakeLists.txt
@@ -1,0 +1,142 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+cmake_minimum_required(VERSION 3.15)
+project(proxygen_binding)
+
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+# Find Python
+find_package(Python3 COMPONENTS Interpreter Development REQUIRED)
+
+# Find pybind11
+find_package(pybind11 REQUIRED)
+
+# Set Proxygen paths from environment variable or use default
+if(DEFINED ENV{PROXYGEN_INSTALL_DIR})
+    set(PROXYGEN_INSTALL_DIR $ENV{PROXYGEN_INSTALL_DIR})
+    message(STATUS "Using PROXYGEN_INSTALL_DIR from environment: ${PROXYGEN_INSTALL_DIR}")
+else()
+    # Use home directory for default path
+    set(PROXYGEN_INSTALL_DIR $ENV{HOME}/proxygen/staging)
+    message(WARNING "PROXYGEN_INSTALL_DIR not set, using default: ${PROXYGEN_INSTALL_DIR}")
+endif()
+
+# Main Proxygen paths
+set(PROXYGEN_INCLUDE_DIR ${PROXYGEN_INSTALL_DIR}/include)
+set(PROXYGEN_LIB_DIR ${PROXYGEN_INSTALL_DIR}/lib)
+
+# Dependency paths (from _build/deps in proxygen source)
+# These are at: <PROXYGEN_INSTALL_DIR>/../proxygen/_build/deps
+get_filename_component(PROXYGEN_PARENT_DIR ${PROXYGEN_INSTALL_DIR} DIRECTORY)
+set(PROXYGEN_SOURCE_DIR ${PROXYGEN_PARENT_DIR}/proxygen)
+set(DEPS_DIR ${PROXYGEN_SOURCE_DIR}/_build/deps)
+set(DEPS_INCLUDE_DIR ${DEPS_DIR}/include)
+set(DEPS_LIB_DIR ${DEPS_DIR}/lib)
+set(DEPS_LIB64_DIR ${DEPS_DIR}/lib64)
+
+# Collect all include directories
+set(ALL_INCLUDE_DIRS ${PROXYGEN_INCLUDE_DIR})
+if(EXISTS ${DEPS_INCLUDE_DIR})
+    list(APPEND ALL_INCLUDE_DIRS ${DEPS_INCLUDE_DIR})
+    message(STATUS "Found deps include directory: ${DEPS_INCLUDE_DIR}")
+endif()
+
+# Collect all library directories
+set(ALL_LIB_DIRS ${PROXYGEN_LIB_DIR})
+if(EXISTS ${DEPS_LIB_DIR})
+    list(APPEND ALL_LIB_DIRS ${DEPS_LIB_DIR})
+    message(STATUS "Found deps lib directory: ${DEPS_LIB_DIR}")
+endif()
+if(EXISTS ${DEPS_LIB64_DIR})
+    list(APPEND ALL_LIB_DIRS ${DEPS_LIB64_DIR})
+    message(STATUS "Found deps lib64 directory: ${DEPS_LIB64_DIR}")
+endif()
+
+# Display paths
+message(STATUS "Using Proxygen installation: ${PROXYGEN_INSTALL_DIR}")
+message(STATUS "Include directories: ${ALL_INCLUDE_DIRS}")
+message(STATUS "Library directories: ${ALL_LIB_DIRS}")
+
+# Include directories
+include_directories(
+    ${ALL_INCLUDE_DIRS}
+    ${Python3_INCLUDE_DIRS}
+)
+
+# Link directories
+link_directories(${ALL_LIB_DIRS})
+
+# Boost configuration - force CMake to use our custom-built Boost
+# This prevents linking against system Boost libraries (e.g., /usr/lib64 or /usr/local/lib)
+set(BOOST_ROOT "${DEPS_DIR}")
+set(Boost_NO_SYSTEM_PATHS ON)
+set(Boost_USE_STATIC_LIBS OFF)  # Use shared libs to match Proxygen
+set(Boost_USE_MULTITHREADED ON)
+set(Boost_NO_BOOST_CMAKE ON)
+message(STATUS "Boost configuration:")
+message(STATUS "  BOOST_ROOT=${BOOST_ROOT}")
+message(STATUS "  Boost_NO_SYSTEM_PATHS=ON (ignoring system Boost)")
+message(STATUS "  Looking for Boost in: ${BOOST_ROOT}/lib and ${BOOST_ROOT}/include")
+
+# Find Boost with explicit version check
+find_package(Boost 1.75.0 REQUIRED COMPONENTS context filesystem system)
+if(Boost_FOUND)
+    message(STATUS "Found Boost ${Boost_VERSION} at ${Boost_INCLUDE_DIRS}")
+    message(STATUS "Boost libraries: ${Boost_LIBRARIES}")
+else()
+    message(FATAL_ERROR "Boost 1.75.0 not found in ${BOOST_ROOT}")
+endif()
+
+# Source files
+set(SOURCES
+    PythonRequestHandler.cpp
+    PythonRequestHandlerFactory.cpp
+    proxygen_binding.cpp
+)
+
+# Create Python module
+pybind11_add_module(proxygen_binding ${SOURCES})
+
+# Link libraries
+target_link_libraries(proxygen_binding PRIVATE
+    ${PROXYGEN_LIB_DIR}/libproxygenhttpserver.a
+    ${PROXYGEN_LIB_DIR}/libproxygen.a
+    wangle
+    folly
+    fizz
+    aegis
+    glog
+    gflags
+    fmt
+    boost_filesystem
+    boost_system
+    boost_context
+    double-conversion
+    event
+    ssl
+    snappy
+    crypto
+    z
+    pthread
+    dl
+    iberty
+    lz4
+    bz2
+    sodium
+    zstd
+    mvfst_folly_utils
+    mvfst_codec_types
+    mvfst_contiguous_cursor
+    mvfst_exception
+    lzma
+    cares
+    unwind
+)
+
+# Install the module
+install(TARGETS proxygen_binding DESTINATION .)

--- a/packages/django_workload/srcs/proxygen_binding/PythonRequestHandler.cpp
+++ b/packages/django_workload/srcs/proxygen_binding/PythonRequestHandler.cpp
@@ -1,0 +1,317 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "PythonRequestHandler.h"
+
+#include <folly/io/IOBuf.h>
+#include <glog/logging.h>
+#include <proxygen/httpserver/ResponseBuilder.h>
+#include <proxygen/lib/http/HTTPMessage.h>
+
+// Debug logging macros - only enabled in debug builds
+// Define PROXYGEN_BINDING_DEBUG to enable detailed logging
+#ifdef PROXYGEN_BINDING_DEBUG
+#define DEBUG_LOG(fmt, ...)                                            \
+  do {                                                                 \
+    std::fprintf(stderr, "[PROXYGEN_DEBUG] " fmt "\n", ##__VA_ARGS__); \
+    std::fflush(stderr);                                               \
+  } while (0)
+
+#define DEBUG_TIMER_START() std::chrono::steady_clock::now()
+
+#define DEBUG_TIMER_END(start, operation)                                  \
+  do {                                                                     \
+    auto duration = std::chrono::duration_cast<std::chrono::milliseconds>( \
+                        std::chrono::steady_clock::now() - (start))        \
+                        .count();                                          \
+    std::fprintf(                                                          \
+        stderr, "[PROXYGEN_DEBUG] %s took %ldms\n", operation, duration);  \
+    std::fflush(stderr);                                                   \
+  } while (0)
+#else
+#define DEBUG_LOG(fmt, ...) \
+  do {                      \
+  } while (0)
+#define DEBUG_TIMER_START() std::chrono::steady_clock::time_point()
+#define DEBUG_TIMER_END(start, operation) \
+  do {                                    \
+  } while (0)
+#endif
+
+namespace ProxygenBinding {
+
+// Constructor for synchronous callback (deprecated)
+PythonRequestHandler::PythonRequestHandler(PythonRequestCallback callback)
+    : sync_callback_(std::move(callback)),
+      async_callback_(nullptr),
+      is_async_(false) {}
+
+// Constructor for asynchronous callback (recommended)
+PythonRequestHandler::PythonRequestHandler(
+    PythonAsyncRequestCallback async_callback,
+    bool is_async)
+    : sync_callback_(nullptr),
+      async_callback_(std::move(async_callback)),
+      is_async_(is_async) {}
+
+void PythonRequestHandler::onRequest(
+    std::unique_ptr<proxygen::HTTPMessage> headers) noexcept {
+  request_headers_ = std::move(headers);
+
+  // Capture the Proxygen event base from this thread
+  // This is the event base we'll use to marshal responses back
+  proxygen_event_base_ = folly::EventBaseManager::get()->getEventBase();
+  DEBUG_LOG(
+      "[INIT] Captured event base from Proxygen thread: %p",
+      static_cast<void*>(proxygen_event_base_));
+}
+
+void PythonRequestHandler::onBody(std::unique_ptr<folly::IOBuf> body) noexcept {
+  if (request_body_) {
+    request_body_->prependChain(std::move(body));
+  } else {
+    request_body_ = std::move(body);
+  }
+}
+
+void PythonRequestHandler::onEOM() noexcept {
+  try {
+    if (is_async_) {
+      handleRequestAsync();
+    } else {
+      handleRequestSync();
+    }
+  } catch (const std::exception& e) {
+    LOG(ERROR) << "Exception in PythonRequestHandler: " << e.what();
+    proxygen::ResponseBuilder(downstream_)
+        .status(500, "Internal Server Error")
+        .body(folly::IOBuf::copyBuffer("Internal Server Error\n"))
+        .sendWithEOM();
+  }
+}
+
+void PythonRequestHandler::onUpgrade(
+    proxygen::UpgradeProtocol /*proto*/) noexcept {}
+
+void PythonRequestHandler::requestComplete() noexcept {
+  delete this;
+}
+
+void PythonRequestHandler::onError(proxygen::ProxygenError err) noexcept {
+  LOG(ERROR) << "Proxygen error: " << proxygen::getErrorString(err);
+  delete this;
+}
+
+void PythonRequestHandler::handleRequestSync() {
+  RequestData req = buildRequestData();
+
+  ResponseData response;
+  {
+    py::gil_scoped_acquire acquire;
+    try {
+      response = sync_callback_(req);
+    } catch (const py::error_already_set& e) {
+      LOG(ERROR) << "Python exception in request handler: " << e.what();
+      response.status_code = 500;
+      response.status_message = "Internal Server Error";
+      response.body = "Internal Server Error\n";
+    }
+  }
+
+  sendResponse(response);
+}
+
+void PythonRequestHandler::handleRequestAsync() {
+  RequestData req = buildRequestData();
+
+  // CRITICAL: Keep py::object coro alive until scheduleCoroutine completes
+  // to avoid GIL issues during destruction
+  {
+    py::gil_scoped_acquire acquire;
+    try {
+      // Call async_callback which returns a coroutine
+      py::object coro = async_callback_(req);
+
+      // Schedule the coroutine while still holding GIL
+      // scheduleCoroutine will also acquire GIL (nested is OK)
+      scheduleCoroutine(coro);
+
+      // coro will be destroyed here while GIL is still held
+    } catch (const py::error_already_set& e) {
+      LOG(ERROR) << "Python exception in async callback: " << e.what();
+      ResponseData error_response;
+      error_response.status_code = 500;
+      error_response.status_message = "Internal Server Error";
+      error_response.body = "Internal Server Error\n";
+      sendResponse(error_response);
+      return;
+    }
+  }
+  // GIL is released here, after coro has been safely destroyed
+}
+
+void PythonRequestHandler::scheduleCoroutine(py::object coro) {
+  // Acquire GIL to interact with Python
+  py::gil_scoped_acquire acquire;
+
+  try {
+    // Get the event loop manager module
+    py::object event_loop_manager = py::module::import("event_loop_manager");
+    py::object get_event_loop_manager =
+        event_loop_manager.attr("get_event_loop_manager");
+
+    // Get or create the background event loop for this thread
+    py::object manager = get_event_loop_manager();
+    py::object background_loop = manager.attr("get_or_create_loop")();
+
+    // Create callback that will be called when coroutine completes
+    // This callback will run in the background event loop thread
+    auto* self = this;
+
+    auto done_callback = py::cpp_function([self](py::object future) {
+      // This callback runs in the background Python thread
+      // Extract response while holding GIL, then release before sending
+
+      DEBUG_LOG("[CALLBACK] Done callback starting...");
+      auto callback_start = DEBUG_TIMER_START();
+
+      ResponseData response;
+
+      {
+        // Acquire GIL only for extracting Python objects
+        py::gil_scoped_acquire acquire_inner;
+        DEBUG_LOG("[CALLBACK] GIL acquired");
+
+        try {
+          // Get the result (ResponseData) from the future
+          py::object result = future.attr("result")();
+          response = result.cast<ResponseData>();
+          DEBUG_LOG(
+              "[CALLBACK] Response extracted (status=%d)",
+              response.status_code);
+
+        } catch (const py::error_already_set& e) {
+          DEBUG_LOG("[CALLBACK] Exception in coroutine: %s", e.what());
+          response.status_code = 500;
+          response.status_message = "Internal Server Error";
+          response.body = "Internal Server Error\n";
+        } catch (const std::exception& e) {
+          DEBUG_LOG("[CALLBACK] C++ exception: %s", e.what());
+          response.status_code = 500;
+          response.status_message = "Internal Server Error";
+          response.body = "Internal Server Error\n";
+        }
+
+        // GIL is released at end of this scope
+        DEBUG_LOG("[CALLBACK] Releasing GIL...");
+      }
+
+      // GIL is now released - marshal response back to Proxygen thread
+      DEBUG_LOG("[CALLBACK] Marshaling response back to Proxygen thread...");
+      auto marshal_start = DEBUG_TIMER_START();
+
+      // Get the Proxygen event base
+      auto* event_base = self->proxygen_event_base_;
+
+      if (event_base) {
+        DEBUG_LOG(
+            "[CALLBACK] Event base available (%p), scheduling on Proxygen thread...",
+            static_cast<void*>(event_base));
+
+        // Schedule sendResponse to run on the Proxygen thread
+        // This is THE KEY FIX for the 1-second delay!
+        event_base->runInEventBaseThread([self, response]() {
+          DEBUG_LOG(
+              "[CALLBACK] Now running in Proxygen thread, sending response...");
+          self->sendResponse(response);
+          DEBUG_LOG("[CALLBACK] Response sent from Proxygen thread!");
+        });
+
+        DEBUG_TIMER_END(marshal_start, "[CALLBACK] Response marshaling");
+        DEBUG_TIMER_END(callback_start, "[CALLBACK] Total callback");
+      } else {
+        // Fallback: send directly (will have 1s delay but won't crash)
+        LOG(WARNING)
+            << "[CALLBACK] No event base available, sending directly (will be slow)";
+        self->sendResponse(response);
+      }
+    });
+
+    // Schedule the coroutine on the background event loop (NON-BLOCKING!)
+    // This is the key change - we no longer block here
+    DEBUG_LOG("[SCHEDULE] Scheduling coroutine on background loop...");
+
+    background_loop.attr("schedule_coroutine")(coro, done_callback);
+
+    // We return immediately - the Proxygen thread is NOT blocked!
+    // The coroutine will run concurrently in the background event loop
+    // and the response will be sent when it completes.
+    DEBUG_LOG("[SCHEDULE] Coroutine scheduled, returning to Proxygen thread");
+
+  } catch (const py::error_already_set& e) {
+    LOG(ERROR) << "Failed to schedule coroutine: " << e.what();
+    ResponseData error_response;
+    error_response.status_code = 500;
+    error_response.status_message = "Internal Server Error";
+    error_response.body = "Internal Server Error\n";
+    sendResponse(error_response);
+  }
+}
+
+void PythonRequestHandler::sendResponse(const ResponseData& response) {
+  DEBUG_LOG("[SEND] sendResponse starting (status=%d)", response.status_code);
+  auto start_time = DEBUG_TIMER_START();
+
+  proxygen::ResponseBuilder builder(downstream_);
+  builder.status(response.status_code, response.status_message);
+
+  for (const auto& [key, value] : response.headers) {
+    builder.header(key, value);
+  }
+
+  if (!response.body.empty()) {
+    builder.body(folly::IOBuf::copyBuffer(response.body));
+  }
+
+  DEBUG_LOG("[SEND] Calling sendWithEOM()...");
+  auto send_eom_start = DEBUG_TIMER_START();
+
+  builder.sendWithEOM();
+
+  DEBUG_TIMER_END(send_eom_start, "[SEND] sendWithEOM");
+  DEBUG_TIMER_END(start_time, "[SEND] Total sendResponse");
+}
+
+RequestData PythonRequestHandler::buildRequestData() {
+  RequestData data;
+
+  if (request_headers_) {
+    data.method = request_headers_->getMethodString();
+    data.url = request_headers_->getURL();
+    data.path = request_headers_->getPath();
+    data.query_string = request_headers_->getQueryString();
+
+    auto httpVersion = request_headers_->getVersionString();
+    data.http_version = std::string(httpVersion.data(), httpVersion.size());
+
+    request_headers_->getHeaders().forEach(
+        [&data](const std::string& header, const std::string& value) {
+          data.headers[header] = value;
+        });
+  }
+
+  if (request_body_) {
+    auto bodyRange = request_body_->coalesce();
+    data.body = std::string(
+        reinterpret_cast<const char*>(bodyRange.data()), bodyRange.size());
+  }
+
+  return data;
+}
+
+} // namespace ProxygenBinding

--- a/packages/django_workload/srcs/proxygen_binding/PythonRequestHandler.h
+++ b/packages/django_workload/srcs/proxygen_binding/PythonRequestHandler.h
@@ -1,0 +1,119 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <folly/Memory.h>
+#include <folly/io/async/EventBaseManager.h>
+#include <proxygen/httpserver/RequestHandler.h>
+#include <pybind11/functional.h>
+#include <pybind11/pybind11.h>
+#include <string>
+#include <unordered_map>
+
+namespace py = pybind11;
+
+namespace ProxygenBinding {
+
+/**
+ * Request data structure passed to Python callback
+ */
+struct RequestData {
+  std::string method;
+  std::string url;
+  std::string path;
+  std::string query_string;
+  std::unordered_map<std::string, std::string> headers;
+  std::string body;
+  std::string http_version;
+};
+
+/**
+ * Response data structure returned from Python callback
+ */
+struct ResponseData {
+  int status_code;
+  std::string status_message;
+  std::unordered_map<std::string, std::string> headers;
+  std::string body;
+};
+
+/**
+ * Python callback type for handling HTTP requests synchronously (DEPRECATED)
+ * Takes RequestData and returns ResponseData immediately.
+ *
+ * WARNING: This blocks the Proxygen thread while Python processes the request.
+ * Use PythonAsyncRequestCallback instead for better concurrency.
+ */
+using PythonRequestCallback = std::function<ResponseData(const RequestData&)>;
+
+/**
+ * Python async callback type for handling HTTP requests asynchronously
+ * Takes RequestData and returns a Python coroutine/awaitable.
+ *
+ * The coroutine should resolve to ResponseData when complete.
+ * This is the recommended callback type for Django/ASGI integration as it
+ * doesn't block Proxygen threads while waiting for async operations.
+ */
+using PythonAsyncRequestCallback =
+    std::function<py::object(const RequestData&)>;
+
+/**
+ * RequestHandler implementation that bridges Proxygen to Python
+ *
+ * Supports both synchronous and asynchronous Python callbacks:
+ * - Synchronous: Blocks Proxygen thread until response is ready
+ * - Asynchronous: Schedules coroutine on event loop, returns immediately
+ */
+class PythonRequestHandler : public proxygen::RequestHandler {
+ public:
+  // Constructor for synchronous callback (deprecated)
+  explicit PythonRequestHandler(PythonRequestCallback callback);
+
+  // Constructor for asynchronous callback (recommended)
+  explicit PythonRequestHandler(
+      PythonAsyncRequestCallback async_callback,
+      bool is_async);
+
+  void onRequest(
+      std::unique_ptr<proxygen::HTTPMessage> headers) noexcept override;
+
+  void onBody(std::unique_ptr<folly::IOBuf> body) noexcept override;
+
+  void onEOM() noexcept override;
+
+  void onUpgrade(proxygen::UpgradeProtocol proto) noexcept override;
+
+  void requestComplete() noexcept override;
+
+  void onError(proxygen::ProxygenError err) noexcept override;
+
+ private:
+  // Request handling
+  void handleRequestSync();
+  void handleRequestAsync();
+  RequestData buildRequestData();
+  void scheduleCoroutine(py::object coro);
+
+  // Response sending
+  void sendResponse(const ResponseData& response);
+
+  // Callback storage - only one is set
+  PythonRequestCallback sync_callback_;
+  PythonAsyncRequestCallback async_callback_;
+  bool is_async_;
+
+  // Request data
+  std::unique_ptr<proxygen::HTTPMessage> request_headers_;
+  std::unique_ptr<folly::IOBuf> request_body_;
+
+  // Proxygen event base for thread-safe response sending
+  folly::EventBase* proxygen_event_base_{nullptr};
+};
+
+} // namespace ProxygenBinding

--- a/packages/django_workload/srcs/proxygen_binding/PythonRequestHandlerFactory.cpp
+++ b/packages/django_workload/srcs/proxygen_binding/PythonRequestHandlerFactory.cpp
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "PythonRequestHandlerFactory.h"
+#include <glog/logging.h>
+
+namespace ProxygenBinding {
+
+// Constructor for synchronous callback (deprecated)
+PythonRequestHandlerFactory::PythonRequestHandlerFactory(
+    PythonRequestCallback callback)
+    : sync_callback_(std::move(callback)),
+      async_callback_(nullptr),
+      is_async_(false) {}
+
+// Constructor for asynchronous callback (recommended)
+PythonRequestHandlerFactory::PythonRequestHandlerFactory(
+    PythonAsyncRequestCallback async_callback,
+    bool is_async)
+    : sync_callback_(nullptr),
+      async_callback_(std::move(async_callback)),
+      is_async_(is_async) {}
+
+void PythonRequestHandlerFactory::onServerStart(
+    folly::EventBase* /*evb*/) noexcept {
+  if (is_async_) {
+    LOG(INFO) << "PythonRequestHandlerFactory: Server started (async mode)";
+  } else {
+    LOG(INFO) << "PythonRequestHandlerFactory: Server started (sync mode)";
+  }
+}
+
+void PythonRequestHandlerFactory::onServerStop() noexcept {
+  LOG(INFO) << "PythonRequestHandlerFactory: Server stopped";
+}
+
+proxygen::RequestHandler* PythonRequestHandlerFactory::onRequest(
+    proxygen::RequestHandler* /*handler*/,
+    proxygen::HTTPMessage* /*msg*/) noexcept {
+  if (is_async_) {
+    // Create handler with async callback
+    return new PythonRequestHandler(async_callback_, true);
+  } else {
+    // Create handler with sync callback
+    return new PythonRequestHandler(sync_callback_);
+  }
+}
+
+} // namespace ProxygenBinding

--- a/packages/django_workload/srcs/proxygen_binding/PythonRequestHandlerFactory.h
+++ b/packages/django_workload/srcs/proxygen_binding/PythonRequestHandlerFactory.h
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <folly/Memory.h>
+#include <proxygen/httpserver/RequestHandlerFactory.h>
+#include "PythonRequestHandler.h"
+
+namespace ProxygenBinding {
+
+/**
+ * Factory for creating PythonRequestHandler instances
+ *
+ * Supports both synchronous and asynchronous callback modes.
+ */
+class PythonRequestHandlerFactory : public proxygen::RequestHandlerFactory {
+ public:
+  // Constructor for synchronous callback (deprecated)
+  explicit PythonRequestHandlerFactory(PythonRequestCallback callback);
+
+  // Constructor for asynchronous callback (recommended)
+  explicit PythonRequestHandlerFactory(
+      PythonAsyncRequestCallback async_callback,
+      bool is_async);
+
+  void onServerStart(folly::EventBase* evb) noexcept override;
+
+  void onServerStop() noexcept override;
+
+  proxygen::RequestHandler* onRequest(
+      proxygen::RequestHandler* handler,
+      proxygen::HTTPMessage* message) noexcept override;
+
+ private:
+  PythonRequestCallback sync_callback_;
+  PythonAsyncRequestCallback async_callback_;
+  bool is_async_;
+};
+
+} // namespace ProxygenBinding

--- a/packages/django_workload/srcs/proxygen_binding/README.md
+++ b/packages/django_workload/srcs/proxygen_binding/README.md
@@ -1,0 +1,1207 @@
+# DjangoBench V2: Asynchronous Server Stack \- Complete Guide
+
+**An asynchronous Django server architecture using Proxygen \+ uWSGI \+ HAProxy to best match the IG Django in production**
+
+## Table of Contents
+
+- [DjangoBench V2: Asynchronous Server Stack - Complete Guide](#djangobench-v2-asynchronous-server-stack---complete-guide)
+  - [Table of Contents](#table-of-contents)
+  - [Motivation and Background](#motivation-and-background)
+    - [Why We Developed This Stack](#why-we-developed-this-stack)
+    - [Solution: Proxygen-based Async Stack](#solution-proxygen-based-async-stack)
+  - [How to Build, Test and Run](#how-to-build-test-and-run)
+    - [Install DjangoBench](#install-djangobench)
+    - [System Requirements](#system-requirements)
+    - [2.2 Run DjangoBench](#22-run-djangobench)
+      - [Start Cassandra DB](#start-cassandra-db)
+      - [Start benchmarking](#start-benchmarking)
+      - [Using standalone configuration](#using-standalone-configuration)
+      - [Parameters](#parameters)
+  - [Evaluation](#evaluation)
+    - [Scalability](#scalability)
+    - [Microarch behavior](#microarch-behavior)
+  - [Architecture and Design Deep Dive](#architecture-and-design-deep-dive)
+    - [System Architecture](#system-architecture)
+    - [Component Details](#component-details)
+      - [Proxygen C++ HTTP Server](#proxygen-c-http-server)
+      - [Python Binding (proxygen\_binding)](#python-binding-proxygen_binding)
+      - [Django ASGI Adapter](#django-asgi-adapter)
+      - [uWSGI Process Manager](#uwsgi-process-manager)
+      - [HAProxy Load Balancer](#haproxy-load-balancer)
+    - [Request Flow](#request-flow)
+    - [Port Allocation Strategy](#port-allocation-strategy)
+      - [High Tail Latency (P95, P99)](#high-tail-latency-p95-p99)
+    - [uWSGI Integration Issues](#uwsgi-integration-issues)
+      - [uWSGI Workers Not Spawning](#uwsgi-workers-not-spawning)
+      - [Socket Error on uWSGI Startup](#socket-error-on-uwsgi-startup)
+      - [Environment Variable Override](#environment-variable-override)
+    - [HAProxy Buffer Overflow](#haproxy-buffer-overflow)
+    - [Key Lessons Learned](#key-lessons-learned)
+  - [Usage and Customization](#usage-and-customization)
+    - [For DjangoBench Users (Benchpress)](#for-djangobench-users-benchpress)
+      - [Quick Start](#quick-start)
+      - [Available Jobs](#available-jobs)
+    - [For Standalone Usage (Outside Benchpress)](#for-standalone-usage-outside-benchpress)
+      - [Setup](#setup)
+      - [Running the Server](#running-the-server)
+      - [Test the Setup](#test-the-setup)
+    - [Customization and Tuning](#customization-and-tuning)
+      - [Worker Configuration](#worker-configuration)
+      - [Port Configuration](#port-configuration)
+      - [uWSGI Configuration](#uwsgi-configuration)
+      - [HAProxy Configuration](#haproxy-configuration)
+  - [References and Further Reading](#references-and-further-reading)
+  - [Conclusion](#conclusion)
+  - [Troubleshooting Executions](#troubleshooting-executions)
+    - [Test with Simple Examples](#test-with-simple-examples)
+      - [Basic Echo Server](#basic-echo-server)
+      - [10.1.2 Django Integration Test](#1012-django-integration-test)
+    - [Run Full Load-Balanced Server](#run-full-load-balanced-server)
+      - [Direct Worker Mode (No uWSGI)](#direct-worker-mode-no-uwsgi)
+      - [uWSGI Mode (Production)](#uwsgi-mode-production)
+    - [Monitor and Test](#monitor-and-test)
+
+
+## Motivation and Background
+
+### Why We Developed This Stack
+
+DjangoBench is Meta's web application benchmark that simulates Instagram-like
+workloads. The original implementation used **synchronous uWSGI workers**, which
+don't accurately represent Instagram's production architecture.
+
+**Problem with Traditional uWSGI:**
+
+- Synchronous blocking I/O, one request per worker at a time: poor scaling and
+  low CPU utilization on CPUs with high core counts
+- Not representative of Instagram's architecture: IG Django in production uses the asynchronous model
+
+**Instagram's Production Architecture:** Instagram uses **asynchronous HTTP servers** in production to handle high concurrency:
+
+- Achieving high throughput under concurrent load with async I/O and multi-threaded request processing
+- IG Django's uses Proxygen as the webserver and integrates to the backend webapp with PyProxygen (Python binding).
+  WSGI is still present but only in charge of worker process forking, reloading and memory leak cleanup (and doesn't actually serve traffic).
+
+### Solution: Proxygen-based Async Stack
+
+We developed a fully asynchronous server stack that mirrors Instagram's production architecture:
+
+```
+┌──────────────────────────────────────────────────────────────┐
+│                    Production Architecture                   │
+│          (Instagram Django + Proxygen + Pickwick)            │
+└──────────────────────────────────────────────────────────────┘
+                            │
+                            │ Mirrored in DjangoBench V2
+                            ▼
+┌────────────────────────────────────────────────────────────────────────────────────────┐
+│  Client Requests → HAProxy (Load Balancer) → uWSGI Workers 1   ...    uWSGI Worker N   │
+│                                                    ↓                          ↓        │
+│                                            Proxygen (Async HTTP)    Proxygen (Async)   │
+│                                                    ↓                          ↓        │
+│                                            Django ASGI App          Django ASGI App    │
+└────────────────────────────────────────────────────────────────────────────────────────┘
+```
+
+**Key Components:**
+
+- **Proxygen**: Meta's C++ async HTTP server (used at Instagram)
+- **uWSGI**: Process management, memory cleanup, monitoring
+- **HAProxy**: Load balancing with health checks
+- **Django ASGI**: Async application layer
+
+**Benefits:**
+
+- ✅ **Realistic benchmark**: Software stack matches Instagram's production architecture
+- ✅ **Better CPU utilization**: Async HTTP requests handling and balanced load across all workers
+- ✅ **Higher Scalability**: Relative speedup more linear as core count
+
+---
+
+## How to Build, Test and Run
+
+### Install DjangoBench
+
+The command for building and installing DjangoBench remains the same:
+
+```shell
+./benchpress_cli.py install django_workload_default
+```
+
+### System Requirements
+
+* If using the distributed setup, We recommend placing the DB server machine and
+  the benchmarking machine within the same network and maintain the ping latency
+  between them to be in the range of 0.1 and 0.15ms.
+* **Port availability**: the following ports need to be available on the machines:
+  * Cassandra DB node: port 9042
+  * Clientserver node:
+    * Main HTTP server port: 8000
+    * Load balancer stats port: 8001
+    * Memcached port: 11811
+    * Server worker ports: The range of \[16667, 16667 \+ `server_workers`)
+      (`server_workers` is equal to the number of CPU logical cores).
+    * Load balancer stats port and server worker starting port are adjustable,
+      but the continuous range of server worker ports must be available.
+
+### 2.2 Run DjangoBench
+
+The way of running DjangoBench also remains the same: ideally we recommend
+having one separate server for the Cassandra DB and another for the client and
+server where the benchmark is executed and measured. There is an option for
+running everything on a single machine if you are unable to run distributed
+setup.
+
+#### Start Cassandra DB
+
+On the Cassandra DB server machine:
+
+```
+./benchpress_cli.py run django_workload_default -r db
+```
+
+This should run indefinitely. You will see a lot of java processes running, and
+you can check if Cassandra has started up successfully by running
+`lsof -i -P -n | grep 9042`. Cassandra will also output log at benchmarks/django\_workload/cassandra.log.
+
+If you would like Cassandra DB to bind a custom address, please use the following command:
+
+```
+./benchpress_cli.py run django_workload_default -r db -i '{"bind_ip": "<ip_addr>"}'
+```
+
+This is useful when the output of `hostname -i` does not return a reachable IP
+address or is not the address you would like to use. Please see more details in
+[Troubleshooting](https://github.com/facebookresearch/DCPerf/tree/main/packages/django_workload#troubleshooting).
+
+#### Start benchmarking
+
+On the django benchmarking machine (where the django server and client are run):
+
+```
+./benchpress_cli.py run django_workload_default -r clientserver -i '{"db_addr": "<db-server-ip>"}'
+```
+
+Note that `<db-server-ip>` has to be an IP address, hostname will not work.
+
+If running on ARM platform, please use the job `django_workload_arm`:
+
+```
+./benchpress_cli.py run django_workload_arm -r clientserver -i '{"db_addr": "<db-server-ip>"}'
+```
+
+#### Using standalone configuration
+
+To run the server, client and database on the same benchmarking machine:
+
+```
+./benchpress_cli.py run django_workload_default -r standalone
+```
+
+If running on ARM platform, please use the job django\_workload\_arm:
+
+```
+./benchpress_cli.py run django_workload_arm -r standalone
+```
+
+#### Parameters
+
+We provide the following parameters you can customize for DjangoBench workload:
+
+For `django_workload_default` and `django_workload_arm` jobs:
+
+* Role `clientserver`:
+  * `db_addr` \- **required**, IP address of the Cassandra server
+  * `duration` \- Duration of each iteration of test, default `5M` (5 minutes)
+  * `iterations` \- Number of iterations to run, default 7
+  * `reps`: Number of requests (per client worker) that the load generator will send in each iteration.
+    This will override `duration` and is useful to workaround the hanging problem of Siege (the load generator).
+    Note the total number of requests that Siege will send will be `reps * client_workers`, where
+    `client_workers = 1.2 * NPROC`.
+  * `interpreter` \- Which python interpreter to use: choose between `cpython` or `cinder`.
+    Defaults to `cpython`.
+  * `use_async` \- If this is set to 1, DjangoBench will use this new asynchronous server stack;
+    set to 0 means using the traditional stack. Defaults to 1.
+  * `base_port` \- Starting port that the HTTP server workers will listen to.
+    The range of `[base_port, base_port + nproc)` must be available.
+  * `stats_port` \- Load balancer stats port, defaults 8001
+* Role `standalone`:
+  * Same as role `clientserver` except not having `db_addr`
+
+For `django_workload_custom`:
+
+* Role `clientserver`, there are these extra parameters:
+  * `server_workers` \- number of server workers, required.
+  * `client_workers` \- number of client workers, required
+  * `ib_min` \- ICacheBuster minimum iterations in each request (default 100000\)
+  * `ib_max` \- ICacheBuster maximum iterations in each request (default 200000\)
+
+---
+
+## Evaluation
+
+### Scalability
+
+DjangoBench showed much better scalability and CPU utilization on CPUs with high
+core counts after adopting Proxygen and the asynchronous server model.
+
+In DjangoBench v1, CPU utilization declined significantly (to less than 80\%)
+when run on CPUs of more than 300 logical cores. After adopting the asynchronous
+server model, the CPU utilization and scalability improved significantly on
+those CPUs with ultra high core counts.  While the absolute RPS numbers
+decreased because each request involved more work (measured by MIPS/QPS), the
+relative perf correlation was much better especially on the CPU with 384 logical
+cores in our datacenter. This shows the advantage of adopting the asynchronous
+server model, where each web server worker can handle multiple requests
+concurrently and therefore there'll be less stranded CPU cycles.
+
+### Microarch behavior
+
+This work of Proxygen integration and asynchronous server model adoption
+increased L1-ICache MPKI by 6\~8 on AMD Zen4. After using Cinder with JIT, the
+L1-MPKI increased further, very close to the original version even without
+ICacheBuster.
+
+## Architecture and Design Deep Dive
+
+### System Architecture
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│                      Client Applications                    │
+│             (Siege, curl, benchmark clients)                │
+└──────────────────┬──────────────────────────────────────────┘
+                   │ HTTP Requests
+                   ▼
+┌──────────────────────────────────────────────────────────────┐
+│                   HAProxy Load Balancer                      │
+│  - Port: 8000 (frontend)                                     │
+│  - Algorithm: leastconn (least connections)                  │
+│  - Health checks: GET / every 2s                             │
+│  - Stats dashboard: http://127.0.0.1:9000/stats              │
+└─────────────┬────────────────┬────────────────┬──────────────┘
+              │                │                │
+              ▼                ▼                ▼
+┌─────────────────────┐  ┌─────────────────────┐  ┌────────────
+│   uWSGI Worker 1    │  │   uWSGI Worker 2    │  │  Worker N
+│   PID: 12346        │  │   PID: 12347        │  │  PID: ...
+│ ┌─────────────────┐ │  │ ┌─────────────────┐ │  │ ┌─────────
+│ │ Proxygen Server │ │  │ │ Proxygen Server │ │  │ │ Proxygen
+│ │  0.0.0.0:8001   │ │  │ │  0.0.0.0:8002   │ │  │ │  0.0.0.0
+│ │                 │ │  │ │                 │ │  │ │
+│ │  14 Threads     │ │  │ │  14 Threads     │ │  │ │  14 Thre
+│ │  ┌───┐ ┌───┐    │ │  │ │  ┌───┐ ┌───┐    │ │  │ │  ┌───┐
+│ │  │ T │ │ T │    │ │  │ │  │ T │ │ T │    │ │  │ │  │ T │
+│ │  │ 1 │ │ 2 │... │ │  │ │  │ 1 │ │ 2 │... │ │  │ │  │ 1 │
+│ │  └─┬─┘ └─┬─┘    │ │  │ │  └─┬─┘ └─┬─┘    │ │  │ │  └─┬─┘
+│ └────┼─────┼──────┘ │  │ └────┼─────┼──────┘ │  │ └────┼────
+│      │     │        │  │      │     │        │  │      │
+│      ▼     ▼        │  │      ▼     ▼        │  │      ▼
+│ ┌─────────────────┐ │  │ ┌─────────────────┐ │  │ ┌─────────
+│ │ ASGI Adapter    │ │  │ │ ASGI Adapter    │ │  │ │ ASGI Ada
+│ │ (asyncio loop)  │ │  │ │ (asyncio loop)  │ │  │ │ (asyncio
+│ └────────┬────────┘ │  │ └────────┬────────┘ │  │ └────┬────
+│          │          │  │          │          │  │       │
+│          ▼          │  │          ▼          │  │       ▼
+│ ┌─────────────────┐ │  │ ┌─────────────────┐ │  │ ┌─────────
+│ │  Django ASGI    │ │  │ │  Django ASGI    │ │  │ │  Django
+│ │  Application    │ │  │ │  Application    │ │  │ │  Applica
+│ │                 │ │  │ │                 │ │  │ │
+│ │  - Views        │ │  │ │  - Views        │ │  │ │  - Views
+│ │  - Models       │ │  │ │  - Models       │ │  │ │  - Model
+│ │  - Middleware   │ │  │ │  - Middleware   │ │  │ │  - Middl
+│ └────────┬────────┘ │  │ └────────┬────────┘ │  │ └────┬────
+│          │          │  │          │          │  │       │
+│          ▼          │  │          ▼          │  │       ▼
+└──┬────────────────┬─┘  └──┬────────────────┬─┘  └──┬─────────
+   │                │       │                │       │
+   ▼                ▼       ▼                ▼       ▼
+┌────────────────────────┐  ┌────────────────────────────────┐
+│       Cassandra        │  │            Memcached           │
+│        Database        │  │             (Cache)            │
+└────────────────────────┘  └────────────────────────────────┘
+```
+
+### Component Details
+
+#### Proxygen C++ HTTP Server
+
+**What is Proxygen?**
+
+- Meta's open-source C++ HTTP library
+- Used in production at Instagram, Facebook, WhatsApp
+- Async I/O with multi-threading
+- High performance, low latency
+
+**Key Features:**
+
+- **Event-driven architecture**: Non-blocking I/O
+- **Thread pool**: N threads handle concurrent requests
+- **HTTP/1.1 and HTTP/2** support
+- **Connection pooling**: Keep-alive connections
+- **Memory efficient**: Zero-copy where possible
+
+**In DjangoBench:**
+
+- Each uWSGI worker runs one Proxygen server
+- Proxygen binds to unique port (8001, 8002, ...)
+- Each Proxygen server has multiple threads (configurable)
+- Threads handle HTTP requests asynchronously
+
+#### Python Binding (proxygen\_binding)
+
+**Purpose:** Bridge C++ Proxygen to Python Django application
+
+**Files:**
+
+- `PythonRequestHandler.cpp/h`: C++ request handler
+- `proxygen_binding.cpp`: pybind11 binding code
+- `django_asgi_adapter.py`: ASGI protocol adapter
+- `example_server.py`: Basic usage example
+- `django_server.py`: Django integration example
+- `event_loop_manager.py`: Event loop management
+
+**How It Works:**
+
+```py
+# C++ creates RequestData from HTTP request
+RequestData {
+    method: "GET",
+    url: "http://localhost:8000/timeline",
+    path: "/timeline",
+    query_string: "",
+    headers: {"Host": "localhost:8000", ...},
+    body: "",
+    http_version: "HTTP/1.1"
+}
+
+# Python callback receives RequestData
+def handler(request: RequestData) -> ResponseData:
+    # Convert to ASGI scope
+    scope = {
+        'type': 'http',
+        'method': request.method,
+        'path': request.path,
+        'headers': request.headers,
+        ...
+    }
+
+    # Call Django ASGI app
+    response = await asgi_app(scope, receive, send)
+
+    # Return ResponseData
+    return ResponseData(
+        status_code=200,
+        status_message="OK",
+        headers={"Content-Type": "text/html"},
+        body="<html>...</html>"
+    )
+```
+
+**Thread Safety:**
+
+- GIL (Global Interpreter Lock) properly managed
+- GIL released during C++ operations
+- GIL acquired for Python callbacks
+- Each thread has isolated asyncio event loop
+
+#### Django ASGI Adapter
+
+**File:** `django_asgi_adapter.py`
+
+**Purpose:** Convert between Proxygen's request format and Django's ASGI protocol
+
+**ASGI Protocol Overview:**
+
+ASGI (Asynchronous Server Gateway Interface) is Django's async protocol:
+
+```py
+async def application(scope, receive, send):
+    """
+    scope: dict with request metadata
+    receive: async callable to get request body
+    send: async callable to send response
+    """
+    # Django processes request
+    # Calls send() to return response
+```
+
+**Our Adapter:**
+
+```py
+class ASGIRequestHandler:
+    def __init__(self, asgi_app):
+        self.asgi_app = asgi_app  # Django's get_asgi_application()
+
+    def __call__(self, request: RequestData) -> ResponseData:
+        # 1. Convert RequestData → ASGI scope
+        scope = self._build_scope(request)
+
+        # 2. Create receive/send callables
+        async def receive():
+            return {'type': 'http.request', 'body': request.body}
+
+        responses = []
+        async def send(message):
+            responses.append(message)
+
+        # 3. Call Django ASGI app
+        loop = asyncio.new_event_loop()
+        loop.run_until_complete(self.asgi_app(scope, receive, send))
+
+        # 4. Collect response and convert to ResponseData
+        return self._build_response(responses)
+```
+
+**Event Loop Management:**
+
+Each Proxygen thread gets its own asyncio event loop:
+
+```py
+# In event_loop_manager.py
+_thread_local = threading.local()
+
+def get_event_loop():
+    if not hasattr(_thread_local, 'loop'):
+        _thread_local.loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(_thread_local.loop)
+    return _thread_local.loop
+```
+
+**Why Separate Event Loops?**
+
+- asyncio is NOT thread-safe
+- Each thread needs isolated event loop
+- Prevents race conditions
+- Better performance (no locks)
+
+#### uWSGI Process Manager
+
+**Role:** Process management only (not HTTP serving)
+
+**Responsibilities:**
+
+- Fork N worker processes
+- Monitor worker health
+- Restart dead workers
+- Memory leak detection (reload-on-rss)
+- Timeout enforcement (harakiri)
+- Graceful reload (SIGHUP)
+
+**Configuration:** `uwsgi_loadbalanced.ini`
+
+```
+[uwsgi]
+master = true
+processes = %(workers)  # Overridden by --set workers=N
+lazy-apps = true        # Load app after fork
+
+# Memory management
+reload-on-rss = 2048    # Reload at 2GB RAM
+harakiri = 60           # Kill after 60s timeout
+
+# NO HTTP BINDING - Proxygen handles HTTP
+socket = /tmp/uwsgi-loadbalanced.sock
+```
+
+**Worker Lifecycle:**
+
+```py
+# In proxygen_wsgi.py
+
+# 1. uWSGI imports module
+import proxygen_wsgi
+
+# 2. uWSGI forks worker
+# postfork hook triggered
+
+# 3. Start Proxygen in worker
+@postfork
+def start_proxygen_server():
+    # Calculate port from worker ID
+    worker_id = uwsgi.worker_id()  # 1, 2, 3, ...
+    port = base_port + worker_id - 1  # 8001, 8002, 8003, ...
+
+    # Create Django handler
+    handler = create_django_handler()
+
+    # Start Proxygen server
+    server = ProxygenServer(
+        ip="0.0.0.0",
+        port=port,
+        threads=14,
+        callback=handler
+    )
+    server.start()
+
+# 4. Register cleanup
+@atexit.register
+def cleanup():
+    server.stop()
+```
+
+#### HAProxy Load Balancer
+
+**Role:** Distribute traffic across workers
+
+**Algorithm:** `leastconn` (least connections)
+
+- Routes requests to worker with fewest active connections
+- Optimal for async servers (workers have varying loads)
+- Better than round-robin for uneven request costs
+
+**Configuration:** Auto-generated by `start_loadbalanced_server.py`
+
+```
+frontend django_frontend
+    bind *:8000
+    maxconn 50000
+    default_backend django_workers
+
+backend django_workers
+    balance leastconn
+
+    # Health checks
+    option httpchk GET /
+    http-check expect status 200
+
+    # Workers
+    server worker1 127.0.0.1:8001 check weight 1 maxconn 10000
+    server worker2 127.0.0.1:8002 check weight 1 maxconn 10000
+    ...
+
+listen stats
+    bind *:9000
+    stats enable
+    stats uri /stats
+```
+
+**Health Checks:**
+
+- HAProxy pings each worker every 2 seconds
+- Expects HTTP 200 response
+- Marks worker DOWN after 3 failures
+- Auto-routes traffic to healthy workers
+
+### Request Flow
+
+**Complete Request Journey:**
+
+```
+1. Client sends HTTP request
+   ↓
+2. HAProxy receives on port 8000
+   - Checks worker health status
+   - Selects worker with least connections (leastconn)
+   ↓
+3. HAProxy forwards to Worker 2 (port 8002)
+   ↓
+4. Proxygen receives in Worker 2
+   - One of 14 threads picks up request
+   - Parses HTTP headers and body
+   ↓
+5. Proxygen creates PythonRequestHandler (C++)
+   - Collects request data into RequestData struct
+   ↓
+6. pybind11 bridge: C++ → Python
+   - GIL acquired
+   - RequestData marshaled to Python
+   - Python callback invoked
+   ↓
+7. Django ASGI Adapter processes
+   - Converts RequestData → ASGI scope dict
+   - Creates receive() and send() callables
+   - Gets asyncio event loop for this thread
+   ↓
+8. Django ASGI application executes
+   - URL routing: /timeline → views.timeline_view()
+   - Middleware stack processes request
+   - View function executes
+   - Database query: SELECT * FROM feed_entry_model
+   - Cache query: Memcached GET user:123:feed
+   - Template rendering
+   ↓
+9. Django returns via ASGI send()
+   - send({'type': 'http.response.start', ...})
+   - send({'type': 'http.response.body', 'body': ...})
+   ↓
+10. ASGI Adapter collects response
+    - Assembles ResponseData from send() calls
+    ↓
+11. pybind11 bridge: Python → C++
+    - ResponseData marshaled back to C++
+    - GIL released
+    ↓
+12. Proxygen sends HTTP response
+    - Headers sent
+    - Body sent (chunked or content-length)
+    - Connection closed or kept alive
+    ↓
+13. HAProxy forwards response to client
+    ↓
+14. Client receives response
+```
+
+**Timing Example:**
+
+```
+Request to /timeline endpoint:
+- HAProxy routing: 0.1ms
+- Proxygen parsing: 0.2ms
+- Python marshaling: 0.1ms
+- Django routing: 0.3ms
+- Database query: 5ms
+- Cache query: 1ms
+- Template render: 3ms
+- Response marshaling: 0.1ms
+- Proxygen send: 0.2ms
+Total: ~10ms
+```
+
+### Port Allocation Strategy
+
+**Problem:** Multiple workers need unique ports
+
+**Solution:** Initially we enabled the socket option `SO_REUSEPORT` to allow
+  reusing a single port by multiple server workers, but it will have the problem
+  of different workers having very varied loads. Therefore, we used HAProxy load
+  balancer to address this issue.:
+
+```shell
+# Install HAProxy
+sudo dnf install -y haproxy
+
+# Create HAProxy config
+python start_loadbalanced_server.py --workers 8
+```
+
+**Results:**
+
+```
+Worker 1: 75% CPU (balanced)
+Worker 2: 76% CPU (balanced)
+...
+Worker 7: 74% CPU (balanced)
+Worker 8: 75% CPU (balanced)
+
+Variance: < 2% (improved from 20%)
+```
+
+#### High Tail Latency (P95, P99)
+
+**Symptom:**
+
+```
+P50: 0.03s  (acceptable)
+P95: 0.14s  (4.6x worse than uWSGI)
+P99: 0.21s  (3.5x worse than uWSGI)
+```
+
+**Root Cause:**
+
+- Hot workers have request queue buildup
+- Cold workers sit idle
+- No distribution of work
+
+**Solution:** After adding HAProxy with leastconn algorithm:
+
+```
+P50: 0.02s  (baseline)
+P95: 0.03s  (4.6x improvement!)
+P99: 0.06s  (3.5x improvement!)
+```
+
+### uWSGI Integration Issues
+
+#### uWSGI Workers Not Spawning
+
+**Symptom:**
+
+```
+[uWSGI] *** Operational MODE: no-workers ***
+```
+
+**Root Cause:**
+
+- Used `workers = N` instead of `processes = N`
+- uWSGI configuration error
+
+**Solution:**
+
+```
+# Wrong
+workers = 8
+
+# Correct
+processes = 8
+```
+
+#### Socket Error on uWSGI Startup
+
+**Symptom:**
+
+```
+The -s/--socket option is missing and stdin is not a socket
+```
+
+**Root Cause:**
+
+- uWSGI requires socket configuration to start
+- Even if not used for HTTP
+
+**Solution:** Added socket to `uwsgi_loadbalanced.ini`:
+
+```
+socket = /tmp/uwsgi-loadbalanced.sock
+chmod-socket = 666
+```
+
+#### Environment Variable Override
+
+**Symptom:**
+
+```
+Workers binding to wrong ports
+All workers try to bind to port 8001
+```
+
+**Root Cause:**
+
+- `env =`  directives in uWSGI config override Python script's environment
+- Port calculation broken
+
+**Solution:** Removed `env =` directives from config, let Python script set environment:
+
+```
+# Don't do this - it overrides Python script's environment
+# env = PROXYGEN_BASE_PORT=8001
+# env = PROXYGEN_THREADS=14
+
+# Let Python script set environment variables
+```
+
+### HAProxy Buffer Overflow
+
+**Symptom:**
+
+```
+[HAProxy] logs stop appearing
+Script appears to hang
+```
+
+**Root Cause:**
+
+- Python's `subprocess.Popen()` has limited buffer
+- HAProxy produces lots of output
+- Buffer fills up, HAProxy blocks
+
+**Solution:** Real-time log streaming with threads:
+
+```py
+def _stream_logs(self, process, prefix, log_file=None):
+    """Stream logs in real-time to prevent buffer overflow"""
+    for line in iter(process.stdout.readline, ""):
+        if self.stop_logging.is_set():
+            break
+        if line:
+            print(f"{prefix} {line.rstrip()}", flush=True)
+            if log_file:
+                log_file.write(f"{prefix} {line}")
+                log_file.flush()
+```
+
+### Key Lessons Learned
+
+1. **Event loops are per-thread**: Never share asyncio event loops between threads
+2. **GIL management is critical**: Always acquire GIL for Python, release for C++
+3. **Thread pools matter**: Default 8 threads not enough for async DB queries
+4. **Load balancing is essential**: Raw workers don't distribute load evenly
+5. **Buffer management**: Always stream subprocess output in real-time
+6. **Port conflicts**: Check port availability before starting servers
+7. **Environment variables**: Be careful with uWSGI `env =` directives
+
+---
+
+## Usage and Customization
+
+### For DjangoBench Users (Benchpress)
+
+**NOTE**: for regular DjangoBench usage, we've provided instructions in the
+[How to Build, Test and Run](#how-to-build-test-and-run) section and also in the
+benchmark's main [README](../../README.md).
+
+#### Quick Start
+
+**Run with async mode (default):**
+
+```shell
+cd <DCPerf-folder>
+
+# Run default job with async stack
+./benchpress_cli.py run django_workload_default
+
+# This automatically uses:
+# - uWSGI process management
+# - Proxygen async HTTP
+# - HAProxy load balancing
+# - $(nproc) workers
+```
+
+**Customize workers:**
+
+```shell
+# Override number of workers
+./benchpress_cli.py run django_workload_custom -r clientserver -i '{"server_workers": 16, "client_workers": 32}'
+
+# Disable async mode (fall back to traditional uWSGI)
+./benchpress_cli.py run django_workload_default -r clientserver -i '{"use_async": 0}'
+```
+
+#### Available Jobs
+
+| Job Name | Description | Use Case |
+| :---- | :---- | :---- |
+| `django_workload_default` | Standard run (5M duration) | Full benchmark |
+| `django_workload_arm` | ARM-optimized params | ARM testing |
+| `django_workload_mini` | Quick test (1000 reps) | Emulation support |
+| `django_workload_custom` | More customizable params | Tuning experiments |
+
+**All jobs default to async mode (`use_async=1`)**
+
+### For Standalone Usage (Outside Benchpress)
+
+**NOTE**: This section is not necessary for running DjangoBench. Instead, it is more
+of a "development guide" for people who would like to tweak, customize and debug
+DjangoBench. Also see [Troubleshooting Executions](#troubleshooting-executions) besides
+the instructions in this section if something is broken and you would like to debug.
+
+#### Setup
+
+**Prepare Environment:**
+
+```shell
+# Under the DCPerf repo folder
+
+# Activate virtual envrionment
+source benchmarks/django_workload/django-workload/django-workload/venv_cpython/bin/activate
+
+# Add library paths
+export LD_LIBRARY_PATH="$(pwd)/benchmarks/django_workload/django-workload/django-workload/Python-3.10.2:$(pwd)/benchmarks/django_workload/django-workload/django-workload"
+
+# Set Django settings
+export DJANGO_SETTINGS_MODULE=cluster_settings
+```
+
+**Start Cassandra and Memcached:**
+
+```shell
+# Start Cassandra
+./benchmarks/django_workload/bin/run.sh -r db -b 127.0.0.1 &
+
+# Start Memcached
+./services/memcached/run-memcached &
+
+# Populate database
+cd benchmarks/django_workload/django-workload/django-workload
+DJANGO_SETTINGS_MODULE=cluster_settings django-admin flush
+DJANGO_SETTINGS_MODULE=cluster_settings django-admin setup
+```
+
+#### Running the Server
+
+**Option 1: Direct Workers (Python-managed):**
+
+```shell
+# Assuming you are under the root of DCPerf repo folder
+
+cd benchmarks/django_workload/django-workload/django-workload
+python start_loadbalanced_server.py \
+    --workers 8 \
+    --base-port 8001 \
+    --lb-port 8000 \
+    --stats-port 9000 \
+    --threads-per-worker 14 \
+    --log-dir logs
+```
+
+**Option 2: uWSGI-managed Workers:**
+
+```shell
+cd benchmarks/django_workload/django-workload/django-workload
+DJANGO_SETTINGS_MODULE=cluster_settings \
+python start_loadbalanced_server.py \
+    --use-uwsgi \
+    --workers $(nproc) \
+    --stats-port 9000 \
+    --log-dir uwsgi_logs
+```
+
+#### Test the Setup
+
+```shell
+# Basic connectivity test
+curl http://127.0.0.1:8000/
+
+# Test endpoints
+curl http://127.0.0.1:8000/timeline
+curl http://127.0.0.1:8000/feed_timeline
+curl http://127.0.0.1:8000/bundle_tray
+curl http://127.0.0.1:8000/inbox
+
+# Check stats
+open http://127.0.0.1:9000/stats
+```
+
+### Customization and Tuning
+
+#### Worker Configuration
+
+**Adjust worker count based on CPU:**
+
+```shell
+# CPU-bound workload
+python start_loadbalanced_server.py --workers 16 --threads-per-worker 8
+
+# I/O-bound workload
+python start_loadbalanced_server.py --workers 4 --threads-per-worker 32
+
+# Balanced (default)
+python start_loadbalanced_server.py --workers 8 --threads-per-worker 14
+```
+
+#### Port Configuration
+
+```shell
+# Custom ports
+python start_loadbalanced_server.py \
+    --base-port 9001 \      # Workers start at 9001
+    --lb-port 9000 \        # Frontend on 9000
+    --stats-port 9090       # Stats on 9090
+```
+
+#### uWSGI Configuration
+
+Edit `uwsgi_loadbalanced.ini` for uWSGI-specific settings:
+
+```
+[uwsgi]
+# Process settings
+master = true
+processes = %(workers)
+lazy-apps = true
+
+# Memory management
+reload-on-rss = 2048        # Reload worker at 2GB
+harakiri = 60               # Kill after 60s timeout
+max-requests = 10000        # Reload after 10K requests
+
+# Environment (set by Python script)
+# Don't use env= directives here
+```
+
+#### HAProxy Configuration
+
+Auto-generated config can be customized by editing the generated file:
+
+```shell
+# After first run, config is saved
+ls -la haproxy_generated.cfg
+
+# Edit and restart
+vim haproxy_generated.cfg
+python start_loadbalanced_server.py --haproxy-config haproxy_generated.cfg
+```
+
+
+## References and Further Reading
+
+- [Proxygen GitHub](https://github.com/facebook/proxygen)
+- [Django ASGI](https://docs.djangoproject.com/en/stable/howto/deployment/asgi/)
+- [HAProxy Documentation](http://www.haproxy.org/docs.html)
+- [uWSGI Documentation](https://uwsgi-docs.readthedocs.io/)
+- [pybind11 Documentation](https://pybind11.readthedocs.io/)
+
+
+## Conclusion
+
+This async server stack brings DjangoBench in line with Instagram's production architecture, delivering
+improved scalability and increased CPU front-end I-Cache presssure.
+
+## Troubleshooting Executions
+
+### Test with Simple Examples
+
+#### Basic Echo Server
+
+Test the Proxygen binding with a simple echo server:
+
+```shell
+# Activate virtual envrionment
+source benchmarks/django_workload/django-workload/django-workload/venv_cpython/bin/activate
+
+# Add library paths
+export LD_LIBRARY_PATH="$(pwd)/benchmarks/django_workload/django-workload/django-workload/Python-3.10.2:$(pwd)/benchmarks/django_workload/django-workload/django-workload"
+
+# Start example server
+cd benchmarks/django_workload/proxygen_binding
+python3 example_server.py
+```
+
+**In another terminal:**
+
+```shell
+# Test the server
+curl http://127.0.0.1:8000/abc
+# Expected:
+# Proxygen Python Binding - Echo Server
+# ==================================================
+#
+# Method: GET
+# Path: /abc
+# URL: /abc
+# Query String:
+# HTTP Version: 1.1
+#
+# Headers:
+#   Accept: */*
+#   Host: localhost:8000
+#   User-Agent: curl/7.76.1
+
+# Test POST with data
+curl -X POST -d "test data" http://127.0.0.1:8000/echo
+# Expected: Echo of posted data
+```
+
+**What This Tests:**
+
+- ✓ Proxygen binding works
+- ✓ Request/response marshaling
+- ✓ Multi-threaded handling
+
+#### 10.1.2 Django Integration Test
+
+Test Django ASGI integration:
+
+```shell
+# Activate virtual envrionment
+source benchmarks/django_workload/django-workload/django-workload/venv_cpython/bin/activate
+
+# Add library paths
+export LD_LIBRARY_PATH="$(pwd)/benchmarks/django_workload/django-workload/django-workload/Python-3.10.2:$(pwd)/benchmarks/django_workload/django-workload/django-workload"
+
+# Set Django settings
+export DJANGO_SETTINGS_MODULE=cluster_settings
+
+# Start Django server with Proxygen
+cd benchmarks/django_workload/proxygen_binding
+python3 django_server.py
+```
+
+**Test endpoints:**
+
+```shell
+# Test homepage
+curl http://127.0.0.1:8000/
+
+# Test timeline (will error out if DB not set up)
+curl http://127.0.0.1:8000/timeline
+```
+
+**What This Tests:**
+
+- ✓ Django ASGI adapter works
+- ✓ Async request handling
+- ✓ Database/cache integration
+
+### Run Full Load-Balanced Server
+
+Please first follow the setup steps in [For Standalone Usage (Outside Benchpress)](#for-standalone-usage-outside-benchpress)
+section to prepare the environment.
+
+#### Direct Worker Mode (No uWSGI)
+
+Run multiple workers managed by Python script:
+
+```shell
+cd benchmarks/django_workload/django-workload/django-workload
+
+# Start 8 workers with HAProxy
+python start_loadbalanced_server.py \
+    --workers 8 \
+    --stats-port 9000 \
+    --log-dir load_balancer_logs
+```
+
+**Output:**
+
+```
+[15:23:45] [INFO] Starting 8 Proxygen workers...
+[15:23:46] [INFO] Worker 1 started (PID: 12345)
+[15:23:46] [INFO] Worker 2 started (PID: 12346)
+...
+[15:23:47] [INFO] All workers are ready!
+[15:23:48] [INFO] HAProxy started (PID: 12353)
+============================================================
+Load-balanced Django server is running!
+  Access via: http://127.0.0.1:8000
+  Workers: 8 (ports 8001-8008)
+  Stats UI: http://127.0.0.1:9000/stats
+
+Press Ctrl+C to stop all processes
+============================================================
+```
+
+#### uWSGI Mode (Production)
+
+Run with uWSGI managing Proxygen workers:
+
+```shell
+cd benchmarks/django_workload/django-workload/django-workload
+
+# Start with uWSGI + HAProxy
+DJANGO_SETTINGS_MODULE=cluster_settings \
+python start_loadbalanced_server.py \
+    --use-uwsgi \
+    --workers $(nproc) \
+    --stats-port 9000 \
+    --log-dir uwsgi_logs
+```
+
+**This is the production-ready mode with:**
+
+- ✅ uWSGI process management (harakiri, memory limits)
+- ✅ Proxygen async HTTP in each worker
+- ✅ HAProxy load balancing
+- ✅ Health checks and auto-recovery
+
+### Monitor and Test
+
+**Access HAProxy Stats Dashboard:**
+
+```
+http://127.0.0.1:9000/stats
+```
+
+**Run Load Tests:**
+
+```shell
+# Basic test
+curl http://127.0.0.1:8000/timeline
+
+# Concurrent test
+siege -b -r 1000 -c 112 http://127.0.0.1:8000/timeline
+
+# Expected results:
+# - All requests succeed
+# - Balanced load across workers
+# - Low tail latency
+```
+
+**Monitor CPU Usage:**
+
+```shell
+# Watch worker processes
+watch -n 1 'ps aux | grep proxygen_wsgi | grep -v grep'
+
+# Should show balanced CPU across all workers
+```

--- a/packages/django_workload/srcs/proxygen_binding/__init__.py
+++ b/packages/django_workload/srcs/proxygen_binding/__init__.py
@@ -1,0 +1,21 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""
+Python bindings for Proxygen HTTP server
+
+This module provides a Python interface to the Proxygen C++ HTTP server,
+enabling asynchronous HTTP request handling in Python applications.
+"""
+
+from proxygen_binding import init_logging, ProxygenServer, RequestData, ResponseData
+
+__all__ = [
+    "ProxygenServer",
+    "RequestData",
+    "ResponseData",
+    "init_logging",
+]

--- a/packages/django_workload/srcs/proxygen_binding/build.sh
+++ b/packages/django_workload/srcs/proxygen_binding/build.sh
@@ -1,0 +1,75 @@
+#!/bin/bash
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$SCRIPT_DIR"
+
+echo "=========================================="
+echo "Building Proxygen Python Binding"
+echo "=========================================="
+
+# Check for PROXYGEN_INSTALL_DIR environment variable
+if [ -z "$PROXYGEN_INSTALL_DIR" ]; then
+    echo "WARNING: PROXYGEN_INSTALL_DIR not set, using default: \$HOME/proxygen/staging"
+    echo ""
+    echo "To specify a custom location, set PROXYGEN_INSTALL_DIR:"
+    echo "  export PROXYGEN_INSTALL_DIR=/path/to/proxygen/staging"
+    echo "  ./build.sh"
+    echo ""
+else
+    echo "Using PROXYGEN_INSTALL_DIR: $PROXYGEN_INSTALL_DIR"
+fi
+
+# Check for required tools
+echo ""
+echo "Checking for required dependencies..."
+
+if ! python3 -c "import pybind11" 2>/dev/null; then
+    echo "Installing pybind11..."
+    pip install pybind11
+fi
+
+# Build the extension
+echo ""
+echo "Building C++ extension module..."
+python3 setup.py build_ext --inplace -g
+
+if [ $? -eq 0 ]; then
+    echo ""
+    echo "=========================================="
+    echo "Build successful!"
+    echo "=========================================="
+    echo ""
+    echo "To test the basic server:"
+    echo "  python3 example_server.py"
+    echo ""
+    echo "To test with Django:"
+    echo "  python3 django_server.py"
+    echo ""
+    echo "To install system-wide:"
+    echo "  python3 setup.py install"
+    echo ""
+    echo "To build with a custom Proxygen location:"
+    echo "  export PROXYGEN_INSTALL_DIR=/path/to/proxygen/staging"
+    echo "  python3 setup.py build_ext --inplace"
+    echo ""
+    echo "Or use CLI arguments:"
+    echo "  python3 setup.py build_ext --inplace --proxygen-dir=/path/to/proxygen/staging"
+    echo ""
+    echo "Additional CLI options:"
+    echo "  --extra-include-dirs=/path1:/path2  # Additional include directories"
+    echo "  --extra-lib-dirs=/path1:/path2      # Additional library directories"
+    echo ""
+else
+    echo ""
+    echo "=========================================="
+    echo "Build failed!"
+    echo "=========================================="
+    exit 1
+fi

--- a/packages/django_workload/srcs/proxygen_binding/django_asgi_adapter.py
+++ b/packages/django_workload/srcs/proxygen_binding/django_asgi_adapter.py
@@ -1,0 +1,346 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""
+Django ASGI adapter for Proxygen binding
+
+This module provides integration between Proxygen's request/response model
+and Django's ASGI application interface.
+"""
+
+import asyncio
+import logging
+import threading
+import time
+from typing import Any, Callable, Dict
+from urllib.parse import parse_qs, unquote, urlparse
+
+from proxygen_binding import RequestData, ResponseData
+
+logger = logging.getLogger(__name__)
+
+# Performance debugging support
+try:
+    from quick_perf_debug import get_request_tracker
+
+    _PERF_DEBUG_ENABLED = True
+    logger.info("Performance debugging enabled for ASGI adapter")
+except ImportError:
+    _PERF_DEBUG_ENABLED = False
+
+
+def _log_perf(message: str) -> None:
+    """Log performance debug message with timing"""
+    if logger.isEnabledFor(logging.DEBUG):
+        thread_name = threading.current_thread().name
+        thread_id = threading.current_thread().ident
+        logger.debug(f"[PERF:{time.time():.3f}] [{thread_name}:{thread_id}] {message}")
+
+
+class ASGIRequestHandler:
+    """
+    Handles conversion between Proxygen requests and ASGI protocol
+
+    TRUE ASYNC MODE: Returns coroutines that are scheduled on the event loop by C++.
+    Multiple requests can be processed concurrently on the same event loop.
+
+    This implementation enables Instagram-style async architecture where coroutines
+    are scheduled by C++ and run concurrently without blocking Proxygen threads.
+    """
+
+    def __init__(self, asgi_app: Callable) -> None:
+        """
+        Initialize the handler with a Django ASGI application
+
+        Args:
+            asgi_app: Django ASGI application (e.g., from get_asgi_application())
+        """
+        self.asgi_app = asgi_app
+
+    async def __call__(self, request: RequestData) -> ResponseData:
+        """
+        Handle a Proxygen request and return a response (ASYNC)
+
+        This is an async function that returns a coroutine. The C++ layer
+        schedules this coroutine on the event loop and retrieves the result
+        when it completes. This allows multiple requests to be processed
+        concurrently without blocking.
+
+        Args:
+            request: Proxygen request data
+
+        Returns:
+            ResponseData coroutine that resolves when request is complete
+        """
+        # Return the coroutine directly - C++ will schedule it
+        return await self.handle_request_async(request)
+
+    async def handle_request_async(self, request: RequestData) -> ResponseData:
+        """
+        Async handler for processing requests through ASGI
+
+        Args:
+            request: Proxygen request data
+
+        Returns:
+            ResponseData for Proxygen to send
+        """
+        thread_name = threading.current_thread().name
+        thread_id = threading.current_thread().ident
+
+        # Performance debugging - track request stages
+        request_start_time = time.time()
+        _log_perf(f"🚀 Request started: {request.method} {request.path}")
+
+        logger.debug(
+            "Starting request: %s %s (thread: %s [%s])",
+            request.method,
+            request.path,
+            thread_name,
+            thread_id,
+        )
+
+        try:
+            scope_start = time.time()
+            scope = self.build_asgi_scope(request)
+            _log_perf(f"📋 ASGI scope built in {time.time() - scope_start:.3f}s")
+        except Exception as e:
+            logger.exception("Error building ASGI scope: %s", e)
+            return self.create_error_response(500, "Error building ASGI scope")
+
+        response_started = False
+        status_code = 200
+        status_message = "OK"
+        response_headers: Dict[bytes, bytes] = {}
+        response_body_parts = []
+
+        # Track whether we've already sent the body
+        body_sent = False
+
+        async def receive() -> Dict[str, Any]:
+            """
+            ASGI receive callable
+
+            Per ASGI spec: First call returns the body, subsequent calls should
+            block waiting for disconnect (which never comes in our case).
+
+            IMPORTANT: Django 5.2 calls receive() multiple times during normal
+            processing. We must NOT send http.disconnect unless the client actually
+            disconnects. Instead, we block indefinitely on subsequent calls.
+            """
+            nonlocal body_sent
+
+            if not body_sent:
+                # First call: return the request body
+                body_sent = True
+                message = {
+                    "type": "http.request",
+                    "body": request.body.encode("utf-8") if request.body else b"",
+                    "more_body": False,
+                }
+                logger.debug(
+                    f"[ASGI RECEIVE] Sending http.request with {len(message['body'])} bytes"
+                )
+                return message
+            else:
+                # Subsequent calls: block indefinitely
+                # In a real ASGI server, this would wait for client disconnect
+                # In our case, Django will finish sending the response before
+                # calling receive() again, so this should never actually be reached
+                # during normal operation
+                logger.debug(f"[ASGI RECEIVE] Blocking on subsequent receive() call")
+                # Block forever - Django should finish sending response before this
+                await asyncio.Event().wait()
+                # This line is never reached in normal operation
+                return {"type": "http.disconnect"}
+
+        async def send(message: Dict[str, Any]) -> None:
+            """ASGI send callable"""
+            nonlocal response_started, status_code, status_message, response_headers
+
+            logger.debug(f"[ASGI SEND] Received message type: {message['type']}")
+
+            if message["type"] == "http.response.start":
+                response_started = True
+                status_code = message["status"]
+                status_message = self.get_status_message(status_code)
+
+                for header_name, header_value in message.get("headers", []):
+                    response_headers[header_name] = header_value
+
+                logger.debug(
+                    f"[ASGI SEND] Response started: {status_code} {status_message}"
+                )
+
+            elif message["type"] == "http.response.body":
+                body = message.get("body", b"")
+                more_body = message.get("more_body", False)
+                logger.debug(
+                    f"[ASGI SEND] Body chunk received: {len(body)} bytes, more_body={more_body}"
+                )
+                if body:
+                    response_body_parts.append(body)
+
+        try:
+            asgi_start = time.time()
+            _log_perf(f"🌟 Calling Django ASGI app...")
+            await self.asgi_app(scope, receive, send)
+            asgi_duration = time.time() - asgi_start
+            _log_perf(f"✅ Django ASGI app completed in {asgi_duration:.3f}s")
+        except Exception as e:
+            asgi_duration = time.time() - asgi_start
+            _log_perf(f"❌ Django ASGI app failed in {asgi_duration:.3f}s: {e}")
+            logger.exception("Exception in ASGI application: %s", e)
+            return self.create_error_response(500, "Internal Server Error")
+
+        response = self.build_response(
+            status_code, status_message, response_headers, response_body_parts
+        )
+
+        logger.debug(
+            "Request completed: %s %s -> %d %s",
+            request.method,
+            request.path,
+            response.status_code,
+            response.status_message,
+        )
+
+        return response
+
+    def build_asgi_scope(self, request: RequestData) -> Dict[str, Any]:
+        """
+        Build ASGI scope dict from Proxygen request
+
+        Args:
+            request: Proxygen request data
+
+        Returns:
+            ASGI scope dictionary
+        """
+        parsed_url = urlparse(request.url or request.path)
+        path = unquote(parsed_url.path or "/")
+        query_string = request.query_string.encode("latin1")
+
+        headers = []
+        for name, value in request.headers.items():
+            headers.append((name.lower().encode("latin1"), value.encode("latin1")))
+
+        scope = {
+            "type": "http",
+            "asgi": {"version": "3.0"},
+            "http_version": request.http_version or "1.1",
+            "method": request.method or "GET",
+            "scheme": "http",
+            "path": path,
+            "query_string": query_string,
+            "root_path": "",
+            "headers": headers,
+            "server": ("127.0.0.1", 8000),
+        }
+
+        return scope
+
+    def build_response(
+        self,
+        status_code: int,
+        status_message: str,
+        headers: Dict[bytes, bytes],
+        body_parts: list,
+    ) -> ResponseData:
+        """
+        Build Proxygen response from ASGI data
+
+        Args:
+            status_code: HTTP status code
+            status_message: HTTP status message
+            headers: Response headers as bytes dict
+            body_parts: List of body byte chunks
+
+        Returns:
+            ResponseData for Proxygen
+        """
+        response = ResponseData()
+        response.status_code = status_code
+        response.status_message = status_message
+
+        response.headers = {}
+        for name_bytes, value_bytes in headers.items():
+            name = name_bytes.decode("latin1")
+            value = value_bytes.decode("latin1")
+            response.headers[name] = value
+
+        if body_parts:
+            response.body = b"".join(body_parts).decode("utf-8", errors="replace")
+
+        return response
+
+    def create_error_response(self, status_code: int, message: str) -> ResponseData:
+        """
+        Create an error response
+
+        Args:
+            status_code: HTTP status code
+            message: Error message
+
+        Returns:
+            ResponseData with error
+        """
+        response = ResponseData()
+        response.status_code = status_code
+        response.status_message = message
+        response.headers = {"Content-Type": "text/plain"}
+        response.body = f"{message}\n"
+        return response
+
+    @staticmethod
+    def get_status_message(status_code: int) -> str:
+        """Get HTTP status message for status code"""
+        status_messages = {
+            200: "OK",
+            201: "Created",
+            204: "No Content",
+            301: "Moved Permanently",
+            302: "Found",
+            304: "Not Modified",
+            400: "Bad Request",
+            401: "Unauthorized",
+            403: "Forbidden",
+            404: "Not Found",
+            405: "Method Not Allowed",
+            500: "Internal Server Error",
+            502: "Bad Gateway",
+            503: "Service Unavailable",
+        }
+        return status_messages.get(status_code, "Unknown")
+
+
+def create_django_handler(django_settings_module: str = None) -> Callable:
+    """
+    Create a Proxygen-compatible handler for Django
+
+    Args:
+        django_settings_module: Django settings module path
+                                (e.g., 'django_workload.settings')
+
+    Returns:
+        Callable that handles Proxygen requests
+    """
+    import os
+
+    if django_settings_module:
+        os.environ.setdefault("DJANGO_SETTINGS_MODULE", django_settings_module)
+
+    try:
+        from django.core.asgi import get_asgi_application
+    except ImportError as e:
+        raise ImportError(
+            "Django is not installed. Install it with: pip install django"
+        ) from e
+
+    asgi_app = get_asgi_application()
+    handler = ASGIRequestHandler(asgi_app)
+
+    return handler

--- a/packages/django_workload/srcs/proxygen_binding/django_server.py
+++ b/packages/django_workload/srcs/proxygen_binding/django_server.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""
+Django server using Proxygen Python binding
+
+This integrates Proxygen with DjangoBench via ASGI.
+"""
+
+import logging
+import os
+import signal
+import sys
+
+from django_asgi_adapter import create_django_handler
+from proxygen_binding import init_logging, ProxygenServer
+
+logging.basicConfig(
+    level=logging.INFO, format="%(asctime)s - %(name)s - %(levelname)s - %(message)s"
+)
+
+logger = logging.getLogger(__name__)
+
+# Global reference to server for signal handling
+_server = None
+
+
+def signal_handler(signum, frame):
+    """Handle shutdown signals gracefully"""
+    logger.info("Received signal %d, shutting down...", signum)
+    if _server:
+        _server.stop()
+    sys.exit(0)
+
+
+def main() -> None:
+    """Main entry point for Django + Proxygen server"""
+    global _server
+
+    init_logging()
+
+    django_settings = os.environ.get("DJANGO_SETTINGS_MODULE")
+    if not django_settings:
+        django_settings = "django_workload.settings"
+        os.environ["DJANGO_SETTINGS_MODULE"] = django_settings
+        logger.info("Using default Django settings: %s", django_settings)
+
+    ip = os.environ.get("PROXYGEN_IP", "0.0.0.0")
+    port = int(os.environ.get("PROXYGEN_PORT", "8000"))
+    threads = int(os.environ.get("PROXYGEN_THREADS", "0"))
+
+    if len(sys.argv) > 1:
+        port = int(sys.argv[1])
+    if len(sys.argv) > 2:
+        threads = int(sys.argv[2])
+
+    logger.info("Creating Django ASGI handler (ASYNC MODE)...")
+    django_handler = create_django_handler(django_settings)
+    logger.info("Django handler created successfully")
+
+    logger.info(
+        "Starting Proxygen + Django server (ASYNC MODE) on %s:%d with %d threads",
+        ip,
+        port,
+        threads,
+    )
+    logger.info("Django settings: %s", django_settings)
+    logger.info("NOTE: Using TRUE ASYNC architecture for concurrent request processing")
+    logger.info("Press Ctrl+C to stop")
+
+    # Use async constructor - this enables true concurrent request processing
+    _server = ProxygenServer(
+        ip=ip,
+        port=port,
+        threads=threads,
+        async_callback=django_handler,
+        is_async=True,
+    )
+
+    # Register signal handlers
+    signal.signal(signal.SIGINT, signal_handler)
+    signal.signal(signal.SIGTERM, signal_handler)
+
+    try:
+        _server.start()
+        logger.info("Server started successfully")
+        logger.info("Test it with: curl http://%s:%d/", ip, port)
+        _server.wait()
+    except KeyboardInterrupt:
+        logger.info("Shutting down server...")
+        _server.stop()
+        logger.info("Server stopped")
+    except Exception as e:
+        logger.exception("Error running server: %s", e)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/packages/django_workload/srcs/proxygen_binding/event_loop_manager.py
+++ b/packages/django_workload/srcs/proxygen_binding/event_loop_manager.py
@@ -1,0 +1,392 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""
+Event Loop Manager for Proxygen Worker Threads (TRUE ASYNC VERSION)
+
+This module manages asyncio event loops for Proxygen worker threads.
+Each thread gets its own long-lived event loop that runs continuously
+in a background thread, enabling true async request processing.
+
+Key Features:
+- Each Proxygen thread gets a background event loop thread
+- Coroutines are scheduled non-blocking via thread-safe calls
+- Multiple requests can be processed concurrently per thread
+- Responses are sent via callbacks when coroutines complete
+
+This matches Instagram's async architecture where Proxygen threads
+are never blocked by Python coroutine execution.
+"""
+
+import asyncio
+import concurrent.futures
+import logging
+import queue
+import threading
+from typing import Any, Callable, Optional
+
+logger = logging.getLogger(__name__)
+
+
+class BackgroundEventLoop:
+    """
+    Manages a single event loop running in a background thread.
+
+    This allows the main Proxygen thread to schedule coroutines
+    without blocking, enabling true async concurrency.
+    """
+
+    def __init__(self, thread_name: str) -> None:
+        """
+        Initialize background event loop for a thread.
+
+        Args:
+            thread_name: Name of the Proxygen thread this loop serves
+        """
+        self.thread_name = thread_name
+        self.loop: Optional[asyncio.AbstractEventLoop] = None
+        self.loop_thread: Optional[threading.Thread] = None
+        self._stop_event = threading.Event()
+        self._started_event = threading.Event()
+        self._shutdown = False
+
+    def start(self) -> None:
+        """Start the background event loop thread"""
+        if self.loop_thread and self.loop_thread.is_alive():
+            return  # Already started
+
+        logger.debug(
+            "[ASYNC_LOOP] Starting background event loop for thread %s",
+            self.thread_name,
+        )
+
+        self.loop_thread = threading.Thread(
+            target=self._run_event_loop,
+            name=f"AsyncLoop-{self.thread_name}",
+            daemon=True,  # Dies when main thread dies
+        )
+        self.loop_thread.start()
+
+        # Wait for event loop to be ready
+        self._started_event.wait(timeout=5.0)
+
+        if not self._started_event.is_set():
+            raise RuntimeError(f"Failed to start event loop for {self.thread_name}")
+
+        logger.debug(
+            "[ASYNC_LOOP] Background event loop ready for thread %s",
+            self.thread_name,
+        )
+
+    def _run_event_loop(self) -> None:
+        """Run the event loop in the background thread (INTERNAL)"""
+        try:
+            # Create new event loop for this background thread
+            self.loop = asyncio.new_event_loop()
+            asyncio.set_event_loop(self.loop)
+
+            logger.debug(
+                "[ASYNC_LOOP] Event loop created in background thread for %s",
+                self.thread_name,
+            )
+
+            # Signal that we're ready to accept coroutines
+            self._started_event.set()
+
+            # Run event loop forever until stopped
+            self.loop.run_forever()
+
+        except Exception as e:
+            logger.error(
+                "[ASYNC_LOOP] Event loop crashed for thread %s: %s",
+                self.thread_name,
+                e,
+            )
+        finally:
+            # Clean up
+            if self.loop and not self.loop.is_closed():
+                logger.debug(
+                    "[ASYNC_LOOP] Closing event loop for thread %s",
+                    self.thread_name,
+                )
+                self.loop.close()
+
+    def schedule_coroutine(
+        self, coro: Any, done_callback: Callable[[Any], None]
+    ) -> None:
+        """
+        Schedule a coroutine on the background event loop (NON-BLOCKING).
+
+        This is the key function that enables true async - it schedules
+        the coroutine and returns immediately without waiting.
+
+        Args:
+            coro: Coroutine to schedule
+            done_callback: Callback to call when coroutine completes
+        """
+        if self._shutdown or not self.loop or self.loop.is_closed():
+            logger.error(
+                "[ASYNC_LOOP] Cannot schedule coroutine: loop not running for %s",
+                self.thread_name,
+            )
+            return
+
+        try:
+            # Schedule coroutine on the background event loop (thread-safe)
+            future = asyncio.run_coroutine_threadsafe(coro, self.loop)
+
+            # Add callback to be called when coroutine completes
+            # This callback runs in the background thread
+            future.add_done_callback(done_callback)
+
+            logger.debug(
+                "[ASYNC_LOOP] Coroutine scheduled for thread %s",
+                self.thread_name,
+            )
+
+        except Exception as e:
+            logger.error(
+                "[ASYNC_LOOP] Failed to schedule coroutine for %s: %s",
+                self.thread_name,
+                e,
+            )
+
+    def shutdown(self) -> None:
+        """Shutdown the background event loop and thread"""
+        if self._shutdown:
+            return
+
+        self._shutdown = True
+
+        logger.debug(
+            "[ASYNC_LOOP] Shutting down event loop for thread %s",
+            self.thread_name,
+        )
+
+        # Stop the event loop
+        if self.loop and not self.loop.is_closed():
+            self.loop.call_soon_threadsafe(self.loop.stop)
+
+        # Wait for background thread to finish
+        if self.loop_thread and self.loop_thread.is_alive():
+            self.loop_thread.join(timeout=2.0)
+            if self.loop_thread.is_alive():
+                logger.warning(
+                    "[ASYNC_LOOP] Background thread did not shutdown cleanly for %s",
+                    self.thread_name,
+                )
+
+
+class EventLoopManager:
+    """
+    Manages background event loops for Proxygen worker threads using a thread pool.
+
+    Instead of creating one background thread per Proxygen thread, we maintain
+    a fixed pool of background event loop threads. Proxygen threads are mapped
+    to pool threads using round-robin assignment.
+
+    This prevents thread exhaustion under high concurrency.
+    """
+
+    def __init__(self, pool_size: int = 8) -> None:
+        """
+        Initialize the event loop manager with a thread pool.
+
+        Args:
+            pool_size: Number of background event loop threads to create.
+                      Default is 8, which should handle most workloads.
+        """
+        self._thread_local = threading.local()
+        self._lock = threading.Lock()
+        self._pool_size = pool_size
+        self._event_loop_pool: list[BackgroundEventLoop] = []
+        self._pool_initialized = False
+        self._next_pool_index = 0
+
+        logger.info("[EVENT_LOOP_MANAGER] Initialized with pool size %d", pool_size)
+
+    def _initialize_pool(self) -> None:
+        """Initialize the pool of background event loops (called once)"""
+        if self._pool_initialized:
+            return
+
+        logger.info(
+            "[EVENT_LOOP_MANAGER] Creating pool of %d background event loops",
+            self._pool_size,
+        )
+
+        for i in range(self._pool_size):
+            pool_thread_name = f"AsyncPool-{i}"
+            background_loop = BackgroundEventLoop(pool_thread_name)
+
+            try:
+                background_loop.start()
+                self._event_loop_pool.append(background_loop)
+                logger.info(
+                    "[EVENT_LOOP_MANAGER] Pool thread %d/%d started: %s",
+                    i + 1,
+                    self._pool_size,
+                    pool_thread_name,
+                )
+            except RuntimeError as e:
+                logger.error(
+                    "[EVENT_LOOP_MANAGER] Failed to start pool thread %d: %s", i, e
+                )
+                # Continue with smaller pool
+                break
+
+        if not self._event_loop_pool:
+            raise RuntimeError("Failed to create any background event loop threads")
+
+        self._pool_initialized = True
+        logger.info(
+            "[EVENT_LOOP_MANAGER] Pool initialized with %d threads",
+            len(self._event_loop_pool),
+        )
+
+    def get_or_create_loop(self) -> BackgroundEventLoop:
+        """
+        Get background event loop for current thread.
+
+        Maps the current thread to one of the pooled background event loops
+        using round-robin assignment. Multiple Proxygen threads may share
+        the same background event loop.
+
+        Returns:
+            BackgroundEventLoop from the pool
+        """
+        # Check if this thread already has a background event loop assigned
+        if not hasattr(self._thread_local, "background_loop"):
+            with self._lock:
+                # Double-check after acquiring lock
+                if not hasattr(self._thread_local, "background_loop"):
+                    # Initialize pool if needed (first call)
+                    if not self._pool_initialized:
+                        self._initialize_pool()
+
+                    # Assign a background loop from the pool (round-robin)
+                    self._assign_loop_from_pool()
+
+        return self._thread_local.background_loop
+
+    def _assign_loop_from_pool(self) -> None:
+        """Assign a background event loop from the pool to current thread"""
+        thread_id = threading.current_thread().ident
+        thread_name = threading.current_thread().name
+
+        # Round-robin assignment
+        pool_index = self._next_pool_index % len(self._event_loop_pool)
+        background_loop = self._event_loop_pool[pool_index]
+        self._next_pool_index += 1
+
+        # Store in thread-local storage
+        self._thread_local.background_loop = background_loop
+
+        logger.debug(
+            "[EVENT_LOOP_MANAGER] Assigned pool thread '%s' to Proxygen thread %s [%s]",
+            background_loop.thread_name,
+            thread_name,
+            thread_id,
+        )
+
+    def close_current_loop(self) -> None:
+        """
+        Close background event loop for current thread.
+
+        This should be called when a Proxygen thread is shutting down.
+        """
+        if hasattr(self._thread_local, "background_loop"):
+            background_loop = self._thread_local.background_loop
+            thread_name = threading.current_thread().name
+
+            logger.debug(
+                "[EVENT_LOOP] Closing background event loop for thread %s",
+                thread_name,
+            )
+
+            # Shutdown the background loop
+            try:
+                background_loop.shutdown()
+                logger.debug(
+                    "[EVENT_LOOP] Background event loop closed for thread %s",
+                    thread_name,
+                )
+            except Exception as e:
+                logger.error(
+                    "[EVENT_LOOP] Error closing background event loop for thread %s: %s",
+                    thread_name,
+                    e,
+                )
+
+            # Remove from thread-local storage
+            delattr(self._thread_local, "background_loop")
+
+
+# Global event loop manager instance
+_event_loop_manager: Optional[EventLoopManager] = None
+_manager_lock = threading.Lock()
+
+
+def get_event_loop_manager() -> EventLoopManager:
+    """
+    Get the global event loop manager instance.
+
+    Returns:
+        Global EventLoopManager instance
+    """
+    global _event_loop_manager
+
+    if _event_loop_manager is None:
+        with _manager_lock:
+            if _event_loop_manager is None:
+                _event_loop_manager = EventLoopManager()
+                logger.debug("[EVENT_LOOP] Global EventLoopManager initialized")
+
+    return _event_loop_manager
+
+
+def initialize_thread_event_loop() -> asyncio.AbstractEventLoop:
+    """
+    Initialize event loop for current thread.
+
+    This should be called once per thread (typically when thread starts).
+
+    Returns:
+        Event loop for this thread
+    """
+    manager = get_event_loop_manager()
+    return manager.get_or_create_loop()
+
+
+def get_current_loop() -> asyncio.AbstractEventLoop:
+    """
+    Get event loop for current thread.
+
+    Raises:
+        RuntimeError: If event loop hasn't been initialized for this thread
+
+    Returns:
+        Event loop for this thread
+    """
+    try:
+        loop = asyncio.get_event_loop()
+        if loop.is_closed():
+            raise RuntimeError("Event loop is closed")
+        return loop
+    except RuntimeError:
+        # No loop exists, create one
+        return initialize_thread_event_loop()
+
+
+def cleanup_thread_event_loop() -> None:
+    """
+    Clean up event loop for current thread.
+
+    This should be called when thread is shutting down.
+    """
+    manager = get_event_loop_manager()
+    manager.close_current_loop()

--- a/packages/django_workload/srcs/proxygen_binding/example_server.py
+++ b/packages/django_workload/srcs/proxygen_binding/example_server.py
@@ -1,0 +1,132 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""
+Example server using Proxygen Python binding
+
+This demonstrates a basic HTTP server using the Proxygen binding.
+"""
+
+import logging
+import signal
+import sys
+
+from proxygen_binding import init_logging, ProxygenServer, RequestData, ResponseData
+
+logging.basicConfig(
+    level=logging.INFO, format="%(asctime)s - %(name)s - %(levelname)s - %(message)s"
+)
+
+logger = logging.getLogger(__name__)
+
+# Global reference to server for signal handling
+_server = None
+
+
+def signal_handler(signum, frame):
+    """Handle shutdown signals gracefully"""
+    logger.info("Received signal %d, shutting down...", signum)
+    if _server:
+        _server.stop()
+    sys.exit(0)
+
+
+def handle_request(request: RequestData) -> ResponseData:
+    """
+    Simple request handler that echoes back request information
+
+    Args:
+        request: Proxygen request data
+
+    Returns:
+        ResponseData with the response
+    """
+    logger.debug(
+        "Received request: %s %s from %s",
+        request.method,
+        request.path,
+        request.headers.get("Host", "unknown"),
+    )
+
+    response = ResponseData()
+    response.status_code = 200
+    response.status_message = "OK"
+    response.headers = {
+        "Content-Type": "text/plain",
+        "Server": "Proxygen-Python-Binding",
+    }
+
+    body_lines = [
+        "Proxygen Python Binding - Echo Server\n",
+        "=" * 50,
+        "\n\n",
+        f"Method: {request.method}\n",
+        f"Path: {request.path}\n",
+        f"URL: {request.url}\n",
+        f"Query String: {request.query_string}\n",
+        f"HTTP Version: {request.http_version}\n",
+        "\nHeaders:\n",
+    ]
+
+    for name, value in sorted(request.headers.items()):
+        body_lines.append(f"  {name}: {value}\n")
+
+    if request.body:
+        body_lines.append(f"\nBody ({len(request.body)} bytes):\n")
+        body_lines.append(request.body[:500])
+        if len(request.body) > 500:
+            body_lines.append(f"\n... ({len(request.body) - 500} more bytes)")
+
+    response.body = "".join(body_lines)
+    return response
+
+
+def main() -> None:
+    """Main entry point"""
+    global _server
+
+    init_logging()
+
+    ip = "127.0.0.1"
+    port = 8000
+    threads = 0
+
+    if len(sys.argv) > 1:
+        port = int(sys.argv[1])
+    if len(sys.argv) > 2:
+        threads = int(sys.argv[2])
+
+    logger.info("Starting Proxygen server on %s:%d with %d threads", ip, port, threads)
+    logger.info("Press Ctrl+C to stop")
+
+    _server = ProxygenServer(
+        ip=ip,
+        port=port,
+        threads=threads,
+        callback=handle_request,
+    )
+
+    # Register signal handlers
+    signal.signal(signal.SIGINT, signal_handler)
+    signal.signal(signal.SIGTERM, signal_handler)
+
+    try:
+        _server.start()
+        logger.info("Server started successfully")
+        logger.info("Test it with: curl http://%s:%d/", ip, port)
+        _server.wait()
+    except KeyboardInterrupt:
+        logger.info("Shutting down server...")
+        _server.stop()
+        logger.info("Server stopped")
+    except Exception as e:
+        logger.exception("Error running server: %s", e)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/packages/django_workload/srcs/proxygen_binding/proxygen_binding.cpp
+++ b/packages/django_workload/srcs/proxygen_binding/proxygen_binding.cpp
@@ -1,0 +1,256 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <pybind11/functional.h>
+#include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
+
+#include <folly/SocketAddress.h>
+#include <folly/portability/Unistd.h>
+#include <gflags/gflags.h>
+#include <glog/logging.h>
+#include <proxygen/httpserver/HTTPServer.h>
+#include <proxygen/httpserver/RequestHandlerFactory.h>
+
+#include <memory>
+#include <thread>
+
+#include "PythonRequestHandler.h"
+#include "PythonRequestHandlerFactory.h"
+
+namespace py = pybind11;
+using namespace ProxygenBinding;
+using namespace proxygen;
+
+/**
+ * Wrapper class for Proxygen HTTP Server
+ *
+ * Supports both synchronous and asynchronous callbacks.
+ */
+class ProxygenServer {
+ public:
+  // Constructor for synchronous callback (deprecated)
+  ProxygenServer(
+      const std::string& ip,
+      int port,
+      int threads,
+      PythonRequestCallback callback)
+      : ip_(ip),
+        port_(port),
+        threads_(threads),
+        sync_callback_(std::move(callback)),
+        async_callback_(nullptr),
+        is_async_(false),
+        server_(nullptr),
+        server_thread_(nullptr) {}
+
+  // Constructor for asynchronous callback (recommended)
+  ProxygenServer(
+      const std::string& ip,
+      int port,
+      int threads,
+      PythonAsyncRequestCallback async_callback,
+      bool is_async)
+      : ip_(ip),
+        port_(port),
+        threads_(threads),
+        sync_callback_(nullptr),
+        async_callback_(std::move(async_callback)),
+        is_async_(is_async),
+        server_(nullptr),
+        server_thread_(nullptr) {}
+
+  ~ProxygenServer() {
+    stop();
+  }
+
+  void start() {
+    if (server_ != nullptr) {
+      throw std::runtime_error("Server is already running");
+    }
+
+    py::gil_scoped_release release;
+
+    // Configure socket options to enable SO_REUSEPORT
+    // This allows multiple worker processes to bind to the same port
+    // Essential for uWSGI multi-worker setup where each worker runs its own
+    // Proxygen server
+    folly::SocketOptionMap socket_options;
+    socket_options[{SOL_SOCKET, SO_REUSEPORT}] = 1;
+
+    HTTPServer::IPConfig ip_config(
+        folly::SocketAddress(ip_, port_, true), HTTPServer::Protocol::HTTP);
+    ip_config.acceptorSocketOptions = socket_options;
+
+    std::vector<HTTPServer::IPConfig> IPs = {ip_config};
+
+    int actual_threads = threads_;
+    if (actual_threads <= 0) {
+      actual_threads = sysconf(_SC_NPROCESSORS_ONLN);
+      if (actual_threads <= 0) {
+        actual_threads = 1;
+      }
+    }
+
+    HTTPServerOptions options;
+    options.threads = static_cast<size_t>(actual_threads);
+    options.idleTimeout = std::chrono::milliseconds(60000);
+    options.enableContentCompression = false;
+
+    // Create handler factory based on mode (sync or async)
+    if (is_async_) {
+      options.handlerFactories =
+          RequestHandlerChain()
+              .addThen(
+                  std::make_unique<PythonRequestHandlerFactory>(
+                      async_callback_, is_async_))
+              .build();
+      LOG(INFO) << "Using async callback mode";
+    } else {
+      options.handlerFactories =
+          RequestHandlerChain()
+              .addThen(
+                  std::make_unique<PythonRequestHandlerFactory>(sync_callback_))
+              .build();
+      LOG(INFO) << "Using sync callback mode";
+    }
+
+    options.initialReceiveWindow = uint32_t(1 << 20);
+    options.receiveStreamWindowSize = uint32_t(1 << 20);
+    options.receiveSessionWindowSize = 10 * (1 << 20);
+    options.listenBacklog = 1024;
+
+    server_ = std::make_unique<HTTPServer>(std::move(options));
+    server_->bind(IPs);
+
+    server_thread_ =
+        std::make_unique<std::thread>([this]() { server_->start(); });
+
+    LOG(INFO) << "Proxygen server started on " << ip_ << ":" << port_
+              << " with " << actual_threads
+              << " threads (SO_REUSEPORT enabled)";
+  }
+
+  void stop() {
+    if (server_) {
+      py::gil_scoped_release release;
+
+      server_->stop();
+
+      if (server_thread_ && server_thread_->joinable()) {
+        server_thread_->join();
+      }
+
+      server_.reset();
+      server_thread_.reset();
+
+      LOG(INFO) << "Proxygen server stopped";
+    }
+  }
+
+  void wait() {
+    // Periodically check for Python signals (like KeyboardInterrupt)
+    // instead of blocking indefinitely in join()
+    while (server_thread_ && server_thread_->joinable() && server_) {
+      {
+        py::gil_scoped_release release;
+        // Sleep briefly to allow signal delivery
+        std::this_thread::sleep_for(std::chrono::milliseconds(100));
+      }
+
+      // Check if Python signal occurred (e.g., Ctrl+C)
+      if (PyErr_CheckSignals() != 0) {
+        // Stop the server and let the exception propagate
+        stop();
+        throw py::error_already_set();
+      }
+    }
+
+    // Final join to ensure thread cleanup
+    if (server_thread_ && server_thread_->joinable()) {
+      py::gil_scoped_release release;
+      server_thread_->join();
+    }
+  }
+
+ private:
+  std::string ip_;
+  int port_;
+  int threads_;
+  PythonRequestCallback sync_callback_;
+  PythonAsyncRequestCallback async_callback_;
+  bool is_async_;
+  std::unique_ptr<HTTPServer> server_;
+  std::unique_ptr<std::thread> server_thread_;
+};
+
+PYBIND11_MODULE(proxygen_binding, m) {
+  m.doc() = "Python bindings for Proxygen HTTP server";
+
+  py::class_<RequestData>(m, "RequestData")
+      .def(py::init<>())
+      .def_readwrite("method", &RequestData::method)
+      .def_readwrite("url", &RequestData::url)
+      .def_readwrite("path", &RequestData::path)
+      .def_readwrite("query_string", &RequestData::query_string)
+      .def_readwrite("headers", &RequestData::headers)
+      .def_readwrite("body", &RequestData::body)
+      .def_readwrite("http_version", &RequestData::http_version)
+      .def("__repr__", [](const RequestData& req) {
+        return "<RequestData method=" + req.method + " path=" + req.path + ">";
+      });
+
+  py::class_<ResponseData>(m, "ResponseData")
+      .def(py::init<>())
+      .def_readwrite("status_code", &ResponseData::status_code)
+      .def_readwrite("status_message", &ResponseData::status_message)
+      .def_readwrite("headers", &ResponseData::headers)
+      .def_readwrite("body", &ResponseData::body)
+      .def("__repr__", [](const ResponseData& resp) {
+        return "<ResponseData status_code=" + std::to_string(resp.status_code) +
+            ">";
+      });
+
+  py::class_<ProxygenServer>(m, "ProxygenServer")
+      // Synchronous callback constructor (deprecated)
+      .def(
+          py::init<const std::string&, int, int, PythonRequestCallback>(),
+          py::arg("ip") = "127.0.0.1",
+          py::arg("port") = 8000,
+          py::arg("threads") = 0,
+          py::arg("callback"),
+          "Create server with synchronous callback (deprecated - use async_callback)")
+      // Asynchronous callback constructor (recommended)
+      .def(
+          py::init<
+              const std::string&,
+              int,
+              int,
+              PythonAsyncRequestCallback,
+              bool>(),
+          py::arg("ip") = "127.0.0.1",
+          py::arg("port") = 8000,
+          py::arg("threads") = 0,
+          py::arg("async_callback"),
+          py::arg("is_async") = true,
+          "Create server with asynchronous callback (recommended)")
+      .def("start", &ProxygenServer::start, "Start the HTTP server")
+      .def("stop", &ProxygenServer::stop, "Stop the HTTP server")
+      .def(
+          "wait",
+          &ProxygenServer::wait,
+          "Wait for the server thread to finish");
+
+  m.def(
+      "init_logging",
+      []() {
+        google::InitGoogleLogging("proxygen_binding");
+        LOG(INFO) << "Proxygen binding logging initialized";
+      },
+      "Initialize Google logging for Proxygen");
+}

--- a/packages/django_workload/srcs/proxygen_binding/setup.py
+++ b/packages/django_workload/srcs/proxygen_binding/setup.py
@@ -227,9 +227,36 @@ setup(
     version="0.1.0",
     author="Meta Platforms, Inc.",
     description="Python bindings for Proxygen HTTP server",
-    long_description="",
+    long_description=open("README.md").read() if os.path.exists("README.md") else "",
+    long_description_content_type="text/markdown",
     ext_modules=ext_modules,
+    py_modules=[
+        "django_asgi_adapter",
+        "example_server",
+        "django_server",
+    ],
     cmdclass={"build_ext": build_ext},
     zip_safe=False,
     python_requires=">=3.8",
+    install_requires=[
+        "pybind11>=2.6.0",
+    ],
+    extras_require={
+        "django": ["django>=3.0"],
+    },
+    scripts=[
+        "example_server.py",
+        "django_server.py",
+    ],
+    classifiers=[
+        "Development Status :: 3 - Alpha",
+        "Intended Audience :: Developers",
+        "License :: OSI Approved :: MIT License",
+        "Programming Language :: Python :: 3",
+        "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
+        "Programming Language :: C++",
+    ],
 )

--- a/packages/django_workload/srcs/proxygen_binding/setup.py
+++ b/packages/django_workload/srcs/proxygen_binding/setup.py
@@ -1,0 +1,235 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+import argparse
+import os
+import sys
+from pathlib import Path
+
+from pybind11.setup_helpers import build_ext, Pybind11Extension
+from setuptools import setup
+
+
+def parse_custom_args():
+    """
+    Parse custom command line arguments for the build.
+
+    This uses argparse to handle custom arguments that are not part of
+    setuptools' standard arguments. Custom arguments are removed from
+    sys.argv to avoid confusing setuptools.
+
+    Returns:
+        argparse.Namespace: Parsed arguments
+    """
+    parser = argparse.ArgumentParser(
+        description="Build proxygen_binding Python extension",
+        add_help=False,  # Don't add -h/--help to avoid conflict with setuptools
+    )
+
+    parser.add_argument(
+        "--proxygen-dir",
+        dest="proxygen_dir",
+        metavar="PATH",
+        help="Path to Proxygen installation directory (default: $PROXYGEN_INSTALL_DIR or /home/wsu/proxygen/staging)",
+    )
+
+    parser.add_argument(
+        "--extra-include-dirs",
+        dest="extra_include_dirs",
+        metavar="PATH",
+        help="Additional include directories (colon-separated)",
+    )
+
+    parser.add_argument(
+        "--extra-lib-dirs",
+        dest="extra_lib_dirs",
+        metavar="PATH",
+        help="Additional library directories (colon-separated)",
+    )
+
+    parser.add_argument(
+        "--debug",
+        dest="enable_debug",
+        action="store_true",
+        help="Enable debug logging and performance metrics (adds PROXYGEN_BINDING_DEBUG flag)",
+    )
+
+    # Parse only known args, leaving the rest for setuptools
+    args, remaining = parser.parse_known_args()
+
+    # Update sys.argv to contain only setuptools-compatible arguments
+    sys.argv[1:] = remaining
+
+    return args
+
+
+def get_proxygen_paths(custom_args):
+    """
+    Get Proxygen installation paths from environment, CLI arguments, or defaults.
+
+    Priority order:
+    1. CLI argument: --proxygen-dir=/path/to/proxygen
+    2. Environment variable: PROXYGEN_INSTALL_DIR
+    3. Default: /home/wsu/proxygen/staging
+
+    Args:
+        custom_args: Parsed custom arguments
+
+    Returns:
+        tuple: (install_dir, include_dirs, library_dirs)
+    """
+    proxygen_dir = None
+
+    # Check CLI argument (highest priority)
+    if custom_args.proxygen_dir:
+        proxygen_dir = custom_args.proxygen_dir
+
+    # Check environment variable
+    if not proxygen_dir:
+        proxygen_dir = os.environ.get("PROXYGEN_INSTALL_DIR")
+
+    # Default fallback - use home directory
+    if not proxygen_dir:
+        home_dir = Path.home()
+        proxygen_dir = str(home_dir / "proxygen" / "staging")
+        print(
+            f"WARNING: PROXYGEN_INSTALL_DIR not set, using default: {proxygen_dir}",
+            file=sys.stderr,
+        )
+
+    proxygen_install_dir = Path(proxygen_dir)
+
+    # Main Proxygen paths
+    proxygen_include_dir = proxygen_install_dir / "include"
+    proxygen_lib_dir = proxygen_install_dir / "lib"
+
+    # Dependency paths (from _build/deps in proxygen source)
+    # These are at: <PROXYGEN_INSTALL_DIR>/../proxygen/_build/deps
+    proxygen_source_dir = proxygen_install_dir.parent / "proxygen"
+    deps_dir = proxygen_source_dir / "_build" / "deps"
+    deps_include_dir = deps_dir / "include"
+    deps_lib_dir = deps_dir / "lib"
+    deps_lib64_dir = deps_dir / "lib64"
+
+    # Collect all include directories
+    include_dirs = [str(proxygen_include_dir)]
+    if deps_include_dir.exists():
+        include_dirs.append(str(deps_include_dir))
+
+    # Add extra include directories from CLI
+    if custom_args.extra_include_dirs:
+        extra_includes = custom_args.extra_include_dirs.split(":")
+        include_dirs.extend(extra_includes)
+
+    # Collect all library directories
+    library_dirs = [str(proxygen_lib_dir)]
+    if deps_lib_dir.exists():
+        library_dirs.append(str(deps_lib_dir))
+    if deps_lib64_dir.exists():
+        library_dirs.append(str(deps_lib64_dir))
+
+    # Add extra library directories from CLI
+    if custom_args.extra_lib_dirs:
+        extra_libs = custom_args.extra_lib_dirs.split(":")
+        library_dirs.extend(extra_libs)
+
+    return proxygen_install_dir, include_dirs, library_dirs
+
+
+# Parse custom arguments first
+custom_args = parse_custom_args()
+
+# Get Proxygen paths
+proxygen_install_dir, include_dirs, library_dirs = get_proxygen_paths(custom_args)
+
+# Calculate BOOST_ROOT from dependencies directory
+# Boost is built in <PROXYGEN_INSTALL_DIR>/../proxygen/_build/deps
+proxygen_source_dir = proxygen_install_dir.parent / "proxygen"
+deps_dir = proxygen_source_dir / "_build" / "deps"
+boost_root = str(deps_dir)
+
+# Set BOOST_ROOT environment variable to force using our custom-built Boost
+# This prevents CMake from using system Boost libraries
+os.environ["BOOST_ROOT"] = boost_root
+os.environ["Boost_NO_SYSTEM_PATHS"] = "ON"
+
+print(f"Using Proxygen installation: {proxygen_install_dir}")
+print(f"BOOST_ROOT set to: {boost_root}")
+print(f"Include directories: {include_dirs}")
+print(f"Library directories: {library_dirs}")
+
+# Prepare compile arguments
+compile_args = ["-std=c++17", "-fPIC", "-g"]
+if custom_args.enable_debug:
+    print("DEBUG MODE ENABLED: Adding -DPROXYGEN_BINDING_DEBUG")
+    compile_args.append("-DPROXYGEN_BINDING_DEBUG")
+
+ext_modules = [
+    Pybind11Extension(
+        "proxygen_binding",
+        [
+            "PythonRequestHandler.cpp",
+            "PythonRequestHandlerFactory.cpp",
+            "proxygen_binding.cpp",
+        ],
+        include_dirs=include_dirs,
+        library_dirs=library_dirs,
+        libraries=[
+            "proxygenhttpserver",
+            "proxygen",
+            "wangle",
+            "folly",
+            "fizz",
+            "aegis",
+            "glog",
+            "gflags",
+            "fmt",
+            "boost_filesystem",
+            "boost_system",
+            "boost_context",
+            "double-conversion",
+            "event",
+            "ssl",
+            "crypto",
+            "z",
+            "pthread",
+            "dl",
+            "snappy",
+            "iberty",
+            "lz4",
+            "bz2",
+            "sodium",
+            "zstd",
+            "mvfst_folly_utils",
+            "mvfst_codec_types",
+            "mvfst_contiguous_cursor",
+            "mvfst_exception",
+            "lzma",
+            "cares",
+            "unwind",
+        ],
+        extra_compile_args=compile_args,
+        extra_link_args=[
+            f"-L{library_dirs[0]}",
+            "-Wl,-rpath," + str(library_dirs[0]),
+            # Add rpath for Boost libraries from DEPS_DIR
+            f"-L{deps_dir}/lib",
+            "-Wl,-rpath," + str(deps_dir / "lib"),
+        ],
+    ),
+]
+
+setup(
+    name="proxygen_binding",
+    version="0.1.0",
+    author="Meta Platforms, Inc.",
+    description="Python bindings for Proxygen HTTP server",
+    long_description="",
+    ext_modules=ext_modules,
+    cmdclass={"build_ext": build_ext},
+    zip_safe=False,
+    python_requires=">=3.8",
+)

--- a/packages/django_workload/templates/build_proxygen.sh
+++ b/packages/django_workload/templates/build_proxygen.sh
@@ -1,0 +1,690 @@
+#!/usr/bin/env bash
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+## Run this script to build proxygen and run the tests. If you want to
+## install proxygen to use in another C++ project on this machine, run
+## the sibling file `reinstall.sh`.
+
+# Obtain the base directory this script resides in.
+BASE_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+BENCHPRESS_ROOT="$(readlink -f "${BASE_DIR}/../../../../")"
+COMMON_DIR="${BENCHPRESS_ROOT}/packages/common"
+
+# Useful constants
+COLOR_RED="\033[0;31m"
+COLOR_GREEN="\033[0;32m"
+COLOR_OFF="\033[0m"
+
+function detect_platform() {
+  unameOut="$(uname -s)"
+  case "${unameOut}" in
+      Linux*)
+        PLATFORM=Linux
+        source "${COMMON_DIR}/os-distro.sh"
+        DISTRO="$(get_os_distro_id)"
+        ;;
+      Darwin*)    PLATFORM=Mac;;
+      *)          PLATFORM="UNKNOWN:${unameOut}"
+  esac
+  echo -e "${COLOR_GREEN}Detected platform: $PLATFORM  Distribution $DISTRO ${COLOR_OFF}"
+}
+
+function install_dependencies_linux_default() {
+  apt-get install -yq \
+    $deps_universal \
+    libbz2-dev \
+    libc-ares-dev \
+    libgflags-dev \
+    libgoogle-glog-dev \
+    libkrb5-dev \
+    libsasl2-dev \
+    libnuma-dev \
+    pkg-config \
+    libssl-dev \
+    libcap-dev \
+    libevent-dev \
+    libtool \
+    libjemalloc-dev \
+    libsnappy-dev \
+    libiberty-dev \
+    liblz4-dev \
+    liblzma-dev \
+    zlib1g-dev \
+    binutils-dev \
+    libsodium-dev \
+    libdouble-conversion-dev \
+    libunwind-dev
+}
+
+function install_dependencies_linux_fedora() {
+  dnf install -y \
+    $deps_universal \
+    m4 \
+    g++ \
+    flex \
+    bison \
+    c-ares-devel \
+    gflags-devel \
+    glog-devel \
+    krb5-libs \
+    double-conversion-devel \
+    libzstd-devel \
+    libsodium-devel \
+    binutils-devel \
+    zlib-devel \
+    make \
+    lz4-devel \
+    wget \
+    unzip \
+    snappy-devel \
+    jemalloc-devel \
+    cyrus-sasl-devel \
+    numactl-libs \
+    openssl-devel \
+    libcap-devel \
+    libevent-devel \
+    libunwind-devel \
+    libtool \
+    gperf
+}
+
+function install_dependencies_linux_centos() {
+  dnf install -y \
+    $deps_universal \
+    m4 \
+    g++ \
+    flex \
+    bison \
+    c-ares-devel \
+    gflags-devel \
+    glog-devel \
+    krb5-libs \
+    double-conversion-devel \
+    libzstd-devel \
+    libsodium-devel \
+    binutils-devel \
+    zlib-devel \
+    make \
+    lz4-devel \
+    wget \
+    unzip \
+    snappy-devel \
+    jemalloc-devel \
+    cyrus-sasl-devel \
+    numactl-libs \
+    openssl-devel \
+    libcap-devel \
+    libevent-devel \
+    libunwind-devel \
+    libtool \
+    gperf
+}
+
+function install_dependencies_linux {
+  deps_universal="\
+    git \
+    cmake \
+    m4 \
+    g++ \
+    flex \
+    bison \
+    gperf \
+    wget \
+    unzip \
+    make"
+
+  case "$DISTRO" in
+      fedora*)    install_dependencies_linux_fedora;;
+      centos*)    install_dependencies_linux_centos;;
+      rhel*)      install_dependencies_linux_centos;;
+      *)          install_dependencies_linux_default;;
+  esac
+}
+
+function install_dependencies_mac() {
+  # install the default dependencies from homebrew
+  brew install -f            \
+    cmake                    \
+    m4                       \
+    double-conversion        \
+    gflags                   \
+    glog                     \
+    gperf                    \
+    libevent                 \
+    lz4                      \
+    snappy                   \
+    xz                       \
+    openssl                  \
+    libsodium
+
+  brew link                 \
+    cmake                   \
+    double-conversion       \
+    gflags                  \
+    glog                    \
+    gperf                   \
+    libevent                \
+    lz4                     \
+    snappy                  \
+    openssl                 \
+    xz                      \
+    libsodium
+}
+
+function install_dependencies() {
+  echo -e "${COLOR_GREEN}[ INFO ] install dependencies ${COLOR_OFF}"
+  if [ "$PLATFORM" = "Linux" ]; then
+    install_dependencies_linux
+  elif [ "$PLATFORM" = "Mac" ]; then
+    install_dependencies_mac
+  else
+    echo -e "${COLOR_RED}[ ERROR ] Unknown platform: $PLATFORM ${COLOR_OFF}"
+    exit 1
+  fi
+}
+
+function synch_dependency_to_commit() {
+  # Utility function to synch a dependency to a specific commit. Takes two arguments:
+  #   - $1: folder of the dependency's git repository
+  #   - $2: path to the text file containing the desired commit hash
+  if [ "$FETCH_DEPENDENCIES" = false ] ; then
+    return
+  fi
+  DEP_REV=$(sed 's/Subproject commit //' "$2")
+  pushd "$1"
+  git fetch
+  # Disable git warning about detached head when checking out a specific commit.
+  git -c advice.detachedHead=false checkout "$DEP_REV"
+  popd
+}
+
+function setup_boost() {
+  BOOST_DIR=$DEPS_DIR/boost
+  BOOST_VERSION="1.75.0"
+  BOOST_VERSION_UNDERSCORE="1_75_0"
+  BOOST_ARCHIVE="boost_${BOOST_VERSION_UNDERSCORE}.tar.gz"
+  BOOST_URL="https://archives.boost.io/release/${BOOST_VERSION}/source/boost_${BOOST_VERSION_UNDERSCORE}.tar.gz"
+
+  if [ -d "$BOOST_DIR" ] && [ -f "$DEPS_DIR/lib/libboost_context.a" ]; then
+    echo -e "${COLOR_GREEN}Boost ${BOOST_VERSION} already installed, skipping ${COLOR_OFF}"
+    cd "$BWD" || exit
+    return
+  fi
+
+  echo -e "${COLOR_GREEN}[ INFO ] Downloading Boost ${BOOST_VERSION} ${COLOR_OFF}"
+  cd "$DEPS_DIR" || exit
+
+  # Download Boost tarball
+  if [ ! -f "$BOOST_ARCHIVE" ]; then
+    wget "$BOOST_URL" || {
+      echo -e "${COLOR_RED}Failed to download Boost from $BOOST_URL ${COLOR_OFF}"
+      exit 1
+    }
+  fi
+
+  # Extract Boost
+  if [ ! -d "boost_${BOOST_VERSION_UNDERSCORE}" ]; then
+    echo -e "${COLOR_GREEN}Extracting Boost ${BOOST_VERSION} ${COLOR_OFF}"
+    tar -xzf "$BOOST_ARCHIVE" || {
+      echo -e "${COLOR_RED}Failed to extract Boost archive ${COLOR_OFF}"
+      exit 1
+    }
+  fi
+
+  cd "boost_${BOOST_VERSION_UNDERSCORE}" || exit
+  BOOST_SRC_DIR=$(pwd)
+
+  echo -e "${COLOR_GREEN}Building Boost ${BOOST_VERSION} ${COLOR_OFF}"
+
+  # Bootstrap Boost.Build
+  if [ ! -f "./b2" ]; then
+    ./bootstrap.sh --prefix="$DEPS_DIR" --with-libraries=context,filesystem,program_options,regex,system,thread || {
+      echo -e "${COLOR_RED}Boost bootstrap failed ${COLOR_OFF}"
+      exit 1
+    }
+  fi
+
+  # Build and install Boost libraries
+  # Only build the libraries needed by Proxygen and its dependencies
+  ./b2 \
+    --prefix="$DEPS_DIR" \
+    --build-dir="$BOOST_SRC_DIR/build" \
+    --without-python \
+    variant=release \
+    link=static,shared \
+    threading=multi \
+    cxxflags="-fPIC" \
+    -j "$JOBS" \
+    install || {
+      echo -e "${COLOR_RED}Boost build failed ${COLOR_OFF}"
+      exit 1
+    }
+
+  echo -e "${COLOR_GREEN}Boost ${BOOST_VERSION} is installed in $DEPS_DIR ${COLOR_OFF}"
+  cd "$BWD" || exit
+}
+
+function setup_fast_float() {
+  FF_DIR="$DEPS_DIR/fast_float"
+  FF_TAG="v8.1.0"
+  if [ ! -d "$FF_DIR" ] ; then
+    echo -e "${COLOR_GREEN}[ INFO ] Cloning fast_float repo ${COLOR_OFF}"
+    git clone https://github.com/fastfloat/fast_float.git "$FF_DIR"
+  fi
+  cd "$FF_DIR"
+  git fetch --tags
+  git checkout "$FF_TAG"
+  echo -e "${COLOR_GREEN}Building fast_float ${COLOR_OFF}"
+  mkdir -p "$DEPS_DIR/include/fast_float"
+  python3 script/amalgamate.py --output "$DEPS_DIR/include/fast_float/fast_float.h" || exit
+  echo -e "${COLOR_GREEN}fast_float is installed ${COLOR_OFF}"
+  cd "$BWD" || exit
+}
+
+function setup_fmt() {
+  FMT_DIR=$DEPS_DIR/fmt
+  FMT_BUILD_DIR=$DEPS_DIR/fmt/build/
+  FMT_TAG=$(grep "subdir = " ../../build/fbcode_builder/manifests/fmt | cut -d "-" -f 2)
+  if [ ! -d "$FMT_DIR" ] ; then
+    echo -e "${COLOR_GREEN}[ INFO ] Cloning fmt repo ${COLOR_OFF}"
+    git clone https://github.com/fmtlib/fmt.git  "$FMT_DIR"
+  fi
+  cd "$FMT_DIR"
+  git fetch --tags
+  git checkout "${FMT_TAG}"
+  echo -e "${COLOR_GREEN}Building fmt ${COLOR_OFF}"
+  mkdir -p "$FMT_BUILD_DIR"
+  cd "$FMT_BUILD_DIR" || exit
+
+  cmake                                           \
+    -DCMAKE_PREFIX_PATH="$DEPS_DIR"               \
+    -DCMAKE_INSTALL_PREFIX="$DEPS_DIR"            \
+    -DCMAKE_BUILD_TYPE=RelWithDebInfo             \
+    -DCMAKE_POSITION_INDEPENDENT_CODE=ON          \
+    "$MAYBE_OVERRIDE_CXX_FLAGS"                   \
+    -DFMT_DOC=OFF                                 \
+    -DFMT_TEST=OFF                                \
+    ..
+  make -j "$JOBS"
+  make install
+  echo -e "${COLOR_GREEN}fmt is installed ${COLOR_OFF}"
+  cd "$BWD" || exit
+}
+
+function setup_googletest() {
+  GTEST_DIR=$DEPS_DIR/googletest
+  GTEST_BUILD_DIR=$DEPS_DIR/googletest/build/
+  GTEST_TAG=$(grep "subdir = " ../../build/fbcode_builder/manifests/googletest | cut -d "-" -f 2,3)
+  if [ ! -d "$GTEST_DIR" ] ; then
+    echo -e "${COLOR_GREEN}[ INFO ] Cloning googletest repo ${COLOR_OFF}"
+    git clone https://github.com/google/googletest.git  "$GTEST_DIR"
+  fi
+  cd "$GTEST_DIR"
+  git fetch --tags
+  git checkout "${GTEST_TAG}"
+  echo -e "${COLOR_GREEN}Building googletest ${COLOR_OFF}"
+  mkdir -p "$GTEST_BUILD_DIR"
+  cd "$GTEST_BUILD_DIR" || exit
+
+  cmake                                           \
+    -DCMAKE_PREFIX_PATH="$DEPS_DIR"               \
+    -DCMAKE_INSTALL_PREFIX="$DEPS_DIR"            \
+    -DCMAKE_BUILD_TYPE=RelWithDebInfo             \
+    -DCMAKE_POSITION_INDEPENDENT_CODE=ON          \
+    ..
+  make -j "$JOBS"
+  make install
+  echo -e "${COLOR_GREEN}googletest is installed ${COLOR_OFF}"
+  cd "$BWD" || exit
+}
+
+function setup_zstd() {
+  ZSTD_DIR=$DEPS_DIR/zstd
+  ZSTD_BUILD_DIR=$DEPS_DIR/zstd/build/cmake/builddir
+  ZSTD_INSTALL_DIR=$DEPS_DIR
+  ZSTD_TAG=$(grep "subdir = " ../../build/fbcode_builder/manifests/zstd | cut -d "-" -f 2 | cut -d "/" -f 1)
+  if [ ! -d "$ZSTD_DIR" ] ; then
+    echo -e "${COLOR_GREEN}[ INFO ] Cloning zstd repo ${COLOR_OFF}"
+    git clone https://github.com/facebook/zstd.git "$ZSTD_DIR"
+  fi
+  cd "$ZSTD_DIR"
+  git fetch --tags
+  git checkout "v${ZSTD_TAG}"
+  echo -e "${COLOR_GREEN}Building Zstd ${COLOR_OFF}"
+  mkdir -p "$ZSTD_BUILD_DIR"
+  cd "$ZSTD_BUILD_DIR" || exit
+  cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo           \
+    -DBUILD_TESTS=OFF                               \
+    -DCMAKE_PREFIX_PATH="$ZSTD_INSTALL_DIR"         \
+    -DCMAKE_INSTALL_PREFIX="$ZSTD_INSTALL_DIR"      \
+    -DCMAKE_POSITION_INDEPENDENT_CODE=ON            \
+    ${CMAKE_EXTRA_ARGS[@]+"${CMAKE_EXTRA_ARGS[@]}"} \
+    ..
+  make -j "$JOBS"
+  make install
+  echo -e "${COLOR_GREEN}Zstd is installed ${COLOR_OFF}"
+  cd "$BWD" || exit
+}
+
+function setup_folly() {
+  FOLLY_DIR=$DEPS_DIR/folly
+  FOLLY_BUILD_DIR=$DEPS_DIR/folly/build/
+
+  if [ ! -d "$FOLLY_DIR" ] ; then
+    echo -e "${COLOR_GREEN}[ INFO ] Cloning folly repo ${COLOR_OFF}"
+    git clone https://github.com/facebook/folly.git "$FOLLY_DIR"
+  fi
+  synch_dependency_to_commit "$FOLLY_DIR" "$BASE_DIR"/../build/deps/github_hashes/facebook/folly-rev.txt
+  if [ "$PLATFORM" = "Mac" ]; then
+    # Homebrew installs OpenSSL in a non-default location on MacOS >= Mojave
+    # 10.14 because MacOS has its own SSL implementation.  If we find the
+    # typical Homebrew OpenSSL dir, load OPENSSL_ROOT_DIR so that cmake
+    # will find the Homebrew version.
+    dir=/usr/local/opt/openssl
+    if [ -d $dir ]; then
+        export OPENSSL_ROOT_DIR=$dir
+    fi
+  fi
+  echo -e "${COLOR_GREEN}Building Folly ${COLOR_OFF}"
+  mkdir -p "$FOLLY_BUILD_DIR"
+  cd "$FOLLY_BUILD_DIR" || exit
+  MAYBE_DISABLE_JEMALLOC=""
+  if [ "$NO_JEMALLOC" == true ] ; then
+    MAYBE_DISABLE_JEMALLOC="-DFOLLY_USE_JEMALLOC=0"
+  fi
+
+  MAYBE_USE_STATIC_DEPS=""
+  MAYBE_USE_STATIC_BOOST=""
+  MAYBE_BUILD_SHARED_LIBS=""
+  if [ "$BUILD_FOR_FUZZING" == true ] ; then
+    MAYBE_USE_STATIC_DEPS="-DUSE_STATIC_DEPS_ON_UNIX=ON"
+    MAYBE_USE_STATIC_BOOST="-DBOOST_LINK_STATIC=ON"
+    MAYBE_BUILD_SHARED_LIBS="-DBUILD_SHARED_LIBS=OFF"
+  fi
+
+  cmake                                           \
+    -DCMAKE_PREFIX_PATH="$DEPS_DIR"               \
+    -DCMAKE_INSTALL_PREFIX="$DEPS_DIR"            \
+    -DCMAKE_BUILD_TYPE=RelWithDebInfo             \
+    -DCMAKE_POSITION_INDEPENDENT_CODE=ON          \
+    -DBUILD_TESTS=OFF                             \
+    "$MAYBE_USE_STATIC_DEPS"                      \
+    "$MAYBE_USE_STATIC_BOOST"                     \
+    "$MAYBE_BUILD_SHARED_LIBS"                    \
+    "$MAYBE_OVERRIDE_CXX_FLAGS"                   \
+    $MAYBE_DISABLE_JEMALLOC                       \
+    ..
+  make -j "$JOBS"
+  make install
+  echo -e "${COLOR_GREEN}Folly is installed ${COLOR_OFF}"
+  cd "$BWD" || exit
+}
+
+function setup_libaegis() {
+  LIBAEGIS_DIR=$DEPS_DIR/libaegis
+  LIBAEGIS_BUILD_DIR=$DEPS_DIR/libaegis/build/
+  LIBAEGIS_TAG="0.4.0"
+  if [ ! -d "$LIBAEGIS_DIR" ] ; then
+    echo -e "${COLOR_GREEN}[ INFO ] Cloning libaegis repo ${COLOR_OFF}"
+    git clone https://github.com/aegis-aead/libaegis.git "$LIBAEGIS_DIR"
+  fi
+  cd "$LIBAEGIS_DIR"
+  git fetch --tags
+  git checkout "${LIBAEGIS_TAG}"
+  echo -e "${COLOR_GREEN}Building libaegis ${COLOR_OFF}"
+  mkdir -p "$LIBAEGIS_BUILD_DIR"
+  cd "$LIBAEGIS_BUILD_DIR" || exit
+
+  cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo       \
+    -DCMAKE_PREFIX_PATH="$DEPS_DIR"             \
+    -DCMAKE_INSTALL_PREFIX="$DEPS_DIR"          \
+    -DCMAKE_POSITION_INDEPENDENT_CODE=ON        \
+    -DBUILD_TESTS=OFF                           \
+    "${LIBAEGIS_DIR}"
+  make -j "$JOBS"
+  make install
+
+  echo -e "${COLOR_GREEN}Libaegis is installed ${COLOR_OFF}"
+  cd "$BWD" || exit
+}
+
+function setup_fizz() {
+  FIZZ_DIR=$DEPS_DIR/fizz
+  FIZZ_BUILD_DIR=$DEPS_DIR/fizz/build/
+  if [ ! -d "$FIZZ_DIR" ] ; then
+    echo -e "${COLOR_GREEN}[ INFO ] Cloning fizz repo ${COLOR_OFF}"
+    git clone https://github.com/facebookincubator/fizz "$FIZZ_DIR"
+  fi
+  synch_dependency_to_commit "$FIZZ_DIR" "$BASE_DIR"/../build/deps/github_hashes/facebookincubator/fizz-rev.txt
+  echo -e "${COLOR_GREEN}Building Fizz ${COLOR_OFF}"
+  mkdir -p "$FIZZ_BUILD_DIR"
+  cd "$FIZZ_BUILD_DIR" || exit
+
+  MAYBE_USE_STATIC_DEPS=""
+  MAYBE_USE_SODIUM_STATIC_LIBS=""
+  MAYBE_BUILD_SHARED_LIBS=""
+  if [ "$BUILD_FOR_FUZZING" == true ] ; then
+    MAYBE_USE_STATIC_DEPS="-DUSE_STATIC_DEPS_ON_UNIX=ON"
+    MAYBE_USE_SODIUM_STATIC_LIBS="-Dsodium_USE_STATIC_LIBS=ON"
+    MAYBE_BUILD_SHARED_LIBS="-DBUILD_SHARED_LIBS=OFF"
+  fi
+
+  cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo       \
+    -DCMAKE_PREFIX_PATH="$DEPS_DIR"             \
+    -DCMAKE_INSTALL_PREFIX="$DEPS_DIR"          \
+    -DCMAKE_POSITION_INDEPENDENT_CODE=ON        \
+    -DBUILD_TESTS=OFF                           \
+    "$MAYBE_USE_STATIC_DEPS"                    \
+    "$MAYBE_BUILD_SHARED_LIBS"                  \
+    "$MAYBE_OVERRIDE_CXX_FLAGS"                 \
+    "$MAYBE_USE_SODIUM_STATIC_LIBS"             \
+    "$FIZZ_DIR/fizz"
+  make -j "$JOBS"
+  make install
+  echo -e "${COLOR_GREEN}Fizz is installed ${COLOR_OFF}"
+  cd "$BWD" || exit
+}
+
+function setup_wangle() {
+  WANGLE_DIR=$DEPS_DIR/wangle
+  WANGLE_BUILD_DIR=$DEPS_DIR/wangle/build/
+  if [ ! -d "$WANGLE_DIR" ] ; then
+    echo -e "${COLOR_GREEN}[ INFO ] Cloning wangle repo ${COLOR_OFF}"
+    git clone https://github.com/facebook/wangle "$WANGLE_DIR"
+  fi
+  synch_dependency_to_commit "$WANGLE_DIR" "$BASE_DIR"/../build/deps/github_hashes/facebook/wangle-rev.txt
+  echo -e "${COLOR_GREEN}Building Wangle ${COLOR_OFF}"
+  mkdir -p "$WANGLE_BUILD_DIR"
+  cd "$WANGLE_BUILD_DIR" || exit
+
+  MAYBE_USE_STATIC_DEPS=""
+  MAYBE_BUILD_SHARED_LIBS=""
+  if [ "$BUILD_FOR_FUZZING" == true ] ; then
+    MAYBE_USE_STATIC_DEPS="-DUSE_STATIC_DEPS_ON_UNIX=ON"
+    MAYBE_BUILD_SHARED_LIBS="-DBUILD_SHARED_LIBS=OFF"
+  fi
+
+  cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo       \
+    -DCMAKE_PREFIX_PATH="$DEPS_DIR"             \
+    -DCMAKE_INSTALL_PREFIX="$DEPS_DIR"          \
+    -DCMAKE_POSITION_INDEPENDENT_CODE=ON        \
+    -DBUILD_TESTS=OFF                           \
+    "$MAYBE_USE_STATIC_DEPS"                    \
+    "$MAYBE_BUILD_SHARED_LIBS"                  \
+    "$MAYBE_OVERRIDE_CXX_FLAGS"                 \
+    "$WANGLE_DIR/wangle"
+  make -j "$JOBS"
+  make install
+  echo -e "${COLOR_GREEN}Wangle is installed ${COLOR_OFF}"
+  cd "$BWD" || exit
+}
+
+function setup_mvfst() {
+  MVFST_DIR=$DEPS_DIR/mvfst
+  MVFST_BUILD_DIR=$DEPS_DIR/mvfst/build/
+  if [ ! -d "$MVFST_DIR" ] ; then
+    echo -e "${COLOR_GREEN}[ INFO ] Cloning mvfst repo ${COLOR_OFF}"
+    git clone https://github.com/facebook/mvfst "$MVFST_DIR"
+  fi
+  synch_dependency_to_commit "$MVFST_DIR" "$BASE_DIR"/../build/deps/github_hashes/facebook/mvfst-rev.txt
+  echo -e "${COLOR_GREEN}Building Mvfst ${COLOR_OFF}"
+  mkdir -p "$MVFST_BUILD_DIR"
+  cd "$MVFST_BUILD_DIR" || exit
+
+  MAYBE_USE_STATIC_DEPS=""
+  MAYBE_BUILD_SHARED_LIBS=""
+  if [ "$BUILD_FOR_FUZZING" == true ] ; then
+    MAYBE_USE_STATIC_DEPS="-DUSE_STATIC_DEPS_ON_UNIX=ON"
+    MAYBE_BUILD_SHARED_LIBS="-DBUILD_SHARED_LIBS=OFF"
+  fi
+
+
+  cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo       \
+    -DCMAKE_PREFIX_PATH="$DEPS_DIR"             \
+    -DCMAKE_INSTALL_PREFIX="$DEPS_DIR"          \
+    -DCMAKE_POSITION_INDEPENDENT_CODE=ON        \
+    -DBUILD_TESTS=OFF                           \
+    "$MAYBE_USE_STATIC_DEPS"                    \
+    "$MAYBE_BUILD_SHARED_LIBS"                  \
+    "$MAYBE_OVERRIDE_CXX_FLAGS"                 \
+    "$MVFST_DIR"
+  make -j "$JOBS"
+  make install
+  echo -e "${COLOR_GREEN}Mvfst is installed ${COLOR_OFF}"
+  cd "$BWD" || exit
+}
+
+# Parse args
+JOBS=8
+INSTALL_DEPENDENCIES=true
+FETCH_DEPENDENCIES=true
+PREFIX=""
+COMPILER_FLAGS=""
+PROXY_SERVER_HOST=""
+PROXY_SERVER_PORT="8080"
+
+USAGE="./build.sh [-j num_jobs] [-m|--no-jemalloc] [--no-install-dependencies] [-p|--prefix] [-x|--compiler-flags] [--no-fetch-dependencies] [--proxy_server_host] [--proxy_server_port]"
+while [ "$1" != "" ]; do
+  case $1 in
+    -j | --jobs ) shift
+                  JOBS=$1
+                  ;;
+    -m | --no-jemalloc )
+                  NO_JEMALLOC=true
+                  ;;
+    --no-install-dependencies )
+                  INSTALL_DEPENDENCIES=false
+          ;;
+    --no-fetch-dependencies )
+                  FETCH_DEPENDENCIES=false
+          ;;
+    --build-for-fuzzing )
+                  BUILD_FOR_FUZZING=true
+      ;;
+    -t | --no-tests )
+                  NO_BUILD_TESTS=true
+      ;;
+    -p | --prefix )
+                  shift
+                  PREFIX=$1
+      ;;
+    -x | --compiler-flags )
+                  shift
+                  COMPILER_FLAGS=$1
+      ;;
+    --proxy_server_host )
+                  shift
+                  PROXY_SERVER_HOST=$1
+      ;;
+    --proxy_server_port )
+                  shift
+                  PROXY_SERVER_PORT=$1
+      ;;
+    * )           echo $USAGE
+                  exit 1
+esac
+shift
+done
+
+detect_platform
+
+if [ "$INSTALL_DEPENDENCIES" == true ] ; then
+  install_dependencies
+fi
+
+MAYBE_OVERRIDE_CXX_FLAGS=""
+if [ -n "$COMPILER_FLAGS" ] ; then
+  MAYBE_OVERRIDE_CXX_FLAGS="-DCMAKE_CXX_FLAGS=$COMPILER_FLAGS"
+fi
+
+BUILD_DIR=_build
+mkdir -p $BUILD_DIR
+
+set -e nounset
+trap 'cd $BASE_DIR' EXIT
+cd $BUILD_DIR || exit
+BWD=$(pwd)
+DEPS_DIR=$BWD/deps
+mkdir -p "$DEPS_DIR"
+
+# Must execute from the directory containing this script
+cd "$(dirname "$0")"
+
+if [ -n "$PROXY_SERVER_HOST" ]; then
+    export https_proxy=http://$PROXY_SERVER_HOST:$PROXY_SERVER_PORT
+    export http_proxy=http://$PROXY_SERVER_HOST:$PROXY_SERVER_PORT
+fi
+
+# Build Boost first since other dependencies may need it
+setup_boost
+setup_fast_float
+setup_fmt
+setup_googletest
+setup_zstd
+setup_folly
+setup_libaegis
+setup_fizz
+setup_wangle
+setup_mvfst
+
+MAYBE_BUILD_FUZZERS=""
+MAYBE_USE_STATIC_DEPS=""
+MAYBE_LIB_FUZZING_ENGINE=""
+MAYBE_BUILD_SHARED_LIBS=""
+MAYBE_BUILD_TESTS="-DBUILD_TESTS=ON"
+if [ "$NO_BUILD_TESTS" == true ] ; then
+  MAYBE_BUILD_TESTS="-DBUILD_TESTS=OFF"
+fi
+if [ "$BUILD_FOR_FUZZING" == true ] ; then
+  MAYBE_BUILD_FUZZERS="-DBUILD_FUZZERS=ON"
+  MAYBE_USE_STATIC_DEPS="-DUSE_STATIC_DEPS_ON_UNIX=ON"
+  MAYBE_LIB_FUZZING_ENGINE="-DLIB_FUZZING_ENGINE='$LIB_FUZZING_ENGINE'"
+  MAYBE_BUILD_SHARED_LIBS="-DBUILD_SHARED_LIBS=OFF"
+fi
+
+if [ -z "$PREFIX" ]; then
+  PREFIX=$BWD
+fi
+
+# Build proxygen with cmake
+cd "$BWD" || exit
+cmake                                     \
+  -DCMAKE_BUILD_TYPE=RelWithDebInfo       \
+  -DCMAKE_PREFIX_PATH="$DEPS_DIR"         \
+  -DCMAKE_INSTALL_PREFIX="$PREFIX"        \
+  -DCMAKE_POSITION_INDEPENDENT_CODE=ON    \
+  "$MAYBE_BUILD_TESTS"                    \
+  "$MAYBE_BUILD_FUZZERS"                  \
+  "$MAYBE_BUILD_SHARED_LIBS"              \
+  "$MAYBE_OVERRIDE_CXX_FLAGS"             \
+  "$MAYBE_USE_STATIC_DEPS"                \
+  "$MAYBE_LIB_FUZZING_ENGINE"             \
+  ../..
+
+make -j "$JOBS"
+echo -e "${COLOR_GREEN}Proxygen build is complete. To run unit test: \
+  cd _build/ && make test ${COLOR_OFF}"


### PR DESCRIPTION
Summary:
After benchmark finishes, move these logs into benchmark_metrics_* folder to help debugging:
- 'benchmarks/django_workload/django-workload/django-workload/*.log'
- 'benchmarks/django_workload/django-workload/django-workload/log_load_balancer'
- 'benchmarks/django_workload/django-workload/client/*.log'
- 'benchmarks/django_workload/*.log'
- '/tmp/siege_out_*'

Reviewed By: YifanYuan3

Differential Revision: D85721594
