### PR TITLE
Fix counter names and remove "mux" from SCF bandwidth calculations

### DIFF
--- a/perfutils/generate_arm_perf_report.py
+++ b/perfutils/generate_arm_perf_report.py
@@ -307,9 +307,9 @@ def branch_inst_percent(grouped_df):
 
 @skip_if_missing
 def gflops(grouped_df):
-    fp_scale_series = grouped_df.get_group("r80c0").counter_value  # FP_SCALE_OPS_SPEC
-    fp_fixed_series = grouped_df.get_group("r80c1").counter_value  # FP_FIXED_OPS_SPEC
-    duration_series = get_duration_series(grouped_df.get_group("r80c0"))
+    fp_scale_series = grouped_df.get_group("r80C0").counter_value  # FP_SCALE_OPS_SPEC
+    fp_fixed_series = grouped_df.get_group("r80C1").counter_value  # FP_FIXED_OPS_SPEC
+    duration_series = get_duration_series(grouped_df.get_group("r80C0"))
 
     fp_scale_series.index = duration_series.index
     fp_fixed_series.index = duration_series.index
@@ -324,8 +324,8 @@ def gflops(grouped_df):
 
 @skip_if_missing
 def sve_gflops(grouped_df):
-    fp_scale_series = grouped_df.get_group("r80c1").counter_value  # FP_FIXED_OPS_SPEC
-    duration_series = get_duration_series(grouped_df.get_group("r80c1"))
+    fp_scale_series = grouped_df.get_group("r80C1").counter_value  # FP_FIXED_OPS_SPEC
+    duration_series = get_duration_series(grouped_df.get_group("r80C1"))
 
     fp_scale_series.index = duration_series.index
 
@@ -789,13 +789,10 @@ def nvidia_scf_mem_read_bw_MBps(grouped_df):
         "nvidia_scf_pmu_0/cmem_rd_data/"
     ).counter_runtime
 
-    pcnt_running_series = grouped_df.get_group("nvidia_scf_pmu_0/cmem_rd_data/").mux
-    dt_series = duration_series * (100.0 / pcnt_running_series)
-
-    cmem_rd_data_series.index = dt_series.index
+    cmem_rd_data_series.index = duration_series.index
 
     local_mem_read_series = cmem_rd_data_series * 32
-    local_mem_bw_read_series = local_mem_read_series.div(dt_series)
+    local_mem_bw_read_series = local_mem_read_series.div(duration_series)
     return {
         "name": "SCF Local Memory Read Bandwidth (MBps)",
         "series": local_mem_bw_read_series,
@@ -812,14 +809,9 @@ def nvidia_scf_mem_write_bw_MBps(grouped_df):
         "nvidia_scf_pmu_0/cmem_wr_total_bytes/"
     ).counter_runtime
 
-    pcnt_running_series = grouped_df.get_group(
-        "nvidia_scf_pmu_0/cmem_wr_total_bytes/"
-    ).mux
-    dt_series = duration_series * (100.0 / pcnt_running_series)
+    cmem_wr_bytes_series.index = duration_series.index
 
-    cmem_wr_bytes_series.index = dt_series.index
-
-    local_mem_bw_write_series = cmem_wr_bytes_series.div(dt_series)
+    local_mem_bw_write_series = cmem_wr_bytes_series.div(duration_series)
     return {
         "name": "SCF Local Memory Write Bandwidth (MBps)",
         "series": local_mem_bw_write_series,
@@ -843,16 +835,10 @@ def nvidia_scf_mem_latency_ns(grouped_df):
     cmem_rd_outstanding_series.index = sfc_cycles_series.index
     cmem_rd_access_series.index = sfc_cycles_series.index
     duration_series.index = sfc_cycles_series.index
-    pcnt_running_series = grouped_df.get_group(
-        "nvidia_scf_pmu_0/cmem_rd_outstanding/"
-    ).mux
-    pcnt_running_series.index = duration_series.index
-    dt_series = duration_series * (100.0 / pcnt_running_series)
-    dt_series.index = sfc_cycles_series.index
 
     local_mem_read_lat_ns_series = (
         cmem_rd_outstanding_series.div(cmem_rd_access_series)
-    ) / (sfc_cycles_series.div(dt_series))
+    ) / (sfc_cycles_series.div(duration_series))
     return {
         "name": "SCF Local Memory Read Latency (nsecs)",
         "series": local_mem_read_lat_ns_series,


### PR DESCRIPTION
Summary:
This diff makes two improvements to the ARM perf report generation:

1. **Fixed counter group name casing**: Changed `r80c0` and `r80c1` to `r80C0` and `r80C1` to match the actual counter names used for FP_SCALE_OPS_SPEC and FP_FIXED_OPS_SPEC. This results in additional stats being generated in the output since the data is now found properly.

2. **Corrected SCF Local Memory metrics calculation**: Removed incorrect percentage-running (`mux`) adjustments in the SCF Local Memory bandwidth and latency functions. The `perf stat` tool automatically scales measurements unless run with `--no-scale`, and we are not using that. The examples of data I've seen has SCF counters at 100%, so I don't expect this to result in any change.

Reviewed By: excelle08

Differential Revision: D92222329


