### PR TITLE
use local directory as source to build folly and fbthrift

### DIFF
--- a/packages/wdl_bench/install_wdl_bench.sh
+++ b/packages/wdl_bench/install_wdl_bench.sh
@@ -115,7 +115,7 @@ build_folly()
 
     ./build/fbcode_builder/getdeps.py install-system-deps --recursive
 
-    python3 ./build/fbcode_builder/getdeps.py --allow-system-packages build --scratch-path "${WDL_BUILD}"
+    python3 ./build/fbcode_builder/getdeps.py --allow-system-packages build --src-dir "." --scratch-path "${WDL_BUILD}"
 
     for benchmark in $folly_benchmark_list; do
       cp "$WDL_BUILD/build/folly/$benchmark" "$WDL_ROOT/$benchmark"
@@ -134,7 +134,7 @@ build_fbthrift()
 
     ./build/fbcode_builder/getdeps.py install-system-deps --recursive fbthrift
 
-    python3 ./build/fbcode_builder/getdeps.py --allow-system-packages build fbthrift --scratch-path "${WDL_BUILD}" --extra-cmake-defines='{"enable_tests": "1"}'
+    python3 ./build/fbcode_builder/getdeps.py --allow-system-packages build fbthrift --src-dir "." --scratch-path "${WDL_BUILD}" --extra-cmake-defines='{"enable_tests": "1"}'
 
     for benchmark in $fbthrift_benchmark_list; do
       cp "$WDL_BUILD/build/fbthrift/bin/$benchmark" "$WDL_ROOT/$benchmark"


### PR DESCRIPTION
Summary:
as titled. This way we can enforce the source version after `git checkout` and don't panic with some transient bugs/issues on folly/fbthrift. 

the solution is inspired by this comment: https://fb.workplace.com/groups/getdeps/posts/1655556078376455/?comment_id=1656863204912409

Differential Revision: D88655816


