### PR TITLE
CI fix, update zlib URI

### DIFF
--- a/packages/tao_bench/folly_zlib_uri.patch
+++ b/packages/tao_bench/folly_zlib_uri.patch
@@ -1,0 +1,13 @@
+diff --git a/build/fbcode_builder/manifests/zlib b/build/fbcode_builder/manifests/zlib
+index 8c52088db..559ce9ae7 100644
+--- a/build/fbcode_builder/manifests/zlib
++++ b/build/fbcode_builder/manifests/zlib
+@@ -16,7 +16,7 @@ zlib-ng-compat-devel
+ zlib-ng-compat-static
+ 
+ [download]
+-url = https://zlib.net/zlib-1.3.1.tar.gz
++url = https://zlib.net/fossils/zlib-1.3.1.tar.gz
+ sha256 = 9a93b2b7dfdac77ceba5a558a580e74667dd6fede4585b91eefb60f03b72df23
+ 
+ [build]

--- a/packages/tao_bench/install_tao_bench_aarch64.sh
+++ b/packages/tao_bench/install_tao_bench_aarch64.sh
@@ -103,6 +103,7 @@ else
 fi
 pushd folly
 git checkout v2024.06.24.00
+git apply "${BENCHPRESS_ROOT}/packages/tao_bench/folly_zlib_uri.patch"
 sed -i 's/FOLLY_ALWAYS_INLINE//g' "${TAO_BENCH_ROOT}/folly/folly/experimental/symbolizer/StackTrace.cpp"
 OPENSSL_ROOT_DIR="${TAO_BENCH_DEPS}" ./build/fbcode_builder/getdeps.py --allow-system-packages build \
     --extra-cmake-defines '{"CMAKE_LIBRARY_ARCHITECTURE": "aarch64"}' \

--- a/packages/tao_bench/install_tao_bench_x86_64.sh
+++ b/packages/tao_bench/install_tao_bench_x86_64.sh
@@ -99,6 +99,7 @@ else
 fi
 pushd folly
 git checkout v2024.06.24.00
+git apply "${BENCHPRESS_ROOT}/packages/tao_bench/folly_zlib_uri.patch"
 sed -i 's/FOLLY_ALWAYS_INLINE//g' "${TAO_BENCH_ROOT}/folly/folly/experimental/symbolizer/StackTrace.cpp"
 OPENSSL_ROOT_DIR="${TAO_BENCH_DEPS}" ./build/fbcode_builder/getdeps.py --allow-system-packages build \
     --scratch-path "${FOLLY_BUILD_ROOT}"


### PR DESCRIPTION
Summary:
Taobench fails in CI with an error message as shown in the second half of this paste: https://www.internalfb.com/phabricator/paste/view/P2192163122

This is similar to the fix D93488447 for top of trunk of folly, but using the same domain as nginx instead of github.

Differential Revision: D93624799


