### PR TITLE
Update all uname -p to uname -m

### DIFF
--- a/packages/django_workload/install_django_workload.sh
+++ b/packages/django_workload/install_django_workload.sh
@@ -14,16 +14,16 @@ DJANGO_REPO_ROOT="${DJANGO_WORKLOAD_ROOT}/django-workload"
 
 source "${BENCHPRESS_ROOT}/packages/common/os-distro.sh"
 
-if distro_is_like ubuntu && [ "$(uname -p)" = "aarch64" ]; then
+if distro_is_like ubuntu && [ "$(uname -m)" = "aarch64" ]; then
     "${DJANGO_PKG_ROOT}"/install_django_workload_aarch64_ubuntu22.sh
     exit $?
 fi
-if distro_is_like ubuntu && [ "$(uname -p)" = "x86_64" ]; then
+if distro_is_like ubuntu && [ "$(uname -m)" = "x86_64" ]; then
     "${DJANGO_PKG_ROOT}"/install_django_workload_x86_64_ubuntu22.sh
     exit $?
 fi
 
-if [ "$(uname -p)" = "aarch64" ]; then
+if [ "$(uname -m)" = "aarch64" ]; then
     "${DJANGO_PKG_ROOT}"/install_django_workload_aarch64.sh
     exit $?
 fi

--- a/packages/feedsim/install_feedsim.sh
+++ b/packages/feedsim/install_feedsim.sh
@@ -33,7 +33,7 @@ die() {
   exit "$code"
 }
 
-ARCH="$(uname -p)"
+ARCH="$(uname -m)"
 if [ "$ARCH" = "aarch64" ]; then
   if distro_is_like ubuntu; then
     "${FEEDSIM_ROOT}"/install_feedsim_aarch64_ubuntu.sh
@@ -43,7 +43,7 @@ if [ "$ARCH" = "aarch64" ]; then
     exit $?
   fi
 fi
-if distro_is_like ubuntu && [ "$(uname -p)" = "x86_64" ]; then
+if distro_is_like ubuntu && [ "$(uname -m)" = "x86_64" ]; then
   "${FEEDSIM_ROOT}"/install_feedsim_ubuntu.sh
   exit $?
 fi

--- a/packages/health_check/run.sh
+++ b/packages/health_check/run.sh
@@ -59,7 +59,7 @@ if [ "$role" = "server" ]; then
   cpus=$(nproc)
   workers=$(echo "scale=0; $cpus * 2.5" | bc)
   python3 "$HEALTH_ROOT"/sleepbench/collect-cpu-util.py "$HEALTH_ROOT"/sleepbench/sleepbench "$workers" 30
-  if [ "$(uname -p)" = "aarch64" ]; then
+  if [ "$(uname -m)" = "aarch64" ]; then
     pushd "${HEALTH_ROOT}/infra-microbenchmarks/loaded-latency" || exit 1
     ./sweep.finedelay.sh $(seq -f "-B%.0f" 0 $(($(nproc)-1))) > /tmp/bw-lat.txt
     ./summarize.sh /tmp/bw-lat.txt > /tmp/bw-lat.tsv

--- a/packages/tao_bench/install_tao_bench.sh
+++ b/packages/tao_bench/install_tao_bench.sh
@@ -9,6 +9,6 @@ set -Eeuo pipefail
 BPKGS_TAO_BENCH_ROOT="$(dirname "$(readlink -f "$0")")" # Path to dir with this file.
 
 # Use the alternative arch-specific installer scripts
-ARCH="$(uname -p)"
+ARCH="$(uname -m)"
 "${BPKGS_TAO_BENCH_ROOT}"/install_tao_bench_"${ARCH}".sh
 exit $?

--- a/packages/video_transcode_bench/install_video_transcode_bench.sh
+++ b/packages/video_transcode_bench/install_video_transcode_bench.sh
@@ -28,7 +28,7 @@ declare -A TAGS=(
 ##################### SYS CONFIG AND DEPS #########################
 
 BPKGS_FFMPEG_ROOT="$(dirname "$(readlink -f "$0")")" # Path to dir with this file.
-ARCH="$(uname -p)"
+ARCH="$(uname -m)"
 BENCHPRESS_ROOT="$(readlink -f "$BPKGS_FFMPEG_ROOT/../..")"
 FFMPEG_ROOT="${BENCHPRESS_ROOT}/benchmarks/video_transcode_bench"
 FFMPEG_SOURCE="${FFMPEG_ROOT}/ffmpeg_sources"


### PR DESCRIPTION
Summary:
The change from uname -p to uname -m ensures the architecture detection works consistently across different platforms, as uname -p can return "unknown" on some Linux systems while uname -m reliably returns the machine hardware name (e.g., x86_64 or aarch64).

This suggestion is 


E.g. Google Axion: P2121404927

Reviewed By: YifanYuan3, mcfi

Differential Revision: D90587921


