### PR TITLE
Pass -march=native to WDL folly and fbthrift arm64 builds

### DIFF
--- a/packages/wdl_bench/common.sh
+++ b/packages/wdl_bench/common.sh
@@ -81,3 +81,47 @@ get_curl_proxy_args() {
 get_conda_proxy_args() {
     : # Replace with your proxy args
 }
+
+get_march_for_host() {
+    if [ "$ARCH" = "aarch64" ]; then
+        # Compare GCC macro sets (sorted to avoid ordering differences)
+        local base native
+        base="$(echo | gcc -dM -E - | grep -E 'ARM_FEATURE' | sort)"
+        native="$(echo | gcc -dM -E -march=native - | grep -E 'ARM_FEATURE' | sort)"
+
+        if [[ "$base" != "$native" ]]; then
+            # -march=native actually unlocks more features, so use it.
+            echo "-march=native"
+            return 0
+        fi
+
+        # Otherwise, build -march from lscpu Flags
+        local flags march_base ext=""
+        flags="$(lscpu | awk -F': *' 'tolower($1)=="flags"{print $2; exit}')"
+
+        # Choose a conservative base ISA (Neoverse N1).
+        march_base="armv8.2-a"
+
+        # crypto: GCC uses +crypto to cover aes/sha1/sha2/pmull
+        if grep -qwE 'aes|sha1|sha2|pmull' <<<"$flags"; then
+            ext+="+crypto"
+        fi
+
+        grep -qw rng      <<<"$flags" && ext+="+rng"
+        grep -qw asimddp  <<<"$flags" && ext+="+dotprod"
+        grep -qw lrcpc    <<<"$flags" && ext+="+rcpc"
+        grep -qw sha3     <<<"$flags" && ext+="+sha3"
+        grep -qw i8mm     <<<"$flags" && ext+="+i8mm"
+
+        # bf16 and fp16
+        grep -qw fphp    <<<"$flags" && ext+="+fp16"
+        grep -qw asimdhp <<<"$flags" && ext+="+fp16fml"
+        grep -qw bf16    <<<"$flags" && ext+="+bf16"
+
+        # SVE family
+        grep -qw sve      <<<"$flags" && ext+="+sve"
+        grep -qw sve2     <<<"$flags" && ext+="+sve2"
+
+        echo "-march=${march_base}${ext}"
+    fi
+}

--- a/packages/wdl_bench/install_wdl_bench.sh
+++ b/packages/wdl_bench/install_wdl_bench.sh
@@ -155,7 +155,10 @@ build_folly()
         env $(get_conda_proxy_args) conda create --override-channels -y -c conda-forge --force -n "$FBENV" "python=3.12" "numpy<2"
         conda activate "$FBENV"
         python3 ./build/fbcode_builder/getdeps.py install-system-deps --recursive
-        python3 ./build/fbcode_builder/getdeps.py --allow-system-packages build --src-dir "." --scratch-path "${WDL_BUILD}"
+        echo "Building folly with $(get_march_for_host)"
+        MARCH="$(get_march_for_host)"
+        EXTRA_DEFINES=$(printf '{"CMAKE_C_FLAGS":"%s","CMAKE_CXX_FLAGS":"%s"}' "$MARCH" "$MARCH")
+        python3 ./build/fbcode_builder/getdeps.py --allow-system-packages build --src-dir "." --scratch-path "${WDL_BUILD}" --extra-cmake-defines="$EXTRA_DEFINES"
         conda deactivate
         conda env remove -n "$FBENV" -y
     )
@@ -176,9 +179,10 @@ build_fbthrift()
     cd "$lib" || exit
 
     ./build/fbcode_builder/getdeps.py install-system-deps --recursive fbthrift
-
-    python3 ./build/fbcode_builder/getdeps.py --allow-system-packages build fbthrift --src-dir "." --scratch-path "${WDL_BUILD}" --extra-cmake-defines='{"enable_tests": "1"}'
-
+    echo "Building fbthrift with $(get_march_for_host)"
+    MARCH="$(get_march_for_host)"
+    EXTRA_DEFINES=$(printf '{"enable_tests": "1", "CMAKE_C_FLAGS":"%s","CMAKE_CXX_FLAGS":"%s"}' "$MARCH" "$MARCH")
+    python3 ./build/fbcode_builder/getdeps.py --allow-system-packages build fbthrift --src-dir "." --scratch-path "${WDL_BUILD}" --extra-cmake-defines="$EXTRA_DEFINES"
     for benchmark in $fbthrift_benchmark_list; do
       cp "$WDL_BUILD/build/fbthrift/bin/$benchmark" "$WDL_ROOT/$benchmark"
     done


### PR DESCRIPTION
folly and fbthrift uses gcc to build, and on Centos 9, gcc defaults to -march=armv8a. This substantially impacts WDL benchmark performance on Arm64 due to lack of crc32, LSE, LRCPC, etc.

To fix this, we pass -march=native to arm64 build if -march=native unlocks feature macros. This is not always true. For example, in a Centos 9 VM atop MacOS, gcc -march=native doesn't make a difference. If that's the case, we query CPU capabilities and build up a string of capabilities and pass it to gcc.

Note that we don't do the same for x64 since passing -march=native would break folly build. In fact, gcc already assumes SSE4.2, which unlocks crc/aes and 128-bit SSE instructions, etc, which should cover most optimization paths. For code that requires AVX+, we assume folly's source code and build scripts already have dynamic selection logic since AVX has been in market for over 10+ years.

Differential Revision: D90905333


