### PR TITLE
Add std::shared_ptr benchmark to WDL bench

### DIFF
--- a/packages/wdl_bench/README.md
+++ b/packages/wdl_bench/README.md
@@ -29,6 +29,7 @@ This installs all production benchmarks including:
 - **Data Structures**: F14 maps (folly)
 - **System Calls**: vdso_bench
 - **Math**: SLEEF SIMD math functions
+- **C++ standard library**: std::shared_ptr
 
 ## 2. Run Production Benchmark Suite
 

--- a/packages/wdl_bench/baseline_results/baseline_benchsleef128.json
+++ b/packages/wdl_bench/baseline_results/baseline_benchsleef128.json
@@ -1,43 +1,4 @@
 {
-  "context": {
-    "date": "2025-11-24T16:37:00-08:00",
-    "host_name": "rtptest4455.ftw5.facebook.com",
-    "executable": "./benchsleef128",
-    "num_cpus": 52,
-    "mhz_per_cpu": 2201,
-    "cpu_scaling_enabled": false,
-    "aslr_enabled": false,
-    "caches": [
-      {
-        "type": "Data",
-        "level": 1,
-        "size": 32768,
-        "num_sharing": 2
-      },
-      {
-        "type": "Instruction",
-        "level": 1,
-        "size": 32768,
-        "num_sharing": 2
-      },
-      {
-        "type": "Unified",
-        "level": 2,
-        "size": 1048576,
-        "num_sharing": 2
-      },
-      {
-        "type": "Unified",
-        "level": 3,
-        "size": 37486592,
-        "num_sharing": 52
-      }
-    ],
-    "load_avg": [20.04,9.72,5.61],
-    "library_version": "v1.9.4-75-gc3f86578",
-    "library_build_type": "release",
-    "json_schema_version": 1
-  },
   "benchmarks": [
     {
       "name": "MB_Sleef_sinf_u10_scalarf_0_6.28",

--- a/packages/wdl_bench/baseline_results/baseline_benchsleef256.json
+++ b/packages/wdl_bench/baseline_results/baseline_benchsleef256.json
@@ -1,43 +1,4 @@
 {
-  "context": {
-    "date": "2025-12-11T09:56:55-08:00",
-    "host_name": "rtptest4455.ftw5.facebook.com",
-    "executable": "./benchsleef256",
-    "num_cpus": 52,
-    "mhz_per_cpu": 1401,
-    "cpu_scaling_enabled": false,
-    "aslr_enabled": false,
-    "caches": [
-      {
-        "type": "Data",
-        "level": 1,
-        "size": 32768,
-        "num_sharing": 2
-      },
-      {
-        "type": "Instruction",
-        "level": 1,
-        "size": 32768,
-        "num_sharing": 2
-      },
-      {
-        "type": "Unified",
-        "level": 2,
-        "size": 1048576,
-        "num_sharing": 2
-      },
-      {
-        "type": "Unified",
-        "level": 3,
-        "size": 37486592,
-        "num_sharing": 52
-      }
-    ],
-    "load_avg": [1.33,1.15,0.98],
-    "library_version": "v1.9.4-75-gc3f86578",
-    "library_build_type": "release",
-    "json_schema_version": 1
-  },
   "benchmarks": [
     {
       "name": "MB_Sleef_sinf_u10_scalarf_0_6.28",

--- a/packages/wdl_bench/baseline_results/baseline_benchsleef512.json
+++ b/packages/wdl_bench/baseline_results/baseline_benchsleef512.json
@@ -1,43 +1,4 @@
 {
-  "context": {
-    "date": "2025-12-11T09:59:53-08:00",
-    "host_name": "rtptest4455.ftw5.facebook.com",
-    "executable": "./benchsleef512",
-    "num_cpus": 52,
-    "mhz_per_cpu": 2705,
-    "cpu_scaling_enabled": false,
-    "aslr_enabled": false,
-    "caches": [
-      {
-        "type": "Data",
-        "level": 1,
-        "size": 32768,
-        "num_sharing": 2
-      },
-      {
-        "type": "Instruction",
-        "level": 1,
-        "size": 32768,
-        "num_sharing": 2
-      },
-      {
-        "type": "Unified",
-        "level": 2,
-        "size": 1048576,
-        "num_sharing": 2
-      },
-      {
-        "type": "Unified",
-        "level": 3,
-        "size": 37486592,
-        "num_sharing": 52
-      }
-    ],
-    "load_avg": [1.24,1.19,1.02],
-    "library_version": "v1.9.4-75-gc3f86578",
-    "library_build_type": "release",
-    "json_schema_version": 1
-  },
   "benchmarks": [
     {
       "name": "MB_Sleef_sinf_u10_scalarf_0_6.28",

--- a/packages/wdl_bench/baseline_results/baseline_stdcpp_bench.json
+++ b/packages/wdl_bench/baseline_results/baseline_stdcpp_bench.json
@@ -1,0 +1,32 @@
+{
+  "benchmarks": [
+    {
+      "name": "BM_SharedPtr_IncDec",
+      "family_index": 0,
+      "per_family_instance_index": 0,
+      "run_name": "BM_SharedPtr_IncDec",
+      "run_type": "iteration",
+      "repetitions": 1,
+      "repetition_index": 0,
+      "threads": 1,
+      "iterations": 33753074,
+      "real_time": 2.0561665861475671e+01,
+      "cpu_time": 2.0502706746058156e+01,
+      "time_unit": "ns"
+    },
+    {
+      "name": "BM_WeakPtr_IncDec",
+      "family_index": 1,
+      "per_family_instance_index": 0,
+      "run_name": "BM_WeakPtr_IncDec",
+      "run_type": "iteration",
+      "repetitions": 1,
+      "repetition_index": 0,
+      "threads": 1,
+      "iterations": 39678689,
+      "real_time": 2.0800585749515815e+01,
+      "cpu_time": 2.0725731109714840e+01,
+      "time_unit": "ns"
+    }
+  ]
+}

--- a/packages/wdl_bench/install_wdl_bench.sh
+++ b/packages/wdl_bench/install_wdl_bench.sh
@@ -57,14 +57,15 @@ if [ "$LINUX_DIST_ID" = "ubuntu" ]; then
   apt install -y cmake autoconf automake flex bison \
     nasm clang patch git libssl-dev libc6-dev\
     tar unzip perl openssl python3-dev gawk libstdc++6 python3-numpy \
-    glibc-source
+    glibc-source libbenchmark-dev
 
 elif [ "$LINUX_DIST_ID" = "centos" ]; then
   dnf install -y cmake autoconf automake flex bison \
     meson nasm clang patch glibc-static libstdc++-static \
     git tar unzip perl openssl-devel python3-devel gawk python3-numpy \
     dnf-plugins-core rpm-build audit-libs-devel gd-devel gdb \
-    libcap-devel libpng-devel libselinux-devel texinfo valgrind
+    libcap-devel libpng-devel libselinux-devel texinfo valgrind \
+    google-benchmark-devel
 fi
 
 
@@ -345,6 +346,15 @@ EOF
 }
 
 
+build_stdcpp()
+{
+    lib='stdcpp_bench'
+    pushd "$WDL_BUILD"
+    cmake -S "$BPKGS_WDL_ROOT/$lib" -B "$lib-build" -DCMAKE_BUILD_TYPE=Release && cmake --build "$lib-build"
+    cp "$lib-build/$lib" "${WDL_ROOT}/" || exit 1
+    popd || exit
+}
+
 ##################### BUILD AND INSTALL #########################
 
 pushd "${WDL_ROOT}"
@@ -387,6 +397,7 @@ case "$TARGET" in
         build_glibc
         build_isa_l
         build_sleef
+        build_stdcpp
         ;;
     folly)    build_folly ;;
     fbthrift) build_fbthrift ;;
@@ -398,6 +409,7 @@ case "$TARGET" in
     glibc)    build_glibc ;;
     isa_l)    build_isa_l ;;
     sleef)    build_sleef ;;
+    stdcpp)   build_stdcpp ;;
     *)
         echo "Error: Unknown build target '$TARGET'"
         exit 1

--- a/packages/wdl_bench/run_prod.sh
+++ b/packages/wdl_bench/run_prod.sh
@@ -29,6 +29,7 @@ Usage: ${0##*/} [-h] [--name benchmark_name]
 EOF
 }
 
+# @lint-ignore-section SHELLCHECK on
 prod_benchmark_list_mem="memcpy_benchmark bench-memcmp memset_benchmark"
 prod_benchmark_list_hash="hash_hash_benchmark xxhash_benchmark"
 prod_benchmark_compression="lzbench"
@@ -41,8 +42,10 @@ prod_benchmark_f14="container_hash_maps_bench"
 prod_benchmark_lock="synchronization_small_locks_benchmark synchronization_lifo_sem_bench"
 prod_benchmark_vdso="vdso_bench"
 prod_benchmark_math="benchsleef128 benchsleef256 benchsleef512"
+prod_benchmark_stdcpp="stdcpp_bench"
+# @lint-ignore-section SHELLCHECK off
 
-prod_benchmarks="memcpy_benchmark memset_benchmark bench-memcmp hash_hash_benchmark xxhash_benchmark lzbench openssl libaegis_benchmark hash_checksum_benchmark  erasure_code_perf random_benchmark concurrency_concurrent_hash_map_bench ProtocolBench VarintUtilsBench container_hash_maps_bench synchronization_small_locks_benchmark synchronization_lifo_sem_bench vdso_bench benchsleef128 benchsleef256 benchsleef512"
+prod_benchmarks="memcpy_benchmark memset_benchmark bench-memcmp hash_hash_benchmark xxhash_benchmark lzbench openssl libaegis_benchmark hash_checksum_benchmark  erasure_code_perf random_benchmark concurrency_concurrent_hash_map_bench ProtocolBench VarintUtilsBench container_hash_maps_bench synchronization_small_locks_benchmark synchronization_lifo_sem_bench vdso_bench benchsleef128 benchsleef256 benchsleef512 stdcpp_bench"
 
 benchmark_non_json_list=("openssl" "libaegis_benchmark" "lzbench" "vdso_bench" "xxhash_benchmark" "concurrency_concurrent_hash_map_bench" "container_hash_maps_bench" "erasure_code_perf")
 
@@ -81,6 +84,7 @@ declare -A prod_benchmark_config=(
     ['benchsleef128']="--benchmark_format=json"
     ['benchsleef256']="--benchmark_format=json"
     ['benchsleef512']="--benchmark_format=json"
+    ['stdcpp_bench']="--benchmark_format=json"
 )
 
 main() {

--- a/packages/wdl_bench/scoring.py
+++ b/packages/wdl_bench/scoring.py
@@ -60,14 +60,14 @@ def generate_sleef_benchmark_name(
     return benchmark_name
 
 
-def find_ns_per_el_in_sleef_results(
-    data: dict[str, Any], names: list[str]
+def extract_gbench_metric(
+    data: dict[str, Any], benchmark_names: list[str], metric_key: str
 ) -> list[float]:
     results: list[float] = []
-    for name in names:
+    for name in benchmark_names:
         for b in data["benchmarks"]:
             if b["name"] == name:
-                results.append(float(b["NSperEl"]))
+                results.append(float(b[metric_key]))
     return results
 
 
@@ -83,7 +83,7 @@ def calculate_sleef_score(sum_baseline: dict[str, Any], sum_c: dict[str, Any]) -
         )
 
     baseline_time = weighted_geomean(
-        find_ns_per_el_in_sleef_results(sum_baseline, baseline_names),
+        extract_gbench_metric(sum_baseline, baseline_names, "NSperEl"),
         math_function_weights,
     )
 
@@ -93,7 +93,7 @@ def calculate_sleef_score(sum_baseline: dict[str, Any], sum_c: dict[str, Any]) -
             generate_sleef_benchmark_name(math_function[0], "x", math_function[1], True)
         )
 
-    sve_ns_per_elem = find_ns_per_el_in_sleef_results(sum_c, sve_variant_names)
+    sve_ns_per_elem = extract_gbench_metric(sum_c, sve_variant_names, "NSperEl")
     if len(sve_ns_per_elem) > 0:
         sve_variant_time = weighted_geomean(sve_ns_per_elem, math_function_weights)
     else:
@@ -109,7 +109,7 @@ def calculate_sleef_score(sum_baseline: dict[str, Any], sum_c: dict[str, Any]) -
             )
         )
     fixed_vl_variant_time = weighted_geomean(
-        find_ns_per_el_in_sleef_results(sum_c, fixed_vl_variant_names),
+        extract_gbench_metric(sum_c, fixed_vl_variant_names, "NSperEl"),
         math_function_weights,
     )
 
@@ -233,6 +233,31 @@ def calculate_memcmp_score(
     return baseline_time / min_time
 
 
+def calculate_stdcpp_score(
+    sum_baseline: dict[str, Any], sum_c: dict[str, Any]
+) -> float:
+    """
+    Calculate stdcpp_bench score using weighted geometric mean.
+
+    Args:
+        sum_baseline: Baseline benchmark results
+        sum_c: Current benchmark results
+
+    Returns:
+        Score as ratio of baseline to current performance
+    """
+    benchmark_names = ["BM_SharedPtr_IncDec", "BM_WeakPtr_IncDec"]
+    weights = [0.9, 0.1]
+
+    baseline_times = extract_gbench_metric(sum_baseline, benchmark_names, "cpu_time")
+    current_times = extract_gbench_metric(sum_c, benchmark_names, "cpu_time")
+
+    baseline_geomean = weighted_geomean(baseline_times, weights)
+    current_geomean = weighted_geomean(current_times, weights)
+
+    return baseline_geomean / current_geomean
+
+
 with open(input_file_name) as f:
     with open(baseline_name) as f_baseline:
         sum_c = json.load(f)
@@ -306,6 +331,8 @@ with open(input_file_name) as f:
             score = calculate_sleef_score(sum_baseline, sum_c)
         elif benchmark_name == "bench-memcmp":
             score = calculate_memcmp_score(sum_baseline, sum_c)
+        elif benchmark_name == "stdcpp_bench":
+            score = calculate_stdcpp_score(sum_baseline, sum_c)
         else:
             for key in sum_baseline:
                 if key in sum_c:

--- a/packages/wdl_bench/stdcpp_bench/CMakeLists.txt
+++ b/packages/wdl_bench/stdcpp_bench/CMakeLists.txt
@@ -1,0 +1,49 @@
+cmake_minimum_required(VERSION 3.16)
+project(stdcpp_bench LANGUAGES CXX)
+
+# ------------------------------------------------------------
+# C++ settings
+# ------------------------------------------------------------
+set(CMAKE_CXX_STANDARD 20)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
+
+if(NOT CMAKE_BUILD_TYPE)
+  set(CMAKE_BUILD_TYPE Release CACHE STRING "" FORCE)
+endif()
+
+# ------------------------------------------------------------
+# Google Benchmark (required)
+# ------------------------------------------------------------
+find_package(benchmark REQUIRED)
+
+# ------------------------------------------------------------
+# Benchmark executable
+# ------------------------------------------------------------
+add_executable(stdcpp_bench
+  stdcpp_bench.cpp
+)
+
+target_link_libraries(stdcpp_bench
+  PRIVATE
+    benchmark::benchmark
+    pthread
+)
+
+# ------------------------------------------------------------
+# Microbenchmark-friendly flags
+# ------------------------------------------------------------
+target_compile_options(stdcpp_bench PRIVATE
+  -march=native
+)
+
+target_compile_definitions(stdcpp_bench PRIVATE
+  NDEBUG
+)
+
+# ------------------------------------------------------------
+# Info
+# ------------------------------------------------------------
+message(STATUS "Using Google Benchmark: ${benchmark_DIR}")
+message(STATUS "CXX compiler: ${CMAKE_CXX_COMPILER}")
+message(STATUS "Build type: ${CMAKE_BUILD_TYPE}")

--- a/packages/wdl_bench/stdcpp_bench/stdcpp_bench.cpp
+++ b/packages/wdl_bench/stdcpp_bench/stdcpp_bench.cpp
@@ -1,0 +1,35 @@
+#include <benchmark/benchmark.h>
+#include <sys/single_threaded.h>
+#include <memory>
+
+struct Dummy {
+  int x;
+};
+
+std::shared_ptr<Dummy> base = std::make_shared<Dummy>();
+
+static void BM_SharedPtr_IncDec(benchmark::State& state) {
+  for (auto _ : state) {
+    std::shared_ptr<Dummy> local = base;
+    benchmark::DoNotOptimize(local.use_count());
+  }
+}
+
+BENCHMARK(BM_SharedPtr_IncDec);
+
+static void BM_WeakPtr_IncDec(benchmark::State& state) {
+  for (auto _ : state) {
+    std::weak_ptr<Dummy> local = base;
+    benchmark::DoNotOptimize(local.use_count());
+  }
+}
+
+BENCHMARK(BM_WeakPtr_IncDec);
+
+int main(int argc, char** argv) {
+  // Force-set __libc_single_threaded to 0 to disable optimizations
+  // for single-threaded apps.
+  __libc_single_threaded = 0;
+  ::benchmark::Initialize(&argc, argv);
+  ::benchmark::RunSpecifiedBenchmarks();
+}


### PR DESCRIPTION
Summary: Add a simple microbenchmark for std::shared_ptr to WDL bench. std::shared is used extensively in Meta workloads.

Differential Revision: D89508782


