### PR TITLE
Fix load-latency command invocation

### DIFF
--- a/benchpress/plugins/parsers/health_check.py
+++ b/benchpress/plugins/parsers/health_check.py
@@ -147,8 +147,8 @@ class HealthCheckParser(Parser):
         if os.path.exists("/tmp/latency.txt"):
             with open("/tmp/latency.txt", "r") as f:
                 for line in f:
-                    # Search for "avg_latency = 179.559148 ns"
-                    match = re.search(r"avg_latency = (\d+\.\d+) ns", line)
+                    # Search for "Average Latency = 179.559148 ns"
+                    match = re.search(r"Average Latency = (\d+\.\d+) ns", line)
                     if match:
                         self.metrics["memory"]["idle_latency"]["avg_latency"] = float(
                             match.group(1)

--- a/packages/health_check/run.sh
+++ b/packages/health_check/run.sh
@@ -60,13 +60,8 @@ if [ "$role" = "server" ]; then
   workers=$(echo "scale=0; $cpus * 2.5" | bc)
   python3 "$HEALTH_ROOT"/sleepbench/collect-cpu-util.py "$HEALTH_ROOT"/sleepbench/sleepbench "$workers" 30
   if [ "$(uname -p)" = "aarch64" ]; then
-    NPROC="$(nproc)"
-    BW_CORES=""
-    for ((i=0; i<NPROC-1; i+=2)); do
-      BW_CORES="${BW_CORES}-B${i} "
-    done
     pushd "${HEALTH_ROOT}/infra-microbenchmarks/loaded-latency" || exit 1
-    ./sweep.finedelay.sh ${BW_CORES} > /tmp/bw-lat.txt
+    ./sweep.finedelay.sh $(seq -f "-B%.0f" 0 $(($(nproc)-1))) > /tmp/bw-lat.txt
     ./summarize.sh /tmp/bw-lat.txt > /tmp/bw-lat.tsv
     ./run-200mb.latency-only.sh > /tmp/latency.txt
   else


### PR DESCRIPTION
Summary:
1. To obtain the max memory bandwidth, we should saturate all the CPU cores, but currently, sweep.finedelay.sh is invoked only with even-numbered CPU cores, so half the cores in total. As I tested, this may not get the max memory bandwidth. The fix passes all cores to sweep.finedelay.sh.

2. Instead of matching "avg latency" by the parser, we should match "Average Latency". "avg latency" is for per-thread latency while "Average Latency" is averaged across threads. For the current invocation of ./run-200mb.latency-only.sh, this may not make a difference though.

Differential Revision: D89314543


