### PR TITLE
Fix string-conversion issue in cea/chips/benchpress/packages/wdl_bench/gemm_bench/gemm_bench.cpp +1

### DIFF
--- a/packages/wdl_bench/gemm_bench/gemm_bench.cpp
+++ b/packages/wdl_bench/gemm_bench/gemm_bench.cpp
@@ -859,7 +859,7 @@ inline void write_to_dnnl_memory(void* handle, dnnl::memory& mem) {
     return;
   }
 
-  assert(!"not expected");
+  assert(false && "not expected");
 }
 
 static void


### PR DESCRIPTION
Summary:
This could is triggering `-Wstring-conversion`, which presents as:
```
warning: implicit conversion turns string literal into bool: A to B
```
This is often a bug and what was intended. The most frequent cause is the code was:
```
void foo(bool) { ... }
void foo(std::string) { ... }
foo("this gets interpreted as a bool");
```

It is also possible the issue is innocuous as part of an assert:
```
assert(false && "this string is true, so the assertion is false");
EXPECT_FALSE("this string is true, so the expect fails");
```
in these cases the use is to "cute", so we modify the code to make it more obvious.
```
assert(false && "the compiler recognizes and doesn't complain about this pattern");
FAIL() << "much more obvious";
```

Reviewed By: mcfi

Differential Revision: D92886036


