### PR TITLE
Fix ARMPerfUtil.__init__ parameter ordering for perf hook compatibility

### DIFF
--- a/benchpress/plugins/hooks/perf_monitors/topdown.py
+++ b/benchpress/plugins/hooks/perf_monitors/topdown.py
@@ -424,7 +424,7 @@ class ARMPerfUtil(Monitor):
         "https://git.gitlab.arm.com/telemetry-solution/telemetry-solution.git"
     )
 
-    def __init__(self, interval, job_uuid, **kwargs):
+    def __init__(self, job_uuid, interval=5, **kwargs):
         super(ARMPerfUtil, self).__init__(interval, "arm-perf-collector", job_uuid)
         self.avail = self.install_if_not_available()
         if not self.avail:


### PR DESCRIPTION
Summary:
Running benchmarks with `-k perf` on ARM systems fails with:
```
TypeError: ARMPerfUtil.__init__() missing 1 required positional argument: 'interval'
```

The issue is that `ARMPerfUtil.__init__()` expects `interval` as the first positional parameter, but the perf hook calls all monitor classes with `job_uuid` as the first keyword argument followed by `interval` in `**init_args`.

This fix reorders the parameters to match the calling convention used by the perf hook.

Reviewed By: YifanYuan3

Differential Revision: D89999769


