### PR TITLE
Make DLRM seed deterministic by default

### DIFF
--- a/packages/feedsim/third_party/src/workloads/ranking/LeafNodeRankCmdline.ggo
+++ b/packages/feedsim/third_party/src/workloads/ranking/LeafNodeRankCmdline.ggo
@@ -58,7 +58,7 @@ option "dlrm_model_path" - "Path to TorchScript DLRM model file (.pt)." string t
 option "dlrm_batch_size" - "Batch size for DLRM inference." int default="256"
 option "dlrm_inferences_per_request" - "Number of DLRM inference calls per request." int default="1"
 option "dlrm_threads" - "Number of LibTorch threads for DLRM inference." int default="8"
-option "dlrm_seed" - "Seed for DLRM feature generation. If not provided, current time will be used." long optional
+option "dlrm_seed" - "Seed for DLRM feature generation. Default is 42 for deterministic results. Use -1 for random (time-based) seed." long default="42"
 
 # Phase 3: Non-blocking I/O options
 option "async_io" - "Enable non-blocking async I/O pattern (eliminates thread starvation)."

--- a/packages/feedsim/third_party/src/workloads/ranking/dwarfs/dlrm.cpp
+++ b/packages/feedsim/third_party/src/workloads/ranking/dwarfs/dlrm.cpp
@@ -51,12 +51,16 @@ struct DLRM::Impl {
       auto state = std::make_unique<ThreadState>();
 
       // Initialize RNG
-      unsigned actual_seed = seed;
-      if (actual_seed == 0) {
+      // seed == static_cast<unsigned>(-1) means use time-based random seed
+      // Any other seed value (including default 42) is used directly
+      unsigned actual_seed;
+      if (seed == static_cast<unsigned>(-1)) {
+        // Time-based random seed for non-deterministic behavior
         actual_seed =
             std::chrono::system_clock::now().time_since_epoch().count() + i;
       } else {
-        actual_seed += i; // Unique seed per thread
+        // Deterministic seed (default 42 or user-specified)
+        actual_seed = seed + i; // Unique seed per thread
       }
       state->rng.seed(actual_seed);
 


### PR DESCRIPTION
Summary: Address run-to-run variation in FeedSim V2 benchmarks by making DLRM feature generation deterministic by default. Previously, omitting --dlrm_seed caused time-based seeding, leading to unstable results. Now defaults to seed 42 for reproducibility, with -1 available for explicit random behavior.

Reviewed By: YifanYuan3

Differential Revision: D91532835


