### PR TITLE
VideoBench: recording exact benchmark time, so that Perfpub can filter unrelevant part of the benchmark

### DIFF
--- a/benchpress/config/jobs.yml
+++ b/benchpress/config/jobs.yml
@@ -976,6 +976,7 @@
         after:
           - 'benchmarks/video_transcode_bench/video_transcode_bench_results.txt'
           - 'benchmarks/video_transcode_bench/perf.data'
+          - 'benchmarks/video_transcode_bench/breakdown.csv'
 
 - name: video_transcode_bench_svt_mini
   benchmark: video_transcode_bench
@@ -1009,6 +1010,7 @@
         after:
           - 'benchmarks/video_transcode_bench/video_transcode_bench_results.txt'
           - 'benchmarks/video_transcode_bench/perf.data'
+          - 'benchmarks/video_transcode_bench/breakdown.csv'
 
 
 - name: video_transcode_bench_aom
@@ -1037,6 +1039,7 @@
         after:
           - 'benchmarks/video_transcode_bench/video_transcode_bench_results.txt'
           - 'benchmarks/video_transcode_bench/perf.data'
+          - 'benchmarks/video_transcode_bench/breakdown.csv'
 
 - name: video_transcode_bench_x264
   benchmark: video_transcode_bench
@@ -1064,6 +1067,7 @@
         after:
           - 'benchmarks/video_transcode_bench/video_transcode_bench_results.txt'
           - 'benchmarks/video_transcode_bench/perf.data'
+          - 'benchmarks/video_transcode_bench/breakdown.csv'
 
 - benchmark: health_check
   name: health_check

--- a/packages/common/runtime_breakdown_utils.sh
+++ b/packages/common/runtime_breakdown_utils.sh
@@ -4,11 +4,14 @@
 
 # Function to create a CSV file for runtime breakdown tracking
 # Usage: create_breakdown_csv <folder_path>
-breakdown_file_name="breakdown.csv"
+export breakdown_file_name="breakdown.csv"
 # By using a variable here and putting the name (string) in it,
 # we avoids repeating the string in
 # all other benchmarks and avoid mistakes like typos in string.
-main_operation_name="main_benchmark"
+export main_operation_name="main_benchmark"
+export preprocessing_operation_name="preprocessing"
+export postprocessing_operation_name="postprocessing"
+
 create_breakdown_csv() {
     local folder_path="$1"
 
@@ -23,7 +26,7 @@ create_breakdown_csv() {
     local csv_file="${folder_path}/${breakdown_file_name}"
 
     # Create CSV file with headers
-    if echo "operation_name,PID,timestamp_type,timestamp" > "$csv_file"; then
+    if echo "operation_name,PID,timestamp_type,timestamp,sub_operation_name" > "$csv_file"; then
         echo "Created breakdown CSV file: $csv_file"
         return 0
     else
@@ -33,13 +36,14 @@ create_breakdown_csv() {
 }
 
 # Function to log an entry to the breakdown CSV file
-# Usage: log_breakdown_entry <folder_path> <operation_name> <pid> <timestamp_type> [timestamp]
+# Usage: log_breakdown_entry <folder_path> <operation_name> <pid> <timestamp_type> [timestamp] [sub_operation_name]
 log_breakdown_entry() {
     local folder_path="$1"
     local operation_name="$2"
     local pid="$3"
     local timestamp_type="$4"  # e.g., "start" or "end"
     local timestamp="$5"
+    local sub_operation_name="${6:-}"
 
     if [ -z "$folder_path" ] || [ -z "$operation_name" ] || [ -z "$pid" ] || [ -z "$timestamp_type" ]; then
         echo "Error: folder_path, operation_name, pid, and timestamp_type are required" >&2
@@ -59,7 +63,7 @@ log_breakdown_entry() {
     fi
 
     # Append entry to CSV file
-    if echo "$operation_name,$pid,$timestamp_type,$timestamp" >> "$csv_file"; then
+    if echo "$operation_name,$pid,$timestamp_type,$timestamp,$sub_operation_name" >> "$csv_file"; then
         echo "Logged entry: $operation_name ($timestamp_type) at $timestamp"
         return 0
     else
@@ -69,25 +73,49 @@ log_breakdown_entry() {
 }
 
 # Helper function to log start of an operation
-# Usage: log_start <folder_path> <operation_name> <pid>
+# Usage: log_start <folder_path> <operation_name> <pid> [sub_operation_name]
 log_start() {
-    log_breakdown_entry "$1" "$2" "$3" "start"
+    log_breakdown_entry "$1" "$2" "$3" "start" "" "${4:-}"
 }
 
 # Helper function to log end of an operation
-# Usage: log_end <folder_path> <operation_name> <pid>
+# Usage: log_end <folder_path> <operation_name> <pid> [sub_operation_name]
 log_end() {
-    log_breakdown_entry "$1" "$2" "$3" "end"
+    log_breakdown_entry "$1" "$2" "$3" "end" "" "${4:-}"
 }
 
 # Helper function to log start of main_benchmark operation
-# Usage: log_main_benchmark_start <folder_path> <pid>
+# Usage: log_main_benchmark_start <folder_path> <pid> [sub_operation_name]
 log_main_benchmark_start() {
-    log_breakdown_entry "$1" "$main_operation_name" "$2" "start"
+    log_breakdown_entry "$1" "$main_operation_name" "$2" "start" "" "${3:-}"
 }
 
 # Helper function to log end of main_benchmark operation
-# Usage: log_main_benchmark_end <folder_path> <pid>
+# Usage: log_main_benchmark_end <folder_path> <pid> [sub_operation_name]
 log_main_benchmark_end() {
-    log_breakdown_entry "$1" "$main_operation_name" "$2" "end"
+    log_breakdown_entry "$1" "$main_operation_name" "$2" "end" "" "${3:-}"
+}
+
+# Helper function to log start of preprocessing operation
+# Usage: log_preprocessing_start <folder_path> <pid> [sub_operation_name]
+log_preprocessing_start() {
+    log_breakdown_entry "$1" "$preprocessing_operation_name" "$2" "start" "" "${3:-}"
+}
+
+# Helper function to log end of preprocessing operation
+# Usage: log_preprocessing_end <folder_path> <pid> [sub_operation_name]
+log_preprocessing_end() {
+    log_breakdown_entry "$1" "$preprocessing_operation_name" "$2" "end" "" "${3:-}"
+}
+
+# Helper function to log start of postprocessing operation
+# Usage: log_postprocessing_start <folder_path> <pid> [sub_operation_name]
+log_postprocessing_start() {
+    log_breakdown_entry "$1" "$postprocessing_operation_name" "$2" "start" "" "${3:-}"
+}
+
+# Helper function to log end of postprocessing operation
+# Usage: log_postprocessing_end <folder_path> <pid> [sub_operation_name]
+log_postprocessing_end() {
+    log_breakdown_entry "$1" "$postprocessing_operation_name" "$2" "end" "" "${3:-}"
 }


### PR DESCRIPTION
Summary:
Implemented runtime breakdown tracking for `video_transcode_bench` to record exact timestamps of different benchmark stages (preprocessing, main_benchmark, postprocessing). This enables Perfpub to filter out irrelevant parts of the benchmark and focus only on the actual benchmark execution time.

Key changes:

1.  Added `breakdown.csv` to video_transcode_bench job artifacts in `jobs.yml`
2.  Integrated runtime breakdown logging into `video_transcode_bench/run.sh` to track timestamps for:
    *   Preprocessing stage (setup, configuration, warmup)
    *   Main benchmark stage (actual video transcoding workload)
    *   Postprocessing stage (result collection, cleanup)
3.  Enhanced `runtime_breakdown_utils.sh` with:
    *   Dedicated helper functions (`log_preprocessing_start/end`, `log_postprocessing_start/end`) for cleaner code
    *   Added `sub_operation_name` column to support future granular breakdown (e.g., separating warmup time within preprocessing)

Current Perfpub filtering works with the `operation_name` column to identify the main benchmark window. The `sub_operation_name` column is not currently used but provides infrastructure for future enhanced analysis. Perfpub will be updated to handle the new CSV format more robustly.

Reviewed By: YifanYuan3

Differential Revision: D86130088


