### PR TITLE
add prod-focused configruations

### DIFF
--- a/benchpress/config/jobs_wdl.yml
+++ b/benchpress/config/jobs_wdl.yml
@@ -175,3 +175,26 @@
         after:
           - 'benchmarks/wdl_bench/wdl_bench_results.txt'
           - 'benchmarks/wdl_bench/out_*.json'
+
+- name: prod_set
+  benchmark: wdl_bench
+  description: >
+    a set of most popular and ubiquitous WDLs across Meta's fleet, with configs close to real production.
+  args:
+    - '--type {type}'
+    - '--output {output}'
+  vars:
+    - 'type=prod'
+    - 'output=wdl_bench_results.txt'
+  hooks:
+    - hook: cpu-mpstat
+      options:
+        args:
+          - '-u'   # utilization
+          - '1'    # second interval
+    - hook: copymove
+      options:
+        is_move: true
+        after:
+          - 'benchmarks/wdl_bench/wdl_bench_results.txt'
+          - 'benchmarks/wdl_bench/out_*.json'

--- a/packages/wdl_bench/convert.py
+++ b/packages/wdl_bench/convert.py
@@ -16,7 +16,7 @@ input_file_name = "out_" + sys.argv[1] + ".txt"
 
 
 with open(input_file_name) as f:
-    if sys.argv[1] == "concurrent_hash_map_benchmark":
+    if sys.argv[1] == "concurrency_concurrent_hash_map_benchmark":
         parse_line.parse_line_chm(f, sum_c)
     elif sys.argv[1] == "lzbench":
         parse_line.parse_line_lzbench(f, sum_c)
@@ -24,6 +24,12 @@ with open(input_file_name) as f:
         parse_line.parse_line_openssl(f, sum_c)
     elif sys.argv[1] == "vdso_bench":
         parse_line.parse_line_vdso_bench(f, sum_c)
+    elif sys.argv[1] == "libaegis_benchmark":
+        parse_line.parse_line_libaegis_benchmark(f, sum_c)
+    elif sys.argv[1] == "xxhash_benchmark":
+        parse_line.parse_line_xxhash_benchmark(f, sum_c)
+    elif sys.argv[1] == "container_hash_maps_bench":
+        parse_line.parse_line_container_hash_maps_bench(f, sum_c)
     else:
         parse_line.parse_line(f, sum_c)
 

--- a/packages/wdl_bench/run.sh
+++ b/packages/wdl_bench/run.sh
@@ -120,7 +120,9 @@ main() {
     done
 
 
-
+    if [ "$run_type" = "prod" ]; then
+        bash "${WDL_ROOT}/run_prod.sh"
+    fi
 
     set -u  # Enable unbound variables check from here onwards
     benchreps_tell_state "working on config"

--- a/packages/wdl_bench/run_prod.sh
+++ b/packages/wdl_bench/run_prod.sh
@@ -1,0 +1,158 @@
+#!/bin/bash
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+set -Eeo pipefail
+#trap SIGINT SIGTERM ERR EXIT
+
+
+BREPS_LFILE=/tmp/wdl_log.txt
+
+function benchreps_tell_state () {
+    date +"%Y-%m-%d_%T ${1}" >> $BREPS_LFILE
+}
+
+
+# Constants
+WDL_ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")" &>/dev/null && pwd -P)
+WDL_DATASETS="${WDL_ROOT}/datasets"
+WDL_BUILD="${WDL_ROOT}/wdl_build"
+
+show_help() {
+cat <<EOF
+Usage: ${0##*/} [-h] [--type single_core|all_core|multi_thread]
+
+    -h Display this help and exit
+    -output Result output file name. Default: "wdl_results.txt"
+    -dataset Dataset file name. Default: "silesia.tar"
+EOF
+}
+
+prod_benchmark_list_mem="memcpy_benchmark bench-memcmp"
+prod_benchmark_list_hash="hash_hash_benchmark xxhash_benchmark"
+prod_benchmark_compression="lzbench"
+prod_benchmark_crypto="openssl libaegis_benchmark"
+prod_benchmark_checksum="hash_checksum_benchmark"
+prod_benchmark_rng="random_benchmark"
+prod_benchmark_chm="concurrency_concurrent_hash_map_bench"
+prod_benchmark_thrift="ProtocolBench VarintUtilsBench"
+prod_benchmark_f14="container_hash_maps_bench"
+prod_benchmark_lock="synchronization_small_locks_benchmark synchronization_lifo_sem_bench"
+prod_benchmark_vdso="vdso_bench"
+
+prod_benchmarks="memcpy_benchmark bench-memcmp hash_hash_benchmark xxhash_benchmark lzbench openssl libaegis_benchmark hash_checksum_benchmark random_benchmark concurrency_concurrent_hash_map_bench ProtocolBench VarintUtilsBench container_hash_maps_bench synchronization_small_locks_benchmark synchronization_lifo_sem_bench vdso_bench"
+
+benchmark_non_json_list=("openssl" "libaegis_benchmark" "lzbench" "vdso_bench" "xxhash_benchmark" "concurrency_concurrent_hash_map_bench" "container_hash_maps_bench")
+
+run_list=""
+
+declare -A prod_benchmark_config=(
+    ['random_benchmark']="--bm_regex=xoshiro --json"
+    ['memcpy_benchmark']="--json"
+    ['hash_hash_benchmark']="--bm_regex=RapidHash --json"
+    ['hash_checksum_benchmark']="--json"
+    ['synchronization_lifo_sem_bench']="--bm_min_iters=1000000 --json"
+    ['synchronization_small_locks_benchmark']="--bm_min_iters=1000000 --bm_regex=folly_RWSpinlock --json"
+    ['container_hash_maps_bench']="--bm_regex=\"f14(vec)|(val)\" --json" # filter find, insert, InsertSqBr, erase, and Iter operations in results parse script
+    ['ProtocolBench']="--bm_regex=\"(^Binary)|(^Compact)Protocol\" --json"
+    ['VarintUtilsBench']=" --json"
+    ['concurrency_concurrent_hash_map_bench']=""
+    ['lzbench']="-v -ezstd1,3 ${WDL_DATASETS}/${dataset}"
+    ['openssl']="speed -seconds 20 -evp aes-256-gcm"
+    ['vdso_bench']="-t 10 -p 20"
+    ['libaegis_benchmark']=""
+    ['xxhash_benchmark']="xxh3"
+    ['bench-memcmp']=""
+)
+
+main() {
+    local result_filename
+    result_filename="wdl_bench_results.txt"
+
+    local name
+    name="none"
+
+
+    while :; do
+        case $1 in
+            --name)
+                name="$2"
+                ;;
+            -h)
+                show_help >&2
+                exit 1
+                ;;
+            *)  # end of input
+                echo "Unsupported arg $1"
+                break
+        esac
+
+        case $1 in
+            --name)
+                if [ -z "$2" ]; then
+                    echo "Invalid option: $1 requires an argument" 1>&2
+                    exit 1
+                fi
+                shift   # Additional shift for the argument
+                ;;
+        esac
+        shift
+    done
+
+
+
+
+    set -u  # Enable unbound variables check from here onwards
+    benchreps_tell_state "working on config"
+    pushd "${WDL_ROOT}"
+
+    #run
+    benchreps_tell_state "start"
+
+    if [ "$name" != "none" ]; then
+        run_list="$name"
+    else
+        run_list="$prod_benchmarks"
+    fi
+
+    for benchmark in $run_list; do
+        if [ "$benchmark" = "openssl" ]; then
+            export LD_LIBRARY_PATH="${WDL_BUILD}/openssl/lib64:${WDL_BUILD}/openssl/lib"
+            ldconfig
+        fi
+        out_file=""
+        if [[ " $benchmark_non_json_list{[*]} " =~ " ${benchmark} " ]]; then
+            out_file="out_${benchmark}.txt"
+        else
+            out_file="out_${benchmark}.json"
+        fi
+         "./${benchmark}" "${prod_benchmark_config[$benchmark]}" 2>&1 | tee -a "${out_file}"
+        if [ "$benchmark" = "openssl" ]; then
+            unset LD_LIBRARY_PATH
+            ldconfig
+        fi
+    done
+
+    benchreps_tell_state "done"
+    #generate output
+    if [ -f "${result_filename}" ]; then
+        rm "${result_filename}"
+    fi
+
+    for benchmark in $run_list; do
+        if [[ " $benchmark_non_json_list{[*]} " =~ " ${benchmark} " ]]; then
+            python3 ./convert.py "$benchmark"
+        fi
+    done
+    echo "benchmark results:" "$run_list" | tee -a "${result_filename}"
+
+
+    echo "results in each individual json file." | tee -a "${result_filename}"
+
+    popd
+
+}
+
+main "$@"


### PR DESCRIPTION
Summary:
This diff adds:
(1) one new microbenchmark (glibc `memcmp`)
(2) configurations of running all microbenchmarks so that they focus on the most relevant and representative operations
(3) a new benchpress job and run script for (2)
(4) some affiliated things like parsers.


Scoring (e.g. how to interpret the results) as well as sizing (e.g. dataset size) will come in the next diff

Differential Revision: D85820722


