### PR TITLE
Fix CQS signal facebook-unused-include-check in fbcode/cea/chips

### DIFF
--- a/packages/ucache_bench/server/UcacheBenchIOThreadContext.cpp
+++ b/packages/ucache_bench/server/UcacheBenchIOThreadContext.cpp
@@ -2,7 +2,6 @@
 
 #include "UcacheBenchIOThreadContext.h"
 
-#include <fmt/format.h>
 #include <folly/fibers/EventBaseLoopController.h>
 
 #include <folly/portability/GFlags.h>


### PR DESCRIPTION
Reviewed By: excelle08

Differential Revision: D91312124


