### PR TITLE
Accelerating fbthrift Builds by Skipping Folly Tests in Dependency Compilation

### DIFF
--- a/packages/wdl_bench/install_wdl_bench.sh
+++ b/packages/wdl_bench/install_wdl_bench.sh
@@ -181,8 +181,9 @@ build_fbthrift()
     ./build/fbcode_builder/getdeps.py install-system-deps --recursive fbthrift
     echo "Building fbthrift with $(get_march_for_host)"
     MARCH="$(get_march_for_host)"
-    EXTRA_DEFINES=$(printf '{"enable_tests": "1", "CMAKE_C_FLAGS":"%s","CMAKE_CXX_FLAGS":"%s"}' "$MARCH" "$MARCH")
-    python3 ./build/fbcode_builder/getdeps.py --allow-system-packages build fbthrift --src-dir "." --scratch-path "${WDL_BUILD}" --extra-cmake-defines="$EXTRA_DEFINES"
+    EXTRA_DEFINES=$(printf '{"CMAKE_C_FLAGS":"%s","CMAKE_CXX_FLAGS":"%s"}' "$MARCH" "$MARCH")
+    python3 ./build/fbcode_builder/getdeps.py --allow-system-packages build fbthrift --src-dir "." --scratch-path "${WDL_BUILD}" --extra-cmake-defines="$EXTRA_DEFINES" --only-deps --no-tests
+    python3 ./build/fbcode_builder/getdeps.py --allow-system-packages build fbthrift --src-dir "." --scratch-path "${WDL_BUILD}" --extra-cmake-defines="$EXTRA_DEFINES" --no-deps
     for benchmark in $fbthrift_benchmark_list; do
       cp "$WDL_BUILD/build/fbthrift/bin/$benchmark" "$WDL_ROOT/$benchmark"
     done


### PR DESCRIPTION
Summary: fbthrift relies on folly, which by default builds all tests—significantly slowing down the process. This update separates the builds for fbthrift dependencies and fbthrift itself. By passing --no-tests to the dedicated dependencies build, folly tests are skipped, reducing about two-thirds of folly's build targets and noticeably accelerating the fbthrift build.

Reviewed By: YifanYuan3

Differential Revision: D91095879


