### PR TITLE
Bump APL ver to 26.01 and ACL ver to 52.8.0

### DIFF
--- a/packages/wdl_bench/common.sh
+++ b/packages/wdl_bench/common.sh
@@ -10,7 +10,7 @@ WDL_SOURCE="${WDL_ROOT}/wdl_sources"
 WDL_BUILD="${WDL_ROOT}/wdl_build"
 WDL_DATASETS="${WDL_ROOT}/datasets"
 MKL_VERSION="2025.3.0.462"
-ARMPL_VERSION="25.07.1"
+ARMPL_VERSION="26.01"
 # Determine OS version
 LINUX_DIST_ID="$(awk -F "=" '/^ID=/ {print $2}' /etc/os-release | tr -d '"')"
 

--- a/packages/wdl_bench/install_wdl_bench.sh
+++ b/packages/wdl_bench/install_wdl_bench.sh
@@ -85,7 +85,7 @@ declare -A TAGS=(
     ['isa-l']='d36de972efc18f2e85ca182a8b6758ecc7da512b'
     ['sleef']='3.8'
     ['aocl']='AOCL-5.2'
-    ['acl']='v52.7.0'
+    ['acl']='v52.8.0'
     ['onednn']='v3.10.2'
 )
 
@@ -459,7 +459,7 @@ build_gemm()
             bash -c "./arm-performance-libraries_${ARMPL_VERSION}_rpm/arm-performance-libraries_${ARMPL_VERSION}_rpm.sh --accept --install-to ./apl"
         fi
         module use apl/modulefiles
-        module load "armpl/${ARMPL_VERSION}_gcc"
+        module load "armpl/${ARMPL_VERSION}.0_gcc"
         lib='gemm_bench' # reset lib to gemm_bench
         cmake -S "$BPKGS_WDL_ROOT/$lib" -B "$lib-build" -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_RPATH="${ARMPL_LIBRARIES};${WDL_BUILD}/acl/lib64;${WDL_BUILD}/acl/lib" -DCMAKE_CXX_FLAGS="-I${WDL_BUILD}/acl/include -L ${WDL_BUILD}/acl/lib64 -L ${WDL_BUILD}/acl/lib" && cmake --build "$lib-build"
         cp "$lib-build/$lib" "${WDL_ROOT}/" || exit 1


### PR DESCRIPTION
Summary: as titled, update APL version to 26.01 and ACL version to v52.8.0.

Differential Revision: D92982424


