### PR TITLE
Fix multi-copy benchmark OSError and update libc10.so path

### DIFF
--- a/packages/ai_wdl/fbgemm/install_fbgemm_bench.sh
+++ b/packages/ai_wdl/fbgemm/install_fbgemm_bench.sh
@@ -1131,7 +1131,7 @@ if [[ "$OS_TYPE" == "Linux" && "$ARCH_TYPE" == "aarch64" ]]; then
   if [[ "$BIN" == "tbe_inference_benchmark" ]]; then
     # Resolve repository root based on script location
     SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-    REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+    REPO_ROOT="$(cd "${SCRIPT_DIR}/../../.." && pwd)"
 
     # Expected environment name and Python version
     BUILD_ENV="fbgemm_build_oss_env"

--- a/packages/ai_wdl/fbgemm/install_fbgemm_bench.sh
+++ b/packages/ai_wdl/fbgemm/install_fbgemm_bench.sh
@@ -906,6 +906,8 @@ clone_fbgemm_repo() {
   echo "[SETUP] Cloning repository with submodules..."
   git clone --recursive https://github.com/pytorch/FBGEMM.git fbgemm_${FBGEMM_VERSION}
   git -C fbgemm_${FBGEMM_VERSION} checkout ${FBGEMM_VERSION}
+ # Cherry-pick the latest commit from the FBGEMM main branch to fix issue https://github.com/pytorch/FBGEMM/pull/5037
+  git -C fbgemm_${FBGEMM_VERSION} cherry-pick 9df97a7090c2c5edecea4fd08bad11ab8a23284c
 
   # Disable the postbuild script to prevent race conditions during linking
   # This is a workaround for a known issue in the build process


### PR DESCRIPTION
This PR includes two fixes:

1. Fix OSError 24 (“Too many open files”) in the multi-copy benchmark by cherry-picking the latest upstream FBGEMM patch.
Enables switching to the file_system sharing strategy via:
export PYTORCH_SHARE_STRATEGY='file_system'.

2. Fix missing libc10.so caused by a recent path change, which breaks functionality from PR #290.
Updates the expected path to the correct library location.