### PR TITLE
New icache-iteration limit to improve throughput of feedsim_autoscale workload

### DIFF
--- a/benchpress/config/jobs.yml
+++ b/benchpress/config/jobs.yml
@@ -326,9 +326,11 @@
     instance (rounded up).
   args:
     - '-n {num_instances}'
+    - '-i {icache_iterations}'
     - '{extra_args}'
   vars:
     - 'num_instances=-1'
+    - 'icache_iterations=50000'
     - 'extra_args='
   hooks:
     - hook: cpu-mpstat


### PR DESCRIPTION
Hi, 

While evaluating DCPerf/feedsim_autoscale workload, I came across a scaling issue. During the investigation I found, a default icache-iteration setting is the cause of lower score and throughput. With the new icache-iteration value, I'm seeing +25% score  improvement ( and approx. +30% increase in throughput) while keeping latency below 500ms.

| feedsim_autoscale | Patched/Baseline | |
|---|---|--:|
| icache-iterations| Score | average_latency 
| 160000 (Current default)      |  1.00 |  1.00 | 
|   50000      |  1.26 | 0.73 | 

I’d appreciate your review and any feedback needed to get this patch accepted and merged.

Thanks.