### PR TITLE
Fix OSS build cpp_include path handling

### DIFF
--- a/packages/ucache_bench/install_ucache_bench.sh
+++ b/packages/ucache_bench/install_ucache_bench.sh
@@ -564,6 +564,8 @@ for f in "$PROTOCOL_GEN_DIR"/*.cpp "$PROTOCOL_GEN_DIR"/*.h "$PROTOCOL_GEN_DIR"/*
         sed -i 's|#include "cea/chips/benchpress/packages/ucache_bench/server/|#include "../server/|g' "$f"
         # Fix thrift include paths (for .thrift files)
         sed -i 's|include "cea/chips/benchpress/packages/ucache_bench/protocol/gen/|include "|g' "$f"
+        # Fix cpp_include paths (for .thrift files)
+        sed -i 's|cpp_include "cea/chips/benchpress/packages/ucache_bench/protocol/gen/|cpp_include "|g' "$f"
     fi
 done
 


### PR DESCRIPTION
Summary: The OSS build install script was missing sed handling for `cpp_include` directives in Thrift files, which caused build failures when the thrift compiler processed `UcacheBenchService.thrift` with hardcoded internal fbcode paths.

Reviewed By: excelle08

Differential Revision: D92609819


