### PR TITLE
Improved install detection

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ benchmarks/
 
 # benchmarks install log
 benchmark_installs.txt
+installed.txt
 
 # Byte-compiled / optimized / DLL files
 __pycache__/

--- a/benchpress/cli/commands/install.py
+++ b/benchpress/cli/commands/install.py
@@ -66,7 +66,7 @@ class InstallCommand(BenchpressCommand):
                 elif retcode == 0:
                     install_log.write("Tool {} already installed \n".format(hook[0]))
                     click.echo("Tool {} already installed".format(hook[0]))
-            if args.force or not verify_install(job.install_script):
+            if args.force or not verify_install(job):
                 install_log.write(
                     "Installing benchmark for {}: {}\n".format(
                         job.name, job.description

--- a/benchpress/cli/commands/run.py
+++ b/benchpress/cli/commands/run.py
@@ -195,7 +195,7 @@ class RunCommand(BenchpressCommand):
                 exit(1)
 
         for job in jobs:
-            if not verify_install(job.install_script):
+            if not verify_install(job):
                 logger.error("Benchmark {} not installed".format(job.name))
                 continue
             click.echo('Running "{}": {}'.format(job.name, job.description), err=True)

--- a/benchpress/config/benchmarks.yml
+++ b/benchpress/config/benchmarks.yml
@@ -6,6 +6,10 @@ oss_performance_mediawiki:
   parser: mediawiki
   install_script: ./packages/mediawiki/install_oss_performance_mediawiki.sh
   cleanup_script: ./packages/mediawiki/cleanup_oss_performance_mediawiki.sh
+  install_markers:
+    - ./oss-performance/perf.php
+    - ./oss-performance/base/PerfRunner.php
+    - ./oss-performance/composer.phar
   path: ./packages/mediawiki/run.sh
   tags:
     scope:
@@ -19,6 +23,15 @@ django_workload:
   parser: django_workload
   install_script: ./packages/django_workload/install_django_workload.sh
   cleanup_script: ./packages/django_workload/cleanup_django_workload.sh
+  install_markers:
+    - ./benchmarks/django_workload/bin/run.sh
+    - ./benchmarks/django_workload/proxygen_binding/proxygen_binding*.so
+    - ./benchmarks/django_workload/django-workload/django-workload/django_workload/thrift/build/gen-py3/mock_services/MockAdsService-remote
+    - ./benchmarks/django_workload/django-workload/django-workload/django_workload/feed_timeline.py
+    - ./benchmarks/django_workload/django-workload/django-workload/cinder/cinder-build/bin/python3.10
+    - ./benchmarks/django_workload/django-workload/django-workload/Python-3.10.2/python-build/bin/python3.10
+    - ./benchmarks/django_workload/wrk/wrk
+    - ./benchmarks/django_workload/apache-cassandra/bin/cassandra
   path: ./benchmarks/django_workload/bin/run.sh
   tags:
     scope:
@@ -32,6 +45,9 @@ tao_bench:
   parser: tao_bench
   install_script: ./packages/tao_bench/install_tao_bench.sh
   cleanup_script: ./packages/tao_bench/cleanup_tao_bench.sh
+  install_markers:
+    - ./benchmarks/tao_bench/tao_bench_server
+    - ./benchmarks/tao_bench/tao_bench_client
   path: ./packages/tao_bench/run.py
   tags:
     scope:
@@ -77,6 +93,9 @@ feedsim:
   parser: feedsim
   install_script: ./packages/feedsim/install_feedsim.sh
   cleanup_script: ./packages/feedsim/cleanup_feedsim.sh
+  install_markers:
+    - ./benchmarks/feedsim/src/build/workloads/ranking/LeafNodeRank
+    - ./benchmarks/feedsim/src/build/workloads/ranking/DriverNodeRank
   path: ./benchmarks/feedsim/run.sh
   tags:
     scope:
@@ -116,6 +135,10 @@ spark_standalone:
   parser: spark_standalone
   install_script: ./packages/spark_standalone/install_spark_standalone.sh
   cleanup_script: ./packages/spark_standalone/cleanup_spark_standalone.sh
+  install_markers:
+    - ./benchmarks/spark_standalone/spark-4.0.1-bin-hadoop3/bin/spark-sql
+    - ./benchmarks/spark_standalone/scripts/run_perf_common.py
+    - /usr/lib/jvm/graalvm-community-openjdk-17.0.9+9.1/bin/java
   path: ./packages/spark_standalone/templates/runner.py
   tags:
     scope:

--- a/benchpress/config/benchmarks_ai.yml
+++ b/benchpress/config/benchmarks_ai.yml
@@ -10,6 +10,10 @@ rebatch:
   parser: rebatch
   install_script: ./packages/ai_wdl/rebatch/install_rebatch.sh
   cleanup_script: ./packages/ai_wdl/rebatch/cleanup_rebatch.sh
+  install_markers:
+    - ./benchmarks/ai_wdl/rebatch/rebatchBench
+    - ./benchmarks/ai_wdl/rebatch/model_a.dist
+    - ./benchmarks/ai_wdl/rebatch/model_b.dist
   path: ./benchmarks/ai_wdl/rebatch/rebatchBench
   metrics:
     - bandwidth
@@ -19,6 +23,10 @@ chm:
   parser: chm
   install_script: ./packages/ai_wdl/chm/install_chm.sh
   cleanup_script: ./packages/ai_wdl/chm/cleanup_chm.sh
+  install_markers:
+    - ./benchmarks/ai_wdl/chm/chm_bench
+    - ./benchmarks/ai_wdl/chm/model_a.dist
+    - ./benchmarks/ai_wdl/chm/model_b.dist
   path: ./benchmarks/ai_wdl/chm/chm_bench
   metrics:
     - Mops/sec
@@ -28,6 +36,10 @@ deser:
   install_script: ./packages/ai_wdl/deser/install_deser.sh
   cleanup_script: ./packages/ai_wdl/deser/cleanup_deser.sh
   path: ./benchmarks/ai_wdl/deser/deser_bench
+  install_markers:
+    - ./benchmarks/ai_wdl/deser/deser_bench
+    - ./benchmarks/ai_wdl/deser/model_a.dist
+    - ./benchmarks/ai_wdl/deser/model_b.dist
   metrics:
     - Mops/sec
 

--- a/benchpress/lib/job.py
+++ b/benchpress/lib/job.py
@@ -76,6 +76,7 @@ class Job:
         self.description = job_config["description"]
         self.install_script = benchmark_config.get("install_script", "")
         self.cleanup_script = benchmark_config.get("cleanup_script", "")
+        self.install_markers = benchmark_config.get("install_markers", [])
         self.stdout = job_config.get("stdout", "")
         self.uuid = job_config.get("uuid", "")
         self.timestamp = job_config["timestamp"]

--- a/benchpress/lib/util.py
+++ b/benchpress/lib/util.py
@@ -5,6 +5,7 @@
 # LICENSE file in the root directory of this source tree.
 
 import errno
+import glob
 import multiprocessing
 import os
 import pathlib
@@ -55,16 +56,52 @@ def issue_background_command(cmd, stdout, stderr, env=None):
     return proc
 
 
-def verify_install(install_script):
-    if not install_script:
-        # install_script not set means this "benchmark" does not need installation
+def install_list_contains(installer_name: str) -> bool:
+    if not installer_name:
         return True
-    if os.path.exists("benchmark_installs.txt"):
-        with open("benchmark_installs.txt", "r") as benchmark_installs:
-            for benchmark_install in benchmark_installs:
-                if install_script.strip() == benchmark_install.strip():
+    if os.path.exists("installed.txt"):
+        with open("installed.txt", "r") as installs_file:
+            for installed_script in installs_file:
+                if installer_name.strip() == installed_script.strip():
                     return True
     return False
+
+
+def install_list_append(installer_name: str):
+    if not install_list_contains(installer_name):
+        with open("installed.txt", "a") as installs_file:
+            # Note: we could os.path.expandvars() to match the echo approach
+            installs_file.write(installer_name + "\n")
+
+
+def install_list_remove(installer_name: str):
+    if os.path.exists("installed.txt"):
+        with open("installed.txt", "r") as benchmark_installs_fp:
+            lines = benchmark_installs_fp.readlines()
+        with open("installed.txt", "w") as benchmark_installs_fp:
+            for line in lines:
+                if line.strip() != installer_name.strip():
+                    benchmark_installs_fp.write(line)
+
+
+def verify_install(job) -> bool:
+    """
+    If the yaml file provided install markers, any marker being missing will
+    lead to this function returning False. Assuming no markers are provided,
+    this function checks installed.txt for a record of the install script
+    being run. The actual binary is allways checked for existance.
+
+    Arguments
+        - job is a Benchpress Job. Class is defined in lib/job.py
+    """
+
+    if job.install_markers:
+        return all(glob.glob(marker) for marker in job.install_markers)
+    elif job.install_script:
+        return install_list_contains(job.install_script)
+    else:
+        # No install markers and no install script --> assume installed
+        return True
 
 
 def output_catcher(reader, writer=None):
@@ -108,16 +145,7 @@ def install_benchmark(install_script, args=None, env=None, install_log=None):
     stderr_catcher.join()
 
     if install_benchmark_proc.returncode == 0:
-        verify_install_cmd_1 = ["touch", "benchmark_installs.txt"]
-        verify_install_proc_1 = subprocess.Popen(verify_install_cmd_1, shell=False)
-        verify_install_proc_1.wait()
-        benchmark_installs_fp = open("benchmark_installs.txt", "a+")
-        verify_install_cmd_2 = ["echo", install_script]
-        verify_install_proc_2 = subprocess.Popen(
-            verify_install_cmd_2, stdout=benchmark_installs_fp, shell=False
-        )
-        verify_install_proc_2.wait()
-        benchmark_installs_fp.close()
+        install_list_append(install_script)
     else:
         cmd_str = " ".join(install_benchmark_cmd)
         raise Exception(f"Failed to run '{cmd_str}'")
@@ -128,7 +156,7 @@ def install_benchmark(install_script, args=None, env=None, install_log=None):
 def install_tool(tool_name):
     install_script = "install_tool_" + tool_name + ".sh"
     if os.path.exists(install_script):
-        if verify_install(install_script):
+        if install_list_contains(install_script):
             return 0
         else:
             install_benchmark(install_script)
@@ -153,14 +181,7 @@ def clean_benchmark(clean_script, install_script):
     clean_benchmark_proc = subprocess.Popen(clean_benchmark_cmd, shell=False)
     clean_benchmark_proc.wait()
     if clean_benchmark_proc.returncode == 0:
-        if os.path.exists("benchmark_installs.txt"):
-            with open("benchmark_installs.txt", "r") as benchmark_installs_fp:
-                lines = benchmark_installs_fp.readlines()
-            with open("benchmark_installs.txt", "w") as benchmark_installs_fp:
-                for line in lines:
-                    if line.strip("\n") != install_script:
-                        benchmark_installs_fp.write(line)
-                benchmark_installs_fp.close()
+        install_list_remove(install_script)
 
 
 def clean_tool(tool_name):


### PR DESCRIPTION
Summary:
Adding a better way to determine if a benchmark has been installed.

Added install_markers (AKA Key Workload Components from the task) to the yaml files, added install_markers to the Job class, and modified the relevant util functions to accept jobs instead of strings.

Note that install_markers are checked using glob, and accept wildcards.

Renamed benchmark_installs.txt to be more general (As it also seems to manage the install of hooks), and added gitignore for the new name.

Differential Revision: D92906290
