### PR TITLE
SparkBench V2: Add `spark_standalone_remote_3x` benchmark job

### DIFF
--- a/benchpress/config/jobs.yml
+++ b/benchpress/config/jobs.yml
@@ -811,6 +811,31 @@
           - 'benchmarks/spark_standalone/work'
           - 'benchmarks/spark_standalone/breakdown.csv'
 
+- benchmark: spark_standalone
+  name: spark_standalone_remote_3x
+  description: Spark standalone using remote SSDs with 3x query load (2 more joins) and auto-scaled shuffle partitions
+  args:
+    - 'run'
+    - '--dataset-path /flash23/'
+    - '--warehouse-dir /flash23/warehouse'
+    - '--shuffle-dir /flash23/spark_local_dir'
+    - '--ipv4 {ipv4}'
+    - '--real'
+    - '--sanity {sanity}'
+    - '--shuffle-partitions 0'
+    - '--query queries/release_test_93586_3x.sql'
+  vars:
+    - 'ipv4=0'
+    - 'sanity=0'
+  hooks:
+    - hook: copymove
+      options:
+        is_move: true
+        after:
+          - 'benchmarks/spark_standalone/work'
+          - 'benchmarks/spark_standalone/breakdown.csv'
+
+
 - benchmark: tao_bench
   name: tao_bench_64g
   description:

--- a/packages/spark_standalone/README.md
+++ b/packages/spark_standalone/README.md
@@ -148,7 +148,7 @@ to run your systems exclusively with IPv6. If your systems only support IPv4,
 we now provide a flag to enable support for it.
 
 * `JAVA_HOME`: You may need to manually set the environment variable `JAVA_HOME`
-to be the path of the JDK: /usr/lib/jvm/graalvm-jdk-17.0.12+8.1/ if Spark benchmark fails.
+to be the path of the JDK: /usr/lib/jvm/graalvm-community-openjdk-17.0.9+9.1 if Spark benchmark fails.
 
 ## Also Note
 

--- a/packages/spark_standalone/install_spark_standalone.sh
+++ b/packages/spark_standalone/install_spark_standalone.sh
@@ -47,5 +47,9 @@ popd || exit 1
 # create sub directories
 mkdir -p "${OUT}/work"
 mkdir -p "${OUT}/dataset"
+mkdir -p "${OUT}/queries"
+
+# copy custom query files
+cp "${TEMPLATES_DIR}/release_test_93586_3x.sql" "${OUT}/queries/"
 
 echo "SPARK_Standalone installed into ./benchmarks/spark_standalone"

--- a/packages/spark_standalone/templates/proj_root/scripts/run_perf_common.py
+++ b/packages/spark_standalone/templates/proj_root/scripts/run_perf_common.py
@@ -91,10 +91,15 @@ def write_sql_create_tables(args) -> List[str]:
     filename = joinpath(WORK_PATH, "create_tables.sql")
     with open(filename, "wt") as fp:
         # Set spark.sql.shuffle.partitions if specified
-        if hasattr(args, "shuffle_partitions") and args.shuffle_partitions:
-            fp.write(
-                f"""SET spark.sql.shuffle.partitions = {args.shuffle_partitions};\n"""
-            )
+        if hasattr(args, "shuffle_partitions") and args.shuffle_partitions is not None:
+            shuffle_partitions = args.shuffle_partitions
+            # Auto-scale to 4 * CPU cores if set to 0 or negative
+            if shuffle_partitions <= 0:
+                shuffle_partitions = 4 * os.cpu_count()
+                print(
+                    f"Auto-scaling shuffle partitions to {shuffle_partitions} (4 * {os.cpu_count()} CPU cores)"
+                )
+            fp.write(f"""SET spark.sql.shuffle.partitions = {shuffle_partitions};\n""")
         fp.write(f"""USE {args.database};""")
         for table_info, query_dir in table_list:
             table_name = table_info["name"]
@@ -128,6 +133,20 @@ def list_tests(args) -> None:
 
 def write_sql_tests(args) -> List[str]:
     sql_files = []
+
+    # If custom query is specified, use it instead of dataset's built-in queries
+    if hasattr(args, "query") and args.query:
+        custom_sql_path = args.query
+        if not os.path.isabs(custom_sql_path):
+            custom_sql_path = joinpath(PROJ_ROOT, custom_sql_path)
+        if not os.path.exists(custom_sql_path):
+            raise FileNotFoundError(f"Custom query file not found: {custom_sql_path}")
+        sql_filename = os.path.basename(custom_sql_path)
+        filename = joinpath(WORK_PATH, sql_filename)
+        shutil.copy(custom_sql_path, filename)
+        sql_files.append(filename)
+        return sql_files
+
     dataset_path = joinpath(DATA_PATH, args.database)
     with open(joinpath(dataset_path, "release_info_suite.json"), "rt") as fp:
         query_tests_info = json.load(fp)
@@ -611,7 +630,16 @@ def init_parser():
             "--shuffle-partitions",
             type=int,
             default=None,
-            help="Set the number of partitions for Spark SQL shuffle operations",
+            help="Set the number of partitions for Spark SQL shuffle operations. "
+            "If set to 0 or negative, automatically scales to 4 * number of available CPU cores.",
+        )
+    # custom query option (for run_parser and exp_parser since they run queries)
+    for x in [run_parser, exp_parser]:
+        x.add_argument(
+            "--query",
+            type=str,
+            default=None,
+            help="Path to a custom SQL file to run instead of the dataset's built-in query",
         )
     # numa setting
     for x in [start_parser, run_parser, exp_parser]:

--- a/packages/spark_standalone/templates/proj_root/scripts/utils.py
+++ b/packages/spark_standalone/templates/proj_root/scripts/utils.py
@@ -99,7 +99,7 @@ def read_sys_configs() -> Dict[str, int]:
 
 def find_java_home() -> str:
     # Always use the specific GraalVM JDK 17.0.12 path
-    return "/usr/lib/jvm/graalvm-jdk-17.0.12+8.1"
+    return "/usr/lib/jvm/graalvm-community-openjdk-17.0.9+9.1"
 
 
 def read_environ() -> Dict[str, str]:

--- a/packages/spark_standalone/templates/release_test_93586_3x.sql
+++ b/packages/spark_standalone/templates/release_test_93586_3x.sql
@@ -1,0 +1,62 @@
+INSERT OVERWRITE TABLE table_SPdBtF_Y9di_dNz1Hh3XBLWloMbgaL_el8BCohoZGlQ_
+                  PARTITION (ds='2018-12-29')
+                  SELECT
+                  coalesce(d.`c8k3`, b.`c8k3`), coalesce(d.`cvwqz6MyB1`, b.`cvwqz6MyB1`), CAST(coalesce(d.`A3nORKj`, b.`A3nORKj`) AS bigint), CAST(coalesce(d.`RB9`, b.`RB9`) AS bigint), CAST(coalesce(d.`YYk8V71j`, b.`YYk8V71j`) AS bigint), CAST(coalesce(d.`DLqnqUwZ`, b.`DLqnqUwZ`) AS bigint), coalesce(d.`fq7ay`, b.`fq7ay`), CAST(coalesce(d.`FJuZpmHF6Y`, b.`FJuZpmHF6Y`) AS bigint), CAST(coalesce(d.`r7h`, b.`r7h`) AS bigint)
+                  FROM
+                  (
+                      SELECT *
+                      FROM table__CkHRpFW2Qb5fJVQSg91UOUPBHBj8lnRjzeTRxWzuDI_
+                      WHERE ds='2018-12-29'
+                  ) d
+                  FULL OUTER JOIN
+                  (
+                      SELECT *
+                      FROM table_uu9fgFJsVdtOC878DXBVyo_IqVwQVjeAOXhXDBOM8Tc_ b
+                      WHERE ds='2018-12-28'
+                  ) b
+                  ON b.`r7h` = d.`r7h` AND b.`RB9` = d.`RB9` AND b.`FJuZpmHF6Y` = d.`FJuZpmHF6Y`
+                  WHERE 
+                  (coalesce(d.cvwqz6MyB1, b.cvwqz6MyB1) = 105)
+               AND coalesce(d.`FJuZpmHF6Y`, b.`FJuZpmHF6Y`)  in (1137159934)
+
+		UNION ALL
+               
+	       SELECT
+                  coalesce(d.`c8k3`, b.`c8k3`), coalesce(d.`cvwqz6MyB1`, b.`cvwqz6MyB1`), CAST(coalesce(d.`A3nORKj`, b.`A3nORKj`) AS bigint), CAST(coalesce(d.`RB9`, b.`RB9`) AS bigint), CAST(coalesce(d.`YYk8V71j`, b.`YYk8V71j`) AS bigint), CAST(coalesce(d.`DLqnqUwZ`, b.`DLqnqUwZ`) AS bigint), coalesce(d.`fq7ay`, b.`fq7ay`), CAST(coalesce(d.`FJuZpmHF6Y`, b.`FJuZpmHF6Y`) AS bigint), CAST(coalesce(d.`r7h`, b.`r7h`) AS bigint)
+                  FROM
+                  (
+                      SELECT *
+                      FROM table__CkHRpFW2Qb5fJVQSg91UOUPBHBj8lnRjzeTRxWzuDI_
+                      WHERE ds='2018-12-29'
+                  ) d
+                  FULL OUTER JOIN
+                  (
+                      SELECT *
+                      FROM table_uu9fgFJsVdtOC878DXBVyo_IqVwQVjeAOXhXDBOM8Tc_ b
+                      WHERE ds='2018-12-28'
+                  ) b
+                  ON b.`r7h` = d.`r7h` AND b.`RB9` = d.`RB9` AND b.`FJuZpmHF6Y` = d.`FJuZpmHF6Y`
+                  WHERE 
+                  (coalesce(d.cvwqz6MyB1, b.cvwqz6MyB1) = 127)
+               AND coalesce(d.`FJuZpmHF6Y`, b.`FJuZpmHF6Y`)  in (1137159934)
+
+		UNION ALL
+               
+	       SELECT
+                  coalesce(d.`c8k3`, b.`c8k3`), coalesce(d.`cvwqz6MyB1`, b.`cvwqz6MyB1`), CAST(coalesce(d.`A3nORKj`, b.`A3nORKj`) AS bigint), CAST(coalesce(d.`RB9`, b.`RB9`) AS bigint), CAST(coalesce(d.`YYk8V71j`, b.`YYk8V71j`) AS bigint), CAST(coalesce(d.`DLqnqUwZ`, b.`DLqnqUwZ`) AS bigint), coalesce(d.`fq7ay`, b.`fq7ay`), CAST(coalesce(d.`FJuZpmHF6Y`, b.`FJuZpmHF6Y`) AS bigint), CAST(coalesce(d.`r7h`, b.`r7h`) AS bigint)
+                  FROM
+                  (
+                      SELECT *
+                      FROM table__CkHRpFW2Qb5fJVQSg91UOUPBHBj8lnRjzeTRxWzuDI_
+                      WHERE ds='2018-12-29'
+                  ) d
+                  FULL OUTER JOIN
+                  (
+                      SELECT *
+                      FROM table_uu9fgFJsVdtOC878DXBVyo_IqVwQVjeAOXhXDBOM8Tc_ b
+                      WHERE ds='2018-12-28'
+                  ) b
+                  ON b.`r7h` = d.`r7h` AND b.`RB9` = d.`RB9` AND b.`FJuZpmHF6Y` = d.`FJuZpmHF6Y`
+                  WHERE 
+                  (coalesce(d.cvwqz6MyB1, b.cvwqz6MyB1) = 127)
+               AND coalesce(d.`FJuZpmHF6Y`, b.`FJuZpmHF6Y`)  in (1137159934)

--- a/packages/spark_standalone/templates/runner.py
+++ b/packages/spark_standalone/templates/runner.py
@@ -79,7 +79,7 @@ def install_database(args):
         cmd_list.append(args.local_hostname)
     if args.aggressive > 0:
         cmd_list.append(f"--aggressive {args.aggressive}")
-    if hasattr(args, "shuffle_partitions") and args.shuffle_partitions:
+    if hasattr(args, "shuffle_partitions") and args.shuffle_partitions is not None:
         cmd_list.append("--shuffle-partitions")
         cmd_list.append(str(args.shuffle_partitions))
     cmd_list.append("--real")
@@ -179,9 +179,12 @@ def run_test(args):
         cmd_list.append(args.local_hostname)
     if args.aggressive > 0:
         cmd_list.append(f"--aggressive {args.aggressive}")
-    if hasattr(args, "shuffle_partitions") and args.shuffle_partitions:
+    if hasattr(args, "shuffle_partitions") and args.shuffle_partitions is not None:
         cmd_list.append("--shuffle-partitions")
         cmd_list.append(str(args.shuffle_partitions))
+    if hasattr(args, "query") and args.query:
+        cmd_list.append("--query")
+        cmd_list.append(args.query)
     cmd_list.append("--real")
 
     if "DCPERF_PERF_RECORD" in os.environ and os.environ["DCPERF_PERF_RECORD"] == "1":
@@ -419,7 +422,14 @@ def init_parser():
         "--shuffle-partitions",
         type=int,
         default=None,
-        help="Set the number of partitions for Spark SQL shuffle operations",
+        help="Set the number of partitions for Spark SQL shuffle operations. "
+        "If set to 0 or negative, automatically scales to 4 * number of available CPU cores.",
+    )
+    run_parser.add_argument(
+        "--query",
+        type=str,
+        default=None,
+        help="Path to a custom SQL file to run instead of the dataset's built-in query",
     )
     run_parser.add_argument(
         "--ipv4",


### PR DESCRIPTION
Summary:
A new SparkBench benchmark job which provides:
- 3x query workload length compared with the original job
- Automatically scales up the number of shuffle partitions and executor tasks to 4x num CPU cores, ensuring max parallelism and addressing the tail partial batch problem.

Reviewed By: marziehlenjaniMeta

Differential Revision: D89506947


