### PR TITLE
Fix parameters for folly benchmarks

### DIFF
--- a/packages/wdl_bench/run_prod.sh
+++ b/packages/wdl_bench/run_prod.sh
@@ -69,9 +69,9 @@ declare -A prod_benchmark_config=(
     ['hash_checksum_benchmark']="--json"
     ['synchronization_lifo_sem_bench']="--bm_min_iters=1000000 --json"
     ['synchronization_small_locks_benchmark']="--bm_min_iters=1000000 --bm_regex=\"(atomic_cas|atomics_fetch_add|std_mutex_simple).*\" -run_fairness=false -unlocked_work 0 --json"
-    ['container_hash_maps_bench']="--bm_regex=\"f14(vec)|(val)\" --json" # filter find, insert, InsertSqBr, erase, and Iter operations in results parse script
+    ['container_hash_maps_bench']="--bm_max_iters=1073741824 --bm_regex=\"f14(vec)|(val)\" --json" # filter find, insert, InsertSqBr, erase, and Iter operations in results parse script
     ['ProtocolBench']="--bm_regex=\"(^Binary)|(^Compact)Protocol\" --json"
-    ['VarintUtilsBench']=" --json"
+    ['VarintUtilsBench']="--json"
     ['concurrency_concurrent_hash_map_bench']=""
     ['lzbench']="-v -ezstd,1,3 ${WDL_DATASETS}/silesia.tar"
     ['openssl']="speed -seconds 20 -evp aes-256-gcm"
@@ -164,14 +164,14 @@ main() {
             fi
             if [ "$benchmark" = "bench-memcmp" ]; then
                 pushd "${WDL_BUILD}/glibc-build"
-                bash -c "./testrun.sh ./benchtests/${benchmark} -- ${prod_benchmark_config[$benchmark]}" 2>&1 | tee -a "${WDL_ROOT}/${out_file}"
+                bash -c "nice -n -20 ./testrun.sh ./benchtests/${benchmark} -- ${prod_benchmark_config[$benchmark]}" 2>&1 | tee -a "${WDL_ROOT}/${out_file}"
                 popd
             else
                 ENV_VARS=""
                 if [ "$benchmark" = "gemm_bench" ]; then
                     ENV_VARS="OMP_NUM_THREADS=1"
                 fi
-                bash -c "${ENV_VARS} ./${benchmark} ${prod_benchmark_config[$benchmark]}" 2>&1 | tee -a "${out_file}"
+                bash -c "nice -n -20 env ${ENV_VARS} ./${benchmark} ${prod_benchmark_config[$benchmark]}" 2>&1 | tee -a "${out_file}"
             fi
             if [ "$benchmark" = "openssl" ]; then
                 unset LD_LIBRARY_PATH

--- a/packages/wdl_bench/scoring.py
+++ b/packages/wdl_bench/scoring.py
@@ -8,7 +8,7 @@
 import json
 import math
 import sys
-from typing import Any
+from typing import Any, Optional
 
 
 def weighted_geomean(values: list[float], weights: list[float]) -> float:
@@ -398,7 +398,7 @@ def compute_xxhash_score(sum_baseline: dict[str, Any], sum_c: dict[str, Any]):
 def compute_score_from_time(
     sum_baseline: dict[str, Any],
     sum_c: dict[str, Any],
-    skip_set: set[str] | None = None,
+    skip_set: Optional[set[str]] = None,
 ) -> float:
     if skip_set is None:
         skip_set = set()
@@ -413,7 +413,7 @@ def compute_score_from_time(
 def compute_score_from_rate(
     sum_baseline: dict[str, Any],
     sum_c: dict[str, Any],
-    skip_set: set[str] | None = None,
+    skip_set: Optional[set[str]] = None,
 ) -> float:
     if skip_set is None:
         skip_set = set()


### PR DESCRIPTION
Differential Revision: D90933216

1. Folly benchmarks use --bm_min_iters and --bm_max_iters to control iteration counts. If the benchmarked function is extremely fast and max_iters is set too low, Folly may report a time of zero because it considers a run legit only if it takes more than 100 microseconds. To prevent this, we now explicitly set --bm_max_iters=1073741824 (the default 1 << 30) for container_hash_maps_bench, ensuring valid time measurements.

2. The run_prod.sh script now runs all microbenchmarks with nice -n -20, reducing scheduler jitter and improving result stability.

3. Use Optional for type optionality in scoring.py instead of union type since python 3.9 does not support union type syntax.