### PR TITLE
Correct DATASET_DIR2 destination in DjangoBench installation

### DIFF
--- a/packages/django_workload/install_django_workload_aarch64.sh
+++ b/packages/django_workload/install_django_workload_aarch64.sh
@@ -433,7 +433,7 @@ DATASET_DIR="${DJANGO_SERVER_ROOT}/django_workload/feed_flow/dataset"
 mkdir -p "${DATASET_DIR}/text"
 mkdir -p "${DATASET_DIR}/binary"
 
-DATASET_DIR2="${DJANGO_SERVER_ROOT}/django_workload/feed_flow/dataset"
+DATASET_DIR2="${DJANGO_SERVER_ROOT}/django_workload/clips_discovery/dataset"
 ln -sf "${DATASET_DIR}" "${DATASET_DIR2}"
 
 DATASET_DIR3="${DJANGO_SERVER_ROOT}/django_workload/reels_tray/dataset"

--- a/packages/django_workload/install_django_workload_aarch64_ubuntu22.sh
+++ b/packages/django_workload/install_django_workload_aarch64_ubuntu22.sh
@@ -420,7 +420,7 @@ DATASET_DIR="${DJANGO_SERVER_ROOT}/django_workload/feed_flow/dataset"
 mkdir -p "${DATASET_DIR}/text"
 mkdir -p "${DATASET_DIR}/binary"
 
-DATASET_DIR2="${DJANGO_SERVER_ROOT}/django_workload/feed_flow/dataset"
+DATASET_DIR2="${DJANGO_SERVER_ROOT}/django_workload/clips_discovery/dataset"
 ln -sf "${DATASET_DIR}" "${DATASET_DIR2}"
 
 DATASET_DIR3="${DJANGO_SERVER_ROOT}/django_workload/reels_tray/dataset"

--- a/packages/django_workload/install_django_workload_x86_64_centos9.sh
+++ b/packages/django_workload/install_django_workload_x86_64_centos9.sh
@@ -430,7 +430,7 @@ DATASET_DIR="${DJANGO_SERVER_ROOT}/django_workload/feed_flow/dataset"
 mkdir -p "${DATASET_DIR}/text"
 mkdir -p "${DATASET_DIR}/binary"
 
-DATASET_DIR2="${DJANGO_SERVER_ROOT}/django_workload/feed_flow/dataset"
+DATASET_DIR2="${DJANGO_SERVER_ROOT}/django_workload/clips_discovery/dataset"
 ln -sf "${DATASET_DIR}" "${DATASET_DIR2}"
 
 DATASET_DIR3="${DJANGO_SERVER_ROOT}/django_workload/reels_tray/dataset"

--- a/packages/django_workload/install_django_workload_x86_64_ubuntu22.sh
+++ b/packages/django_workload/install_django_workload_x86_64_ubuntu22.sh
@@ -417,7 +417,7 @@ DATASET_DIR="${DJANGO_SERVER_ROOT}/django_workload/feed_flow/dataset"
 mkdir -p "${DATASET_DIR}/text"
 mkdir -p "${DATASET_DIR}/binary"
 
-DATASET_DIR2="${DJANGO_SERVER_ROOT}/django_workload/feed_flow/dataset"
+DATASET_DIR2="${DJANGO_SERVER_ROOT}/django_workload/clips_discovery/dataset"
 ln -sf "${DATASET_DIR}" "${DATASET_DIR2}"
 
 DATASET_DIR3="${DJANGO_SERVER_ROOT}/django_workload/reels_tray/dataset"


### PR DESCRIPTION
Summary: Correct the typo in DATASET_DIR2 which should be in `clips_discovery` folder

Differential Revision: D90784853


