### PR TITLE
  Improve robustness of WDL scripts

### DIFF
--- a/packages/wdl_bench/common.sh
+++ b/packages/wdl_bench/common.sh
@@ -69,3 +69,15 @@ source_conda() {
     # shellcheck disable=SC1090
     source "$conda_sh"
 }
+
+get_git_proxy_args() {
+    : # Replace with your proxy args
+}
+
+get_curl_proxy_args() {
+    : # Replace with your proxy args
+}
+
+get_conda_proxy_args() {
+    : # Replace with your proxy args
+}

--- a/packages/wdl_bench/install_wdl_bench.sh
+++ b/packages/wdl_bench/install_wdl_bench.sh
@@ -61,10 +61,10 @@ if [ "$LINUX_DIST_ID" = "ubuntu" ]; then
     flex bison gfortran nasm clang gcc g++ patch git libssl-dev libc6-dev \
     tar unzip perl openssl python3-dev gawk libstdc++6 python3-numpy \
     glibc-source libbenchmark-dev environment-modules libopenblas-dev \
-    pkg-config
+    pkg-config curl
 
 elif [ "$LINUX_DIST_ID" = "centos" ]; then
-  dnf install -y cmake autoconf automake flex bison gfortran \
+  dnf install -y cmake autoconf automake flex bison gfortran curl \
     meson nasm clang gcc g++ patch glibc-static libstdc++-static \
     git tar unzip perl openssl-devel python3-devel gawk python3-numpy \
     dnf-plugins-core rpm-build audit-libs-devel gd-devel gdb \
@@ -87,9 +87,11 @@ if ! in_conda_env; then
             echo "Installing miniconda."
             mkdir -p "${WDL_ROOT}/miniconda3"
             if [ "$ARCH" = "aarch64" ]; then
-                wget https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-aarch64.sh -O "${WDL_ROOT}/miniconda3/miniconda.sh" || exit
+                # shellcheck disable=SC2046
+                curl $(get_curl_proxy_args) -o "${WDL_ROOT}/miniconda3/miniconda.sh" https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-aarch64.sh || exit
             else
-                wget https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh -O "${WDL_ROOT}/miniconda3/miniconda.sh" || exit
+                # shellcheck disable=SC2046
+                curl $(get_curl_proxy_args) -o "${WDL_ROOT}/miniconda3/miniconda.sh" https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh || exit
             fi
             bash -c "sh ${WDL_ROOT}/miniconda3/miniconda.sh -b -u -p ${WDL_ROOT}/miniconda3" || exit
             # shellcheck disable=SC1091
@@ -110,7 +112,8 @@ clone()
 {
     lib=$1
     repo=${REPOS[$lib]}
-    if ! git clone "${repo}" "${lib}" 2>/dev/null && [ -d "${lib}" ]; then
+    # shellcheck disable=SC2046
+    if ! git $(get_git_proxy_args) clone "${repo}" "${lib}" 2>/dev/null && [ -d "${lib}" ]; then
         echo "Clone failed because the folder ${lib} exists"
         return 1
     fi
@@ -129,7 +132,8 @@ download_dataset()
     dataset="$1"
     pushd "${WDL_DATASETS}"
     link=${DATASETS[$dataset]}
-    wget "${link}" || exit 1
+    # shellcheck disable=SC2046
+    curl $(get_curl_proxy_args) -O "${link}" || exit 1
 
     popd || exit
 }
@@ -147,7 +151,8 @@ build_folly()
     (
         FBENV="folly_build_env"
         source_conda
-        conda create --override-channels -y -c conda-forge --force -n "$FBENV" "python=3.12" "numpy<2"
+        # shellcheck disable=SC2046,SC2086
+        env $(get_conda_proxy_args) conda create --override-channels -y -c conda-forge --force -n "$FBENV" "python=3.12" "numpy<2"
         conda activate "$FBENV"
         python3 ./build/fbcode_builder/getdeps.py install-system-deps --recursive
         python3 ./build/fbcode_builder/getdeps.py --allow-system-packages build --src-dir "." --scratch-path "${WDL_BUILD}"
@@ -233,11 +238,13 @@ build_libaegis()
     pushd "${WDL_SOURCE}"
     clone $lib || echo "Failed to clone $lib"
     if [ "$ARCH" = "aarch64" ]; then
-        wget https://ziglang.org/download/0.15.2/zig-aarch64-linux-0.15.2.tar.xz
+        # shellcheck disable=SC2046
+        curl $(get_curl_proxy_args) -O https://ziglang.org/download/0.15.2/zig-aarch64-linux-0.15.2.tar.xz
         tar xvf zig-aarch64-linux-0.15.2.tar.xz
         mv zig-aarch64-linux-0.15.2 zig
     else
-        wget https://ziglang.org/download/0.15.2/zig-x86_64-linux-0.15.2.tar.xz
+        # shellcheck disable=SC2046
+        curl $(get_curl_proxy_args) -O https://ziglang.org/download/0.15.2/zig-x86_64-linux-0.15.2.tar.xz
         tar xvf zig-x86_64-linux-0.15.2.tar.xz
         mv zig-x86_64-linux-0.15.2 zig
     fi
@@ -396,11 +403,13 @@ build_gemm()
         cmake -S . -B build -DCMAKE_BUILD_TYPE=Release -DARM_COMPUTE_BUILD_SHARED_LIB=ON -DARM_COMPUTE_ENABLE_OPENMP=ON -DACL_MULTI_ISA=ON -DACL_BUILD_SVE=ON -DACL_BUILD_SVE2=ON -DACL_BUILD_SME2=ON -DCMAKE_INSTALL_PREFIX="${WDL_BUILD}/acl" && cmake --build build --config release --target install -- -j"$(nproc)"
         cd .. || exit
         if [ "$LINUX_DIST_ID" = "ubuntu" ]; then
-            wget -nc "https://developer.arm.com/-/cdn-downloads/permalink/Arm-Performance-Libraries/Version_${ARMPL_VERSION}/arm-performance-libraries_${ARMPL_VERSION}_deb_gcc.tar"
+            # shellcheck disable=SC2046
+            curl $(get_curl_proxy_args) -O "https://developer.arm.com/-/cdn-downloads/permalink/Arm-Performance-Libraries/Version_${ARMPL_VERSION}/arm-performance-libraries_${ARMPL_VERSION}_deb_gcc.tar"
             tar xvf "arm-performance-libraries_${ARMPL_VERSION}_deb_gcc.tar"
             bash -c "./arm-performance-libraries_${ARMPL_VERSION}_deb/arm-performance-libraries_${ARMPL_VERSION}_deb.sh --accept --install-to ./apl"
         elif [ "$LINUX_DIST_ID" = "centos" ]; then
-            wget -nc "https://developer.arm.com/-/cdn-downloads/permalink/Arm-Performance-Libraries/Version_${ARMPL_VERSION}/arm-performance-libraries_${ARMPL_VERSION}_rpm_gcc.tar"
+            # shellcheck disable=SC2046
+            curl $(get_curl_proxy_args) -O "https://developer.arm.com/-/cdn-downloads/permalink/Arm-Performance-Libraries/Version_${ARMPL_VERSION}/arm-performance-libraries_${ARMPL_VERSION}_rpm_gcc.tar"
             tar xvf "arm-performance-libraries_${ARMPL_VERSION}_rpm_gcc.tar"
             bash -c "./arm-performance-libraries_${ARMPL_VERSION}_rpm/arm-performance-libraries_${ARMPL_VERSION}_rpm.sh --accept --install-to ./apl"
         fi
@@ -411,7 +420,8 @@ build_gemm()
         cp "$lib-build/$lib" "${WDL_ROOT}/" || exit 1
     else
         cpu_vendor=$(grep -m 1 'vendor_id' /proc/cpuinfo | awk '{print $3}')
-        wget -nc https://registrationcenter-download.intel.com/akdlm/IRC_NAS/2ad98b49-1fb2-4294-ab3d-6889b434ebd3/intel-onemkl-${MKL_VERSION}_offline.sh
+        # shellcheck disable=SC2046,SC2086
+        curl $(get_curl_proxy_args) -O https://registrationcenter-download.intel.com/akdlm/IRC_NAS/2ad98b49-1fb2-4294-ab3d-6889b434ebd3/intel-onemkl-${MKL_VERSION}_offline.sh
         bash -c "sh ./intel-onemkl-${MKL_VERSION}_offline.sh -a --action install --silent --eula accept --install-dir ./onemkl"
         bash -c "onemkl/modulefiles-setup.sh --output-dir=onemkl/modulefiles"
         module use onemkl/modulefiles
@@ -422,7 +432,8 @@ build_gemm()
         (
             AOCL_BUILD_ENV="aocl_build_env"
             source_conda
-            conda create --override-channels -y -c conda-forge --force -n "$AOCL_BUILD_ENV" "cmake>=3.26"
+            # shellcheck disable=SC2046,SC2086
+            env $(get_conda_proxy_args) conda create --override-channels -y -c conda-forge --force -n "$AOCL_BUILD_ENV" "cmake>=3.26"
             conda activate "$AOCL_BUILD_ENV"
             cmake -S . -B build -DCMAKE_BUILD_TYPE=Release -DENABLE_AOCL_BLAS=ON -DENABLE_AOCL_UTILS=ON -DENABLE_ADDON="aocl_gemm" -DENABLE_MULTITHREADING=ON -DCMAKE_INSTALL_PREFIX="${WDL_BUILD}/aocl"
             cmake --build build --config release --target install -- -j"$(nproc)"

--- a/packages/wdl_bench/run_prod.sh
+++ b/packages/wdl_bench/run_prod.sh
@@ -94,6 +94,8 @@ main() {
 
     local name
     name="none"
+    local score_only
+    score_only=false
 
     while [[ $# -gt 0 ]]; do
         case "$1" in
@@ -101,6 +103,10 @@ main() {
                 [[ -n "$2" ]] || { echo "Invalid option: $1 requires an argument" 1>&2; exit 1; }
                 name="$2"
                 shift 2
+                ;;
+            --score_only)
+                score_only=true
+                shift 1
                 ;;
             -h|--help)
                 show_help >&2
@@ -116,10 +122,6 @@ main() {
     set -u  # Enable unbound variables check from here onwards
     benchreps_tell_state "working on config"
     pushd "${WDL_ROOT}"
-    rm -f out_*.txt out_*.json
-
-    #run
-    benchreps_tell_state "start"
 
     prod_benchmark_candidates=""
     if [ "$name" != "none" ]; then
@@ -142,35 +144,44 @@ main() {
     done
     run_list="${valid_prod_benchmarks[*]}"
 
-    for benchmark in $run_list; do
-        if [ "$benchmark" = "openssl" ]; then
-            export LD_LIBRARY_PATH="${WDL_BUILD}/openssl/lib64:${WDL_BUILD}/openssl/lib"
-            ldconfig
-        fi
-        out_file=""
-        if exec_non_json "${benchmark}"; then
-            out_file="out_${benchmark}.txt"
-        else
-            out_file="out_${benchmark}.json"
-        fi
-        if [ "$benchmark" = "bench-memcmp" ]; then
-            pushd "${WDL_BUILD}/glibc-build"
-            bash -c "./testrun.sh ./benchtests/${benchmark} -- ${prod_benchmark_config[$benchmark]}" 2>&1 | tee -a "${WDL_ROOT}/${out_file}"
-            popd
-        else
-            ENV_VARS=""
-            if [ "$benchmark" = "gemm_bench" ]; then
-                ENV_VARS="OMP_NUM_THREADS=1"
-            fi
-            bash -c "${ENV_VARS} ./${benchmark} ${prod_benchmark_config[$benchmark]}" 2>&1 | tee -a "${out_file}"
-        fi
-        if [ "$benchmark" = "openssl" ]; then
-            unset LD_LIBRARY_PATH
-            ldconfig
-        fi
-    done
+    if [ "$score_only" = false ]; then
+        #run
+        benchreps_tell_state "start"
 
-    benchreps_tell_state "done"
+        for benchmark in $run_list; do
+            # Remove old results
+            rm -f "out_${benchmark}.txt" "out_${benchmark}.json"
+
+            if [ "$benchmark" = "openssl" ]; then
+                export LD_LIBRARY_PATH="${WDL_BUILD}/openssl/lib64:${WDL_BUILD}/openssl/lib"
+                ldconfig
+            fi
+            out_file=""
+            if exec_non_json "${benchmark}"; then
+                out_file="out_${benchmark}.txt"
+            else
+                out_file="out_${benchmark}.json"
+            fi
+            if [ "$benchmark" = "bench-memcmp" ]; then
+                pushd "${WDL_BUILD}/glibc-build"
+                bash -c "./testrun.sh ./benchtests/${benchmark} -- ${prod_benchmark_config[$benchmark]}" 2>&1 | tee -a "${WDL_ROOT}/${out_file}"
+                popd
+            else
+                ENV_VARS=""
+                if [ "$benchmark" = "gemm_bench" ]; then
+                    ENV_VARS="OMP_NUM_THREADS=1"
+                fi
+                bash -c "${ENV_VARS} ./${benchmark} ${prod_benchmark_config[$benchmark]}" 2>&1 | tee -a "${out_file}"
+            fi
+            if [ "$benchmark" = "openssl" ]; then
+                unset LD_LIBRARY_PATH
+                ldconfig
+            fi
+        done
+
+        benchreps_tell_state "done"
+    fi
+
     #generate output
     if [ -f "${result_filename}" ]; then
         rm "${result_filename}"
@@ -179,21 +190,12 @@ main() {
     echo "benchmark results:" "$run_list" | tee -a "${result_filename}"
     echo "---------------------------------------------" | tee -a "${result_filename}"
 
-    # Execute scoring in a subshell to guarantee numpy availability
-    (
-        WDL_RUN_ENV="wdl_run_env"
-        source_conda
-        conda create --override-channels -y -c conda-forge --force -n "$WDL_RUN_ENV" python numpy
-        conda activate "$WDL_RUN_ENV"
-        for benchmark in $run_list; do
-            if exec_non_json "${benchmark}"; then
-                python3 ./convert.py "$benchmark"
-            fi
-            python3 ./scoring.py "$benchmark" | tee -a "${result_filename}"
-        done
-        conda deactivate
-        conda env remove -n "$WDL_RUN_ENV" -y
-    )
+    for benchmark in $run_list; do
+        if exec_non_json "${benchmark}"; then
+            python3 ./convert.py "$benchmark"
+        fi
+        python3 ./scoring.py "$benchmark" | tee -a "${result_filename}"
+    done
 
     echo "---------------------------------------------" | tee -a "${result_filename}"
     echo "detailed results in each individual json file." | tee -a "${result_filename}"

--- a/packages/wdl_bench/scoring.py
+++ b/packages/wdl_bench/scoring.py
@@ -6,41 +6,64 @@
 
 
 import json
+import math
 import sys
 from typing import Any
 
-import numpy as np
-
-sum_c = {}
-
-if len(sys.argv) != 2:
-    print("scoring.py benchmark_name")
-    sys.exit(-1)
-
 
 def weighted_geomean(values: list[float], weights: list[float]) -> float:
-    return np.exp(np.average(np.log(np.array(values)), weights=weights))
+    """Compute weighted geometric mean without numpy.
+    Requires:
+      - len(values) == len(weights) > 0
+      - all values > 0
+      - all weights >= 0
+      - sum(weights) > 0
+    """
+    if not values:
+        raise ValueError("values must be non-empty")
+    if len(values) != len(weights):
+        raise ValueError("values and weights must have the same length")
+    total_weight = 0.0
+    weighted_log_sum = 0.0
+    for v, w in zip(values, weights):
+        if v <= 0:
+            raise ValueError("all values must be > 0 for geometric mean")
+        if w < 0:
+            raise ValueError("all weights must be >= 0")
+        total_weight += w
+        weighted_log_sum += w * math.log(v)
+    if total_weight <= 0:
+        raise ValueError("sum of weights must be > 0")
+    return math.exp(weighted_log_sum / total_weight)
 
 
 def geomean(values: list[float]) -> float:
-    return np.exp(np.mean(np.log(np.array(values))))
+    """Compute geometric mean without numpy.
+    Requires:
+      - len(values) > 0
+      - all values > 0
+    """
+    if not values:
+        raise ValueError("values must be non-empty")
+    log_sum = 0.0
+    for v in values:
+        if v <= 0:
+            raise ValueError("all values must be > 0 for geometric mean")
+        log_sum += math.log(v)
+    return math.exp(log_sum / len(values))
 
 
-def max(values: list[float]) -> float:
-    return float(np.max(np.array(values)))
+def max_value(values: list[float]) -> float:
+    """Return maximum value from a list."""
+    if not values:
+        raise ValueError("values must be non-empty")
+    return max(values)
 
-
-benchmark_name = sys.argv[1]
-
-input_file_name = "out_" + benchmark_name + ".json"
-
-baseline_name = "baseline_results/baseline_" + benchmark_name + ".json"
 
 # For sleef, we use the benchsleef256 results collected on
 # Intel Cooperlake as the baseline since AVX512 may not be enabled
 # on many prod servers.
-if benchmark_name.startswith("benchsleef"):
-    baseline_name = "baseline_results/baseline_benchsleef256.json"
+baseline_sleef_vec_width = 256
 
 
 def generate_sleef_benchmark_name(
@@ -80,7 +103,9 @@ def extract_gbench_metric(
     return results
 
 
-def calculate_sleef_score(sum_baseline: dict[str, Any], sum_c: dict[str, Any]) -> float:
+def compute_sleef_score(
+    benchmark_name: str, sum_baseline: dict[str, Any], sum_c: dict[str, Any]
+) -> float:
     # Function name, value range
     math_functions = [["expf", "-700_700"], ["logf", "0_1e+38"]]
     math_function_weights = [80, 20]
@@ -88,7 +113,9 @@ def calculate_sleef_score(sum_baseline: dict[str, Any], sum_c: dict[str, Any]) -
     baseline_names = []
     for math_function in math_functions:
         baseline_names.append(
-            generate_sleef_benchmark_name(math_function[0], 512, math_function[1])
+            generate_sleef_benchmark_name(
+                math_function[0], baseline_sleef_vec_width, math_function[1]
+            )
         )
 
     baseline_time = weighted_geomean(
@@ -226,9 +253,7 @@ def get_memcmp_variant_names(data: dict[str, Any]) -> list[str]:
     return []
 
 
-def calculate_memcmp_score(
-    sum_baseline: dict[str, Any], sum_c: dict[str, Any]
-) -> float:
+def compute_memcmp_score(sum_baseline: dict[str, Any], sum_c: dict[str, Any]) -> float:
     # Use AVX512 memcmp as the baseline since it is the fastest variant
     # in baseline.
     baseline_time = calculate_memcmp_geomean_by_range(
@@ -242,9 +267,7 @@ def calculate_memcmp_score(
     return baseline_time / min_time
 
 
-def calculate_stdcpp_score(
-    sum_baseline: dict[str, Any], sum_c: dict[str, Any]
-) -> float:
+def compute_stdcpp_score(sum_baseline: dict[str, Any], sum_c: dict[str, Any]) -> float:
     """
     Calculate stdcpp_bench score using weighted geometric mean.
 
@@ -267,7 +290,7 @@ def calculate_stdcpp_score(
     return baseline_geomean / current_geomean
 
 
-def calculate_gemm_score(sum_baseline: dict[str, Any], sum_c: dict[str, Any]) -> float:
+def compute_gemm_score(sum_baseline: dict[str, Any], sum_c: dict[str, Any]) -> float:
     """
     Calculate gemm_bench score based on peak flops.
 
@@ -280,14 +303,14 @@ def calculate_gemm_score(sum_baseline: dict[str, Any], sum_c: dict[str, Any]) ->
     """
 
     baseline_peak_ops = [
-        max(extract_gbench_metric(sum_baseline, ["BM_SGEMM"], "FLOPS", True)),
-        max(extract_gbench_metric(sum_baseline, ["BM_BF16GEMM"], "FLOPS", True)),
-        max(extract_gbench_metric(sum_baseline, ["BM_I8GEMM"], "TOPS", True)),
+        max_value(extract_gbench_metric(sum_baseline, ["BM_SGEMM"], "FLOPS", True)),
+        max_value(extract_gbench_metric(sum_baseline, ["BM_BF16GEMM"], "FLOPS", True)),
+        max_value(extract_gbench_metric(sum_baseline, ["BM_I8GEMM"], "TOPS", True)),
     ]
     current_peak_ops = [
-        max(extract_gbench_metric(sum_c, ["BM_SGEMM"], "FLOPS", True)),
-        max(extract_gbench_metric(sum_c, ["BM_BF16GEMM"], "FLOPS", True)),
-        max(extract_gbench_metric(sum_c, ["BM_I8GEMM"], "TOPS", True)),
+        max_value(extract_gbench_metric(sum_c, ["BM_SGEMM"], "FLOPS", True)),
+        max_value(extract_gbench_metric(sum_c, ["BM_BF16GEMM"], "FLOPS", True)),
+        max_value(extract_gbench_metric(sum_c, ["BM_I8GEMM"], "TOPS", True)),
     ]
 
     try:
@@ -295,10 +318,10 @@ def calculate_gemm_score(sum_baseline: dict[str, Any], sum_c: dict[str, Any]) ->
         # an exception is thrown and we don't add BM_HGEMM to the list of peak
         # baseline ops.
         current_peak_ops.append(
-            max(extract_gbench_metric(sum_c, ["BM_HGEMM"], "FLOPS", True))
+            max_value(extract_gbench_metric(sum_c, ["BM_HGEMM"], "FLOPS", True))
         )
         baseline_peak_ops.append(
-            max(extract_gbench_metric(sum_baseline, ["BM_HGEMM"], "FLOPS", True))
+            max_value(extract_gbench_metric(sum_baseline, ["BM_HGEMM"], "FLOPS", True))
         )
     except Exception:
         pass
@@ -306,87 +329,182 @@ def calculate_gemm_score(sum_baseline: dict[str, Any], sum_c: dict[str, Any]) ->
     return geomean(current_peak_ops) / geomean(baseline_peak_ops)
 
 
-with open(input_file_name) as f:
-    with open(baseline_name) as f_baseline:
-        sum_c = json.load(f)
-        sum_baseline = json.load(f_baseline)
-
-        scores = []
-        score = 0
-
-        if benchmark_name == "memcpy_benchmark":
-            for low, high in [
-                ("0", "7"),
-                ("8", "16"),
-                ("16", "32"),
-                ("32", "256"),
-                ("256", "1024"),
-                ("1024", "8192"),
-                ("8192", "32768"),
-            ]:
-                scores.append(
-                    (
-                        sum_c["%bench(" + low + "_to_" + high + "_COLD_folly)"]
-                        / sum_baseline["%bench(" + low + "_to_" + high + "_COLD_folly)"]
-                        + sum_c["%bench(" + low + "_to_" + high + "_HOT_folly)"]
-                        / sum_baseline["%bench(" + low + "_to_" + high + "_HOT_folly)"]
-                    )
-                    / 2
-                )
-            weights = np.array([1, 1.38, 1.02, 0.61, 0.33, 0.05, 0.01])
-            score = weighted_geomean(scores, weights)
-        elif benchmark_name == "memset_benchmark":
-            size = 1
-            while size <= 32768:
-                scores.append(
-                    sum_c["folly::__folly_memset: size=" + str(size)]
-                    / sum_baseline["folly::__folly_memset: size=" + str(size)]
-                )
-                size *= 2
-            weights = np.array(
-                [
-                    1,
-                    6.38,
-                    13.41,
-                    64.81,
-                    52.82,
-                    12.3,
-                    13.48,
-                    11.8,
-                    4.79,
-                    4.8,
-                    4.72,
-                    2.1,
-                    0.85,
-                    0.45,
-                    0.1,
-                    0.06,
-                ]
+def compute_memcpy_score(sum_baseline: dict[str, Any], sum_c: dict[str, Any]):
+    scores = []
+    for low, high in [
+        ("0", "7"),
+        ("8", "16"),
+        ("16", "32"),
+        ("32", "256"),
+        ("256", "1024"),
+        ("1024", "8192"),
+        ("8192", "32768"),
+    ]:
+        scores.append(
+            (
+                sum_baseline["%bench(" + low + "_to_" + high + "_COLD_folly)"]
+                / sum_c["%bench(" + low + "_to_" + high + "_COLD_folly)"]
+                + sum_baseline["%bench(" + low + "_to_" + high + "_HOT_folly)"]
+                / sum_c["%bench(" + low + "_to_" + high + "_HOT_folly)"]
             )
-            score = weighted_geomean(scores, weights)
-        elif benchmark_name == "xxhash_benchmark":
-            res_large = sum_c["large_inputs"]["xxh3"]
-            res_baseline = sum_baseline["large_inputs"]["xxh3"]
-            for key in res_large:
-                scores.append(res_large[key] / res_baseline[key])
-            score = geomean(np.array(scores))
-        elif benchmark_name == "concurrency_concurrent_hash_map_bench":
-            for key in sum_baseline:
-                if key in sum_c:
-                    scores.append(sum_baseline[key] / sum_c[key])
-            score = geomean(np.array(scores))
-        elif benchmark_name.startswith("benchsleef"):
-            score = calculate_sleef_score(sum_baseline, sum_c)
-        elif benchmark_name == "bench-memcmp":
-            score = calculate_memcmp_score(sum_baseline, sum_c)
-        elif benchmark_name == "stdcpp_bench":
-            score = calculate_stdcpp_score(sum_baseline, sum_c)
-        elif benchmark_name == "gemm_bench":
-            score = calculate_gemm_score(sum_baseline, sum_c)
-        else:
-            for key in sum_baseline:
-                if key in sum_c:
-                    scores.append(sum_c[key] / sum_baseline[key])
-            score = geomean(np.array(scores))
+            / 2
+        )
+    weights = [1, 1.38, 1.02, 0.61, 0.33, 0.05, 0.01]
+    score = weighted_geomean(scores, weights)
+    return score
 
-print(benchmark_name + f" score: {score:.2f}")
+
+def compute_memset_score(sum_baseline: dict[str, Any], sum_c: dict[str, Any]):
+    scores = []
+    size = 1
+    while size <= 32768:
+        scores.append(
+            sum_baseline["folly::__folly_memset: size=" + str(size)]
+            / sum_c["folly::__folly_memset: size=" + str(size)]
+        )
+        size *= 2
+    weights = [
+        1,
+        6.38,
+        13.41,
+        64.81,
+        52.82,
+        12.3,
+        13.48,
+        11.8,
+        4.79,
+        4.8,
+        4.72,
+        2.1,
+        0.85,
+        0.45,
+        0.1,
+        0.06,
+    ]
+    score = weighted_geomean(scores, weights)
+    return score
+
+
+def compute_xxhash_score(sum_baseline: dict[str, Any], sum_c: dict[str, Any]):
+    scores = []
+    res_large = sum_c["large_inputs"]["xxh3"]
+    res_baseline = sum_baseline["large_inputs"]["xxh3"]
+    for key in res_large:
+        scores.append(res_large[key] / res_baseline[key])
+    score = geomean(scores)
+    return score
+
+
+def compute_score_from_time(
+    sum_baseline: dict[str, Any],
+    sum_c: dict[str, Any],
+    skip_set: set[str] | None = None,
+) -> float:
+    if skip_set is None:
+        skip_set = set()
+    scores = []
+    for key in sum_baseline:
+        if key in sum_c and key not in skip_set:
+            scores.append(sum_baseline[key] / sum_c[key])
+    score = geomean(scores)
+    return score
+
+
+def compute_score_from_rate(
+    sum_baseline: dict[str, Any],
+    sum_c: dict[str, Any],
+    skip_set: set[str] | None = None,
+) -> float:
+    if skip_set is None:
+        skip_set = set()
+    scores = []
+    for key in sum_baseline:
+        if key in sum_c and key not in skip_set:
+            scores.append(sum_c[key] / sum_baseline[key])
+    score = geomean(scores)
+    return score
+
+
+def compute_benchmark_score(
+    benchmark_name: str, input_file_name: str, baseline_name: str
+) -> float:
+    with open(input_file_name) as f:
+        with open(baseline_name) as f_baseline:
+            sum_c = json.load(f)
+            sum_baseline = json.load(f_baseline)
+            if benchmark_name == "memcpy_benchmark":
+                score = compute_memcpy_score(sum_baseline, sum_c)
+            elif benchmark_name == "memset_benchmark":
+                score = compute_memset_score(sum_baseline, sum_c)
+            elif benchmark_name == "xxhash_benchmark":
+                score = compute_xxhash_score(sum_baseline, sum_c)
+            elif benchmark_name.startswith("benchsleef"):
+                score = compute_sleef_score(benchmark_name, sum_baseline, sum_c)
+            elif benchmark_name == "bench-memcmp":
+                score = compute_memcmp_score(sum_baseline, sum_c)
+            elif benchmark_name == "stdcpp_bench":
+                score = compute_stdcpp_score(sum_baseline, sum_c)
+            elif benchmark_name == "gemm_bench":
+                score = compute_gemm_score(sum_baseline, sum_c)
+            elif benchmark_name == "vdso_bench":
+                # Some Linux kernels may not support these clocks, so do not
+                # count them in the score.
+                skip_set = {"CLOCK_BOOTTIME_ALARM: M/s", "CLOCK_REALTIME_ALARM: M/s"}
+                score = compute_score_from_rate(sum_baseline, sum_c, skip_set)
+            elif benchmark_name in {
+                "lzbench",
+                "openssl",
+                "erasure_code_perf",
+                "libaegis_benchmark",
+            }:
+                score = compute_score_from_rate(sum_baseline, sum_c)
+            elif benchmark_name in {
+                "hash_hash_benchmark",
+                "hash_checksum_benchmark",
+                "random_benchmark",
+                "concurrency_concurrent_hash_map_bench",
+                "container_hash_maps_bench",
+                "ProtocolBench",
+                "VarintUtilsBench",
+                "synchronization_small_locks_benchmark",
+                "synchronization_lifo_sem_bench",
+                "benchsleef128",
+            }:
+                score = compute_score_from_time(sum_baseline, sum_c)
+            else:
+                # N.B.: if you add a new benchmark, double-check if the results are time
+                #       or rates. Call compute_score_from_time or compute_score_from_rate
+                #       accordingly.
+                print(
+                    f"{benchmark_name} score: error (unclear if results are time or rates)"
+                )
+                sys.exit(0)  # return 0 so run_prod.sh can continue
+
+    return score
+
+
+def main() -> None:
+    if len(sys.argv) != 2:
+        print("scoring.py benchmark_name")
+        sys.exit(-1)
+
+    benchmark_name = sys.argv[1]
+    input_file_name = "out_" + benchmark_name + ".json"
+    if benchmark_name.startswith("benchsleef"):
+        baseline_name = "baseline_results/baseline_benchsleef{}.json".format(
+            baseline_sleef_vec_width
+        )
+    else:
+        baseline_name = "baseline_results/baseline_" + benchmark_name + ".json"
+
+    try:
+        score = compute_benchmark_score(benchmark_name, input_file_name, baseline_name)
+    except Exception as e:
+        print(f"{benchmark_name} score: error ({e})")
+        sys.exit(0)  # return 0 so run_prod.sh can continue
+
+    print(f"{benchmark_name} score: {score:.2f}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This diff includes the following fixes and changes to improve robustness:

1. Removed numpy dependency from scoring.py. This eliminates complex python environment setup. Since python numerical values are double-precision by default and CPU perf gap can't be insanely large, this should be fine.

2. Vector length of the sleef baseline file needs to be consistent between the file name and the argument passed to extract_gbench_metric.

3. Refactored main in scoring.py to be smaller so that it's easier to maintain and added exception handling for numerical errors (e.g., division by zero).

4. Fixed score computation for multiple benchmarks so that score calculated out of time or rate have the same meaning (higher score means higher performance).

5. For vdso_bench, those ALARM clocks may not be available on a Linux kernel, so exclude them from score calculation.

6. Added get_xxx_proxy_args functions in common.sh to allow custom proxy settings for git, curl and conda.

7. Refactored install_wdl_bench.sh to prefer curl to wget (following internal recommendation).

8. Added a new option --score_only to run_prod.sh to skip benchmark runs and only test scoring.

Differential Revision: D90805817


