### PR TITLE
Spark mini: recording the exact benchmark time

### DIFF
--- a/benchpress/config/jobs.yml
+++ b/benchpress/config/jobs.yml
@@ -697,6 +697,7 @@
         is_move: true
         after:
           - 'benchmarks/spark_standalone/work'
+          - 'benchmarks/spark_standalone/breakdown.csv'
 
 - benchmark: spark_standalone
   name: spark_standalone_remote_setup
@@ -726,6 +727,7 @@
         is_move: true
         after:
           - 'benchmarks/spark_standalone/work'
+          - 'benchmarks/spark_standalone/breakdown.csv'
 
 - benchmark: spark_standalone
   name: spark_standalone_remote_mini
@@ -753,6 +755,7 @@
         is_move: true
         after:
           - 'benchmarks/spark_standalone/work'
+          - 'benchmarks/spark_standalone/breakdown.csv'
 
 - benchmark: spark_standalone
   name: spark_standalone_remote_compute
@@ -775,6 +778,7 @@
         is_move: true
         after:
           - 'benchmarks/spark_standalone/work'
+          - 'benchmarks/spark_standalone/breakdown.csv'
 
 - benchmark: tao_bench
   name: tao_bench_64g

--- a/packages/common/breakdown_utils.py
+++ b/packages/common/breakdown_utils.py
@@ -53,6 +53,7 @@ def _log_breakdown_entry(
     pid: int,
     timestamp_type: str,
     sub_operation_name: str = "",
+    timestamp=None,
 ) -> None:
     """
     Log an entry to the breakdown CSV file.
@@ -63,106 +64,155 @@ def _log_breakdown_entry(
         pid: Process ID
         timestamp_type: Type of timestamp ('start' or 'end')
         sub_operation_name: Optional sub-operation name
+        timestamp: Optional timestamp. Can be a string (formatted as 'YYYY-MM-DD HH:MM:SS.mmm'),
+                   a float (Unix timestamp), or None. If not provided, current timestamp will be used
     """
     csv_file = Path(folder_path) / BREAKDOWN_FILE_NAME
 
     # Get timestamp in format: YYYY-MM-DD HH:MM:SS.mmm (milliseconds)
-    timestamp = datetime.now().strftime("%Y-%m-%d %H:%M:%S.%f")[:-3]
+    if timestamp is None:
+        timestamp_str = datetime.now().strftime("%Y-%m-%d %H:%M:%S.%f")[:-3]
+    elif isinstance(timestamp, float):
+        # Convert Unix timestamp (float) to formatted string
+        timestamp_str = datetime.fromtimestamp(timestamp).strftime(
+            "%Y-%m-%d %H:%M:%S.%f"
+        )[:-3]
+    else:
+        # Use the string timestamp as-is
+        timestamp_str = timestamp
 
     with open(csv_file, "a", newline="") as f:
         writer = csv.writer(f)
         writer.writerow(
-            [operation_name, pid, timestamp_type, timestamp, sub_operation_name]
+            [operation_name, pid, timestamp_type, timestamp_str, sub_operation_name]
         )
 
 
-def log_preprocessing_start(folder_path: str, pid: int) -> None:
+def log_preprocessing_start(folder_path: str, pid: int, timestamp=None) -> None:
     """
     Log the start of the preprocessing operation.
 
     Args:
         folder_path: Path to the folder containing the CSV file
         pid: Process ID
+        timestamp: Optional timestamp. Can be a string (formatted as 'YYYY-MM-DD HH:MM:SS.mmm'),
+                   a float (Unix timestamp), or None. If not provided, current timestamp will be used
     """
-    _log_breakdown_entry(folder_path, PREPROCESSING_OPERATION_NAME, pid, "start")
+    _log_breakdown_entry(
+        folder_path, PREPROCESSING_OPERATION_NAME, pid, "start", timestamp=timestamp
+    )
 
 
-def log_preprocessing_end(folder_path: str, pid: int) -> None:
+def log_preprocessing_end(folder_path: str, pid: int, timestamp=None) -> None:
     """
     Log the end of the preprocessing operation.
 
     Args:
         folder_path: Path to the folder containing the CSV file
         pid: Process ID
+        timestamp: Optional timestamp. Can be a string (formatted as 'YYYY-MM-DD HH:MM:SS.mmm'),
+                   a float (Unix timestamp), or None. If not provided, current timestamp will be used
     """
-    _log_breakdown_entry(folder_path, PREPROCESSING_OPERATION_NAME, pid, "end")
+    _log_breakdown_entry(
+        folder_path, PREPROCESSING_OPERATION_NAME, pid, "end", timestamp=timestamp
+    )
 
 
-def log_preprocessing_warmup_start(folder_path: str, pid: int) -> None:
+def log_preprocessing_warmup_start(folder_path: str, pid: int, timestamp=None) -> None:
     """
     Log the start of the preprocessing warmup sub-operation.
 
     Args:
         folder_path: Path to the folder containing the CSV file
         pid: Process ID
+        timestamp: Optional timestamp. Can be a string (formatted as 'YYYY-MM-DD HH:MM:SS.mmm'),
+                   a float (Unix timestamp), or None. If not provided, current timestamp will be used
     """
     _log_breakdown_entry(
-        folder_path, PREPROCESSING_OPERATION_NAME, pid, "start", "warmup"
+        folder_path,
+        PREPROCESSING_OPERATION_NAME,
+        pid,
+        "start",
+        "warmup",
+        timestamp=timestamp,
     )
 
 
-def log_preprocessing_warmup_end(folder_path: str, pid: int) -> None:
+def log_preprocessing_warmup_end(folder_path: str, pid: int, timestamp=None) -> None:
     """
     Log the end of the preprocessing warmup sub-operation.
 
     Args:
         folder_path: Path to the folder containing the CSV file
         pid: Process ID
+        timestamp: Optional timestamp. Can be a string (formatted as 'YYYY-MM-DD HH:MM:SS.mmm'),
+                   a float (Unix timestamp), or None. If not provided, current timestamp will be used
     """
     _log_breakdown_entry(
-        folder_path, PREPROCESSING_OPERATION_NAME, pid, "end", "warmup"
+        folder_path,
+        PREPROCESSING_OPERATION_NAME,
+        pid,
+        "end",
+        "warmup",
+        timestamp=timestamp,
     )
 
 
-def log_main_benchmark_start(folder_path: str, pid: int) -> None:
+def log_main_benchmark_start(folder_path: str, pid: int, timestamp=None) -> None:
     """
     Log the start of the main benchmark operation.
 
     Args:
         folder_path: Path to the folder containing the CSV file
         pid: Process ID
+        timestamp: Optional timestamp. Can be a string (formatted as 'YYYY-MM-DD HH:MM:SS.mmm'),
+                   a float (Unix timestamp), or None. If not provided, current timestamp will be used
     """
-    _log_breakdown_entry(folder_path, MAIN_OPERATION_NAME, pid, "start")
+    _log_breakdown_entry(
+        folder_path, MAIN_OPERATION_NAME, pid, "start", timestamp=timestamp
+    )
 
 
-def log_main_benchmark_end(folder_path: str, pid: int) -> None:
+def log_main_benchmark_end(folder_path: str, pid: int, timestamp=None) -> None:
     """
     Log the end of the main benchmark operation.
 
     Args:
         folder_path: Path to the folder containing the CSV file
         pid: Process ID
+        timestamp: Optional timestamp. Can be a string (formatted as 'YYYY-MM-DD HH:MM:SS.mmm'),
+                   a float (Unix timestamp), or None. If not provided, current timestamp will be used
     """
-    _log_breakdown_entry(folder_path, MAIN_OPERATION_NAME, pid, "end")
+    _log_breakdown_entry(
+        folder_path, MAIN_OPERATION_NAME, pid, "end", timestamp=timestamp
+    )
 
 
-def log_postprocessing_start(folder_path: str, pid: int) -> None:
+def log_postprocessing_start(folder_path: str, pid: int, timestamp=None) -> None:
     """
     Log the start of the postprocessing operation.
 
     Args:
         folder_path: Path to the folder containing the CSV file
         pid: Process ID
+        timestamp: Optional timestamp. Can be a string (formatted as 'YYYY-MM-DD HH:MM:SS.mmm'),
+                   a float (Unix timestamp), or None. If not provided, current timestamp will be used
     """
-    _log_breakdown_entry(folder_path, POSTPROCESSING_OPERATION_NAME, pid, "start")
+    _log_breakdown_entry(
+        folder_path, POSTPROCESSING_OPERATION_NAME, pid, "start", timestamp=timestamp
+    )
 
 
-def log_postprocessing_end(folder_path: str, pid: int) -> None:
+def log_postprocessing_end(folder_path: str, pid: int, timestamp=None) -> None:
     """
     Log the end of the postprocessing operation.
 
     Args:
         folder_path: Path to the folder containing the CSV file
         pid: Process ID
+        timestamp: Optional timestamp. Can be a string (formatted as 'YYYY-MM-DD HH:MM:SS.mmm'),
+                   a float (Unix timestamp), or None. If not provided, current timestamp will be used
     """
-    _log_breakdown_entry(folder_path, POSTPROCESSING_OPERATION_NAME, pid, "end")
+    _log_breakdown_entry(
+        folder_path, POSTPROCESSING_OPERATION_NAME, pid, "end", timestamp=timestamp
+    )


### PR DESCRIPTION
Summary:
This diff improves benchmark timing accuracy for Spark standalone benchmarks by extracting and recording the exact Stage 4.0 execution timestamps from Spark logs instead of relying on Python script execution times.

Key Changes:
Enhanced breakdown_utils.py: Added optional timestamp parameter to all breakdown logging functions, allowing manual timestamp specification instead of always using current time.

Added timestamp extraction in runner.py:

New extract_stage_4_timestamps() function parses Spark logs to find Stage 4.0 start/end times
New log_stage_4_to_breakdown() function writes these exact timestamps to breakdown.csv
Creates breakdown CSV file at the start and logs Stage 4.0 timing boundaries (preprocessing end → main benchmark → postprocessing start)
Updated jobs.yml: Added breakdown.csv to the list of artifacts collected after benchmark runs for all Spark standalone job variants (remote, remote_mini, remote_compute).

Impact:
This provides more accurate benchmark timing by capturing the actual Spark computation time (Stage 4.0) rather than the entire Python runner script execution time, which includes setup overhead.

Differential Revision: D87987533


