### PR TITLE
Fix benchpress list subcommand (add ucache_bench parser to internal parser list)

### DIFF
--- a/benchpress/plugins/parsers/__init__.py
+++ b/benchpress/plugins/parsers/__init__.py
@@ -59,6 +59,7 @@ from .wdl import WDLParser
 
 if not open_source:
     from .hackperf import HackperfParser
+    from .ucache_bench import UcacheBenchParser
 
 
 def register_parsers(factory):
@@ -115,3 +116,4 @@ def register_parsers(factory):
 
     if not open_source:
         factory.register("hackperf", HackperfParser)
+        factory.register("ucache_bench", UcacheBenchParser)


### PR DESCRIPTION
Summary: Was trying to run the list subcommand and encountered an error about a missing parser

Reviewed By: charles-typ

Differential Revision: D86554430


