### PR TITLE
Update Spark URI

### DIFF
--- a/packages/spark_standalone/install_spark_standalone.sh
+++ b/packages/spark_standalone/install_spark_standalone.sh
@@ -39,7 +39,7 @@ fi
 # download spark
 pushd "${OUT}" || exit 1
 if [ ! -f spark-4.0.1-bin-hadoop3.tgz ]; then
-  wget https://dlcdn.apache.org/spark/spark-4.0.1/spark-4.0.1-bin-hadoop3.tgz
+  wget https://archive.apache.org/dist/spark/spark-4.0.1/spark-4.0.1-bin-hadoop3.tgz
 fi
 tar xzf spark-4.0.1-bin-hadoop3.tgz
 popd || exit 1


### PR DESCRIPTION
Summary: The URI for Spark 4.0.1 bin hadoop3 is now a 404 as the resource has now been moved to the archive. This change updates the install link to point at the new location.

Differential Revision: D93281141


