### PR TITLE
Move ucache_bench definitions from internal to main config files

### DIFF
--- a/benchpress/config/benchmarks.yml
+++ b/benchpress/config/benchmarks.yml
@@ -151,3 +151,39 @@ sleep:
   path: /usr/bin/sleep
   parser: returncode
   metrics: []
+
+ucache_bench:
+  parser: ucache_bench
+  install_script: ./packages/ucache_bench/install_ucache_bench.sh
+  cleanup_script: ./packages/ucache_bench/cleanup_ucache_bench.sh
+  path: ./packages/ucache_bench/run.py
+  roles:
+    - server
+    - client
+  tags:
+    scope:
+      - app
+      - cache
+    component:
+      - cpu
+      - memory
+  metrics:
+    - qps
+    - hit_ratio_percent
+    - latency:
+        - p50
+        - p95
+        - p99
+        - p99_9
+    - get_operations
+    - set_operations
+    - get_hits
+    - get_misses
+    - get_errors
+    - set_successes
+    - set_errors
+    - warmup:
+        - success
+        - qps
+        - total_operations
+        - success_rate_percent

--- a/benchpress/config/jobs.yml
+++ b/benchpress/config/jobs.yml
@@ -1395,3 +1395,186 @@
     - '{duration}'
   vars:
     - 'duration'
+
+- benchmark: ucache_bench
+  name: ucache_bench_memory
+  description: UcacheBench - Memory-only cache benchmark using CacheLib
+  roles:
+    server:
+      args:
+        - 'server'
+        - '--port={port}'
+        - '--memory-mb={memory_mb}'
+        - '--hash-power={hash_power}'
+        - '--pool-name={pool_name}'
+        - '--cache-mode=memory'
+        - '--warmup-time={warmup_time}'
+        - '--test-time={test_time}'
+        - '--verbose={verbose}'
+        - '--real'
+      vars:
+        - 'port=11211'
+        - 'memory_mb=1024'
+        - 'hash_power=20'
+        - 'pool_name=default'
+        - 'warmup_time=10'
+        - 'test_time=60'
+        - 'verbose=false'
+    client:
+      args:
+        - 'client'
+        - '--server-hostname={server_hostname}'
+        - '--server-port={server_port}'
+        - '--key-count={key_count}'
+        - '--value-size-min={value_size_min}'
+        - '--value-size-max={value_size_max}'
+        - '--get-ratio={get_ratio}'
+        - '--qps-target={qps_target}'
+        - '--warmup-time={warmup_time}'
+        - '--test-time={test_time}'
+        - '--verbose={verbose}'
+        - '--real'
+      vars:
+        - 'server_hostname'
+        - 'server_port=11211'
+        - 'key_count=100000'
+        - 'value_size_min=64'
+        - 'value_size_max=1024'
+        - 'get_ratio=0.9'
+        - 'qps_target=0'
+        - 'warmup_time=10'
+        - 'test_time=60'
+        - 'verbose=false'
+  hooks:
+    - hook: copymove
+      options:
+        is_move: true
+        after:
+          - 'perf.data'
+
+- benchmark: ucache_bench
+  name: ucache_bench_hybrid
+  description: UcacheBench - Hybrid RAM+SSD cache benchmark using CacheLib
+  roles:
+    server:
+      args:
+        - 'server'
+        - '--port={port}'
+        - '--memory-mb={memory_mb}'
+        - '--hash-power={hash_power}'
+        - '--pool-name={pool_name}'
+        - '--cache-mode=hybrid'
+        - '--ssd-cache-path={ssd_cache_path}'
+        - '--ssd-cache-size-mb={ssd_cache_size_mb}'
+        - '--ssd-block-size={ssd_block_size}'
+        - '--ssd-region-size-mb={ssd_region_size_mb}'
+        - '--ssd-clean-regions-pool={ssd_clean_regions_pool}'
+        - '--ssd-device-max-write-rate={ssd_device_max_write_rate}'
+        - '--ssd-truncate-file={ssd_truncate_file}'
+        - '--warmup-time={warmup_time}'
+        - '--test-time={test_time}'
+        - '--verbose={verbose}'
+        - '--real'
+      vars:
+        - 'port=11211'
+        - 'memory_mb=1024'
+        - 'hash_power=20'
+        - 'pool_name=hybrid'
+        - 'ssd_cache_path=/tmp/ucachebench_ssd'
+        - 'ssd_cache_size_mb=4096'
+        - 'ssd_block_size=4096'
+        - 'ssd_region_size_mb=16'
+        - 'ssd_clean_regions_pool=4'
+        - 'ssd_device_max_write_rate=0'
+        - 'ssd_truncate_file=true'
+        - 'warmup_time=30'
+        - 'test_time=300'
+        - 'verbose=true'
+    client:
+      args:
+        - 'client'
+        - '--server-hostname={server_hostname}'
+        - '--server-port={server_port}'
+        - '--key-count={key_count}'
+        - '--value-size-min={value_size_min}'
+        - '--value-size-max={value_size_max}'
+        - '--get-ratio={get_ratio}'
+        - '--qps-target={qps_target}'
+        - '--warmup-time={warmup_time}'
+        - '--test-time={test_time}'
+        - '--verbose={verbose}'
+        - '--real'
+      vars:
+        - 'server_hostname'
+        - 'server_port=11211'
+        - 'key_count=1000000'
+        - 'value_size_min=128'
+        - 'value_size_max=2048'
+        - 'get_ratio=0.95'
+        - 'qps_target=5000'
+        - 'warmup_time=30'
+        - 'test_time=300'
+        - 'verbose=true'
+  hooks:
+    - hook: copymove
+      options:
+        is_move: true
+        after:
+          - 'perf.data'
+
+- benchmark: ucache_bench
+  name: ucache_bench_custom
+  description: UcacheBench - Cache benchmark with custom parameters
+  roles:
+    server:
+      args:
+        - 'server'
+        - '--port={port}'
+        - '--memory-mb={memory_mb}'
+        - '--hash-power={hash_power}'
+        - '--pool-name={pool_name}'
+        - '--cache-mode={cache_mode}'
+        - '--warmup-time={warmup_time}'
+        - '--test-time={test_time}'
+        - '--verbose={verbose}'
+        - '--real'
+      vars:
+        - 'port=11211'
+        - 'memory_mb=2048'
+        - 'hash_power=22'
+        - 'pool_name=benchmark'
+        - 'cache_mode=memory'
+        - 'warmup_time=30'
+        - 'test_time=300'
+        - 'verbose=true'
+    client:
+      args:
+        - 'client'
+        - '--server-hostname={server_hostname}'
+        - '--server-port={server_port}'
+        - '--key-count={key_count}'
+        - '--value-size-min={value_size_min}'
+        - '--value-size-max={value_size_max}'
+        - '--get-ratio={get_ratio}'
+        - '--qps-target={qps_target}'
+        - '--warmup-time={warmup_time}'
+        - '--test-time={test_time}'
+        - '--verbose={verbose}'
+        - '--real'
+      vars:
+        - 'server_hostname'
+        - 'server_port=11211'
+        - 'key_count=1000000'
+        - 'value_size_min=128'
+        - 'value_size_max=2048'
+        - 'get_ratio=0.95'
+        - 'qps_target=10000'
+        - 'warmup_time=30'
+        - 'test_time=300'
+        - 'verbose=true'
+  hooks:
+    - hook: copymove
+      options:
+        is_move: true
+        after:
+          - 'perf.data'


### PR DESCRIPTION
Summary:
## Instructions about RACER Diffs:
**Commandeer this diff (recommended) or land with accept2ship tag.**

**This diff was generated by Racer AI agent on behalf of [Yupeng Tang](https://www.internalfb.com/profile/view/1242827886858623) for T255377166. If the diff quality is poor, consider contacting the user to provide clearer instructions on the task.**




- If you are happy with the changes, commandeer it if minor edits are needed. (**we encourage commandeer to get the diff credit**)
- If you are not happy with the changes, please comment on the diff with clear actions and send it back to the author. Racer will pick it up and re-generate.
- If you really feel the Racer is not helping with this change (alas, some complex changes are hard for AI) feel free to abandon this diff.
- **For M10N reviewers:** as you review AI-generated diffs, we ask you to give them the same priority as human-generated diffs, and take action in a timely manner by either accepting, rejecting, or resigning as a reviewer. For diffs that don't meet the quality bar (e.g. code doesn't compile, not readable or introduces functionality regressions), we ask that you use the following hashtags to provide clear signals to improve our tools - `#monlowqualitydiff` `#monwrongreviewerdiff`

## Summary:
Moves the `ucache_bench` benchmark and job definitions from internal config files to the main config files:

- **benchmarks.yml**: Added `ucache_bench` benchmark definition (parser, install/cleanup scripts, path, roles, tags, metrics)
- **benchmarks_internal.yml**: Removed the same `ucache_bench` benchmark definition
- **jobs.yml**: Added three job definitions: `ucache_bench_memory`, `ucache_bench_hybrid`, `ucache_bench_custom`
- **jobs_internal.yml**: Removed the same three job definitions

This addresses the review comment on D92957631 requesting these definitions be available outside internal-only configurations, and the reviewer feedback on v1 of this diff requesting removal of the old definitions from the internal files.
---
> Generated by [RACER](https://www.internalfb.com/wiki/RACER_(Risk-Aware_Code_Editing_and_Refactoring)/), powered by [Confucius](https://www.internalfb.com/wiki/Confucius/Analect/Shared_Analects/Confucius_Code_Assist_(CCA)/)
[Session](https://www.internalfb.com/confucius?session_id=c64707b4-0845-11f1-bf50-95a9a7d7a6c3&tab=Chat), [Trace](https://www.internalfb.com/confucius?session_id=c64707b4-0845-11f1-bf50-95a9a7d7a6c3&tab=Trace)

Differential Revision: D93121388


