### PR TITLE
Add support for DynamoRIO to Video Transcode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -107,3 +107,4 @@ ENV/
 .mypy_cache/
 
 benchmark_metrics*
+drmemtrace.*

--- a/packages/video_transcode_bench/0002-ffmpeg-dr.patch
+++ b/packages/video_transcode_bench/0002-ffmpeg-dr.patch
@@ -1,0 +1,90 @@
+diff --git a/fftools/ffmpeg.c b/fftools/ffmpeg.c
+index de607cac93..7b3468f882 100644
+--- a/fftools/ffmpeg.c
++++ b/fftools/ffmpeg.c
+@@ -23,6 +23,24 @@
+  * multimedia converter based on the FFmpeg libraries
+  */
+ 
++// DynamoRIO required start
++#define LINUX
++#if defined(__x86_64__) || defined(__i386__)
++#define X86_64
++#elif defined(__aarch64__) || defined(__arm__)
++#define ARM_64
++#endif
++
++#include "dr_api.h"
++
++#define TRACE_DURATION_S_DEFAULT 2
++#define TRACE_DURATION_S_ENV "TRACE_DURATION_S"
++
++#define ITERATION_WAIT_S_DEFAULT 10
++#define ITERATION_WAIT_S_ENV "ITERATION_WAIT_S"
++
++// DynamoRIO required end
++
+ #include "config.h"
+ 
+ #include <errno.h>
+@@ -960,10 +978,60 @@ static int64_t getmaxrss(void)
+ #endif
+ }
+ 
++
++void *tracing_thread(void *arg);
++
++void *tracing_thread(void* arg) {
++  // Do nothing for now
++
++  int trace_duration_s = TRACE_DURATION_S_DEFAULT;
++  int iteration_wait_s = ITERATION_WAIT_S_DEFAULT;
++
++  char *trace_dur_raw = getenv(TRACE_DURATION_S_ENV);
++  if (trace_dur_raw) {
++    errno = 0;
++    trace_duration_s = strtol(trace_dur_raw, NULL, 0);
++    if (errno != 0) {
++      perror("Unable to parse TRACE_DURATION_S env var");
++      exit(1);
++    }
++  }
++
++  char *iter_wait_raw = getenv(ITERATION_WAIT_S_ENV);
++  if (iter_wait_raw) {
++    errno = 0;
++    iteration_wait_s = strtol(iter_wait_raw, NULL, 0);
++    if (errno != 0) {
++      perror("Unable to parse ITERATION_WAIT_S env var");
++      exit(1);
++    }
++  }
++
++  printf("Tracing duration set to %d, wait between iteration set to %d.\n",
++         trace_duration_s, iteration_wait_s);
++
++  sleep(1);
++  int trace_iter = 0;
++  while (1) {
++    dr_app_setup_and_start();
++    printf("Sleeping for %d seconds\n", trace_duration_s);
++    sleep(trace_duration_s);
++    dr_app_stop_and_cleanup();
++
++    printf("Completed %d iteration\n", trace_iter);
++    trace_iter++;
++    sleep(iteration_wait_s);
++  }
++}
++
++
+ int main(int argc, char **argv)
+ {
+     Scheduler *sch = NULL;
+ 
++    pthread_t tracing_thread_handler;
++    pthread_create(&tracing_thread_handler, NULL, &tracing_thread, NULL);
++
+     int ret;
+     BenchmarkTimeStamps ti;
+ 

--- a/packages/video_transcode_bench/install_video_transcode_bench.sh
+++ b/packages/video_transcode_bench/install_video_transcode_bench.sh
@@ -5,6 +5,17 @@
 # LICENSE file in the root directory of this source tree.
 set -Eeuo pipefail
 
+##################### DYNAMORIO CONFIG #########################
+
+# Needs DR_ROOT to be set to the root of the DynamoRIO installation
+export DR_ROOT="${DR_ROOT:-/home/smahar/DynamoRIO-Linux-11.90.20391}"
+export DR_RELEASE_TYPE="${DR_RELEASE_TYPE:-debug}"
+
+if ! [ -d "$DR_ROOT" ]; then
+    echo "DR_ROOT=$DR_ROOT does not exist, please check!"
+    exit 1
+fi
+
 ##################### BENCHMARK CONFIG #########################
 
 declare -A REPOS=(
@@ -145,7 +156,10 @@ build_ffmpeg()
     lib='ffmpeg'
     clone $lib || echo "Failed to clone $lib"
     cd "$lib" || exit
-    git apply "${BPKGS_FFMPEG_ROOT}/0001-ffmpeg.patch"
+    # git apply "${BPKGS_FFMPEG_ROOT}/0001-ffmpeg.patch"
+    git apply "${BPKGS_FFMPEG_ROOT}/0002-ffmpeg-dr.patch"
+
+    export LD_LIBRARY_PATH="$DR_ROOT/tools/lib64/${DR_RELEASE_TYPE}/;$DR_ROOT/lib64/${DR_RELEASE_TYPE}/;$DR_ROOT/ext/lib64/${DR_RELEASE_TYPE}/"
     mkdir -p _build && cd _build || exit
     if [ -v PKG_CONFIG_PATH ]; then
         PKG_CONFIG_PATH=$PKG_CONFIG_PATH:$FFMPEG_BUILD/lib/pkgconfig:$FFMPEG_BUILD/lib64/pkgconfig:$FFMPEG_BUILD/lib/pkgconfig:$FFMPEG_BUILD/lib/x86_64-linux-gnu/pkgconfig:$FFMPEG_BUILD/lib/aarch64-linux-gnu/pkgconfig \
@@ -159,9 +173,10 @@ build_ffmpeg()
             --enable-libaom \
             --enable-libsvtav1 \
             --enable-libvmaf \
-            --extra-cflags="-I${FFMPEG_BUILD}/include ${platform_cc_flags}" \
-            --extra-cxxflags="-I${FFMPEG_BUILD}/include ${platform_cc_flags}" \
-            --extra-ldflags="-L${FFMPEG_BUILD}/lib" \
+            --extra-libs="-ldynamorio" \
+            --extra-cflags="-I${FFMPEG_BUILD}/include ${platform_cc_flags} -I${DR_ROOT}/include" \
+            --extra-cxxflags="-I${FFMPEG_BUILD}/include ${platform_cc_flags} -I${DR_ROOT}/include" \
+            --extra-ldflags="-L${FFMPEG_BUILD}/lib -L${DR_ROOT}/lib64/${DR_RELEASE_TYPE}/ -Wl,-rpath=${DR_ROOT}/lib64/${DR_RELEASE_TYPE}/" \
             --prefix="${FFMPEG_BUILD}"
 
     else
@@ -176,9 +191,10 @@ build_ffmpeg()
             --enable-libaom \
             --enable-libsvtav1 \
             --enable-libvmaf \
-            --extra-cflags="-I${FFMPEG_BUILD}/include ${platform_cc_flags}" \
-            --extra-cxxflags="-I${FFMPEG_BUILD}/include ${platform_cc_flags}" \
-            --extra-ldflags="-L${FFMPEG_BUILD}/lib" \
+            --extra-libs="-ldynamorio" \
+            --extra-cflags="-I${FFMPEG_BUILD}/include ${platform_cc_flags} -I${DR_ROOT}/include" \
+            --extra-cxxflags="-I${FFMPEG_BUILD}/include ${platform_cc_flags} -I${DR_ROOT}/include" \
+            --extra-ldflags="-L${FFMPEG_BUILD}/lib -L${DR_ROOT}/lib64/${DR_RELEASE_TYPE}/ -Wl,-rpath=${DR_ROOT}/lib64/${DR_RELEASE_TYPE}/" \
             --prefix="${FFMPEG_BUILD}"
 
     fi
@@ -208,7 +224,6 @@ build_svtav1
 build_aom
 build_vmaf
 build_ffmpeg
-
 
 
 download_testing_scripts


### PR DESCRIPTION
Summary:
This diff adds support for DynamoRIO to ffmpeg, ability to rebuild local changes

To rebuild local changes use this command:
```console
# rm benchmark_installs.txt
# sudo LOCAL_CHANGE_BUILD=y ./benchpress_cli.py install video_transcode_bench_svt
```

Once video transcode benchmark is installed, tracing can be controlled with these env vars:
```
TRACE_DURATION_S
ITERATION_WAIT_S
```


---
install_video_transcode_bench.sh -- Rebuild with local ffmpeg changes: P2032836224

Differential Revision: D86680182


