### PR TITLE
Move conda init inside miniconda installation block

### DIFF
--- a/packages/wdl_bench/install_wdl_bench.sh
+++ b/packages/wdl_bench/install_wdl_bench.sh
@@ -92,10 +92,10 @@ if ! in_conda_env; then
                 wget https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh -O "${WDL_ROOT}/miniconda3/miniconda.sh" || exit
             fi
             bash -c "sh ${WDL_ROOT}/miniconda3/miniconda.sh -b -u -p ${WDL_ROOT}/miniconda3" || exit
+            # shellcheck disable=SC1091
+            source "${WDL_ROOT}"/miniconda3/etc/profile.d/conda.sh
+            conda tos accept
         fi
-        # shellcheck disable=SC1091
-        source "${WDL_ROOT}"/miniconda3/etc/profile.d/conda.sh
-        conda tos accept
     fi
 fi
 


### PR DESCRIPTION
Summary: The conda initialization (`source conda.sh`) and terms of service acceptance (`conda tos accept`) were previously running on every script invocation, even when miniconda was already installed. This change moves these commands inside the installation block so they only execute when miniconda is first being set up, avoiding unnecessary overhead on subsequent runs.

Differential Revision: D90449199


