### PR TITLE
Fix DjangoBench installation

### DIFF
--- a/packages/django_workload/install_django_workload_aarch64.sh
+++ b/packages/django_workload/install_django_workload_aarch64.sh
@@ -434,13 +434,13 @@ mkdir -p "${DATASET_DIR}/text"
 mkdir -p "${DATASET_DIR}/binary"
 
 DATASET_DIR2="${DJANGO_SERVER_ROOT}/django_workload/feed_flow/dataset"
-ln -s "${DATASET_DIR}" "${DATASET_DIR2}"
+ln -sf "${DATASET_DIR}" "${DATASET_DIR2}"
 
 DATASET_DIR3="${DJANGO_SERVER_ROOT}/django_workload/reels_tray/dataset"
-ln -s "${DATASET_DIR}" "${DATASET_DIR3}"
+ln -sf "${DATASET_DIR}" "${DATASET_DIR3}"
 
 DATASET_DIR4="${DJANGO_SERVER_ROOT}/django_workload/inbox/dataset"
-ln -s "${DATASET_DIR}" "${DATASET_DIR4}"
+ln -sf "${DATASET_DIR}" "${DATASET_DIR4}"
 
 # Download Silesia Corpus if not already present
 if [ ! -f "${DJANGO_WORKLOAD_ROOT}/silesia.zip" ]; then

--- a/packages/django_workload/install_django_workload_aarch64_ubuntu22.sh
+++ b/packages/django_workload/install_django_workload_aarch64_ubuntu22.sh
@@ -421,13 +421,13 @@ mkdir -p "${DATASET_DIR}/text"
 mkdir -p "${DATASET_DIR}/binary"
 
 DATASET_DIR2="${DJANGO_SERVER_ROOT}/django_workload/feed_flow/dataset"
-ln -s "${DATASET_DIR}" "${DATASET_DIR2}"
+ln -sf "${DATASET_DIR}" "${DATASET_DIR2}"
 
 DATASET_DIR3="${DJANGO_SERVER_ROOT}/django_workload/reels_tray/dataset"
-ln -s "${DATASET_DIR}" "${DATASET_DIR3}"
+ln -sf "${DATASET_DIR}" "${DATASET_DIR3}"
 
 DATASET_DIR4="${DJANGO_SERVER_ROOT}/django_workload/inbox/dataset"
-ln -s "${DATASET_DIR}" "${DATASET_DIR4}"
+ln -sf "${DATASET_DIR}" "${DATASET_DIR4}"
 
 # Download Silesia Corpus if not already present
 if [ ! -f "${DJANGO_WORKLOAD_ROOT}/silesia.zip" ]; then

--- a/packages/django_workload/install_django_workload_x86_64_centos9.sh
+++ b/packages/django_workload/install_django_workload_x86_64_centos9.sh
@@ -431,13 +431,13 @@ mkdir -p "${DATASET_DIR}/text"
 mkdir -p "${DATASET_DIR}/binary"
 
 DATASET_DIR2="${DJANGO_SERVER_ROOT}/django_workload/feed_flow/dataset"
-ln -s "${DATASET_DIR}" "${DATASET_DIR2}"
+ln -sf "${DATASET_DIR}" "${DATASET_DIR2}"
 
 DATASET_DIR3="${DJANGO_SERVER_ROOT}/django_workload/reels_tray/dataset"
-ln -s "${DATASET_DIR}" "${DATASET_DIR3}"
+ln -sf "${DATASET_DIR}" "${DATASET_DIR3}"
 
 DATASET_DIR4="${DJANGO_SERVER_ROOT}/django_workload/inbox/dataset"
-ln -s "${DATASET_DIR}" "${DATASET_DIR4}"
+ln -sf "${DATASET_DIR}" "${DATASET_DIR4}"
 
 # Download Silesia Corpus if not already present
 if [ ! -f "${DJANGO_WORKLOAD_ROOT}/silesia.zip" ]; then

--- a/packages/django_workload/install_django_workload_x86_64_ubuntu22.sh
+++ b/packages/django_workload/install_django_workload_x86_64_ubuntu22.sh
@@ -418,13 +418,13 @@ mkdir -p "${DATASET_DIR}/text"
 mkdir -p "${DATASET_DIR}/binary"
 
 DATASET_DIR2="${DJANGO_SERVER_ROOT}/django_workload/feed_flow/dataset"
-ln -s "${DATASET_DIR}" "${DATASET_DIR2}"
+ln -sf "${DATASET_DIR}" "${DATASET_DIR2}"
 
 DATASET_DIR3="${DJANGO_SERVER_ROOT}/django_workload/reels_tray/dataset"
-ln -s "${DATASET_DIR}" "${DATASET_DIR3}"
+ln -sf "${DATASET_DIR}" "${DATASET_DIR3}"
 
 DATASET_DIR4="${DJANGO_SERVER_ROOT}/django_workload/inbox/dataset"
-ln -s "${DATASET_DIR}" "${DATASET_DIR4}"
+ln -sf "${DATASET_DIR}" "${DATASET_DIR4}"
 
 # Download Silesia Corpus if not already present
 if [ ! -f "${DJANGO_WORKLOAD_ROOT}/silesia.zip" ]; then

--- a/packages/django_workload/srcs/django-workload/django-workload/django_workload/thrift/mock_services.thrift
+++ b/packages/django_workload/srcs/django-workload/django-workload/django_workload/thrift/mock_services.thrift
@@ -3,10 +3,12 @@
 // Mock Thrift service for DjangoBench V2 - SIMPLIFIED VERSION
 // Minimal structures for performance
 
-include "thrift/annotation/thrift.thrift"
-
-@thrift.AllowLegacyMissingUris
-package;
+// Back out the change in https://github.com/facebookresearch/DCPerf/pull/387
+// Only uncomment the following 4 lines when we upgrade the version of fbthrift
+// include "thrift/annotation/thrift.thrift"
+//
+// @thrift.AllowLegacyMissingUris
+// package;
 
 namespace py mock_services
 


### PR DESCRIPTION
Summary: Remove the change made by D90140411 (https://github.com/facebookresearch/DCPerf/pull/387). It broke the building of DjangoBench's mock thrift server because `thrift.AllowLegacyMissingUris` is not yet defined in the version of fbthrift we're using.

Differential Revision: D90715212


