### PR TITLE
Fix WDL build issue on Ubuntu 22.04

### DIFF
--- a/packages/wdl_bench/cleanup_wdl_bench.sh
+++ b/packages/wdl_bench/cleanup_wdl_bench.sh
@@ -4,16 +4,16 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-ARCH="$(uname -m)"
-BPKGS_WDL_ROOT="$(dirname "$(readlink -f "$0")")"
+BPKGS_WDL_ROOT="$(dirname "$(readlink -f -- "$0")")" # Path to dir with this file.
 BENCHPRESS_ROOT="$(readlink -f "$BPKGS_WDL_ROOT/../..")"
-BENCHMARKS_DIR="${BENCHPRESS_ROOT}/benchmarks"
-WDL_DIR="${BENCHMARKS_DIR}/wdl_bench"
+WDL_ROOT="${BENCHPRESS_ROOT}/benchmarks/wdl_bench"
 
-if [ "$ARCH" = "x86_64" ]; then
+# shellcheck disable=SC1091
+source "$BPKGS_WDL_ROOT"/common.sh
+
+if [ "$ARCH" = "x86_64" ] && [ -f "$WDL_ROOT/wdl_build/intel-onemkl-${MKL_VERSION}_offline.sh" ]; then
     echo "Removing Intel OneMKL"
-    MKL_VERSION="2025.3.0.462"
-    bash -c "sh $WDL_DIR/wdl_build/intel-onemkl-${MKL_VERSION}_offline.sh -a --action remove --silent --eula accept"
+    bash -c "sh $WDL_ROOT/wdl_build/intel-onemkl-${MKL_VERSION}_offline.sh -a --action remove --silent --eula accept"
 fi
 
-rm -rf "$WDL_DIR"
+rm -rf "$WDL_ROOT"

--- a/packages/wdl_bench/common.sh
+++ b/packages/wdl_bench/common.sh
@@ -1,0 +1,71 @@
+#!/bin/bash
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+# shellcheck disable=SC2034
+ARCH="$(uname -m)"
+WDL_SOURCE="${WDL_ROOT}/wdl_sources"
+WDL_BUILD="${WDL_ROOT}/wdl_build"
+WDL_DATASETS="${WDL_ROOT}/datasets"
+MKL_VERSION="2025.3.0.462"
+ARMPL_VERSION="25.07.1"
+# Determine OS version
+LINUX_DIST_ID="$(awk -F "=" '/^ID=/ {print $2}' /etc/os-release | tr -d '"')"
+
+has_real_conda() {
+    # 1. Check if 'conda' command exists at all
+    if ! command -v conda >/dev/null 2>&1; then
+        return 1 # False: Not found
+    fi
+
+    # 2. Check if conda base exists. On dev servers, conda might be
+    #    pointing to /usr/bin/local/conda that is a wrapper just telling
+    #    the user how to install conda. If that's the case, fail and tell
+    #.   the user to install conda.
+    local conda_base
+    conda_base=$(conda info --base 2>/dev/null)
+    if [ -z "$conda_base" ]; then
+        echo "You might be running this on a dev server. Please do the following and restart this command."
+        echo "  1. Install conda on your dev server (feature install conda)."
+        echo "  2. sudo conda init bash"
+        echo "  3. exec bash"
+        exit 1
+    fi
+
+    return 0
+}
+
+in_conda_env() {
+    # The :- suffix prevents the "unbound variable" error
+    [[ -n "${CONDA_PREFIX:-}" && -d "${CONDA_PREFIX:-}" ]]
+}
+
+source_conda() {
+    local conda_sh=""
+    local conda_base
+    conda_base=$(conda info --base 2>/dev/null)
+    if [ -f "$conda_base/etc/profile.d/conda.sh" ]; then
+        # 1. Check the default Miniconda first
+        conda_sh="$conda_base/etc/profile.d/conda.sh"
+        echo "Sourced local conda from $conda_base"
+
+    elif [ -f "/etc/profile.d/conda.sh" ]; then
+        # 2. Check system-wide location if the default location fails
+        conda_sh=/etc/profile.d/conda.sh
+        echo "Sourced system conda from /etc/profile.d/conda.sh"
+
+    elif [ -f "${WDL_ROOT}"/miniconda3/etc/profile.d/conda.sh ]; then
+        # 3. Check the local Miniconda if the system-wide location fails
+        conda_sh="${WDL_ROOT}/miniconda3/etc/profile.d/conda.sh"
+        echo "Sourced local conda from ${WDL_ROOT}/miniconda3/etc/profile.d/conda.sh"
+
+    else
+        echo "Error: conda.sh not found in local or system paths."
+        exit 1
+    fi
+
+    # shellcheck disable=SC1090
+    source "$conda_sh"
+}

--- a/packages/wdl_bench/install_wdl_bench.sh
+++ b/packages/wdl_bench/install_wdl_bench.sh
@@ -49,27 +49,23 @@ declare -A DATASETS=(
 
 ##################### SYS CONFIG AND DEPS #########################
 
-ARCH="$(uname -m)"
 BPKGS_WDL_ROOT="$(dirname "$(readlink -f -- "$0")")" # Path to dir with this file.
 BENCHPRESS_ROOT="$(readlink -f "$BPKGS_WDL_ROOT/../..")"
 WDL_ROOT="${BENCHPRESS_ROOT}/benchmarks/wdl_bench"
-WDL_SOURCE="${WDL_ROOT}/wdl_sources"
-WDL_BUILD="${WDL_ROOT}/wdl_build"
-WDL_DATASETS="${WDL_ROOT}/datasets"
 
-# Determine OS version
-LINUX_DIST_ID="$(awk -F "=" '/^ID=/ {print $2}' /etc/os-release | tr -d '"')"
+# shellcheck disable=SC1091
+source "$BPKGS_WDL_ROOT"/common.sh
 
 if [ "$LINUX_DIST_ID" = "ubuntu" ]; then
-  apt install -y cmake autoconf automake flex bison gfortran \
-    nasm clang patch git libssl-dev libc6-dev\
+  DEBIAN_FRONTEND=noninteractive apt install -y cmake autoconf automake \
+    flex bison gfortran nasm clang gcc g++ patch git libssl-dev libc6-dev \
     tar unzip perl openssl python3-dev gawk libstdc++6 python3-numpy \
     glibc-source libbenchmark-dev environment-modules libopenblas-dev \
     pkg-config
 
 elif [ "$LINUX_DIST_ID" = "centos" ]; then
   dnf install -y cmake autoconf automake flex bison gfortran \
-    meson nasm clang patch glibc-static libstdc++-static \
+    meson nasm clang gcc g++ patch glibc-static libstdc++-static \
     git tar unzip perl openssl-devel python3-devel gawk python3-numpy \
     dnf-plugins-core rpm-build audit-libs-devel gd-devel gdb \
     libcap-devel libpng-devel libselinux-devel texinfo valgrind \
@@ -83,6 +79,24 @@ mkdir -p "${WDL_DATASETS}"
 
 if ! [ -f "/usr/local/bin/cmake" ]; then
     ln -s /usr/bin/cmake /usr/local/bin/cmake
+fi
+
+if ! in_conda_env; then
+    if ! has_real_conda; then
+        if [ ! -f "${WDL_ROOT}/miniconda3/etc/profile.d/conda.sh" ]; then
+            echo "Installing miniconda."
+            mkdir -p "${WDL_ROOT}/miniconda3"
+            if [ "$ARCH" = "aarch64" ]; then
+                wget https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-aarch64.sh -O "${WDL_ROOT}/miniconda3/miniconda.sh" || exit
+            else
+                wget https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh -O "${WDL_ROOT}/miniconda3/miniconda.sh" || exit
+            fi
+            bash -c "sh ${WDL_ROOT}/miniconda3/miniconda.sh -b -u -p ${WDL_ROOT}/miniconda3" || exit
+        fi
+        # shellcheck disable=SC1091
+        source "${WDL_ROOT}"/miniconda3/etc/profile.d/conda.sh
+        conda tos accept
+    fi
 fi
 
 ##################### BUILD AND INSTALL FUNCTIONS #########################
@@ -129,9 +143,17 @@ build_folly()
     clone "$lib" || echo "Failed to clone $lib"
     cd "$lib" || exit
 
-    python3 ./build/fbcode_builder/getdeps.py install-system-deps --recursive
-
-    python3 ./build/fbcode_builder/getdeps.py --allow-system-packages build --src-dir "." --scratch-path "${WDL_BUILD}"
+    # execute the build in a subshell with a new conda build environment
+    (
+        FBENV="folly_build_env"
+        source_conda
+        conda create --override-channels -y -c conda-forge --force -n "$FBENV" "python=3.12" "numpy<2"
+        conda activate "$FBENV"
+        python3 ./build/fbcode_builder/getdeps.py install-system-deps --recursive
+        python3 ./build/fbcode_builder/getdeps.py --allow-system-packages build --src-dir "." --scratch-path "${WDL_BUILD}"
+        conda deactivate
+        conda env remove -n "$FBENV" -y
+    )
 
     for benchmark in $folly_benchmark_list; do
       cp "$WDL_BUILD/build/folly/$benchmark" "$WDL_ROOT/$benchmark"
@@ -373,7 +395,6 @@ build_gemm()
         cd acl || exit
         cmake -S . -B build -DCMAKE_BUILD_TYPE=Release -DARM_COMPUTE_BUILD_SHARED_LIB=ON -DARM_COMPUTE_ENABLE_OPENMP=ON -DACL_MULTI_ISA=ON -DACL_BUILD_SVE=ON -DACL_BUILD_SVE2=ON -DACL_BUILD_SME2=ON -DCMAKE_INSTALL_PREFIX="${WDL_BUILD}/acl" && cmake --build build --config release --target install -- -j"$(nproc)"
         cd .. || exit
-        ARMPL_VERSION="25.07.1"
         if [ "$LINUX_DIST_ID" = "ubuntu" ]; then
             wget -nc "https://developer.arm.com/-/cdn-downloads/permalink/Arm-Performance-Libraries/Version_${ARMPL_VERSION}/arm-performance-libraries_${ARMPL_VERSION}_deb_gcc.tar"
             tar xvf "arm-performance-libraries_${ARMPL_VERSION}_deb_gcc.tar"
@@ -390,7 +411,6 @@ build_gemm()
         cp "$lib-build/$lib" "${WDL_ROOT}/" || exit 1
     else
         cpu_vendor=$(grep -m 1 'vendor_id' /proc/cpuinfo | awk '{print $3}')
-        MKL_VERSION="2025.3.0.462"
         wget -nc https://registrationcenter-download.intel.com/akdlm/IRC_NAS/2ad98b49-1fb2-4294-ab3d-6889b434ebd3/intel-onemkl-${MKL_VERSION}_offline.sh
         bash -c "sh ./intel-onemkl-${MKL_VERSION}_offline.sh -a --action install --silent --eula accept --install-dir ./onemkl"
         bash -c "onemkl/modulefiles-setup.sh --output-dir=onemkl/modulefiles"
@@ -398,8 +418,17 @@ build_gemm()
         module load mkl/latest
         clone aocl || echo "Failed to clone aocl"
         cd aocl || exit
-        cmake -S . -B build -DCMAKE_BUILD_TYPE=Release -DENABLE_AOCL_BLAS=ON -DENABLE_AOCL_UTILS=ON -DENABLE_ADDON="aocl_gemm" -DENABLE_MULTITHREADING=ON -DCMAKE_INSTALL_PREFIX="${WDL_BUILD}/aocl"
-        cmake --build build --config release --target install -- -j"$(nproc)"
+        # execute the build in a subshell with a new conda build environment
+        (
+            AOCL_BUILD_ENV="aocl_build_env"
+            source_conda
+            conda create --override-channels -y -c conda-forge --force -n "$AOCL_BUILD_ENV" "cmake>=3.26"
+            conda activate "$AOCL_BUILD_ENV"
+            cmake -S . -B build -DCMAKE_BUILD_TYPE=Release -DENABLE_AOCL_BLAS=ON -DENABLE_AOCL_UTILS=ON -DENABLE_ADDON="aocl_gemm" -DENABLE_MULTITHREADING=ON -DCMAKE_INSTALL_PREFIX="${WDL_BUILD}/aocl"
+            cmake --build build --config release --target install -- -j"$(nproc)"
+            conda deactivate
+            conda env remove -n "$AOCL_BUILD_ENV" -y
+        )
         cd .. || exit
         lib='gemm_bench' # reset lib to gemm_bench
         cmake -S "$BPKGS_WDL_ROOT/$lib" -B "$lib-build-onemkl" -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_RPATH="${MKLROOT}/lib" && cmake --build "$lib-build-onemkl"
@@ -489,6 +518,7 @@ case "$TARGET" in
         ;;
 esac
 
+cp "${BPKGS_WDL_ROOT}/common.sh" ./
 cp "${BPKGS_WDL_ROOT}/run.sh" ./
 cp "${BPKGS_WDL_ROOT}/run_prod.sh" ./
 cp "${BPKGS_WDL_ROOT}/convert.py" ./

--- a/packages/wdl_bench/run_prod.sh
+++ b/packages/wdl_bench/run_prod.sh
@@ -17,8 +17,8 @@ function benchreps_tell_state () {
 
 # Constants
 WDL_ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")" &>/dev/null && pwd -P)
-WDL_DATASETS="${WDL_ROOT}/datasets"
-WDL_BUILD="${WDL_ROOT}/wdl_build"
+# shellcheck disable=SC1091
+source "$WDL_ROOT"/common.sh
 
 show_help() {
 cat <<EOF
@@ -29,7 +29,7 @@ Usage: ${0##*/} [-h] [--name benchmark_name]
 EOF
 }
 
-# @lint-ignore-section SHELLCHECK on
+# shellcheck disable=SC2034
 prod_benchmark_list_mem="memcpy_benchmark bench-memcmp memset_benchmark"
 prod_benchmark_list_hash="hash_hash_benchmark xxhash_benchmark"
 prod_benchmark_compression="lzbench"
@@ -43,7 +43,6 @@ prod_benchmark_lock="synchronization_small_locks_benchmark synchronization_lifo_
 prod_benchmark_vdso="vdso_bench"
 prod_benchmark_math="benchsleef128 benchsleef256 benchsleef512 gemm_bench"
 prod_benchmark_stdcpp="stdcpp_bench"
-# @lint-ignore-section SHELLCHECK off
 
 prod_benchmarks="memcpy_benchmark memset_benchmark bench-memcmp hash_hash_benchmark xxhash_benchmark lzbench openssl libaegis_benchmark hash_checksum_benchmark  erasure_code_perf random_benchmark concurrency_concurrent_hash_map_bench ProtocolBench VarintUtilsBench container_hash_maps_bench synchronization_small_locks_benchmark synchronization_lifo_sem_bench vdso_bench benchsleef128 benchsleef256 benchsleef512 stdcpp_bench"
 
@@ -87,6 +86,7 @@ declare -A prod_benchmark_config=(
     ['stdcpp_bench']="--benchmark_format=json"
     ['gemm_bench']="--benchmark_format=json"
 )
+
 
 main() {
     local result_filename
@@ -178,12 +178,22 @@ main() {
 
     echo "benchmark results:" "$run_list" | tee -a "${result_filename}"
     echo "---------------------------------------------" | tee -a "${result_filename}"
-    for benchmark in $run_list; do
-        if exec_non_json "${benchmark}"; then
-            python3 ./convert.py "$benchmark"
-        fi
-        python3 ./scoring.py "$benchmark" | tee -a "${result_filename}"
-    done
+
+    # Execute scoring in a subshell to guarantee numpy availability
+    (
+        WDL_RUN_ENV="wdl_run_env"
+        source_conda
+        conda create --override-channels -y -c conda-forge --force -n "$WDL_RUN_ENV" python numpy
+        conda activate "$WDL_RUN_ENV"
+        for benchmark in $run_list; do
+            if exec_non_json "${benchmark}"; then
+                python3 ./convert.py "$benchmark"
+            fi
+            python3 ./scoring.py "$benchmark" | tee -a "${result_filename}"
+        done
+        conda deactivate
+        conda env remove -n "$WDL_RUN_ENV" -y
+    )
 
     echo "---------------------------------------------" | tee -a "${result_filename}"
     echo "detailed results in each individual json file." | tee -a "${result_filename}"


### PR DESCRIPTION
Summary:
For whatever reason, installing WDL on Arm64 Ubuntu 22.04 triggered tzdata update, which by default was an interactive session that required keyboard inputs. On a CI server, this means a server hangs indefinitely.

We fix the issue by executing apt install with DEBIAN_FRONTEND=noninteractive to force a non-interactive session.
On CentOS, dnf/yum -y are non-interactive by design, so there's no need for something similar there.

In addition, building aocl on x64 Ubuntu 22.04 failed cmake version check (3.26+ required while 3.22.1 installed), and to fix that, we added creating conda virtual environment when special versions of tools are needed. Note that we need to handle cases in which a system conda may or may not exist.

Moreover, a common.sh script is added to include common variables and functions among all other scripts, which eliminates dupllication.

Differential Revision: D90338292


