### PR TITLE
Add multi-client coordination support

### DIFF
--- a/benchpress/plugins/parsers/ucache_bench.py
+++ b/benchpress/plugins/parsers/ucache_bench.py
@@ -13,7 +13,11 @@ from benchpress.lib.parser import Parser
 class UcacheBenchParser(Parser):
     """Parser for UcacheBench output.
 
-    Example output:
+    Parses the text output from either:
+    1. The ucachebench_client binary (single-client mode)
+    2. The ucachebench_server binary (multi-client aggregated results)
+
+    Example client output:
     WARMUP PHASE:
       Status: ✓ SUCCESS
       Duration: 10.00 seconds
@@ -42,6 +46,25 @@ class UcacheBenchParser(Parser):
       P95: 0.12
       P99: 0.25
       P99.9: 0.50
+
+    Example server output (multi-client aggregated):
+    ========================================
+         UCACHEBENCH SERVER RESULTS
+    ========================================
+    Benchmark Duration: 60.000 seconds
+
+    Operations:
+      GET requests:    540000
+      GET hits:        432000
+      GET misses:      108000
+      SET requests:    60000
+      DELETE requests: 0
+      Total ops:       600000
+
+    Performance:
+      QPS:        10000.0
+      Hit Ratio:  80.00%
+    ========================================
     """
 
     def parse(
@@ -53,18 +76,80 @@ class UcacheBenchParser(Parser):
 
         metrics: Dict[str, Any] = {}
 
-        # Parse warmup phase metrics
-        warmup_metrics = self._parse_warmup_phase(output)
-        if warmup_metrics:
-            metrics["warmup"] = warmup_metrics
+        # Detect if this is server-side aggregated output
+        is_server_output = "UCACHEBENCH SERVER RESULTS" in output
 
-        # Parse benchmark phase metrics
-        benchmark_metrics = self._parse_benchmark_phase(output)
-        if benchmark_metrics:
-            metrics.update(benchmark_metrics)
+        if is_server_output:
+            # Parse server-side aggregated results
+            server_metrics = self._parse_server_results(output)
+            if server_metrics:
+                metrics.update(server_metrics)
+        else:
+            # Parse client-side output (original format)
+            # Parse warmup phase metrics
+            warmup_metrics = self._parse_warmup_phase(output)
+            if warmup_metrics:
+                metrics["warmup"] = warmup_metrics
+
+            # Parse benchmark phase metrics
+            benchmark_metrics = self._parse_benchmark_phase(output)
+            if benchmark_metrics:
+                metrics.update(benchmark_metrics)
 
         # Add exit code
         metrics["exit_code"] = returncode
+
+        return metrics
+
+    def _parse_server_results(self, output: str) -> Dict[str, Any]:
+        """Parse server-side aggregated results (multi-client mode)."""
+        metrics: Dict[str, Any] = {}
+
+        # Parse benchmark duration
+        duration_match = re.search(r"Benchmark Duration: ([\d.]+) seconds", output)
+        if duration_match:
+            metrics["duration_seconds"] = float(duration_match.group(1))
+
+        # Parse GET operations
+        get_reqs_match = re.search(r"GET requests:\s+(\d+)", output)
+        if get_reqs_match:
+            metrics["get_operations"] = int(get_reqs_match.group(1))
+
+        get_hits_match = re.search(r"GET hits:\s+(\d+)", output)
+        if get_hits_match:
+            metrics["get_hits"] = int(get_hits_match.group(1))
+
+        get_misses_match = re.search(r"GET misses:\s+(\d+)", output)
+        if get_misses_match:
+            metrics["get_misses"] = int(get_misses_match.group(1))
+
+        # Parse SET operations
+        set_reqs_match = re.search(r"SET requests:\s+(\d+)", output)
+        if set_reqs_match:
+            metrics["set_operations"] = int(set_reqs_match.group(1))
+
+        # Parse DELETE operations
+        delete_reqs_match = re.search(r"DELETE requests:\s+(\d+)", output)
+        if delete_reqs_match:
+            metrics["delete_operations"] = int(delete_reqs_match.group(1))
+
+        # Parse total operations
+        total_ops_match = re.search(r"Total ops:\s+(\d+)", output)
+        if total_ops_match:
+            metrics["total_operations"] = int(total_ops_match.group(1))
+
+        # Parse QPS
+        qps_match = re.search(r"QPS:\s+([\d.]+)", output)
+        if qps_match:
+            metrics["qps"] = float(qps_match.group(1))
+
+        # Parse hit ratio
+        hit_ratio_match = re.search(r"Hit Ratio:\s+([\d.]+)%", output)
+        if hit_ratio_match:
+            metrics["hit_ratio_percent"] = float(hit_ratio_match.group(1))
+
+        # Mark this as server-aggregated results
+        metrics["source"] = "server_aggregated"
 
         return metrics
 

--- a/packages/ucache_bench/client/UcacheBenchClient.cpp
+++ b/packages/ucache_bench/client/UcacheBenchClient.cpp
@@ -7,33 +7,307 @@
 
 #include "UcacheBenchClient.h"
 
-#include <fmt/format.h>
-#include <folly/Format.h>
-#include <folly/Random.h>
-#include <folly/dynamic.h>
-#include <folly/json.h>
-
-#include <folly/coro/AsyncScope.h>
-#include <folly/coro/BlockingWait.h>
-#include <folly/coro/Collect.h>
-#include <folly/coro/Promise.h>
-#include <folly/coro/Task.h>
-#include <folly/executors/CPUThreadPoolExecutor.h>
-
-#include <folly/executors/IOThreadPoolExecutor.h>
-#include <folly/fibers/Baton.h>
-
-#include <folly/io/IOBuf.h>
-#include <folly/portability/GFlags.h>
+#include <netdb.h>
+#include <netinet/in.h>
+#include <sys/socket.h>
+#include <unistd.h>
 #include <algorithm>
+#include <chrono>
+#include <cmath>
+#include <cstring>
 #include <fstream>
+#include <iostream>
+#include <random>
+#include <sstream>
 #include <thread>
 
-using namespace facebook::ucachebench;
+#include <folly/Random.h>
+#include <folly/coro/AsyncScope.h>
+#include <folly/coro/BlockingWait.h>
+#include <folly/coro/Promise.h>
+#include <folly/fibers/FiberManager.h>
+#include <folly/fibers/FiberManagerMap.h>
+#include <folly/io/async/ScopedEventBaseThread.h>
+#include <folly/portability/GFlags.h>
+#include <mcrouter/McrouterFiberContext.h>
+#include <mcrouter/lib/network/CpuController.h>
 
-DEFINE_string(server_host, "localhost", "Server hostname");
+DECLARE_string(config);
+DECLARE_uint32(warmup_ops);
+DECLARE_uint32(warmup_ops_per_key);
+DECLARE_uint32(benchmark_ops);
+DECLARE_double(get_ratio);
+DECLARE_uint32(key_size);
+DECLARE_uint32(value_size);
+DECLARE_uint32(num_keys);
+DECLARE_uint32(num_threads);
+DECLARE_bool(verbose);
+DECLARE_bool(enable_zipfian);
+DECLARE_double(zipfian_skew);
+DECLARE_uint32(max_inflight);
+DECLARE_string(traffic_distribution);
+
+// Declare admin port flag (will be defined in main.cpp)
+// Note: We use server_host for admin connection since admin server
+// runs on the same machine as the cache server
+DECLARE_uint32(admin_port);
+
+// Declare server connection flags (will be defined in main.cpp)
+DECLARE_string(server_host);
+DECLARE_uint32(server_port);
+DECLARE_uint32(duration_seconds);
+
+namespace facebook {
+namespace ucachebench {
+
+// Default socket timeout in seconds to prevent indefinite blocking.
+// 600 seconds (10 minutes) is long enough for normal multi-client
+// coordination but prevents the client from hanging forever.
+constexpr uint32_t kDefaultTimeoutSeconds = 600;
+
+// ============================================================================
+// AdminConnection implementation
+// ============================================================================
+
+AdminConnection::~AdminConnection() {
+  disconnect();
+}
+
+bool AdminConnection::connect(const std::string& host, uint16_t port) {
+  if (socket_ >= 0) {
+    disconnect();
+  }
+
+  // Resolve hostname
+  struct addrinfo hints, *result;
+  memset(&hints, 0, sizeof(hints));
+  hints.ai_family = AF_UNSPEC; // IPv4 or IPv6
+  hints.ai_socktype = SOCK_STREAM;
+
+  std::string portStr = std::to_string(port);
+  int ret = getaddrinfo(host.c_str(), portStr.c_str(), &hints, &result);
+  if (ret != 0) {
+    printf(
+        "[AdminConnection] Failed to resolve host %s: %s\n",
+        host.c_str(),
+        gai_strerror(ret));
+    return false;
+  }
+
+  // Try each address until we connect
+  for (struct addrinfo* rp = result; rp != nullptr; rp = rp->ai_next) {
+    socket_ = socket(rp->ai_family, rp->ai_socktype, rp->ai_protocol);
+    if (socket_ < 0) {
+      continue;
+    }
+
+    if (::connect(socket_, rp->ai_addr, rp->ai_addrlen) == 0) {
+      freeaddrinfo(result);
+
+      // Set default receive timeout during connection setup to prevent
+      // indefinite blocking if the server disconnects or the application
+      // needs to shut down. 600 seconds (10 minutes) is long enough for
+      // normal multi-client coordination but prevents hanging forever.
+      struct timeval tv;
+      tv.tv_sec = kDefaultTimeoutSeconds;
+      tv.tv_usec = 0;
+      if (setsockopt(socket_, SOL_SOCKET, SO_RCVTIMEO, &tv, sizeof(tv)) < 0) {
+        printf(
+            "[AdminConnection] Warning: Failed to set socket timeout: %s\n",
+            strerror(errno));
+      }
+
+      printf(
+          "[AdminConnection] Connected to admin server at %s:%u\n",
+          host.c_str(),
+          port);
+      return true;
+    }
+
+    ::close(socket_);
+    socket_ = -1;
+  }
+
+  freeaddrinfo(result);
+  printf(
+      "[AdminConnection] Failed to connect to %s:%u: %s\n",
+      host.c_str(),
+      port,
+      strerror(errno));
+  return false;
+}
+
+void AdminConnection::disconnect() {
+  if (socket_ >= 0) {
+    ::close(socket_);
+    socket_ = -1;
+  }
+  readBuffer_.clear();
+}
+
+std::string AdminConnection::sendCommand(const std::string& command) {
+  if (socket_ < 0) {
+    return "ERROR Not connected";
+  }
+
+  // Send command
+  std::string msg = command + "\n";
+  ssize_t sent = send(socket_, msg.c_str(), msg.size(), 0);
+  if (sent < 0) {
+    printf("[AdminConnection] Send failed: %s\n", strerror(errno));
+    return "ERROR Send failed";
+  }
+
+  // Read response, filtering out any broadcast notifications
+  while (true) {
+    std::string line = readLine();
+    if (line.empty()) {
+      return "ERROR Read failed";
+    }
+
+    // Check if this is a broadcast notification
+    if (isBroadcastNotification(line)) {
+      // Buffer it for later retrieval via waitForNotification()
+      pendingNotifications_.push_back(line);
+      continue;
+    }
+
+    // This is the actual response to our command
+    return line;
+  }
+}
+
+bool AdminConnection::isBroadcastNotification(const std::string& message) {
+  // Broadcast notifications from the server are:
+  // - ALL_REGISTERED
+  // - ALL_WARMUP_DONE
+  // - ALL_DONE
+  // Command responses start with "OK" or "ERROR" or "STATUS"
+  return message == "ALL_REGISTERED" || message == "ALL_WARMUP_DONE" ||
+      message == "ALL_DONE";
+}
+
+std::string AdminConnection::readLine() {
+  // Check if we already have a complete line in the buffer
+  size_t pos = readBuffer_.find('\n');
+  if (pos != std::string::npos) {
+    std::string line = readBuffer_.substr(0, pos);
+    readBuffer_.erase(0, pos + 1);
+    // Remove trailing \r if present
+    if (!line.empty() && line.back() == '\r') {
+      line.pop_back();
+    }
+    return line;
+  }
+
+  // Read more data
+  char buffer[1024];
+  while (true) {
+    ssize_t bytesRead = recv(socket_, buffer, sizeof(buffer) - 1, 0);
+    if (bytesRead <= 0) {
+      if (bytesRead == 0) {
+        printf("[AdminConnection] Connection closed by server\n");
+      } else {
+        printf("[AdminConnection] Recv failed: %s\n", strerror(errno));
+      }
+      return "";
+    }
+
+    buffer[bytesRead] = '\0';
+    readBuffer_ += buffer;
+
+    pos = readBuffer_.find('\n');
+    if (pos != std::string::npos) {
+      std::string line = readBuffer_.substr(0, pos);
+      readBuffer_.erase(0, pos + 1);
+      if (!line.empty() && line.back() == '\r') {
+        line.pop_back();
+      }
+      return line;
+    }
+  }
+}
+
+int32_t AdminConnection::sendRegister() {
+  std::string response = sendCommand("REGISTER");
+  if (response.empty()) {
+    return -1;
+  }
+
+  // Parse "OK <client_id>"
+  if (response.substr(0, 3) == "OK ") {
+    try {
+      return std::stoi(response.substr(3));
+    } catch (const std::exception&) {
+      printf(
+          "[AdminConnection] Failed to parse client ID from: %s\n",
+          response.c_str());
+      return -1;
+    }
+  }
+
+  printf("[AdminConnection] REGISTER failed: %s\n", response.c_str());
+  return -1;
+}
+
+bool AdminConnection::sendWarmupDone(int32_t clientId) {
+  std::string response = sendCommand("WARMUP_DONE " + std::to_string(clientId));
+  return response == "OK";
+}
+
+bool AdminConnection::sendBenchmarkDone(int32_t clientId) {
+  std::string response =
+      sendCommand("BENCHMARK_DONE " + std::to_string(clientId));
+  return response == "OK";
+}
+
+std::string AdminConnection::waitForNotification(uint32_t timeoutSeconds) {
+  if (socket_ < 0) {
+    return "";
+  }
+
+  // First check if we have any buffered notifications from sendCommand()
+  if (!pendingNotifications_.empty()) {
+    std::string notification = pendingNotifications_.front();
+    pendingNotifications_.erase(pendingNotifications_.begin());
+    return notification;
+  }
+
+  // If a custom timeout is specified, set it temporarily.
+  // Otherwise, use the default timeout set during connection setup.
+  bool customTimeout = (timeoutSeconds > 0);
+  if (customTimeout) {
+    struct timeval tv;
+    tv.tv_sec = timeoutSeconds;
+    tv.tv_usec = 0;
+    if (setsockopt(socket_, SOL_SOCKET, SO_RCVTIMEO, &tv, sizeof(tv)) < 0) {
+      printf(
+          "[AdminConnection] Failed to set socket timeout: %s\n",
+          strerror(errno));
+    }
+  }
+
+  std::string line = readLine();
+
+  // Reset to default timeout if a custom one was used
+  if (customTimeout) {
+    struct timeval tv;
+    tv.tv_sec = kDefaultTimeoutSeconds;
+    tv.tv_usec = 0;
+    setsockopt(socket_, SOL_SOCKET, SO_RCVTIMEO, &tv, sizeof(tv));
+  }
+
+  return line;
+}
+
+} // namespace ucachebench
+} // namespace facebook
+
+// Server connection flags
+DEFINE_string(server_host, "::1", "Server hostname or IP address");
 DEFINE_uint32(server_port, 11211, "Server port");
-DEFINE_uint32(duration_seconds, 60, "Test duration in seconds");
+DEFINE_uint32(duration_seconds, 60, "Benchmark duration in seconds");
+
 DEFINE_uint32(warmup_seconds, 10, "Warmup duration in seconds");
 DEFINE_uint32(
     progress_interval_seconds,
@@ -155,8 +429,40 @@ uint64_t ZipfianGenerator::next() {
 }
 
 // ============================================================================
-// UcacheBenchClient Implementation
+// UcacheBenchClient implementation
 // ============================================================================
+
+bool UcacheBenchClient::connectToAdmin(const std::string& host, uint16_t port) {
+  adminConnection_ = std::make_unique<AdminConnection>();
+  if (!adminConnection_->connect(host, port)) {
+    adminConnection_.reset();
+    return false;
+  }
+
+  // Register with the admin server to get our client ID
+  clientId_ = adminConnection_->sendRegister();
+  if (clientId_ < 0) {
+    printf("[Client] Failed to register with admin server\n");
+    adminConnection_->disconnect();
+    adminConnection_.reset();
+    return false;
+  }
+
+  printf("[Client] Registered with admin server as client %d\n", clientId_);
+
+  // Wait for ALL_REGISTERED notification
+  printf("[Client] Waiting for all clients to register...\n");
+  std::string notification = adminConnection_->waitForNotification(0);
+  if (notification != "ALL_REGISTERED") {
+    printf(
+        "[Client] Unexpected notification while waiting for ALL_REGISTERED: %s\n",
+        notification.c_str());
+    return false;
+  }
+
+  printf("[Client] All clients registered, ready to start warmup\n");
+  return true;
+}
 
 UcacheBenchClient::UcacheBenchClient() {
   // Load traffic distribution if configured
@@ -554,6 +860,30 @@ UcacheBenchClient::WarmupResults UcacheBenchClient::warmup() {
     fflush(stdout);
   }
 
+  // Notify admin server that warmup is done (if connected)
+  if (hasAdminConnection()) {
+    printf("[Client %d] Sending WARMUP_DONE to admin server\n", clientId_);
+    if (!adminConnection_->sendWarmupDone(clientId_)) {
+      printf("[Client %d] Failed to send WARMUP_DONE\n", clientId_);
+    } else {
+      // Wait for ALL_WARMUP_DONE notification before returning
+      printf(
+          "[Client %d] Waiting for all clients to complete warmup...\n",
+          clientId_);
+      std::string notification = adminConnection_->waitForNotification(0);
+      if (notification == "ALL_WARMUP_DONE") {
+        printf(
+            "[Client %d] All clients completed warmup, ready for benchmark\n",
+            clientId_);
+      } else {
+        printf(
+            "[Client %d] Unexpected notification while waiting for ALL_WARMUP_DONE: %s\n",
+            clientId_,
+            notification.c_str());
+      }
+    }
+  }
+
   return warmupResults;
 }
 
@@ -949,6 +1279,28 @@ UcacheBenchClient::BenchmarkResults UcacheBenchClient::runBenchmark() {
   }
 
   results.latencies = std::move(allLatencies);
+
+  // Notify admin server that benchmark is done (if connected)
+  if (hasAdminConnection()) {
+    printf("[Client %d] Sending BENCHMARK_DONE to admin server\n", clientId_);
+    if (!adminConnection_->sendBenchmarkDone(clientId_)) {
+      printf("[Client %d] Failed to send BENCHMARK_DONE\n", clientId_);
+    } else {
+      // Wait for ALL_DONE notification (server is printing results)
+      printf("[Client %d] Waiting for server to finish...\n", clientId_);
+      std::string notification = adminConnection_->waitForNotification(0);
+      if (notification == "ALL_DONE") {
+        printf("[Client %d] Server finished, benchmark complete\n", clientId_);
+      } else if (!notification.empty()) {
+        printf(
+            "[Client %d] Received notification: %s\n",
+            clientId_,
+            notification.c_str());
+      }
+    }
+    // Disconnect from admin server
+    adminConnection_->disconnect();
+  }
 
   return results;
 }

--- a/packages/ucache_bench/client/UcacheBenchClient.h
+++ b/packages/ucache_bench/client/UcacheBenchClient.h
@@ -57,6 +57,58 @@ class ZipfianGenerator {
   static double zeta(uint64_t n, double theta);
 };
 
+/**
+ * Admin server connection for multi-client coordination.
+ * Connects to the server's admin port to participate in phase synchronization.
+ */
+class AdminConnection {
+ public:
+  AdminConnection() = default;
+  ~AdminConnection();
+
+  // Connect to the admin server
+  bool connect(const std::string& host, uint16_t port);
+
+  // Disconnect from the admin server
+  void disconnect();
+
+  // Check if connected
+  bool isConnected() const {
+    return socket_ >= 0;
+  }
+
+  // Send REGISTER command and get assigned client ID
+  // Returns the assigned client ID, or -1 on error
+  int32_t sendRegister();
+
+  // Send WARMUP_DONE command
+  bool sendWarmupDone(int32_t clientId);
+
+  // Send BENCHMARK_DONE command
+  bool sendBenchmarkDone(int32_t clientId);
+
+  // Wait for an async notification from the server
+  // Returns the notification message, or empty string on error/timeout
+  std::string waitForNotification(uint32_t timeoutSeconds = 0);
+
+ private:
+  // Send a command and receive response
+  // Filters out broadcast notifications and buffers them for later retrieval
+  std::string sendCommand(const std::string& command);
+
+  // Read a line from the socket
+  std::string readLine();
+
+  // Check if a message is a broadcast notification (vs a command response)
+  static bool isBroadcastNotification(const std::string& message);
+
+  int socket_{-1};
+  std::string readBuffer_;
+  // Buffer for broadcast notifications received while waiting for command
+  // response
+  std::vector<std::string> pendingNotifications_;
+};
+
 class UcacheBenchClient {
  public:
   // Production traffic distribution configuration
@@ -110,6 +162,28 @@ class UcacheBenchClient {
   BenchmarkResults runBenchmark();
   void printResults(const BenchmarkResults& results);
 
+  // Admin server coordination
+  // If admin server is configured, the client will:
+  // 1. Connect and register to get a client ID
+  // 2. Wait for ALL_REGISTERED before starting warmup
+  // 3. Send WARMUP_DONE and wait for ALL_WARMUP_DONE before benchmark
+  // 4. Send BENCHMARK_DONE after completing benchmark
+
+  // Connect to admin server (called from main if --admin_port is set)
+  // Uses server_host since admin server runs on the same machine as cache
+  // server
+  bool connectToAdmin(const std::string& host, uint16_t port);
+
+  // Check if admin connection is active
+  bool hasAdminConnection() const {
+    return adminConnection_ && adminConnection_->isConnected();
+  }
+
+  // Get the client ID assigned by the admin server
+  int32_t getClientId() const {
+    return clientId_;
+  }
+
  private:
   std::string generateKey();
   std::string generateValue();
@@ -141,6 +215,10 @@ class UcacheBenchClient {
       routerInstance_;
   // Note: No longer using a shared client_ member
   // Instead, each thread creates its own client from routerInstance_
+
+  // Admin server connection for multi-client coordination
+  std::unique_ptr<AdminConnection> adminConnection_;
+  int32_t clientId_{-1}; // Assigned by admin server
 };
 
 } // namespace ucachebench

--- a/packages/ucache_bench/client/main.cpp
+++ b/packages/ucache_bench/client/main.cpp
@@ -17,6 +17,26 @@ DECLARE_uint32(duration_seconds);
 DECLARE_uint32(warmup_seconds);
 DECLARE_bool(verbose);
 
+static bool ValidateServerPort(const char* flagname, uint32_t value) {
+  if (value > 0 && value < 65536) {
+    return true;
+  }
+  printf(
+      "Invalid value for --%s: %u (must be between 1 and 65535)\n",
+      flagname,
+      value);
+  return false;
+}
+DEFINE_validator(server_port, &ValidateServerPort);
+
+// Admin server flag for multi-client coordination
+// Note: admin_host is not needed - we use server_host since admin server
+// runs on the same machine as the cache server
+DEFINE_uint32(
+    admin_port,
+    0,
+    "Admin server port for multi-client coordination (0 = disabled)");
+
 using namespace facebook::ucachebench;
 
 int main(int argc, char** argv) {
@@ -36,6 +56,20 @@ int main(int argc, char** argv) {
 
   try {
     UcacheBenchClient client;
+
+    // Connect to admin server if configured (uses server_host since admin runs
+    // on same machine)
+    if (FLAGS_admin_port > 0) {
+      printf(
+          "Connecting to admin server at %s:%u for multi-client coordination\n",
+          FLAGS_server_host.c_str(),
+          FLAGS_admin_port);
+      if (!client.connectToAdmin(
+              FLAGS_server_host, static_cast<uint16_t>(FLAGS_admin_port))) {
+        printf("Failed to connect to admin server\n");
+        return 1;
+      }
+    }
 
     // Warmup phase
     auto warmupResults = client.warmup();

--- a/packages/ucache_bench/run.py
+++ b/packages/ucache_bench/run.py
@@ -5,11 +5,28 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
+"""
+UcacheBench benchmark runner.
+
+This script provides a Python interface to run the ucachebench server and client
+binaries. It aligns with the gflags defined in the C++ implementations:
+- Server: main.cpp, UcacheBenchRpcServer.cpp
+- Client: UcacheBenchClient.cpp
+
+Usage:
+    # Run server
+    ./run.py server --memory-mb=1024 --port=11212 --real
+
+    # Run client
+    ./run.py client --server-host=localhost --server-port=11212 --real
+"""
+
 import argparse
 import os
 import pathlib
 import subprocess
 from typing import List, Optional
+
 
 BENCHPRESS_ROOT: pathlib.Path = pathlib.Path(os.path.abspath(__file__)).parents[2]
 UCACHE_BENCH_DIR: str = os.path.join(BENCHPRESS_ROOT, "benchmarks", "ucache_bench")
@@ -128,11 +145,16 @@ def run_cmd(
 
 
 def run_server(args: argparse.Namespace) -> None:
-    # Calculate number of cores available
-    n_cores = len(os.sched_getaffinity(0))
+    """Run the UcacheBench server.
 
+    Server binary flags are defined in:
+    - main.cpp: port, verbose, cpu_arch, memory_mb, hash_power, pool_name, navy_* options
+               admin_port, num_clients, timeout_seconds (for multi-client coordination)
+    - UcacheBenchRpcServer.cpp: rpc_io_threads, rpc_io_threads_multiplier,
+      rpc_num_acceptor_threads, rpc_num_cpu_worker_threads, cpu_pinning_* options
+    """
     # Calculate memory size
-    memory_mb = int(args.memsize * 1024 * MEM_USAGE_FACTOR)
+    memory_mb = int(args.memory_mb * MEM_USAGE_FACTOR)
 
     # Auto-calculate hash_power if not explicitly set
     # (default value is 20, which is too small for production workloads)
@@ -141,22 +163,18 @@ def run_server(args: argparse.Namespace) -> None:
         hash_power = calculate_hash_power(memory_mb)
         print(f"Auto-calculated hash_power={hash_power} for {memory_mb}MB memory")
 
-    # Calculate number of threads
-    n_threads = calculate_num_threads(memory_mb, args.num_threads, n_cores)
-
     print(
-        f"Starting UcacheBench server with {n_threads} threads and {memory_mb}MB memory"
+        f"Starting UcacheBench server with {args.memory_mb}MB memory on port {args.port}"
     )
 
     server_binary = os.path.join(UCACHE_BENCH_DIR, "server", "ucachebench_server")
     server_cmd = [
         server_binary,
         f"--port={args.port}",
-        f"--memory_mb={memory_mb}",
-        f"--num_threads={n_threads}",
+        f"--memory_mb={args.memory_mb}",
         f"--hash_power={hash_power}",
         f"--pool_name={args.pool_name}",
-        f"--cache_mode={args.cache_mode}",
+        f"--cpu_arch={args.cpu_arch}",
     ]
 
     # Add DRAM tuning parameters if provided
@@ -181,8 +199,48 @@ def run_server(args: argparse.Namespace) -> None:
     if args.min_alloc_size is not None:
         server_cmd.append(f"--min_alloc_size={args.min_alloc_size}")
 
-    # Add Navy-specific options for hybrid mode
-    if args.cache_mode == "hybrid":
+    # Admin server configuration for multi-client coordination
+    # Pass admin_port to server if explicitly set (>0) or if num_clients > 0
+    # The server binary handles -1 as auto-default (port+1 when num_clients > 0)
+    if args.admin_port > 0:
+        server_cmd.append(f"--admin_port={args.admin_port}")
+    if args.num_clients > 0:
+        server_cmd.append(f"--num_clients={args.num_clients}")
+    if args.timeout_seconds != 600:
+        server_cmd.append(f"--timeout_seconds={args.timeout_seconds}")
+
+    # RPC configuration
+    if args.rpc_io_threads > 0:
+        server_cmd.append(f"--rpc_io_threads={args.rpc_io_threads}")
+    if args.rpc_io_threads_multiplier != 1.0:
+        server_cmd.append(
+            f"--rpc_io_threads_multiplier={args.rpc_io_threads_multiplier}"
+        )
+    if args.rpc_num_acceptor_threads != 4:
+        server_cmd.append(f"--rpc_num_acceptor_threads={args.rpc_num_acceptor_threads}")
+    if args.rpc_num_cpu_worker_threads != 1:
+        server_cmd.append(
+            f"--rpc_num_cpu_worker_threads={args.rpc_num_cpu_worker_threads}"
+        )
+
+    # CPU pinning configuration
+    if args.cpu_pinning_enabled:
+        server_cmd.append("--cpu_pinning_enabled=true")
+        if not args.cpu_pinning_avoid_irqs:
+            server_cmd.append("--cpu_pinning_avoid_irqs=false")
+        if args.cpu_pinning_network_interface != "eth0":
+            server_cmd.append(
+                f"--cpu_pinning_network_interface={args.cpu_pinning_network_interface}"
+            )
+        if args.cpu_pinning_physical_cores_only:
+            server_cmd.append("--cpu_pinning_physical_cores_only=true")
+        if args.cpu_pinning_exclusive:
+            server_cmd.append("--cpu_pinning_exclusive=true")
+        if not args.cpu_pinning_reduce_threads:
+            server_cmd.append("--cpu_pinning_reduce_threads=false")
+
+    # Navy (hybrid mode) configuration
+    if args.navy_cache_size_mb > 0:
         server_cmd.extend(
             [
                 f"--navy_cache_path={args.navy_cache_path}",
@@ -191,60 +249,78 @@ def run_server(args: argparse.Namespace) -> None:
                 f"--navy_device_max_write_rate={args.navy_device_max_write_rate}",
                 f"--navy_region_size_mb={args.navy_region_size_mb}",
                 f"--navy_clean_regions_pool={args.navy_clean_regions_pool}",
+                f"--navy_truncate_file={'true' if args.navy_truncate_file else 'false'}",
             ]
         )
-        if args.navy_truncate_file:
-            server_cmd.append("--navy_truncate_file=true")
-        else:
-            server_cmd.append("--navy_truncate_file=false")
 
     if args.verbose:
-        server_cmd.append("--verbose")
+        server_cmd.append("--verbose=true")
 
-    timeout = args.warmup_time + args.test_time + args.timeout_buffer
-    stdout = run_cmd(server_cmd, timeout, args.real)
+    stdout = run_cmd(server_cmd, timeout=None, for_real=args.real)
     print(stdout)
 
 
 def run_client(args: argparse.Namespace) -> None:
-    print("Starting UcacheBench client...")
+    """Run the UcacheBench client.
 
-    # Calculate number of cores available
-    n_cores = len(os.sched_getaffinity(0))
-
-    # Calculate memory size if available (for auto-scaling parameters)
-    # Note: Client doesn't directly use memory_mb, but we estimate based on server
-    # For simplicity, we use default scaling unless explicit values provided
-    memory_mb = 100000  # Default to medium config size for auto-scaling
-
-    # Calculate number of threads
-    n_threads = calculate_num_threads(memory_mb, args.num_threads, n_cores)
-    if args.num_threads == 0:
-        # Client default: use most cores, leaving a few for system
-        n_threads = max(1, n_cores - 2)
-
-    # Calculate number of proxy threads for connection management
-    n_proxies = calculate_num_proxies(memory_mb, args.num_proxies, n_cores)
+    Client binary flags are defined in UcacheBenchClient.cpp.
+    """
+    print(
+        f"Starting UcacheBench client connecting to {args.server_host}:{args.server_port}"
+    )
 
     client_binary = os.path.join(UCACHE_BENCH_DIR, "client", "ucachebench_client")
-
     client_cmd = [
         client_binary,
-        f"--server_host={args.server_hostname}",
-        f"--server_port={args.server_port_number}",
-        f"--num_threads={n_threads}",
-        f"--num_proxies={n_proxies}",
-        f"--duration_seconds={args.test_time}",
-        f"--warmup_seconds={args.warmup_time}",
+        f"--server_host={args.server_host}",
+        f"--server_port={args.server_port}",
+        f"--duration_seconds={args.duration_seconds}",
+        f"--warmup_seconds={args.warmup_seconds}",
         f"--key_count={args.key_count}",
         f"--value_size_min={args.value_size_min}",
         f"--value_size_max={args.value_size_max}",
         f"--get_ratio={args.get_ratio}",
         f"--qps_target={args.qps_target}",
+        f"--num_proxies={args.num_proxies}",
+        f"--num_threads={args.num_threads}",
+        f"--max_inflight={args.max_inflight}",
+        f"--additional_fanout={args.additional_fanout}",
     ]
 
+    # Admin server coordination (uses server_host since admin runs on same machine)
+    if args.admin_port > 0:
+        client_cmd.append(f"--admin_port={args.admin_port}")
+
+    # Timeout configuration
+    if args.connection_timeout_ms != 1000:
+        client_cmd.append(f"--connection_timeout_ms={args.connection_timeout_ms}")
+    if args.send_timeout_ms != 1000:
+        client_cmd.append(f"--send_timeout_ms={args.send_timeout_ms}")
+
+    # Security configuration
+    if args.security_mech != "plain":
+        client_cmd.append(f"--security_mech={args.security_mech}")
+
+    # Distribution configuration
+    if args.use_distribution:
+        client_cmd.append("--use_distribution=true")
+        if args.distribution_config:
+            client_cmd.append(f"--distribution_config={args.distribution_config}")
+
+    # Zipfian distribution configuration
+    if args.zipfian:
+        client_cmd.append("--zipfian=true")
+        if args.zipfian_skew != 0.99:
+            client_cmd.append(f"--zipfian_skew={args.zipfian_skew}")
+    if args.hot_key_ratio > 0.0:
+        client_cmd.append(f"--hot_key_ratio={args.hot_key_ratio}")
+
+    # Random source IP for fanout
+    if args.enable_random_source_ip:
+        client_cmd.append("--enable_random_source_ip=true")
+
     if args.verbose:
-        client_cmd.append("--verbose")
+        client_cmd.append("--verbose=true")
 
     stdout = run_cmd(client_cmd, timeout=None, for_real=args.real)
     print(stdout)
@@ -252,7 +328,8 @@ def run_client(args: argparse.Namespace) -> None:
 
 def init_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
-        formatter_class=argparse.ArgumentDefaultsHelpFormatter
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+        description="UcacheBench benchmark runner",
     )
 
     # Sub-command parsers
@@ -260,36 +337,46 @@ def init_parser() -> argparse.ArgumentParser:
     server_parser = sub_parsers.add_parser(
         "server",
         formatter_class=argparse.ArgumentDefaultsHelpFormatter,
-        help="run server",
+        help="Run UcacheBench server",
     )
     client_parser = sub_parsers.add_parser(
         "client",
         formatter_class=argparse.ArgumentDefaultsHelpFormatter,
-        help="run client",
+        help="Run UcacheBench client",
     )
 
-    # Server-side arguments
+    # =========================================================================
+    # Server arguments (aligned with main.cpp and UcacheBenchRpcServer.cpp)
+    # =========================================================================
+
+    # Basic server configuration
     server_parser.add_argument(
-        "--memsize", type=float, required=True, help="memory size in GB, e.g. 1 or 2"
+        "--port", type=int, default=11212, help="Port to listen on"
     )
-    server_parser.add_argument("--port", type=int, default=11211, help="Server port")
     server_parser.add_argument(
-        "--num-threads",
+        "--memory-mb",
         type=int,
-        default=0,
-        help="Number of server threads (0 = auto-detect)",
+        default=1024,
+        help="Memory size in MB for DRAM cache",
     )
     server_parser.add_argument(
         "--hash-power",
         type=int,
         default=20,
-        help="Hash table power for cachelib",
+        help="Hash table power for cachelib (overridden by cpu_arch if set)",
     )
     server_parser.add_argument(
         "--pool-name",
         type=str,
         default="default",
         help="Pool name for cachelib",
+    )
+    server_parser.add_argument(
+        "--cpu-arch",
+        type=str,
+        default="default",
+        choices=["default", "turin", "sapphire_rapids", "spr", "skylake", "skl"],
+        help="CPU architecture for production-like cachelib settings",
     )
 
     # DRAM tuning parameters (production-like settings)
@@ -336,101 +423,224 @@ def init_parser() -> argparse.ArgumentParser:
         help="Minimum allocation size in bytes",
     )
 
-    # Cache configuration arguments
+    # RPC configuration (from UcacheBenchRpcServer.cpp)
     server_parser.add_argument(
-        "--cache-mode",
-        type=str,
-        default="memory",
-        choices=["memory", "hybrid"],
-        help="Cache mode: 'memory' for RAM-only, 'hybrid' for RAM+SSD",
+        "--rpc-io-threads",
+        type=int,
+        default=0,
+        help="Number of IO threads for RPC server (0 = auto-detect)",
     )
+    server_parser.add_argument(
+        "--rpc-io-threads-multiplier",
+        type=float,
+        default=1.0,
+        help="Multiplier for IO thread count (production typically uses 0.75-1.0)",
+    )
+    server_parser.add_argument(
+        "--rpc-num-acceptor-threads",
+        type=int,
+        default=4,
+        help="Number of acceptor threads for handling new connections",
+    )
+    server_parser.add_argument(
+        "--rpc-num-cpu-worker-threads",
+        type=int,
+        default=1,
+        help="Number of CPU worker threads for ThriftServer",
+    )
+
+    # CPU pinning configuration
+    server_parser.add_argument(
+        "--cpu-pinning-enabled",
+        type=int,
+        default=0,
+        help="Enable CPU pinning for IO threads to reduce softirq overhead (set to non-zero to enable)",
+    )
+    server_parser.add_argument(
+        "--cpu-pinning-avoid-irqs",
+        type=int,
+        default=1,
+        help="Avoid CPUs that handle NIC IRQs (set to non-zero to enable)",
+    )
+    server_parser.add_argument(
+        "--cpu-pinning-network-interface",
+        type=str,
+        default="eth0",
+        help="Network interface name for IRQ detection",
+    )
+    server_parser.add_argument(
+        "--cpu-pinning-physical-cores-only",
+        type=int,
+        default=0,
+        help="Use only physical cores (skip hyperthreads) (set to non-zero to enable)",
+    )
+    server_parser.add_argument(
+        "--cpu-pinning-exclusive",
+        type=int,
+        default=0,
+        help="Pin each thread to exactly one CPU (exclusive mode) (set to non-zero to enable)",
+    )
+    server_parser.add_argument(
+        "--cpu-pinning-reduce-threads",
+        type=int,
+        default=1,
+        help="Reduce IO thread count to match non-IRQ CPU count (set to non-zero to enable)",
+    )
+
+    # Navy (hybrid mode) configuration
     server_parser.add_argument(
         "--navy-cache-path",
         type=str,
         default="/tmp/ucachebench_ssd",
-        help="Path for Navy cache files (hybrid mode only)",
+        help="Path for Navy cache files",
     )
     server_parser.add_argument(
         "--navy-cache-size-mb",
         type=int,
-        default=4096,
-        help="Navy cache size in MB (hybrid mode only)",
+        default=0,
+        help="Navy cache size in MB (0 = DRAM-only, >0 = hybrid mode)",
     )
     server_parser.add_argument(
         "--navy-block-size",
         type=int,
         default=4096,
-        help="Navy block size in bytes (hybrid mode only)",
+        help="Navy block size in bytes",
     )
     server_parser.add_argument(
         "--navy-device-max-write-rate",
         type=int,
         default=0,
-        help="Max Navy write rate MB/s, 0=unlimited (hybrid mode only)",
+        help="Max Navy write rate MB/s (0 = unlimited)",
     )
     server_parser.add_argument(
         "--navy-region-size-mb",
         type=int,
         default=16,
-        help="Navy region size in MB (hybrid mode only)",
+        help="Navy region size in MB",
     )
     server_parser.add_argument(
         "--navy-clean-regions-pool",
         type=int,
         default=4,
-        help="Number of clean regions to maintain (hybrid mode only)",
+        help="Number of clean regions to maintain",
     )
     server_parser.add_argument(
         "--navy-truncate-file",
-        action="store_true",
-        default=True,
-        help="Truncate Navy cache file on startup (hybrid mode only)",
-    )
-    server_parser.add_argument(
-        "--timeout-buffer",
         type=int,
-        default=120,
-        help="extra time the server will wait beyond warmup and test time, "
-        + "in seconds, for the clients to start up",
+        default=1,
+        help="Truncate Navy cache file on startup (set to non-zero to enable)",
+    )
+
+    # Admin server for multi-client coordination
+    server_parser.add_argument(
+        "--admin-port",
+        type=int,
+        default=-1,
+        help="Admin port for multi-client coordination (-1 = auto port+1 when num_clients > 0, 0 = disabled)",
     )
     server_parser.add_argument(
-        "--warmup-time", type=int, default=10, help="warmup time in seconds"
+        "--num-clients",
+        type=int,
+        default=0,
+        help="Number of clients expected to connect (enables admin server when > 0)",
     )
     server_parser.add_argument(
-        "--test-time", type=int, default=60, help="test time in seconds"
+        "--timeout-seconds",
+        type=int,
+        default=600,
+        help="Timeout in seconds for waiting for clients (0 = no timeout)",
     )
+
     server_parser.add_argument(
         "--verbose", action="store_true", help="Enable verbose logging"
     )
-    server_parser.add_argument("--real", action="store_true", help="for real")
+    server_parser.add_argument(
+        "--real", action="store_true", help="Actually run the command"
+    )
 
-    # Client-side arguments
+    # =========================================================================
+    # Client arguments (aligned with UcacheBenchClient.cpp)
+    # =========================================================================
+
+    # Connection configuration
     client_parser.add_argument(
-        "--server-hostname", type=str, required=True, help="Server hostname"
+        "--server-host",
+        type=str,
+        required=True,
+        help="Server hostname",
     )
     client_parser.add_argument(
-        "--server-port-number", type=int, default=11211, help="Server port"
+        "--server-port",
+        type=int,
+        default=11211,
+        help="Server port",
+    )
+    client_parser.add_argument(
+        "--connection-timeout-ms",
+        type=int,
+        default=1000,
+        help="Connection timeout in milliseconds",
+    )
+    client_parser.add_argument(
+        "--send-timeout-ms",
+        type=int,
+        default=1000,
+        help="Send timeout in milliseconds",
+    )
+    client_parser.add_argument(
+        "--security-mech",
+        type=str,
+        default="plain",
+        help="Security mechanism for mcrouter (plain, tls_to_plain, fizz, etc.)",
+    )
+
+    # Benchmark duration
+    client_parser.add_argument(
+        "--duration-seconds",
+        type=int,
+        default=60,
+        help="Test duration in seconds",
+    )
+    client_parser.add_argument(
+        "--warmup-seconds",
+        type=int,
+        default=10,
+        help="Warmup duration in seconds",
+    )
+
+    # Thread and connection configuration
+    client_parser.add_argument(
+        "--num-proxies",
+        type=int,
+        default=0,
+        help="Number of mcrouter proxy threads (0 = auto-detect)",
     )
     client_parser.add_argument(
         "--num-threads",
         type=int,
         default=0,
-        help="Number of client threads (0 = auto-detect)",
+        help="Number of client worker threads for request generation (0 = auto-detect)",
     )
     client_parser.add_argument(
-        "--num-proxies",
+        "--max-inflight",
+        type=int,
+        default=1,
+        help="Maximum number of concurrent in-flight requests",
+    )
+    client_parser.add_argument(
+        "--additional-fanout",
         type=int,
         default=0,
-        help="Number of mcrouter proxy threads for connection pooling (0 = auto-detect). "
-        "To simulate production-scale connections (e.g., 20K), increase this value. "
-        "Each proxy thread establishes connections to the server as needed.",
+        help="Number of additional connections per server for fanout",
     )
     client_parser.add_argument(
-        "--connections-per-thread",
+        "--enable-random-source-ip",
         type=int,
-        default=10,
-        help="[DEPRECATED - Not currently used] Number of connections per client thread",
+        default=0,
+        help="Enable random source IP addresses for connection fanout (set to non-zero to enable)",
     )
+
+    # Workload configuration
     client_parser.add_argument(
         "--key-count",
         type=int,
@@ -461,16 +671,56 @@ def init_parser() -> argparse.ArgumentParser:
         default=0,
         help="Target QPS (0 = unlimited)",
     )
+
+    # Traffic distribution configuration
     client_parser.add_argument(
-        "--warmup-time", type=int, default=10, help="warmup time in seconds"
+        "--use-distribution",
+        type=int,
+        default=0,
+        help="Use production traffic distribution for key/value sizes (set to non-zero to enable)",
     )
     client_parser.add_argument(
-        "--test-time", type=int, default=60, help="test time in seconds"
+        "--distribution-config",
+        type=str,
+        default="",
+        help="Path to JSON file with traffic distribution config",
     )
+
+    # Zipfian distribution configuration
+    client_parser.add_argument(
+        "--zipfian",
+        type=int,
+        default=0,
+        help="Enable Zipfian key distribution for hot-key access patterns (set to non-zero to enable)",
+    )
+    client_parser.add_argument(
+        "--zipfian-skew",
+        type=float,
+        default=0.99,
+        help="Zipfian skew parameter (0.99 = standard Zipf)",
+    )
+    client_parser.add_argument(
+        "--hot-key-ratio",
+        type=float,
+        default=0.0,
+        help="Fraction of keys that are 'hot' (0.0 = disabled, use pure Zipfian)",
+    )
+
+    # Admin server coordination for multi-client benchmarks
+    client_parser.add_argument(
+        "--admin-port",
+        type=int,
+        default=0,
+        help="Admin server port for multi-client coordination (0 = disabled). "
+        "Uses server_host since admin server runs on same machine as cache server.",
+    )
+
     client_parser.add_argument(
         "--verbose", action="store_true", help="Enable verbose logging"
     )
-    client_parser.add_argument("--real", action="store_true", help="for real")
+    client_parser.add_argument(
+        "--real", action="store_true", help="Actually run the command"
+    )
 
     # Set default functions
     server_parser.set_defaults(func=run_server)
@@ -488,20 +738,15 @@ def main() -> None:
     client_binary = os.path.join(UCACHE_BENCH_DIR, "client", "ucachebench_client")
 
     if not os.path.exists(server_binary):
-        print(f"Error: Server binary not found at {server_binary}")
-        print(
-            "Please build the benchmark using: buck build //cea/chips/benchpress/benchmarks/ucache_bench/server:ucachebench_server"
-        )
-        exit(1)
+        print(f"Warning: Server binary not found at {server_binary}")
 
     if not os.path.exists(client_binary):
-        print(f"Error: Client binary not found at {client_binary}")
-        print(
-            "Please build the benchmark using: buck build //cea/chips/benchpress/benchmarks/ucache_bench/client:ucachebench_client"
-        )
-        exit(1)
+        print(f"Warning: Client binary not found at {client_binary}")
 
-    args.func(args)
+    if hasattr(args, "func"):
+        args.func(args)
+    else:
+        parser.print_help()
 
 
 if __name__ == "__main__":

--- a/packages/ucache_bench/server/CMakeLists.txt
+++ b/packages/ucache_bench/server/CMakeLists.txt
@@ -12,6 +12,7 @@ set(SERVER_SOURCES
     UcacheBenchOnRequest.cpp
     UcacheBenchIOThreadContext.cpp
     CpuManager.cpp
+    UcacheBenchAdminServer.cpp
 )
 
 set(SERVER_HEADERS
@@ -22,6 +23,7 @@ set(SERVER_HEADERS
     UcacheBenchRequestCommon.h
     UcacheBenchThreadLoopCallback.h
     CpuManager.h
+    UcacheBenchAdminServer.h
 )
 
 add_executable(ucachebench_server ${SERVER_SOURCES} ${SERVER_HEADERS})

--- a/packages/ucache_bench/server/UcacheBenchAdminServer.cpp
+++ b/packages/ucache_bench/server/UcacheBenchAdminServer.cpp
@@ -1,0 +1,493 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include "UcacheBenchAdminServer.h"
+
+#include <arpa/inet.h>
+#include <netinet/in.h>
+#include <sys/socket.h>
+#include <unistd.h>
+
+#include <algorithm>
+#include <cstring>
+#include <sstream>
+
+namespace facebook::ucachebench {
+
+UcacheBenchAdminServer::UcacheBenchAdminServer(
+    uint16_t port,
+    uint32_t numExpectedClients,
+    uint32_t timeoutSeconds)
+    : port_(port),
+      numExpectedClients_(numExpectedClients),
+      timeoutSeconds_(timeoutSeconds) {}
+
+UcacheBenchAdminServer::~UcacheBenchAdminServer() {
+  stop();
+}
+
+void UcacheBenchAdminServer::start() {
+  if (running_.load()) {
+    return;
+  }
+
+  startTime_ = std::chrono::steady_clock::now();
+  running_ = true;
+
+  serverThread_ = std::thread([this]() { serverLoop(); });
+
+  printf(
+      "[AdminServer] Started on port %u, expecting %u client(s)\n",
+      port_,
+      numExpectedClients_);
+  if (timeoutSeconds_ > 0) {
+    printf("[AdminServer] Timeout: %u seconds\n", timeoutSeconds_);
+  }
+}
+
+void UcacheBenchAdminServer::stop() {
+  if (!running_.load()) {
+    return;
+  }
+
+  running_ = false;
+
+  // Wake up anyone waiting for completion
+  {
+    std::lock_guard<std::mutex> lock(completionMutex_);
+  }
+  completionCv_.notify_all();
+
+  // Close server socket to unblock accept()
+  if (serverSocket_ >= 0) {
+    ::shutdown(serverSocket_, SHUT_RDWR);
+    ::close(serverSocket_);
+    serverSocket_ = -1;
+  }
+
+  // Close all client sockets to unblock recv() in client threads
+  {
+    std::lock_guard<std::mutex> lock(socketsMutex_);
+    for (int sock : clientSockets_) {
+      ::shutdown(sock, SHUT_RDWR);
+      ::close(sock);
+    }
+    clientSockets_.clear();
+  }
+
+  // Wait for all client handler threads to finish (with timeout)
+  {
+    std::unique_lock<std::mutex> lock(activeThreadsMutex_);
+    auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(5);
+    activeThreadsCv_.wait_until(
+        lock, deadline, [this]() { return activeThreadCount_ == 0; });
+  }
+
+  if (serverThread_.joinable()) {
+    serverThread_.join();
+  }
+
+  printf("[AdminServer] Stopped\n");
+}
+
+void UcacheBenchAdminServer::requestShutdown() {
+  // This method can be called from signal handlers
+  // Set running_ to false and wake up waitForCompletion()
+  running_ = false;
+  completionCv_.notify_all();
+}
+
+bool UcacheBenchAdminServer::waitForCompletion() {
+  std::unique_lock<std::mutex> lock(completionMutex_);
+
+  if (timeoutSeconds_ > 0) {
+    auto deadline = startTime_ + std::chrono::seconds(timeoutSeconds_);
+    bool result = completionCv_.wait_until(
+        lock, deadline, [this]() { return completed_ || !running_.load(); });
+
+    if (!result && !completed_) {
+      timedOut_ = true;
+      printf("\n[AdminServer] ERROR: Timeout waiting for clients\n");
+      printf("  Expected clients: %u\n", numExpectedClients_);
+
+      std::lock_guard<std::mutex> clientLock(clientMutex_);
+      printf("  Registered clients: %zu (", registeredClients_.size());
+      for (auto id : registeredClients_) {
+        printf("client%d ", id);
+      }
+      printf(")\n");
+
+      printf("  Warmup complete: %zu (", warmupCompleteClients_.size());
+      for (auto id : warmupCompleteClients_) {
+        printf("client%d ", id);
+      }
+      printf(")\n");
+
+      printf("  Benchmark complete: %zu\n", benchmarkCompleteClients_.size());
+
+      printf("\n  Timeout after %u seconds.\n", timeoutSeconds_);
+
+      return false;
+    }
+  } else {
+    completionCv_.wait(
+        lock, [this]() { return completed_ || !running_.load(); });
+  }
+
+  return completed_;
+}
+
+bool UcacheBenchAdminServer::allClientsRegistered() const {
+  std::lock_guard<std::mutex> lock(clientMutex_);
+  return registeredClients_.size() >= numExpectedClients_;
+}
+
+bool UcacheBenchAdminServer::allClientsWarmupDone() const {
+  std::lock_guard<std::mutex> lock(clientMutex_);
+  return warmupCompleteClients_.size() >= numExpectedClients_;
+}
+
+bool UcacheBenchAdminServer::allClientsBenchmarkDone() const {
+  std::lock_guard<std::mutex> lock(clientMutex_);
+  return benchmarkCompleteClients_.size() >= numExpectedClients_;
+}
+
+void UcacheBenchAdminServer::serverLoop() {
+  serverSocket_ = socket(AF_INET6, SOCK_STREAM, 0);
+  if (serverSocket_ < 0) {
+    printf("[AdminServer] Failed to create socket (errno=%d)\n", errno);
+    return;
+  }
+
+  // Allow port reuse
+  int opt = 1;
+  if (setsockopt(serverSocket_, SOL_SOCKET, SO_REUSEADDR, &opt, sizeof(opt)) <
+      0) {
+    printf(
+        "[AdminServer] Warning: setsockopt SO_REUSEADDR failed (errno=%d)\n",
+        errno);
+  }
+
+  // Allow IPv4 connections on IPv6 socket
+  int v6only = 0;
+  if (setsockopt(
+          serverSocket_, IPPROTO_IPV6, IPV6_V6ONLY, &v6only, sizeof(v6only)) <
+      0) {
+    printf(
+        "[AdminServer] Warning: setsockopt IPV6_V6ONLY failed (errno=%d)\n",
+        errno);
+  }
+
+  struct sockaddr_in6 addr;
+  memset(&addr, 0, sizeof(addr));
+  addr.sin6_family = AF_INET6;
+  addr.sin6_port = htons(port_);
+  addr.sin6_addr = in6addr_any;
+
+  if (bind(serverSocket_, (struct sockaddr*)&addr, sizeof(addr)) < 0) {
+    printf(
+        "[AdminServer] Failed to bind to port %u (errno=%d)\n", port_, errno);
+    ::close(serverSocket_);
+    serverSocket_ = -1;
+    return;
+  }
+
+  if (listen(serverSocket_, 16) < 0) {
+    printf("[AdminServer] Failed to listen (errno=%d)\n", errno);
+    ::close(serverSocket_);
+    serverSocket_ = -1;
+    return;
+  }
+
+  printf("[AdminServer] Listening on port %u\n", port_);
+
+  while (running_.load()) {
+    struct sockaddr_in6 clientAddr;
+    socklen_t clientLen = sizeof(clientAddr);
+    int clientSocket =
+        accept(serverSocket_, (struct sockaddr*)&clientAddr, &clientLen);
+
+    if (clientSocket < 0) {
+      if (running_.load()) {
+        printf("[AdminServer] Accept failed (errno=%d)\n", errno);
+      }
+      continue;
+    }
+
+    // Set receive timeout on client socket to prevent indefinite blocking
+    struct timeval tv;
+    tv.tv_sec = 5;
+    tv.tv_usec = 0;
+    if (setsockopt(clientSocket, SOL_SOCKET, SO_RCVTIMEO, &tv, sizeof(tv)) <
+        0) {
+      printf(
+          "[AdminServer] Warning: setsockopt SO_RCVTIMEO failed (errno=%d)\n",
+          errno);
+    }
+
+    // Handle client in a separate thread
+    // Increment active thread count before spawning
+    {
+      std::lock_guard<std::mutex> lock(activeThreadsMutex_);
+      activeThreadCount_++;
+    }
+    std::thread clientThread([this, clientSocket]() {
+      handleClient(clientSocket);
+      // Decrement active thread count and notify when done
+      {
+        std::lock_guard<std::mutex> lock(activeThreadsMutex_);
+        activeThreadCount_--;
+      }
+      activeThreadsCv_.notify_all();
+    });
+    clientThread.detach();
+  }
+}
+
+void UcacheBenchAdminServer::handleClient(int clientSocket) {
+  {
+    std::lock_guard<std::mutex> lock(socketsMutex_);
+    clientSockets_.push_back(clientSocket);
+  }
+
+  char buffer[1024];
+  std::string lineBuffer;
+
+  while (running_.load()) {
+    ssize_t bytesRead = recv(clientSocket, buffer, sizeof(buffer) - 1, 0);
+    if (bytesRead <= 0) {
+      break;
+    }
+
+    buffer[bytesRead] = '\0';
+    lineBuffer += buffer;
+
+    // Process complete lines
+    size_t pos;
+    while ((pos = lineBuffer.find('\n')) != std::string::npos) {
+      std::string line = lineBuffer.substr(0, pos);
+      lineBuffer.erase(0, pos + 1);
+
+      // Remove trailing \r if present
+      if (!line.empty() && line.back() == '\r') {
+        line.pop_back();
+      }
+
+      if (!line.empty()) {
+        std::string response = processCommand(clientSocket, line);
+        response += "\n";
+        send(clientSocket, response.c_str(), response.size(), 0);
+      }
+    }
+  }
+
+  // Remove from client list
+  {
+    std::lock_guard<std::mutex> lock(socketsMutex_);
+    auto it =
+        std::find(clientSockets_.begin(), clientSockets_.end(), clientSocket);
+    if (it != clientSockets_.end()) {
+      clientSockets_.erase(it);
+    }
+  }
+
+  ::close(clientSocket);
+}
+
+std::string UcacheBenchAdminServer::processCommand(
+    int clientSocket,
+    const std::string& command) {
+  std::istringstream iss(command);
+  std::string cmd;
+  iss >> cmd;
+
+  // Convert to uppercase for case-insensitive matching
+  std::transform(cmd.begin(), cmd.end(), cmd.begin(), ::toupper);
+
+  if (cmd == "REGISTER") {
+    return handleRegister(clientSocket);
+  } else if (cmd == "WARMUP_DONE") {
+    int32_t clientId;
+    if (!(iss >> clientId)) {
+      return "ERROR Missing client_id";
+    }
+    return handleWarmupDone(clientId);
+  } else if (cmd == "BENCHMARK_DONE") {
+    int32_t clientId;
+    if (!(iss >> clientId)) {
+      return "ERROR Missing client_id";
+    }
+    return handleBenchmarkDone(clientId);
+  } else if (cmd == "STATUS") {
+    std::lock_guard<std::mutex> lock(clientMutex_);
+    std::ostringstream oss;
+    oss << "STATUS phase=" << static_cast<int>(currentPhase_.load())
+        << " registered=" << registeredClients_.size()
+        << " warmup_done=" << warmupCompleteClients_.size()
+        << " benchmark_done=" << benchmarkCompleteClients_.size();
+    return oss.str();
+  } else {
+    return "ERROR Unknown command: " + cmd;
+  }
+}
+
+void UcacheBenchAdminServer::broadcast(const std::string& message) {
+  std::string msg = message + "\n";
+  std::lock_guard<std::mutex> lock(socketsMutex_);
+  for (int sock : clientSockets_) {
+    ssize_t sent = send(sock, msg.c_str(), msg.size(), MSG_NOSIGNAL);
+    if (sent < 0) {
+      printf(
+          "[AdminServer] Warning: broadcast send failed on socket %d (errno=%d)\n",
+          sock,
+          errno);
+    }
+  }
+}
+
+std::string UcacheBenchAdminServer::handleRegister(int /* clientSocket */) {
+  bool shouldTransition = false;
+  int32_t clientId;
+  {
+    std::lock_guard<std::mutex> lock(clientMutex_);
+
+    clientId = nextClientId_++;
+    registeredClients_.insert(clientId);
+
+    printf(
+        "[AdminServer] Client %d registered (%zu/%u)\n",
+        clientId,
+        registeredClients_.size(),
+        numExpectedClients_);
+
+    shouldTransition = registeredClients_.size() >= numExpectedClients_;
+  }
+
+  if (shouldTransition) {
+    transitionToWarmup();
+  }
+
+  return "OK " + std::to_string(clientId);
+}
+
+std::string UcacheBenchAdminServer::handleWarmupDone(int32_t clientId) {
+  bool shouldTransition = false;
+  {
+    std::lock_guard<std::mutex> lock(clientMutex_);
+
+    if (registeredClients_.find(clientId) == registeredClients_.end()) {
+      return "ERROR Unknown client_id " + std::to_string(clientId);
+    }
+
+    warmupCompleteClients_.insert(clientId);
+
+    printf(
+        "[AdminServer] Client %d completed warmup (%zu/%u)\n",
+        clientId,
+        warmupCompleteClients_.size(),
+        numExpectedClients_);
+
+    shouldTransition = warmupCompleteClients_.size() >= numExpectedClients_;
+  }
+
+  if (shouldTransition) {
+    transitionToBenchmark();
+  }
+
+  return "OK";
+}
+
+std::string UcacheBenchAdminServer::handleBenchmarkDone(int32_t clientId) {
+  bool shouldTransition = false;
+  {
+    std::lock_guard<std::mutex> lock(clientMutex_);
+
+    if (registeredClients_.find(clientId) == registeredClients_.end()) {
+      return "ERROR Unknown client_id " + std::to_string(clientId);
+    }
+
+    benchmarkCompleteClients_.insert(clientId);
+
+    printf(
+        "[AdminServer] Client %d completed benchmark (%zu/%u)\n",
+        clientId,
+        benchmarkCompleteClients_.size(),
+        numExpectedClients_);
+
+    shouldTransition = benchmarkCompleteClients_.size() >= numExpectedClients_;
+  }
+
+  if (shouldTransition) {
+    transitionToFinished();
+  }
+
+  return "OK";
+}
+
+void UcacheBenchAdminServer::transitionToWarmup() {
+  printf(
+      "[AdminServer] All %u clients registered, starting warmup phase\n",
+      numExpectedClients_);
+
+  warmupStartTime_ = std::chrono::steady_clock::now();
+  currentPhase_ = Phase::WARMUP;
+
+  // Copy callback to invoke outside of lock to avoid potential deadlock
+  PhaseChangeCallback callback;
+  {
+    std::lock_guard<std::mutex> lock(callbackMutex_);
+    callback = phaseChangeCallback_;
+  }
+  if (callback) {
+    callback(Phase::WARMUP);
+  }
+
+  broadcast("ALL_REGISTERED");
+}
+
+void UcacheBenchAdminServer::transitionToBenchmark() {
+  printf(
+      "[AdminServer] All clients finished warmup, starting benchmark phase\n");
+
+  benchmarkStartTime_ = std::chrono::steady_clock::now();
+  currentPhase_ = Phase::BENCHMARK;
+
+  // Copy callback to invoke outside of lock to avoid potential deadlock
+  PhaseChangeCallback callback;
+  {
+    std::lock_guard<std::mutex> lock(callbackMutex_);
+    callback = phaseChangeCallback_;
+  }
+  if (callback) {
+    callback(Phase::BENCHMARK);
+  }
+
+  broadcast("ALL_WARMUP_DONE");
+}
+
+void UcacheBenchAdminServer::transitionToFinished() {
+  printf("[AdminServer] All clients finished benchmark\n");
+
+  benchmarkEndTime_ = std::chrono::steady_clock::now();
+  currentPhase_ = Phase::FINISHED;
+
+  // Copy callback to invoke outside of lock to avoid potential deadlock
+  PrintResultsCallback callback;
+  {
+    std::lock_guard<std::mutex> lock(callbackMutex_);
+    callback = printResultsCallback_;
+  }
+  if (callback) {
+    callback();
+  }
+
+  broadcast("ALL_DONE");
+
+  // Signal completion
+  {
+    std::lock_guard<std::mutex> lock(completionMutex_);
+    completed_ = true;
+  }
+  completionCv_.notify_all();
+}
+
+} // namespace facebook::ucachebench

--- a/packages/ucache_bench/server/UcacheBenchAdminServer.h
+++ b/packages/ucache_bench/server/UcacheBenchAdminServer.h
@@ -1,0 +1,224 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#pragma once
+
+#include <atomic>
+#include <chrono>
+#include <condition_variable>
+#include <functional>
+#include <mutex>
+#include <set>
+#include <string>
+#include <thread>
+
+namespace facebook::ucachebench {
+
+/**
+ * Admin server for coordinating multi-client benchmark runs.
+ *
+ * This server listens on a separate admin port and handles client lifecycle
+ * notifications using a simple line-based text protocol. This follows the
+ * production ucache pattern of separating admin/control traffic from data
+ * traffic.
+ *
+ * Protocol:
+ *   Client -> Server:
+ *     REGISTER                    -> OK <client_id> | ERROR <msg>
+ *     WARMUP_DONE <client_id>     -> OK | ERROR <msg>
+ *     BENCHMARK_DONE <client_id>  -> OK | ERROR <msg>
+ *
+ *   Server -> Client (async notifications, sent to all connected clients):
+ *     ALL_REGISTERED              (after all N clients register)
+ *     ALL_WARMUP_DONE             (after all N clients finish warmup)
+ *     ALL_DONE                    (after results printed, server exiting)
+ *
+ * Lifecycle:
+ *   1. Server starts, waits for all expected clients to register
+ *   2. When all clients register, server broadcasts ALL_REGISTERED
+ *   3. Clients run warmup, then send WARMUP_DONE
+ *   4. When all clients finish warmup, server broadcasts ALL_WARMUP_DONE
+ *      and starts tracking benchmark metrics
+ *   5. Clients run benchmark, then send BENCHMARK_DONE
+ *   6. When all clients finish benchmark, server prints results,
+ *      broadcasts ALL_DONE, and exits
+ */
+class UcacheBenchAdminServer {
+ public:
+  /**
+   * Benchmark phase state machine.
+   */
+  enum class Phase {
+    WAITING_FOR_CLIENTS, // Waiting for all clients to register
+    WARMUP, // All clients registered, warmup in progress
+    BENCHMARK, // Warmup complete, benchmark in progress
+    FINISHED // All clients done, results printed
+  };
+
+  /**
+   * Callback type for metric tracking phase changes.
+   * Called when transitioning to WARMUP and BENCHMARK phases.
+   */
+  using PhaseChangeCallback = std::function<void(Phase)>;
+
+  /**
+   * Callback type for printing final results.
+   * Called when all clients have completed the benchmark.
+   */
+  using PrintResultsCallback = std::function<void()>;
+
+  /**
+   * Construct an admin server.
+   *
+   * @param port Admin port to listen on
+   * @param numExpectedClients Number of clients expected to connect
+   * @param timeoutSeconds Timeout for waiting for clients (0 = no timeout)
+   */
+  UcacheBenchAdminServer(
+      uint16_t port,
+      uint32_t numExpectedClients,
+      uint32_t timeoutSeconds);
+
+  ~UcacheBenchAdminServer();
+
+  /**
+   * Start the admin server.
+   * This spawns a background thread to accept connections and handle commands.
+   */
+  void start();
+
+  /**
+   * Stop the admin server.
+   * Closes all connections and stops the background thread.
+   */
+  void stop();
+
+  /**
+   * Request shutdown (thread-safe).
+   * Can be called from signal handlers to interrupt waitForCompletion().
+   */
+  void requestShutdown();
+
+  /**
+   * Wait for the benchmark to complete.
+   * Blocks until all clients finish or timeout occurs.
+   *
+   * @return true if completed successfully, false if timed out
+   */
+  bool waitForCompletion();
+
+  /**
+   * Get the current benchmark phase.
+   */
+  Phase getCurrentPhase() const {
+    return currentPhase_.load();
+  }
+
+  /**
+   * Check if all clients have registered.
+   */
+  bool allClientsRegistered() const;
+
+  /**
+   * Check if all clients have completed warmup.
+   */
+  bool allClientsWarmupDone() const;
+
+  /**
+   * Check if all clients have completed benchmark.
+   */
+  bool allClientsBenchmarkDone() const;
+
+  /**
+   * Set callback for phase changes.
+   */
+  void setPhaseChangeCallback(PhaseChangeCallback callback) {
+    std::lock_guard<std::mutex> lock(callbackMutex_);
+    phaseChangeCallback_ = std::move(callback);
+  }
+
+  /**
+   * Set callback for printing results.
+   */
+  void setPrintResultsCallback(PrintResultsCallback callback) {
+    std::lock_guard<std::mutex> lock(callbackMutex_);
+    printResultsCallback_ = std::move(callback);
+  }
+
+  /**
+   * Get timing information.
+   */
+  std::chrono::steady_clock::time_point getWarmupStartTime() const {
+    return warmupStartTime_;
+  }
+  std::chrono::steady_clock::time_point getBenchmarkStartTime() const {
+    return benchmarkStartTime_;
+  }
+  std::chrono::steady_clock::time_point getBenchmarkEndTime() const {
+    return benchmarkEndTime_;
+  }
+
+ private:
+  // Server configuration
+  uint16_t port_;
+  uint32_t numExpectedClients_;
+  uint32_t timeoutSeconds_;
+
+  // Phase tracking
+  std::atomic<Phase> currentPhase_{Phase::WAITING_FOR_CLIENTS};
+
+  // Client tracking
+  mutable std::mutex clientMutex_;
+  std::set<int32_t> registeredClients_;
+  std::set<int32_t> warmupCompleteClients_;
+  std::set<int32_t> benchmarkCompleteClients_;
+  int32_t nextClientId_{1};
+
+  // Connected client sockets for broadcasting
+  std::mutex socketsMutex_;
+  std::vector<int> clientSockets_;
+
+  // Timing
+  std::chrono::steady_clock::time_point startTime_;
+  std::chrono::steady_clock::time_point warmupStartTime_;
+  std::chrono::steady_clock::time_point benchmarkStartTime_;
+  std::chrono::steady_clock::time_point benchmarkEndTime_;
+
+  // Callbacks
+  mutable std::mutex callbackMutex_;
+  PhaseChangeCallback phaseChangeCallback_;
+  PrintResultsCallback printResultsCallback_;
+
+  // Server thread
+  std::atomic<bool> running_{false};
+  std::thread serverThread_;
+  int serverSocket_{-1};
+
+  // Completion signaling
+  std::mutex completionMutex_;
+  std::condition_variable completionCv_;
+  bool completed_{false};
+  bool timedOut_{false};
+
+  // Active client thread tracking for safe shutdown
+  std::mutex activeThreadsMutex_;
+  std::condition_variable activeThreadsCv_;
+  uint32_t activeThreadCount_{0};
+
+  // Internal methods
+  void serverLoop();
+  void handleClient(int clientSocket);
+  std::string processCommand(int clientSocket, const std::string& command);
+  void broadcast(const std::string& message);
+
+  // Command handlers
+  std::string handleRegister(int clientSocket);
+  std::string handleWarmupDone(int32_t clientId);
+  std::string handleBenchmarkDone(int32_t clientId);
+
+  // Phase transitions
+  void transitionToWarmup();
+  void transitionToBenchmark();
+  void transitionToFinished();
+};
+
+} // namespace facebook::ucachebench

--- a/packages/ucache_bench/server/UcacheBenchServer.cpp
+++ b/packages/ucache_bench/server/UcacheBenchServer.cpp
@@ -252,12 +252,16 @@ folly::SemiFuture<UcbGetReply> UcacheBenchServer::processUcbGet(
       reply.flags_ref() =
           req.flags_ref().has_value() ? req.flags_ref().value() : 0;
 
+      recordGet(true /* hit */);
+
       if (config_.verbose) {
         printf("Cache hit for key: %s\n", keyStr.c_str());
       }
     } else {
       // Cache miss
       reply.result_ref() = carbon::Result::NOTFOUND;
+      recordGet(false /* miss */);
+
       if (config_.verbose) {
         printf("Cache miss for key: %s\n", keyStr.c_str());
       }
@@ -298,6 +302,8 @@ folly::SemiFuture<UcbSetReply> UcacheBenchServer::processUcbSet(
       reply.flags_ref() =
           req.flags_ref().has_value() ? req.flags_ref().value() : 0;
 
+      recordSet();
+
       if (config_.verbose) {
         printf("Stored key: %s, size: %zu\n", keyStr.c_str(), valueStr.size());
       }
@@ -337,6 +343,8 @@ folly::SemiFuture<UcbDeleteReply> UcacheBenchServer::processUcbDelete(
       reply.flags_ref() =
           req.flags_ref().has_value() ? req.flags_ref().value() : 0;
 
+      recordDelete();
+
       if (config_.verbose) {
         printf("Deleted key: %s\n", keyStr.c_str());
       }
@@ -361,6 +369,110 @@ void UcacheBenchServer::printStats() {
     // version
     printf(
         "Cache stats available - use cache_->getGlobalCacheStats() for detailed metrics\n");
+  }
+}
+
+void UcacheBenchServer::setTrackingPhase(TrackingPhase phase) {
+  auto oldPhase = currentPhase_.exchange(phase);
+
+  // Reset metrics when transitioning to a new tracking phase
+  if (phase == TrackingPhase::WARMUP && oldPhase != TrackingPhase::WARMUP) {
+    warmupMetrics_.reset();
+    printf("[Server] Starting warmup phase metrics tracking\n");
+  } else if (
+      phase == TrackingPhase::BENCHMARK &&
+      oldPhase != TrackingPhase::BENCHMARK) {
+    benchmarkMetrics_.reset();
+    printf("[Server] Starting benchmark phase metrics tracking\n");
+  }
+}
+
+void UcacheBenchServer::recordGet(bool hit) {
+  auto phase = currentPhase_.load();
+  if (phase == TrackingPhase::WARMUP) {
+    warmupMetrics_.getRequests.fetch_add(1, std::memory_order_relaxed);
+    if (hit) {
+      warmupMetrics_.getHits.fetch_add(1, std::memory_order_relaxed);
+    } else {
+      warmupMetrics_.getMisses.fetch_add(1, std::memory_order_relaxed);
+    }
+  } else if (phase == TrackingPhase::BENCHMARK) {
+    benchmarkMetrics_.getRequests.fetch_add(1, std::memory_order_relaxed);
+    if (hit) {
+      benchmarkMetrics_.getHits.fetch_add(1, std::memory_order_relaxed);
+    } else {
+      benchmarkMetrics_.getMisses.fetch_add(1, std::memory_order_relaxed);
+    }
+  }
+}
+
+void UcacheBenchServer::recordSet() {
+  auto phase = currentPhase_.load();
+  if (phase == TrackingPhase::WARMUP) {
+    warmupMetrics_.setRequests.fetch_add(1, std::memory_order_relaxed);
+  } else if (phase == TrackingPhase::BENCHMARK) {
+    benchmarkMetrics_.setRequests.fetch_add(1, std::memory_order_relaxed);
+  }
+}
+
+void UcacheBenchServer::recordDelete() {
+  auto phase = currentPhase_.load();
+  if (phase == TrackingPhase::WARMUP) {
+    warmupMetrics_.deleteRequests.fetch_add(1, std::memory_order_relaxed);
+  } else if (phase == TrackingPhase::BENCHMARK) {
+    benchmarkMetrics_.deleteRequests.fetch_add(1, std::memory_order_relaxed);
+  }
+}
+
+void UcacheBenchServer::printFinalResults(double benchmarkDurationSec) const {
+  const auto& metrics = benchmarkMetrics_;
+
+  uint64_t getReqs = metrics.getRequests.load();
+  uint64_t getHits = metrics.getHits.load();
+  uint64_t getMisses = metrics.getMisses.load();
+  uint64_t setReqs = metrics.setRequests.load();
+  uint64_t deleteReqs = metrics.deleteRequests.load();
+  uint64_t totalOps = getReqs + setReqs + deleteReqs;
+
+  double qps =
+      (benchmarkDurationSec > 0) ? totalOps / benchmarkDurationSec : 0.0;
+  double hitRatio = (getReqs > 0) ? (100.0 * getHits / getReqs) : 0.0;
+
+  // Print in format parseable by benchpress
+  printf("\n");
+  printf("========================================\n");
+  printf("     UCACHEBENCH SERVER RESULTS\n");
+  printf("========================================\n");
+  printf("Benchmark Duration: %.3f seconds\n", benchmarkDurationSec);
+  printf("\n");
+  printf("Operations:\n");
+  printf("  GET requests:    %lu\n", getReqs);
+  printf("  GET hits:        %lu\n", getHits);
+  printf("  GET misses:      %lu\n", getMisses);
+  printf("  SET requests:    %lu\n", setReqs);
+  printf("  DELETE requests: %lu\n", deleteReqs);
+  printf("  Total ops:       %lu\n", totalOps);
+  printf("\n");
+  printf("Performance:\n");
+  printf("  QPS:        %.1f\n", qps);
+  printf("  Hit Ratio:  %.2f%%\n", hitRatio);
+  printf("========================================\n");
+  printf("\n");
+
+  // Also print warmup stats for reference
+  const auto& warmup = warmupMetrics_;
+  uint64_t warmupTotalOps = warmup.getRequests.load() +
+      warmup.setRequests.load() + warmup.deleteRequests.load();
+  if (warmupTotalOps > 0) {
+    printf("Warmup Stats (for reference):\n");
+    printf(
+        "  GET requests: %lu (hits: %lu, misses: %lu)\n",
+        warmup.getRequests.load(),
+        warmup.getHits.load(),
+        warmup.getMisses.load());
+    printf("  SET requests: %lu\n", warmup.setRequests.load());
+    printf("  Total ops:    %lu\n", warmupTotalOps);
+    printf("\n");
   }
 }
 

--- a/packages/ucache_bench/server/UcacheBenchServer.h
+++ b/packages/ucache_bench/server/UcacheBenchServer.h
@@ -9,6 +9,7 @@
 
 #include <cachelib/allocator/CacheAllocator.h>
 #include <folly/futures/Future.h>
+#include <atomic>
 #include <memory>
 #include <string>
 #ifdef OSS_BUILD
@@ -22,6 +23,41 @@ namespace ucachebench {
 
 using CacheAllocator = facebook::cachelib::Lru5B2QAllocator;
 using PoolId = facebook::cachelib::PoolId;
+
+/**
+ * Metrics tracking for a single benchmark phase (warmup or benchmark).
+ * All counters are atomic for thread-safe updates from multiple IO threads.
+ */
+struct PhaseMetrics {
+  std::atomic<uint64_t> getRequests{0};
+  std::atomic<uint64_t> getHits{0};
+  std::atomic<uint64_t> getMisses{0};
+  std::atomic<uint64_t> setRequests{0};
+  std::atomic<uint64_t> deleteRequests{0};
+
+  void reset() {
+    getRequests.store(0);
+    getHits.store(0);
+    getMisses.store(0);
+    setRequests.store(0);
+    deleteRequests.store(0);
+  }
+};
+
+// CPU architecture enum for production-like cache configurations
+// Each profile is tuned for specific CPU characteristics and memory capacity
+enum class CpuArchitecture {
+  DEFAULT, // Basic config without production tuning
+  TURIN, // AMD Turin/Trento - high core count, 256GB+ RAM
+  SKYLAKE, // Intel Skylake - 64GB RAM
+  SAPPHIRE_RAPIDS, // Intel Sapphire Rapids - 128GB RAM
+};
+
+// Convert string to CpuArchitecture
+CpuArchitecture parseCpuArchitecture(const std::string& str);
+
+// Get string representation of CpuArchitecture
+const char* cpuArchitectureToString(CpuArchitecture type);
 
 struct UcacheBenchConfig {
   // Basic cache settings
@@ -99,12 +135,50 @@ class UcacheBenchServer {
 
   void printStats();
 
+  // Phase-based metric tracking for multi-client coordination
+  enum class TrackingPhase {
+    NONE, // Not tracking (before warmup starts)
+    WARMUP, // Tracking warmup phase
+    BENCHMARK // Tracking benchmark phase
+  };
+
+  // Set the current tracking phase and reset corresponding metrics
+  void setTrackingPhase(TrackingPhase phase);
+
+  // Get current tracking phase
+  TrackingPhase getTrackingPhase() const {
+    return currentPhase_.load();
+  }
+
+  // Get metrics for warmup phase
+  const PhaseMetrics& getWarmupMetrics() const {
+    return warmupMetrics_;
+  }
+
+  // Get metrics for benchmark phase
+  const PhaseMetrics& getBenchmarkMetrics() const {
+    return benchmarkMetrics_;
+  }
+
+  // Print final results in parseable format for benchpress
+  void printFinalResults(double benchmarkDurationSec) const;
+
  private:
   void setupCacheLib();
+
+  // Increment metrics based on current phase
+  void recordGet(bool hit);
+  void recordSet();
+  void recordDelete();
 
   UcacheBenchConfig config_;
   std::unique_ptr<CacheAllocator> cache_;
   PoolId poolId_{};
+
+  // Phase-based metric tracking
+  std::atomic<TrackingPhase> currentPhase_{TrackingPhase::NONE};
+  PhaseMetrics warmupMetrics_;
+  PhaseMetrics benchmarkMetrics_;
 };
 
 } // namespace ucachebench

--- a/packages/ucache_bench/server/main.cpp
+++ b/packages/ucache_bench/server/main.cpp
@@ -13,6 +13,7 @@
 #include <signal.h>
 #include <memory>
 
+#include "UcacheBenchAdminServer.h"
 #include "UcacheBenchOnRequest.h"
 #include "UcacheBenchRpcServer.h"
 #include "UcacheBenchServer.h"
@@ -23,6 +24,20 @@
 #endif
 
 DEFINE_uint32(port, 11212, "Port to listen on");
+
+// Admin server flags for multi-client coordination
+DEFINE_int32(
+    admin_port,
+    -1,
+    "Admin port for multi-client coordination (-1 = auto, uses port+1 when num_clients > 0; 0 = disabled)");
+DEFINE_uint32(
+    num_clients,
+    0,
+    "Number of clients expected to connect (enables admin server when > 0)");
+DEFINE_uint32(
+    timeout_seconds,
+    600,
+    "Timeout in seconds for waiting for clients (0 = no timeout)");
 DEFINE_bool(verbose, false, "Enable verbose logging");
 
 // CacheLib configuration flags
@@ -135,10 +150,16 @@ using namespace facebook::ucachebench;
 
 namespace {
 bool shutdown_requested = false;
+UcacheBenchAdminServer* g_adminServer = nullptr;
 
 void signal_handler(int sig) {
   fprintf(stderr, "Received signal %d, shutting down\n", sig);
   shutdown_requested = true;
+
+  // If admin server is running, request it to shutdown
+  if (g_adminServer) {
+    g_adminServer->requestShutdown();
+  }
 }
 
 void setup_signal_handlers() {
@@ -155,8 +176,8 @@ void setup_signal_handlers() {
   }
 }
 
-std::unique_ptr<UcacheBenchRpcServer> makeAndStartUcacheBenchRpcServer() {
-  // Create configuration from flags
+// Create configuration from command-line flags
+UcacheBenchConfig createConfigFromFlags() {
   UcacheBenchConfig config;
 
   // Basic settings
@@ -199,9 +220,11 @@ std::unique_ptr<UcacheBenchRpcServer> makeAndStartUcacheBenchRpcServer() {
   config.navy_clean_region_threads = FLAGS_navy_clean_region_threads;
   config.navy_metadata_size_mb = FLAGS_navy_metadata_size_mb;
 
-  // Create the benchmark server with configuration
-  auto server = std::make_shared<UcacheBenchServer>(config);
+  return config;
+}
 
+std::unique_ptr<UcacheBenchRpcServer> makeAndStartUcacheBenchRpcServer(
+    std::shared_ptr<UcacheBenchServer> server) {
   if (FLAGS_verbose) {
     printf("Server initialized successfully. Starting server...\n");
     server->printStats(); // Print initial cache stats
@@ -255,23 +278,121 @@ int main(int argc, char** argv) {
 
   setup_signal_handlers();
 
+  // Validate port flags
+  if (FLAGS_port > 65535) {
+    fprintf(
+        stderr, "Error: --port must be less than 65536 (got %u)\n", FLAGS_port);
+    return 1;
+  }
+
   if (FLAGS_verbose) {
     printf("Starting UcacheBench server on port %u\n", FLAGS_port);
   }
 
+  // Auto-compute admin_port if num_clients > 0 and admin_port not explicitly
+  // set
+  int32_t effectiveAdminPort = FLAGS_admin_port;
+  if (FLAGS_num_clients > 0 && FLAGS_admin_port == -1) {
+    effectiveAdminPort = static_cast<int32_t>(FLAGS_port) + 1;
+    printf(
+        "[Server] Multi-client mode enabled: admin_port auto-set to %d (port + 1)\n",
+        effectiveAdminPort);
+  } else if (FLAGS_admin_port == -1) {
+    // No multi-client mode, disable admin server
+    effectiveAdminPort = 0;
+  }
+
+  // Validate admin server flags
+  if (effectiveAdminPort > 65535) {
+    fprintf(
+        stderr,
+        "Error: --admin_port must be less than 65536 (got %d)\n",
+        effectiveAdminPort);
+    return 1;
+  }
+  if (effectiveAdminPort > 0 && FLAGS_num_clients == 0) {
+    fprintf(
+        stderr,
+        "Error: --num_clients is required when --admin_port is specified\n");
+    return 1;
+  }
+
   try {
+    // Create the cache server configuration and instance first
+    auto config = createConfigFromFlags();
+    auto server = std::make_shared<UcacheBenchServer>(config);
+
     if (FLAGS_verbose) {
       printf("UcacheBenchRpcServer starting\n");
     }
-    auto ucacheBenchRpcServer = makeAndStartUcacheBenchRpcServer();
+    auto ucacheBenchRpcServer = makeAndStartUcacheBenchRpcServer(server);
     if (FLAGS_verbose) {
       printf("UcacheBenchRpcServer started\n");
     }
 
-    // Wait for shutdown signal
-    folly::EventBase* evb = folly::EventBaseManager::get()->getEventBase();
-    while (!shutdown_requested) {
-      evb->loopOnce();
+    // Set up admin server for multi-client coordination if enabled
+    std::unique_ptr<UcacheBenchAdminServer> adminServer;
+    if (effectiveAdminPort > 0) {
+      adminServer = std::make_unique<UcacheBenchAdminServer>(
+          static_cast<uint16_t>(effectiveAdminPort),
+          FLAGS_num_clients,
+          FLAGS_timeout_seconds);
+
+      // Set global pointer for signal handler
+      g_adminServer = adminServer.get();
+
+      // Set up phase change callback for metric tracking
+      adminServer->setPhaseChangeCallback([server](
+                                              UcacheBenchAdminServer::Phase
+                                                  phase) {
+        switch (phase) {
+          case UcacheBenchAdminServer::Phase::WARMUP:
+            printf(
+                "[Main] Phase changed to WARMUP - starting warmup stats tracking\n");
+            server->setTrackingPhase(UcacheBenchServer::TrackingPhase::WARMUP);
+            break;
+          case UcacheBenchAdminServer::Phase::BENCHMARK:
+            printf(
+                "[Main] Phase changed to BENCHMARK - starting benchmark stats tracking\n");
+            server->setTrackingPhase(
+                UcacheBenchServer::TrackingPhase::BENCHMARK);
+            break;
+          default:
+            break;
+        }
+      });
+
+      // Set up print results callback
+      adminServer->setPrintResultsCallback([&adminServer, server]() {
+        auto benchmarkStart = adminServer->getBenchmarkStartTime();
+        auto benchmarkEnd = adminServer->getBenchmarkEndTime();
+        auto durationMs = std::chrono::duration_cast<std::chrono::milliseconds>(
+                              benchmarkEnd - benchmarkStart)
+                              .count();
+        double durationSec = durationMs / 1000.0;
+
+        // Print results from the cache server
+        server->printFinalResults(durationSec);
+      });
+
+      adminServer->start();
+    }
+
+    // If admin server is enabled, wait for it to complete
+    // Otherwise, wait for shutdown signal
+    if (adminServer) {
+      bool completed = adminServer->waitForCompletion();
+      if (!completed) {
+        printf("Admin server timed out or failed\n");
+      }
+      // Stop the admin server
+      adminServer->stop();
+    } else {
+      // Wait for shutdown signal
+      folly::EventBase* evb = folly::EventBaseManager::get()->getEventBase();
+      while (!shutdown_requested) {
+        evb->loopOnce();
+      }
     }
 
     if (FLAGS_verbose) {


### PR DESCRIPTION
Summary:
UcacheBench currently only supports single-client benchmarks, which doesn't reflect production ucache deployments where multiple clients connect to a single server. This diff adds multi-client coordination support to the ucachebench benchmark infrastructure.

Key changes:
- **Admin server** (`UcacheBenchAdminServer`): A new TCP-based coordination server that runs alongside the cache server. It manages client registration, phase synchronization (REGISTER → WARMUP → BENCHMARK), and aggregated result reporting.
- **Client admin connection** (`AdminConnection`): Clients can now connect to the admin port to register, synchronize warmup/benchmark phases, and report completion.
- **Server-side result reporting**: In multi-client mode, the server tracks aggregate metrics (QPS, hit ratio, operations) across all clients and outputs combined results directly, eliminating the need for client-side result merging.
- **Updated run.py**: The benchmark runner now passes through all server and client configuration flags (RPC threads, CPU pinning, admin port, num_clients, etc.) instead of auto-calculating values, giving full control to the caller.
- **Updated jobs_internal.yml**: Added all new server and client flags as benchpress job variables with sensible defaults.
- **Updated parser**: `UcacheBenchParser` can now parse both client-side output and server-side aggregated results.

Differential Revision: D92957631


