### PR TITLE
Chm: Maximize CPU utilization

### DIFF
--- a/benchpress/config/jobs_ai.yml
+++ b/benchpress/config/jobs_ai.yml
@@ -169,6 +169,7 @@
     - '--duration_seconds={duration_seconds}'
     - '--batch_size={batch_size}'
     - '--num_batch_threads={num_batch_threads}'
+    - '--worker_loop_count={worker_loop_count}'
 
   vars:
     - 'distribution_file=benchmarks/chm/model_a.dist'
@@ -176,6 +177,7 @@
     - 'duration_seconds=360'
     - 'batch_size=10000000'
     - 'num_batch_threads=4'
+    - 'worker_loop_count=10'
 
 
 - benchmark: chm
@@ -187,6 +189,7 @@
     - '--duration_seconds={duration_seconds}'
     - '--batch_size={batch_size}'
     - '--num_batch_threads={num_batch_threads}'
+    - '--worker_loop_count={worker_loop_count}'
 
   vars:
     - 'distribution_file=benchmarks/chm/model_b.dist'
@@ -194,6 +197,7 @@
     - 'duration_seconds=360'
     - 'batch_size=10000000'
     - 'num_batch_threads=4'
+    - 'worker_loop_count=10'
 
 
 - benchmark: deser

--- a/packages/ai_wdl/chm/ChmBenchmark.cpp
+++ b/packages/ai_wdl/chm/ChmBenchmark.cpp
@@ -40,6 +40,7 @@ DEFINE_int32(num_batch_threads, 2, "Number of parallel batch threads");
 DEFINE_int32(duration_seconds, 10, "Benchmark duration in seconds");
 DEFINE_int32(initial_capacity, 0, "Initial hash map capacity hint");
 DEFINE_int32(batch_size, 1000, "Operations per batch");
+DEFINE_int32(worker_loop_count, 1, "The loop count worker do its job");
 DEFINE_int32(hit_ratio, 40, "Desired hit ratio (0-100)");
 DEFINE_bool(verbose, false, "Enable verbose output");
 
@@ -307,6 +308,7 @@ class ChmBenchmark {
     int durationSeconds; // Benchmark duration
     int initialCapacity; // Hash map initial capacity hint
     int batchSize; // Operations per batch
+    int worker_loop_count; // The loop count worker do its job
     int hitRatio; // Desired hit ratio (0-100)
     bool verbose; // Enable detailed output
   };
@@ -573,7 +575,8 @@ class ChmBenchmark {
             totalWorkerTimeNs.fetch_add(
                 workerDuration.count(), std::memory_order_relaxed);
           });
-    }
+      }
+
 
     // Generate keys for next batch while current batch executes (latency
     // hiding)
@@ -599,14 +602,16 @@ class ChmBenchmark {
     uint64_t localOps = 0;
     uint64_t localSuccessfulOps = 0;
 
-    // Process assigned range of operations
-    for (int i = startIdx; i < endIdx; i++) {
-      AdId key = preGeneratedKeys[i];
-      auto result = map.getValue(key); // Core benchmark operation
+    for (int loop = 0; loop < config_.worker_loop_count; loop++) {
+      // Process assigned range of operations
+      for (int i = startIdx; i < endIdx; i++) {
+        AdId key = preGeneratedKeys[i];
+        auto result = map.getValue(key); // Core benchmark operation
 
-      localOps++;
-      if (result.second) { // Check if key was found
-        localSuccessfulOps++;
+        localOps++;
+        if (result.second) { // Check if key was found
+          localSuccessfulOps++;
+        }
       }
     }
 
@@ -654,6 +659,7 @@ int main(int argc, char* argv[]) {
       .durationSeconds = FLAGS_duration_seconds,
       .initialCapacity = FLAGS_initial_capacity,
       .batchSize = FLAGS_batch_size,
+      .worker_loop_count = FLAGS_worker_loop_count,
       .hitRatio = FLAGS_hit_ratio,
       .verbose = FLAGS_verbose};
 


### PR DESCRIPTION
The worker threads are in a starved state because the producer’s production speed cannot keep up with the consumer’s consumption speed. The goal of the CHM benchmark is to maximize CPU utilization while minimizing interference from producers. This patch introduces a new parameter, worker_loop_count, which sets the number of times a worker thread loops over CHM operations. By increasing the worker thread’s active time, CPU utilization can reach 100%. Before this change, CPU utilization was around 20%. Test results show that throughput has significantly improved on some platforms. Alternatively, we could increase the number of producer threads to keep consumers busy, but our primary goal is to measure the throughput of consumer threads without adding extra producer-side overhead.