### PR TITLE
Apply folly compatibility patches on Ubuntu 24.04 for feedsim aarch64

### DIFF
--- a/packages/feedsim/install_feedsim_aarch64_ubuntu.sh
+++ b/packages/feedsim/install_feedsim_aarch64_ubuntu.sh
@@ -180,11 +180,11 @@ do
 
 done < "${FEEDSIM_ROOT}/submodules.txt"
 
-# If running on Ubuntu 22.04, apply compatilibity patches to folly, rsocket and wangle
+# If running on Ubuntu 22.04 or 24.04, apply compatilibity patches to folly, rsocket and wangle
 # TODO: This is a temporary fix. In the long term we should seek to have feedsim
 # support the up-to-date version of these dependencies
 REPOS_TO_PATCH=(folly rsocket-cpp)
-if grep -i 'Ubuntu 22.04' /etc/os-release >/dev/null 2>&1; then
+if grep -iE 'Ubuntu (22|24)\.04' /etc/os-release >/dev/null 2>&1; then
     for repo in "${REPOS_TO_PATCH[@]}"; do
         pushd "third_party/$repo" || exit 1
         git apply --check "${FEEDSIM_ROOT}/patches/ubuntu-22-compatibility/${repo}.diff" && \


### PR DESCRIPTION
Summary: Building feedsim on Ubuntu 24.04 aarch64 fails with compiler errors like `'numeric_limits' is not a member of 'std'` in folly's TimeoutQueue.cpp. The existing ubuntu-22-compatibility patches already fix these issues, so this change extends the OS detection to also apply them on Ubuntu 24.04.

Differential Revision: D90000973


