### PR TITLE
Replace threads time with benchmark time

### DIFF
--- a/packages/ai_wdl/chm/ChmBenchmark.cpp
+++ b/packages/ai_wdl/chm/ChmBenchmark.cpp
@@ -490,9 +490,9 @@ class ChmBenchmark {
     results.workerThreadTime =
         std::chrono::milliseconds(totalWorkerTimeNs.load() / 1000000);
 
-    double workerDurationSeconds = results.workerThreadTime.count() / 1000.0;
+    double benchmarkDurationSeconds = results.benchmarkTime.count() / 1000.0;
     results.operationsPerSecond =
-        results.totalOperations / 1000000 / workerDurationSeconds;
+        results.totalOperations / 1000000 / benchmarkDurationSeconds;
     results.successRate = static_cast<double>(results.successfulOperations) /
         results.totalOperations * 100.0;
 
@@ -507,7 +507,7 @@ class ChmBenchmark {
     std::cout << "Total Benchmark Duration: "
               << results.benchmarkTime.count() / 1000.0 << " seconds"
               << std::endl;
-    std::cout << "Worker Thread Time Only: "
+    std::cout << "Total Worker Threads Time Only: "
               << results.workerThreadTime.count() / 1000.0 << " seconds"
               << std::endl;
     std::cout << "Total Operations: " << results.totalOperations << std::endl;


### PR DESCRIPTION
The metric used for chm is Mops/sec, the time used in computing is the total time of every thread's running time, in order to better reflect the throughput per second, it should be changed to the time of the benchmark running. In this way, if there is more threads used, the throughput will be bigger.