### PR TITLE
Added memory micro to cdn bench

### DIFF
--- a/packages/cdn_bench/mem_micro/cleanup_mem_micro.sh
+++ b/packages/cdn_bench/mem_micro/cleanup_mem_micro.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+set -Eeuo pipefail
+
+MEM_MICRO_DIR="$(dirname "$(readlink -f "$0")")"
+
+echo "Cleaning up mem_micro directory..."
+
+cd "$MEM_MICRO_DIR" || exit 1
+
+# Remove downloaded STREAM source
+if [ -f stream.c ]; then
+  echo "Removing stream.c..."
+  rm -f stream.c
+fi
+
+# Remove compiled binaries
+if [ -f stream-super-large-array ]; then
+  echo "Removing stream-super-large-array binary..."
+  rm -f stream-super-large-array
+fi
+
+# Remove any other STREAM binaries that might have been created
+echo "Removing any other STREAM binaries..."
+rm -f stream stream.exe a.out
+
+# Remove log files
+if [ -f stream_run.log ]; then
+  echo "Removing stream_run.log..."
+  rm -f stream_run.log
+fi
+
+# Remove any other log files
+echo "Removing any other log files..."
+rm -f ./*.log
+
+echo "Cleanup complete!"

--- a/packages/cdn_bench/mem_micro/install_mem_micro.sh
+++ b/packages/cdn_bench/mem_micro/install_mem_micro.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+set -Eeuo pipefail
+
+MEM_MICRO_DIR="$(dirname "$(readlink -f "$0")")"
+LINUX_DIST_ID="$(awk -F "=" '/^ID=/ {print $2}' /etc/os-release | tr -d '"')"
+
+# STREAM benchmark source URL
+STREAM_URL='https://www.cs.virginia.edu/stream/FTP/Code/stream.c'
+
+##########################################
+# Install prerequisite packages
+##########################################
+echo "Installing prerequisite packages..."
+if [ "$LINUX_DIST_ID" = "ubuntu" ]; then
+  apt install -y gcc make linux-tools-common linux-tools-generic linux-tools-"$(uname -r)" wget
+elif [ "$LINUX_DIST_ID" = "centos" ]; then
+  dnf install -y gcc make perf wget
+fi
+
+###########################################
+# Download STREAM benchmark source
+###########################################
+echo "Downloading STREAM benchmark source code..."
+cd "$MEM_MICRO_DIR" || exit 1
+
+if [ ! -f stream.c ]; then
+  wget -O stream.c "$STREAM_URL"
+  if [ ! -f stream.c ]; then
+    echo "ERROR: Failed to download stream.c"
+    exit 1
+  fi
+  echo "Successfully downloaded stream.c"
+else
+  echo "stream.c already exists, skipping download"
+fi
+
+echo "Installation complete!"

--- a/packages/cdn_bench/mem_micro/run.sh
+++ b/packages/cdn_bench/mem_micro/run.sh
@@ -1,0 +1,55 @@
+#!/bin/bash
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+set -Eeuo pipefail
+
+MEM_MICRO_DIR="$(dirname "$(readlink -f "$0")")"
+
+# Parse arguments with defaults
+ARRAY_SIZE="${1:-201326592}"
+NTIMES="${2:-100}"
+LOG_FILE="${3:-stream_run.log}"
+
+# Source file and binary name
+SRC="stream.c"
+BIN="stream-super-large-array"
+
+# Change to mem_micro directory
+cd "$MEM_MICRO_DIR" || exit 1
+
+# Check if stream.c exists
+if [ ! -f "$SRC" ]; then
+  echo "ERROR: $SRC not found. Please run install_mem_micro.sh first."
+  exit 1
+fi
+
+# Compile the STREAM benchmark
+echo "Compiling $SRC with STREAM_ARRAY_SIZE=$ARRAY_SIZE and NTIMES=$NTIMES..."
+gcc -O -mcmodel=large -DSTREAM_ARRAY_SIZE="$ARRAY_SIZE" -DNTIMES="$NTIMES" "$SRC" -o "$BIN"
+
+# Check compilation success
+if [[ ! -x "$BIN" ]]; then
+  echo "ERROR: Compilation failed or binary not found!"
+  exit 1
+fi
+
+# Run perf stat and collect all output to log file
+echo "Running perf stat on $BIN and logging output to $LOG_FILE..."
+{
+  echo "====================================================================="
+  echo "STREAM Benchmark Execution"
+  echo "====================================================================="
+  echo "Script: $0"
+  echo "Execution Date: $(date '+%Y-%m-%d %H:%M:%S')"
+  echo "Arguments Passed:"
+  echo "  - STREAM_ARRAY_SIZE: $ARRAY_SIZE"
+  echo "  - NTIMES: $NTIMES"
+  echo "  - LOG_FILE: $LOG_FILE"
+  echo "====================================================================="
+  echo ""
+  perf stat -e cycles,instructions,cache-references,cache-misses,LLC-load-misses,LLC-store-misses ./"$BIN" 2>&1
+} > "$LOG_FILE" 2>&1
+
+echo "Done. Output collected in $LOG_FILE."


### PR DESCRIPTION
Summary: Adding install run and cleanup scripts for ehw memory microbenchmark. To be fleshed out later with additional configuration in jobs.yml and benchmarks_ehw.yml.

Differential Revision: D87667436


