### PR TITLE
DjangoBench V2: fix bugs of hanging

### DIFF
--- a/packages/django_workload/srcs/django-workload/django-workload/proxygen_wsgi.py
+++ b/packages/django_workload/srcs/django-workload/django-workload/proxygen_wsgi.py
@@ -191,7 +191,12 @@ def stop_proxygen_server():
 
 
 def signal_handler(signum, frame):
-    """Handle shutdown signals"""
+    """
+    Handle shutdown signals (for standalone mode only).
+
+    NOTE: This handler is NOT called when running under uWSGI!
+    uWSGI intercepts signals and uses its signal framework instead.
+    """
     logger.info("Worker %d received signal %d, shutting down", os.getpid(), signum)
     stop_proxygen_server()
     sys.exit(0)


### PR DESCRIPTION
Summary:
Fix the bug of DjangoBench hanging after execution. This diff basically fixes two bugs:

1. Not being able to terminate Cassandra because cassandra sometimes doesn't write the pid file, causing run.sh to hang forever. Fixed by tracking cassandra PID by run.sh itself.

2. DjangoBench's server will fail to start if immediately rerunning, because the ports are still in TIME_WAIT or CLOSE_WAIT state and not available for binding. Fixed by adding socket option `SO_REUSEADDR` in proxygen_binding library to allow binding to ports in the waiting states. (**Therefore reinstalling DjangoBench will be required**)

Reviewed By: marziehlenjaniMeta

Differential Revision: D87942264


