### PR TITLE
migrate rename to folly::available_concurrency (assorted)

### DIFF
--- a/packages/ucache_bench/server/CpuManager.cpp
+++ b/packages/ucache_bench/server/CpuManager.cpp
@@ -65,7 +65,7 @@ void CpuManager::discoverAvailableCpus() {
   }
 
   // Fallback: use hardware concurrency
-  unsigned int numCpus = folly::hardware_concurrency();
+  unsigned int numCpus = folly::available_concurrency();
   if (numCpus == 0) {
     numCpus = 1;
   }


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookincubator/nimble/pull/484

The name `hardware_concurrency`, while parallel to `std::thread::hardware_concurrency`, may be misleading. Migrate to the name `available_concurrency`.

Reviewed By: Magoja

Differential Revision: D93262843


