### PR TITLE
Simplify openssl build and deployment in WDL

### DIFF
--- a/packages/wdl_bench/install_wdl_bench.sh
+++ b/packages/wdl_bench/install_wdl_bench.sh
@@ -216,7 +216,7 @@ build_openssl()
     pushd "${WDL_SOURCE}"
     clone $lib || echo "Failed to clone $lib"
     cd "$lib" || exit
-    ./Configure no-docs --prefix="${WDL_BUILD}/openssl" --openssldir="${WDL_BUILD}/openssl"
+    ./Configure no-docs no-shared --prefix="${WDL_BUILD}/openssl" --openssldir="${WDL_BUILD}/openssl"
     make -j "$(nproc)"
     make install
     cp "${WDL_BUILD}/openssl/bin/openssl" "${WDL_ROOT}/" || exit

--- a/packages/wdl_bench/run_prod.sh
+++ b/packages/wdl_bench/run_prod.sh
@@ -152,10 +152,6 @@ main() {
             # Remove old results
             rm -f "out_${benchmark}.txt" "out_${benchmark}.json"
 
-            if [ "$benchmark" = "openssl" ]; then
-                export LD_LIBRARY_PATH="${WDL_BUILD}/openssl/lib64:${WDL_BUILD}/openssl/lib"
-                ldconfig
-            fi
             out_file=""
             if exec_non_json "${benchmark}"; then
                 out_file="out_${benchmark}.txt"
@@ -172,10 +168,6 @@ main() {
                     ENV_VARS="OMP_NUM_THREADS=1"
                 fi
                 bash -c "nice -n -20 env ${ENV_VARS} ./${benchmark} ${prod_benchmark_config[$benchmark]}" 2>&1 | tee -a "${out_file}"
-            fi
-            if [ "$benchmark" = "openssl" ]; then
-                unset LD_LIBRARY_PATH
-                ldconfig
             fi
         done
 


### PR DESCRIPTION
Summary: Configure openssl with no-shared to build static crypto libs and link them directly in CLI openssl. By doing this, we don't need to explicitly set LD_LIBRARY when running the openssl command.

Differential Revision: D91048978


