### PR TITLE
Generate free function overloads for Carbon cpp.methods

### DIFF
--- a/packages/ucache_bench/protocol/gen/UcacheBenchMessages-inl.h
+++ b/packages/ucache_bench/protocol/gen/UcacheBenchMessages-inl.h
@@ -18,383 +18,503 @@ namespace ucachebench {
 namespace thrift {
 
 template <class Writer>
-void UcacheBenchRequestCommon::serialize(Writer&& writer) const {
+void serialize(const UcacheBenchRequestCommon& self, Writer&& writer) {
   writer.writeStructBegin();
-  writer.writeField(1 /* field id */, productId_ref());
-  writer.writeField(2 /* field id */, bucketId_ref());
+  writer.writeField(1 /* field id */, self.productId_ref());
+  writer.writeField(2 /* field id */, self.bucketId_ref());
   writer.writeFieldStop();
   writer.writeStructEnd();
+}
+
+template <class Writer>
+void UcacheBenchRequestCommon::serialize(Writer&& writer) const {
+  facebook::ucachebench::thrift::serialize(*this, std::forward<Writer>(writer));
+}
+
+template <class V>
+void visitFields(UcacheBenchRequestCommon& self, V&& v) {
+  if (!v.visitField(1, "productId", self.productId_ref())) {
+    return;
+  }
+  if (!v.visitField(2, "bucketId", self.bucketId_ref())) {
+    return;
+  }
+}
+
+template <class V>
+void visitFields(const UcacheBenchRequestCommon& self, V&& v) {
+  if (!v.visitField(1, "productId", self.productId_ref())) {
+    return;
+  }
+  if (!v.visitField(2, "bucketId", self.bucketId_ref())) {
+    return;
+  }
 }
 
 template <class V>
 void UcacheBenchRequestCommon::visitFields(V&& v) {
-  if (!v.visitField(1, "productId", this->productId_ref())) {
-    return;
-  }
-  if (!v.visitField(2, "bucketId", this->bucketId_ref())) {
-    return;
-  }
+  facebook::ucachebench::thrift::visitFields(*this, std::forward<V>(v));
 }
 
 template <class V>
 void UcacheBenchRequestCommon::visitFields(V&& v) const {
-  if (!v.visitField(1, "productId", this->productId_ref())) {
-    return;
-  }
-  if (!v.visitField(2, "bucketId", this->bucketId_ref())) {
-    return;
-  }
+  facebook::ucachebench::thrift::visitFields(*this, std::forward<V>(v));
+}
+
+template <class Writer>
+void serialize(const UcacheBenchReplyCommon& self, Writer&& writer) {
+  writer.writeStructBegin();
+  writer.writeField(1 /* field id */, self.replySourceBitMask_ref());
+  writer.writeFieldStop();
+  writer.writeStructEnd();
 }
 
 template <class Writer>
 void UcacheBenchReplyCommon::serialize(Writer&& writer) const {
-  writer.writeStructBegin();
-  writer.writeField(1 /* field id */, replySourceBitMask_ref());
-  writer.writeFieldStop();
-  writer.writeStructEnd();
+  facebook::ucachebench::thrift::serialize(*this, std::forward<Writer>(writer));
+}
+
+template <class V>
+void visitFields(UcacheBenchReplyCommon& self, V&& v) {
+  if (!v.visitField(1, "replySourceBitMask", *self.replySourceBitMask_ref())) {
+    return;
+  }
+}
+
+template <class V>
+void visitFields(const UcacheBenchReplyCommon& self, V&& v) {
+  if (!v.visitField(1, "replySourceBitMask", *self.replySourceBitMask_ref())) {
+    return;
+  }
 }
 
 template <class V>
 void UcacheBenchReplyCommon::visitFields(V&& v) {
-  if (!v.visitField(1, "replySourceBitMask", *this->replySourceBitMask_ref())) {
-    return;
-  }
+  facebook::ucachebench::thrift::visitFields(*this, std::forward<V>(v));
 }
 
 template <class V>
 void UcacheBenchReplyCommon::visitFields(V&& v) const {
-  if (!v.visitField(1, "replySourceBitMask", *this->replySourceBitMask_ref())) {
-    return;
-  }
+  facebook::ucachebench::thrift::visitFields(*this, std::forward<V>(v));
+}
+
+template <class Writer>
+void serialize(const UcbGetRequest& self, Writer&& writer) {
+  writer.writeStructBegin();
+  writer.writeField(-1 /* field id */, self.ucacheBenchRequestCommon_ref());
+  writer.writeField(1 /* field id */, self.key_ref());
+  writer.writeField(2 /* field id */, self.flags_ref());
+  writer.writeFieldStop();
+  writer.writeStructEnd();
 }
 
 template <class Writer>
 void UcbGetRequest::serialize(Writer&& writer) const {
-  writer.writeStructBegin();
-  writer.writeField(-1 /* field id */, ucacheBenchRequestCommon_ref());
-  writer.writeField(1 /* field id */, key_ref());
-  writer.writeField(2 /* field id */, flags_ref());
-  writer.writeFieldStop();
-  writer.writeStructEnd();
+  facebook::ucachebench::thrift::serialize(*this, std::forward<Writer>(writer));
 }
 
 template <class V>
-void UcbGetRequest::visitFields(V&& v) {
-  if (v.enterMixin(1, "UcacheBenchRequestCommon", ucacheBenchRequestCommon)) {
-    this->ucacheBenchRequestCommon.visitFields(std::forward<V>(v));
+void visitFields(UcbGetRequest& self, V&& v) {
+  if (v.enterMixin(1, "UcacheBenchRequestCommon", *self.ucacheBenchRequestCommon_ref())) {
+    (*self.ucacheBenchRequestCommon_ref()).visitFields(std::forward<V>(v));
   }
   if (!v.leaveMixin()) {
     return;
   }
-  if (!v.visitField(1, "key", *this->key_ref())) {
+  if (!v.visitField(1, "key", *self.key_ref())) {
     return;
   }
-  if (!v.visitField(2, "flags", *this->flags_ref())) {
+  if (!v.visitField(2, "flags", *self.flags_ref())) {
     return;
   }
+}
+
+template <class V>
+void visitFields(const UcbGetRequest& self, V&& v) {
+  if (v.enterMixin(1, "UcacheBenchRequestCommon", *self.ucacheBenchRequestCommon_ref())) {
+    (*self.ucacheBenchRequestCommon_ref()).visitFields(std::forward<V>(v));
+  }
+  if (!v.leaveMixin()) {
+    return;
+  }
+  if (!v.visitField(1, "key", *self.key_ref())) {
+    return;
+  }
+  if (!v.visitField(2, "flags", *self.flags_ref())) {
+    return;
+  }
+}
+
+template <class V>
+void UcbGetRequest::visitFields(V&& v) {
+  facebook::ucachebench::thrift::visitFields(*this, std::forward<V>(v));
 }
 
 template <class V>
 void UcbGetRequest::visitFields(V&& v) const {
-  if (v.enterMixin(1, "UcacheBenchRequestCommon", ucacheBenchRequestCommon)) {
-    this->ucacheBenchRequestCommon.visitFields(std::forward<V>(v));
-  }
-  if (!v.leaveMixin()) {
-    return;
-  }
-  if (!v.visitField(1, "key", *this->key_ref())) {
-    return;
-  }
-  if (!v.visitField(2, "flags", *this->flags_ref())) {
-    return;
-  }
+  facebook::ucachebench::thrift::visitFields(*this, std::forward<V>(v));
+}
+
+template <class Writer>
+void serialize(const UcbGetReply& self, Writer&& writer) {
+  writer.writeStructBegin();
+  writer.writeField(-1 /* field id */, self.ucacheBenchReplyCommon_ref());
+  writer.writeField(1 /* field id */, self.result_ref());
+  writer.writeField(2 /* field id */, self.value_ref());
+  writer.writeField(3 /* field id */, self.flags_ref());
+  writer.writeField(4 /* field id */, self.message_ref());
+  writer.writeField(5 /* field id */, self.appSpecificErrorCode_ref());
+  writer.writeField(6 /* field id */, self.exptime_ref());
+  writer.writeFieldStop();
+  writer.writeStructEnd();
 }
 
 template <class Writer>
 void UcbGetReply::serialize(Writer&& writer) const {
-  writer.writeStructBegin();
-  writer.writeField(-1 /* field id */, ucacheBenchReplyCommon_ref());
-  writer.writeField(1 /* field id */, result_ref());
-  writer.writeField(2 /* field id */, value_ref());
-  writer.writeField(3 /* field id */, flags_ref());
-  writer.writeField(4 /* field id */, message_ref());
-  writer.writeField(5 /* field id */, appSpecificErrorCode_ref());
-  writer.writeField(6 /* field id */, exptime_ref());
-  writer.writeFieldStop();
-  writer.writeStructEnd();
+  facebook::ucachebench::thrift::serialize(*this, std::forward<Writer>(writer));
 }
 
 template <class V>
-void UcbGetReply::visitFields(V&& v) {
-  if (v.enterMixin(1, "UcacheBenchReplyCommon", ucacheBenchReplyCommon)) {
-    this->ucacheBenchReplyCommon.visitFields(std::forward<V>(v));
+void visitFields(UcbGetReply& self, V&& v) {
+  if (v.enterMixin(1, "UcacheBenchReplyCommon", *self.ucacheBenchReplyCommon_ref())) {
+    (*self.ucacheBenchReplyCommon_ref()).visitFields(std::forward<V>(v));
   }
   if (!v.leaveMixin()) {
     return;
   }
-  if (!v.visitField(1, "result", *this->result_ref())) {
+  if (!v.visitField(1, "result", *self.result_ref())) {
     return;
   }
-  if (!v.visitField(2, "value", this->value_ref())) {
+  if (!v.visitField(2, "value", self.value_ref())) {
     return;
   }
-  if (!v.visitField(3, "flags", *this->flags_ref())) {
+  if (!v.visitField(3, "flags", *self.flags_ref())) {
     return;
   }
-  if (!v.visitField(4, "message", *this->message_ref())) {
+  if (!v.visitField(4, "message", *self.message_ref())) {
     return;
   }
-  if (!v.visitField(5, "appSpecificErrorCode", *this->appSpecificErrorCode_ref())) {
+  if (!v.visitField(5, "appSpecificErrorCode", *self.appSpecificErrorCode_ref())) {
     return;
   }
-  if (!v.visitField(6, "exptime", this->exptime_ref())) {
+  if (!v.visitField(6, "exptime", self.exptime_ref())) {
     return;
   }
+}
+
+template <class V>
+void visitFields(const UcbGetReply& self, V&& v) {
+  if (v.enterMixin(1, "UcacheBenchReplyCommon", *self.ucacheBenchReplyCommon_ref())) {
+    (*self.ucacheBenchReplyCommon_ref()).visitFields(std::forward<V>(v));
+  }
+  if (!v.leaveMixin()) {
+    return;
+  }
+  if (!v.visitField(1, "result", *self.result_ref())) {
+    return;
+  }
+  if (!v.visitField(2, "value", self.value_ref())) {
+    return;
+  }
+  if (!v.visitField(3, "flags", *self.flags_ref())) {
+    return;
+  }
+  if (!v.visitField(4, "message", *self.message_ref())) {
+    return;
+  }
+  if (!v.visitField(5, "appSpecificErrorCode", *self.appSpecificErrorCode_ref())) {
+    return;
+  }
+  if (!v.visitField(6, "exptime", self.exptime_ref())) {
+    return;
+  }
+}
+
+template <class V>
+void UcbGetReply::visitFields(V&& v) {
+  facebook::ucachebench::thrift::visitFields(*this, std::forward<V>(v));
 }
 
 template <class V>
 void UcbGetReply::visitFields(V&& v) const {
-  if (v.enterMixin(1, "UcacheBenchReplyCommon", ucacheBenchReplyCommon)) {
-    this->ucacheBenchReplyCommon.visitFields(std::forward<V>(v));
-  }
-  if (!v.leaveMixin()) {
-    return;
-  }
-  if (!v.visitField(1, "result", *this->result_ref())) {
-    return;
-  }
-  if (!v.visitField(2, "value", this->value_ref())) {
-    return;
-  }
-  if (!v.visitField(3, "flags", *this->flags_ref())) {
-    return;
-  }
-  if (!v.visitField(4, "message", *this->message_ref())) {
-    return;
-  }
-  if (!v.visitField(5, "appSpecificErrorCode", *this->appSpecificErrorCode_ref())) {
-    return;
-  }
-  if (!v.visitField(6, "exptime", this->exptime_ref())) {
-    return;
-  }
+  facebook::ucachebench::thrift::visitFields(*this, std::forward<V>(v));
+}
+
+template <class Writer>
+void serialize(const UcbSetRequest& self, Writer&& writer) {
+  writer.writeStructBegin();
+  writer.writeField(-1 /* field id */, self.ucacheBenchRequestCommon_ref());
+  writer.writeField(1 /* field id */, self.key_ref());
+  writer.writeField(2 /* field id */, self.exptime_ref());
+  writer.writeField(3 /* field id */, self.flags_ref());
+  writer.writeField(4 /* field id */, self.value_ref());
+  writer.writeFieldStop();
+  writer.writeStructEnd();
 }
 
 template <class Writer>
 void UcbSetRequest::serialize(Writer&& writer) const {
-  writer.writeStructBegin();
-  writer.writeField(-1 /* field id */, ucacheBenchRequestCommon_ref());
-  writer.writeField(1 /* field id */, key_ref());
-  writer.writeField(2 /* field id */, exptime_ref());
-  writer.writeField(3 /* field id */, flags_ref());
-  writer.writeField(4 /* field id */, value_ref());
-  writer.writeFieldStop();
-  writer.writeStructEnd();
+  facebook::ucachebench::thrift::serialize(*this, std::forward<Writer>(writer));
 }
 
 template <class V>
-void UcbSetRequest::visitFields(V&& v) {
-  if (v.enterMixin(1, "UcacheBenchRequestCommon", ucacheBenchRequestCommon)) {
-    this->ucacheBenchRequestCommon.visitFields(std::forward<V>(v));
+void visitFields(UcbSetRequest& self, V&& v) {
+  if (v.enterMixin(1, "UcacheBenchRequestCommon", *self.ucacheBenchRequestCommon_ref())) {
+    (*self.ucacheBenchRequestCommon_ref()).visitFields(std::forward<V>(v));
   }
   if (!v.leaveMixin()) {
     return;
   }
-  if (!v.visitField(1, "key", *this->key_ref())) {
+  if (!v.visitField(1, "key", *self.key_ref())) {
     return;
   }
-  if (!v.visitField(2, "exptime", *this->exptime_ref())) {
+  if (!v.visitField(2, "exptime", *self.exptime_ref())) {
     return;
   }
-  if (!v.visitField(3, "flags", *this->flags_ref())) {
+  if (!v.visitField(3, "flags", *self.flags_ref())) {
     return;
   }
-  if (!v.visitField(4, "value", *this->value_ref())) {
+  if (!v.visitField(4, "value", *self.value_ref())) {
     return;
   }
+}
+
+template <class V>
+void visitFields(const UcbSetRequest& self, V&& v) {
+  if (v.enterMixin(1, "UcacheBenchRequestCommon", *self.ucacheBenchRequestCommon_ref())) {
+    (*self.ucacheBenchRequestCommon_ref()).visitFields(std::forward<V>(v));
+  }
+  if (!v.leaveMixin()) {
+    return;
+  }
+  if (!v.visitField(1, "key", *self.key_ref())) {
+    return;
+  }
+  if (!v.visitField(2, "exptime", *self.exptime_ref())) {
+    return;
+  }
+  if (!v.visitField(3, "flags", *self.flags_ref())) {
+    return;
+  }
+  if (!v.visitField(4, "value", *self.value_ref())) {
+    return;
+  }
+}
+
+template <class V>
+void UcbSetRequest::visitFields(V&& v) {
+  facebook::ucachebench::thrift::visitFields(*this, std::forward<V>(v));
 }
 
 template <class V>
 void UcbSetRequest::visitFields(V&& v) const {
-  if (v.enterMixin(1, "UcacheBenchRequestCommon", ucacheBenchRequestCommon)) {
-    this->ucacheBenchRequestCommon.visitFields(std::forward<V>(v));
-  }
-  if (!v.leaveMixin()) {
-    return;
-  }
-  if (!v.visitField(1, "key", *this->key_ref())) {
-    return;
-  }
-  if (!v.visitField(2, "exptime", *this->exptime_ref())) {
-    return;
-  }
-  if (!v.visitField(3, "flags", *this->flags_ref())) {
-    return;
-  }
-  if (!v.visitField(4, "value", *this->value_ref())) {
-    return;
-  }
+  facebook::ucachebench::thrift::visitFields(*this, std::forward<V>(v));
+}
+
+template <class Writer>
+void serialize(const UcbSetReply& self, Writer&& writer) {
+  writer.writeStructBegin();
+  writer.writeField(-1 /* field id */, self.ucacheBenchReplyCommon_ref());
+  writer.writeField(1 /* field id */, self.result_ref());
+  writer.writeField(2 /* field id */, self.flags_ref());
+  writer.writeField(3 /* field id */, self.value_ref());
+  writer.writeField(4 /* field id */, self.message_ref());
+  writer.writeField(5 /* field id */, self.appSpecificErrorCode_ref());
+  writer.writeFieldStop();
+  writer.writeStructEnd();
 }
 
 template <class Writer>
 void UcbSetReply::serialize(Writer&& writer) const {
-  writer.writeStructBegin();
-  writer.writeField(-1 /* field id */, ucacheBenchReplyCommon_ref());
-  writer.writeField(1 /* field id */, result_ref());
-  writer.writeField(2 /* field id */, flags_ref());
-  writer.writeField(3 /* field id */, value_ref());
-  writer.writeField(4 /* field id */, message_ref());
-  writer.writeField(5 /* field id */, appSpecificErrorCode_ref());
-  writer.writeFieldStop();
-  writer.writeStructEnd();
+  facebook::ucachebench::thrift::serialize(*this, std::forward<Writer>(writer));
 }
 
 template <class V>
-void UcbSetReply::visitFields(V&& v) {
-  if (v.enterMixin(1, "UcacheBenchReplyCommon", ucacheBenchReplyCommon)) {
-    this->ucacheBenchReplyCommon.visitFields(std::forward<V>(v));
+void visitFields(UcbSetReply& self, V&& v) {
+  if (v.enterMixin(1, "UcacheBenchReplyCommon", *self.ucacheBenchReplyCommon_ref())) {
+    (*self.ucacheBenchReplyCommon_ref()).visitFields(std::forward<V>(v));
   }
   if (!v.leaveMixin()) {
     return;
   }
-  if (!v.visitField(1, "result", *this->result_ref())) {
+  if (!v.visitField(1, "result", *self.result_ref())) {
     return;
   }
-  if (!v.visitField(2, "flags", *this->flags_ref())) {
+  if (!v.visitField(2, "flags", *self.flags_ref())) {
     return;
   }
-  if (!v.visitField(3, "value", *this->value_ref())) {
+  if (!v.visitField(3, "value", *self.value_ref())) {
     return;
   }
-  if (!v.visitField(4, "message", *this->message_ref())) {
+  if (!v.visitField(4, "message", *self.message_ref())) {
     return;
   }
-  if (!v.visitField(5, "appSpecificErrorCode", *this->appSpecificErrorCode_ref())) {
+  if (!v.visitField(5, "appSpecificErrorCode", *self.appSpecificErrorCode_ref())) {
     return;
   }
+}
+
+template <class V>
+void visitFields(const UcbSetReply& self, V&& v) {
+  if (v.enterMixin(1, "UcacheBenchReplyCommon", *self.ucacheBenchReplyCommon_ref())) {
+    (*self.ucacheBenchReplyCommon_ref()).visitFields(std::forward<V>(v));
+  }
+  if (!v.leaveMixin()) {
+    return;
+  }
+  if (!v.visitField(1, "result", *self.result_ref())) {
+    return;
+  }
+  if (!v.visitField(2, "flags", *self.flags_ref())) {
+    return;
+  }
+  if (!v.visitField(3, "value", *self.value_ref())) {
+    return;
+  }
+  if (!v.visitField(4, "message", *self.message_ref())) {
+    return;
+  }
+  if (!v.visitField(5, "appSpecificErrorCode", *self.appSpecificErrorCode_ref())) {
+    return;
+  }
+}
+
+template <class V>
+void UcbSetReply::visitFields(V&& v) {
+  facebook::ucachebench::thrift::visitFields(*this, std::forward<V>(v));
 }
 
 template <class V>
 void UcbSetReply::visitFields(V&& v) const {
-  if (v.enterMixin(1, "UcacheBenchReplyCommon", ucacheBenchReplyCommon)) {
-    this->ucacheBenchReplyCommon.visitFields(std::forward<V>(v));
-  }
-  if (!v.leaveMixin()) {
-    return;
-  }
-  if (!v.visitField(1, "result", *this->result_ref())) {
-    return;
-  }
-  if (!v.visitField(2, "flags", *this->flags_ref())) {
-    return;
-  }
-  if (!v.visitField(3, "value", *this->value_ref())) {
-    return;
-  }
-  if (!v.visitField(4, "message", *this->message_ref())) {
-    return;
-  }
-  if (!v.visitField(5, "appSpecificErrorCode", *this->appSpecificErrorCode_ref())) {
-    return;
-  }
+  facebook::ucachebench::thrift::visitFields(*this, std::forward<V>(v));
+}
+
+template <class Writer>
+void serialize(const UcbDeleteRequest& self, Writer&& writer) {
+  writer.writeStructBegin();
+  writer.writeField(-1 /* field id */, self.ucacheBenchRequestCommon_ref());
+  writer.writeField(1 /* field id */, self.key_ref());
+  writer.writeField(2 /* field id */, self.flags_ref());
+  writer.writeFieldStop();
+  writer.writeStructEnd();
 }
 
 template <class Writer>
 void UcbDeleteRequest::serialize(Writer&& writer) const {
-  writer.writeStructBegin();
-  writer.writeField(-1 /* field id */, ucacheBenchRequestCommon_ref());
-  writer.writeField(1 /* field id */, key_ref());
-  writer.writeField(2 /* field id */, flags_ref());
-  writer.writeFieldStop();
-  writer.writeStructEnd();
+  facebook::ucachebench::thrift::serialize(*this, std::forward<Writer>(writer));
 }
 
 template <class V>
-void UcbDeleteRequest::visitFields(V&& v) {
-  if (v.enterMixin(1, "UcacheBenchRequestCommon", ucacheBenchRequestCommon)) {
-    this->ucacheBenchRequestCommon.visitFields(std::forward<V>(v));
+void visitFields(UcbDeleteRequest& self, V&& v) {
+  if (v.enterMixin(1, "UcacheBenchRequestCommon", *self.ucacheBenchRequestCommon_ref())) {
+    (*self.ucacheBenchRequestCommon_ref()).visitFields(std::forward<V>(v));
   }
   if (!v.leaveMixin()) {
     return;
   }
-  if (!v.visitField(1, "key", *this->key_ref())) {
+  if (!v.visitField(1, "key", *self.key_ref())) {
     return;
   }
-  if (!v.visitField(2, "flags", *this->flags_ref())) {
+  if (!v.visitField(2, "flags", *self.flags_ref())) {
     return;
   }
+}
+
+template <class V>
+void visitFields(const UcbDeleteRequest& self, V&& v) {
+  if (v.enterMixin(1, "UcacheBenchRequestCommon", *self.ucacheBenchRequestCommon_ref())) {
+    (*self.ucacheBenchRequestCommon_ref()).visitFields(std::forward<V>(v));
+  }
+  if (!v.leaveMixin()) {
+    return;
+  }
+  if (!v.visitField(1, "key", *self.key_ref())) {
+    return;
+  }
+  if (!v.visitField(2, "flags", *self.flags_ref())) {
+    return;
+  }
+}
+
+template <class V>
+void UcbDeleteRequest::visitFields(V&& v) {
+  facebook::ucachebench::thrift::visitFields(*this, std::forward<V>(v));
 }
 
 template <class V>
 void UcbDeleteRequest::visitFields(V&& v) const {
-  if (v.enterMixin(1, "UcacheBenchRequestCommon", ucacheBenchRequestCommon)) {
-    this->ucacheBenchRequestCommon.visitFields(std::forward<V>(v));
-  }
-  if (!v.leaveMixin()) {
-    return;
-  }
-  if (!v.visitField(1, "key", *this->key_ref())) {
-    return;
-  }
-  if (!v.visitField(2, "flags", *this->flags_ref())) {
-    return;
-  }
+  facebook::ucachebench::thrift::visitFields(*this, std::forward<V>(v));
 }
 
 template <class Writer>
-void UcbDeleteReply::serialize(Writer&& writer) const {
+void serialize(const UcbDeleteReply& self, Writer&& writer) {
   writer.writeStructBegin();
-  writer.writeField(-1 /* field id */, ucacheBenchReplyCommon_ref());
-  writer.writeField(1 /* field id */, result_ref());
-  writer.writeField(2 /* field id */, flags_ref());
-  writer.writeField(3 /* field id */, message_ref());
-  writer.writeField(4 /* field id */, appSpecificErrorCode_ref());
+  writer.writeField(-1 /* field id */, self.ucacheBenchReplyCommon_ref());
+  writer.writeField(1 /* field id */, self.result_ref());
+  writer.writeField(2 /* field id */, self.flags_ref());
+  writer.writeField(3 /* field id */, self.message_ref());
+  writer.writeField(4 /* field id */, self.appSpecificErrorCode_ref());
   writer.writeFieldStop();
   writer.writeStructEnd();
 }
 
+template <class Writer>
+void UcbDeleteReply::serialize(Writer&& writer) const {
+  facebook::ucachebench::thrift::serialize(*this, std::forward<Writer>(writer));
+}
+
 template <class V>
-void UcbDeleteReply::visitFields(V&& v) {
-  if (v.enterMixin(1, "UcacheBenchReplyCommon", ucacheBenchReplyCommon)) {
-    this->ucacheBenchReplyCommon.visitFields(std::forward<V>(v));
+void visitFields(UcbDeleteReply& self, V&& v) {
+  if (v.enterMixin(1, "UcacheBenchReplyCommon", *self.ucacheBenchReplyCommon_ref())) {
+    (*self.ucacheBenchReplyCommon_ref()).visitFields(std::forward<V>(v));
   }
   if (!v.leaveMixin()) {
     return;
   }
-  if (!v.visitField(1, "result", *this->result_ref())) {
+  if (!v.visitField(1, "result", *self.result_ref())) {
     return;
   }
-  if (!v.visitField(2, "flags", *this->flags_ref())) {
+  if (!v.visitField(2, "flags", *self.flags_ref())) {
     return;
   }
-  if (!v.visitField(3, "message", *this->message_ref())) {
+  if (!v.visitField(3, "message", *self.message_ref())) {
     return;
   }
-  if (!v.visitField(4, "appSpecificErrorCode", *this->appSpecificErrorCode_ref())) {
+  if (!v.visitField(4, "appSpecificErrorCode", *self.appSpecificErrorCode_ref())) {
     return;
   }
 }
 
 template <class V>
-void UcbDeleteReply::visitFields(V&& v) const {
-  if (v.enterMixin(1, "UcacheBenchReplyCommon", ucacheBenchReplyCommon)) {
-    this->ucacheBenchReplyCommon.visitFields(std::forward<V>(v));
+void visitFields(const UcbDeleteReply& self, V&& v) {
+  if (v.enterMixin(1, "UcacheBenchReplyCommon", *self.ucacheBenchReplyCommon_ref())) {
+    (*self.ucacheBenchReplyCommon_ref()).visitFields(std::forward<V>(v));
   }
   if (!v.leaveMixin()) {
     return;
   }
-  if (!v.visitField(1, "result", *this->result_ref())) {
+  if (!v.visitField(1, "result", *self.result_ref())) {
     return;
   }
-  if (!v.visitField(2, "flags", *this->flags_ref())) {
+  if (!v.visitField(2, "flags", *self.flags_ref())) {
     return;
   }
-  if (!v.visitField(3, "message", *this->message_ref())) {
+  if (!v.visitField(3, "message", *self.message_ref())) {
     return;
   }
-  if (!v.visitField(4, "appSpecificErrorCode", *this->appSpecificErrorCode_ref())) {
+  if (!v.visitField(4, "appSpecificErrorCode", *self.appSpecificErrorCode_ref())) {
     return;
   }
+}
+
+template <class V>
+void UcbDeleteReply::visitFields(V&& v) {
+  facebook::ucachebench::thrift::visitFields(*this, std::forward<V>(v));
+}
+
+template <class V>
+void UcbDeleteReply::visitFields(V&& v) const {
+  facebook::ucachebench::thrift::visitFields(*this, std::forward<V>(v));
 }
 } // namespace thrift
 } // namespace ucachebench

--- a/packages/ucache_bench/protocol/gen/UcacheBenchMessages.h
+++ b/packages/ucache_bench/protocol/gen/UcacheBenchMessages.h
@@ -172,7 +172,102 @@ class UcbDeleteReply : public carbon::ReplyCommon, public facebook::ucachebench:
   friend class apache::thrift::Cpp2Ops<UcbDeleteReply>;
 
 };
+
 } // namespace ucachebench
 } // namespace facebook
 
+namespace facebook {
+namespace ucachebench {
+namespace thrift {
+
+template <class Writer>
+void serialize(const UcacheBenchRequestCommon& self, Writer&& writer);
+
+void deserialize(UcacheBenchRequestCommon& self, carbon::CarbonProtocolReader& reader);
+
+template <class V>
+void visitFields(UcacheBenchRequestCommon& self, V&& v);
+
+template <class V>
+void visitFields(const UcacheBenchRequestCommon& self, V&& v);
+
+template <class Writer>
+void serialize(const UcacheBenchReplyCommon& self, Writer&& writer);
+
+void deserialize(UcacheBenchReplyCommon& self, carbon::CarbonProtocolReader& reader);
+
+template <class V>
+void visitFields(UcacheBenchReplyCommon& self, V&& v);
+
+template <class V>
+void visitFields(const UcacheBenchReplyCommon& self, V&& v);
+
+template <class Writer>
+void serialize(const UcbGetRequest& self, Writer&& writer);
+
+void deserialize(UcbGetRequest& self, carbon::CarbonProtocolReader& reader);
+
+template <class V>
+void visitFields(UcbGetRequest& self, V&& v);
+
+template <class V>
+void visitFields(const UcbGetRequest& self, V&& v);
+
+template <class Writer>
+void serialize(const UcbGetReply& self, Writer&& writer);
+
+void deserialize(UcbGetReply& self, carbon::CarbonProtocolReader& reader);
+
+template <class V>
+void visitFields(UcbGetReply& self, V&& v);
+
+template <class V>
+void visitFields(const UcbGetReply& self, V&& v);
+
+template <class Writer>
+void serialize(const UcbSetRequest& self, Writer&& writer);
+
+void deserialize(UcbSetRequest& self, carbon::CarbonProtocolReader& reader);
+
+template <class V>
+void visitFields(UcbSetRequest& self, V&& v);
+
+template <class V>
+void visitFields(const UcbSetRequest& self, V&& v);
+
+template <class Writer>
+void serialize(const UcbSetReply& self, Writer&& writer);
+
+void deserialize(UcbSetReply& self, carbon::CarbonProtocolReader& reader);
+
+template <class V>
+void visitFields(UcbSetReply& self, V&& v);
+
+template <class V>
+void visitFields(const UcbSetReply& self, V&& v);
+
+template <class Writer>
+void serialize(const UcbDeleteRequest& self, Writer&& writer);
+
+void deserialize(UcbDeleteRequest& self, carbon::CarbonProtocolReader& reader);
+
+template <class V>
+void visitFields(UcbDeleteRequest& self, V&& v);
+
+template <class V>
+void visitFields(const UcbDeleteRequest& self, V&& v);
+
+template <class Writer>
+void serialize(const UcbDeleteReply& self, Writer&& writer);
+
+void deserialize(UcbDeleteReply& self, carbon::CarbonProtocolReader& reader);
+
+template <class V>
+void visitFields(UcbDeleteReply& self, V&& v);
+
+template <class V>
+void visitFields(const UcbDeleteReply& self, V&& v);
+} // namespace thrift
+} // namespace ucachebench
+} // namespace facebook
 #include "UcacheBenchMessages-inl.h"

--- a/packages/ucache_bench/protocol/gen/UcacheBenchMessagesThrift.cpp
+++ b/packages/ucache_bench/protocol/gen/UcacheBenchMessagesThrift.cpp
@@ -20,7 +20,7 @@ namespace facebook {
 namespace ucachebench {
 namespace thrift {
 
-void UcacheBenchRequestCommon::deserialize(carbon::CarbonProtocolReader& reader) {
+void deserialize(UcacheBenchRequestCommon& self, carbon::CarbonProtocolReader& reader) {
   reader.readStructBegin();
   while (true) {
     const auto pr = reader.readFieldHeader();
@@ -33,11 +33,40 @@ void UcacheBenchRequestCommon::deserialize(carbon::CarbonProtocolReader& reader)
 
     switch (fieldId) {
       case 1: {
-        reader.readField(productId_ref(), fieldType);
+        reader.readField(self.productId_ref(), fieldType);
         break;
       }
       case 2: {
-        reader.readField(bucketId_ref(), fieldType);
+        reader.readField(self.bucketId_ref(), fieldType);
+        break;
+      }
+      default: {
+        reader.skip(fieldType);
+        break;
+      }
+    }
+  }
+  reader.readStructEnd();
+}
+
+void UcacheBenchRequestCommon::deserialize(carbon::CarbonProtocolReader& reader) {
+  facebook::ucachebench::thrift::deserialize(*this, reader);
+}
+
+void deserialize(UcacheBenchReplyCommon& self, carbon::CarbonProtocolReader& reader) {
+  reader.readStructBegin();
+  while (true) {
+    const auto pr = reader.readFieldHeader();
+    const auto fieldType = pr.first;
+    const auto fieldId = pr.second;
+
+    if (fieldType == carbon::FieldType::Stop) {
+      break;
+    }
+
+    switch (fieldId) {
+      case 1: {
+        reader.readField(self.replySourceBitMask_ref(), fieldType);
         break;
       }
       default: {
@@ -50,6 +79,10 @@ void UcacheBenchRequestCommon::deserialize(carbon::CarbonProtocolReader& reader)
 }
 
 void UcacheBenchReplyCommon::deserialize(carbon::CarbonProtocolReader& reader) {
+  facebook::ucachebench::thrift::deserialize(*this, reader);
+}
+
+void deserialize(UcbGetRequest& self, carbon::CarbonProtocolReader& reader) {
   reader.readStructBegin();
   while (true) {
     const auto pr = reader.readFieldHeader();
@@ -61,8 +94,16 @@ void UcacheBenchReplyCommon::deserialize(carbon::CarbonProtocolReader& reader) {
     }
 
     switch (fieldId) {
+      case -1: {
+        reader.readField(*self.ucacheBenchRequestCommon_ref(), fieldType);
+        break;
+      }
       case 1: {
-        reader.readField(replySourceBitMask_ref(), fieldType);
+        reader.readField(self.key_ref(), fieldType);
+        break;
+      }
+      case 2: {
+        reader.readField(self.flags_ref(), fieldType);
         break;
       }
       default: {
@@ -75,6 +116,10 @@ void UcacheBenchReplyCommon::deserialize(carbon::CarbonProtocolReader& reader) {
 }
 
 void UcbGetRequest::deserialize(carbon::CarbonProtocolReader& reader) {
+  facebook::ucachebench::thrift::deserialize(*this, reader);
+}
+
+void deserialize(UcbGetReply& self, carbon::CarbonProtocolReader& reader) {
   reader.readStructBegin();
   while (true) {
     const auto pr = reader.readFieldHeader();
@@ -87,15 +132,31 @@ void UcbGetRequest::deserialize(carbon::CarbonProtocolReader& reader) {
 
     switch (fieldId) {
       case -1: {
-        reader.readField(ucacheBenchRequestCommon, fieldType);
+        reader.readField(*self.ucacheBenchReplyCommon_ref(), fieldType);
         break;
       }
       case 1: {
-        reader.readField(key_ref(), fieldType);
+        reader.readField(self.result_ref(), fieldType);
         break;
       }
       case 2: {
-        reader.readField(flags_ref(), fieldType);
+        reader.readField(self.value_ref(), fieldType);
+        break;
+      }
+      case 3: {
+        reader.readField(self.flags_ref(), fieldType);
+        break;
+      }
+      case 4: {
+        reader.readField(self.message_ref(), fieldType);
+        break;
+      }
+      case 5: {
+        reader.readField(self.appSpecificErrorCode_ref(), fieldType);
+        break;
+      }
+      case 6: {
+        reader.readField(self.exptime_ref(), fieldType);
         break;
       }
       default: {
@@ -108,6 +169,10 @@ void UcbGetRequest::deserialize(carbon::CarbonProtocolReader& reader) {
 }
 
 void UcbGetReply::deserialize(carbon::CarbonProtocolReader& reader) {
+  facebook::ucachebench::thrift::deserialize(*this, reader);
+}
+
+void deserialize(UcbSetRequest& self, carbon::CarbonProtocolReader& reader) {
   reader.readStructBegin();
   while (true) {
     const auto pr = reader.readFieldHeader();
@@ -120,31 +185,23 @@ void UcbGetReply::deserialize(carbon::CarbonProtocolReader& reader) {
 
     switch (fieldId) {
       case -1: {
-        reader.readField(ucacheBenchReplyCommon, fieldType);
+        reader.readField(*self.ucacheBenchRequestCommon_ref(), fieldType);
         break;
       }
       case 1: {
-        reader.readField(result_ref(), fieldType);
+        reader.readField(self.key_ref(), fieldType);
         break;
       }
       case 2: {
-        reader.readField(value_ref(), fieldType);
+        reader.readField(self.exptime_ref(), fieldType);
         break;
       }
       case 3: {
-        reader.readField(flags_ref(), fieldType);
+        reader.readField(self.flags_ref(), fieldType);
         break;
       }
       case 4: {
-        reader.readField(message_ref(), fieldType);
-        break;
-      }
-      case 5: {
-        reader.readField(appSpecificErrorCode_ref(), fieldType);
-        break;
-      }
-      case 6: {
-        reader.readField(exptime_ref(), fieldType);
+        reader.readField(self.value_ref(), fieldType);
         break;
       }
       default: {
@@ -157,6 +214,10 @@ void UcbGetReply::deserialize(carbon::CarbonProtocolReader& reader) {
 }
 
 void UcbSetRequest::deserialize(carbon::CarbonProtocolReader& reader) {
+  facebook::ucachebench::thrift::deserialize(*this, reader);
+}
+
+void deserialize(UcbSetReply& self, carbon::CarbonProtocolReader& reader) {
   reader.readStructBegin();
   while (true) {
     const auto pr = reader.readFieldHeader();
@@ -169,23 +230,27 @@ void UcbSetRequest::deserialize(carbon::CarbonProtocolReader& reader) {
 
     switch (fieldId) {
       case -1: {
-        reader.readField(ucacheBenchRequestCommon, fieldType);
+        reader.readField(*self.ucacheBenchReplyCommon_ref(), fieldType);
         break;
       }
       case 1: {
-        reader.readField(key_ref(), fieldType);
+        reader.readField(self.result_ref(), fieldType);
         break;
       }
       case 2: {
-        reader.readField(exptime_ref(), fieldType);
+        reader.readField(self.flags_ref(), fieldType);
         break;
       }
       case 3: {
-        reader.readField(flags_ref(), fieldType);
+        reader.readField(self.value_ref(), fieldType);
         break;
       }
       case 4: {
-        reader.readField(value_ref(), fieldType);
+        reader.readField(self.message_ref(), fieldType);
+        break;
+      }
+      case 5: {
+        reader.readField(self.appSpecificErrorCode_ref(), fieldType);
         break;
       }
       default: {
@@ -198,6 +263,10 @@ void UcbSetRequest::deserialize(carbon::CarbonProtocolReader& reader) {
 }
 
 void UcbSetReply::deserialize(carbon::CarbonProtocolReader& reader) {
+  facebook::ucachebench::thrift::deserialize(*this, reader);
+}
+
+void deserialize(UcbDeleteRequest& self, carbon::CarbonProtocolReader& reader) {
   reader.readStructBegin();
   while (true) {
     const auto pr = reader.readFieldHeader();
@@ -210,27 +279,15 @@ void UcbSetReply::deserialize(carbon::CarbonProtocolReader& reader) {
 
     switch (fieldId) {
       case -1: {
-        reader.readField(ucacheBenchReplyCommon, fieldType);
+        reader.readField(*self.ucacheBenchRequestCommon_ref(), fieldType);
         break;
       }
       case 1: {
-        reader.readField(result_ref(), fieldType);
+        reader.readField(self.key_ref(), fieldType);
         break;
       }
       case 2: {
-        reader.readField(flags_ref(), fieldType);
-        break;
-      }
-      case 3: {
-        reader.readField(value_ref(), fieldType);
-        break;
-      }
-      case 4: {
-        reader.readField(message_ref(), fieldType);
-        break;
-      }
-      case 5: {
-        reader.readField(appSpecificErrorCode_ref(), fieldType);
+        reader.readField(self.flags_ref(), fieldType);
         break;
       }
       default: {
@@ -243,6 +300,10 @@ void UcbSetReply::deserialize(carbon::CarbonProtocolReader& reader) {
 }
 
 void UcbDeleteRequest::deserialize(carbon::CarbonProtocolReader& reader) {
+  facebook::ucachebench::thrift::deserialize(*this, reader);
+}
+
+void deserialize(UcbDeleteReply& self, carbon::CarbonProtocolReader& reader) {
   reader.readStructBegin();
   while (true) {
     const auto pr = reader.readFieldHeader();
@@ -255,15 +316,23 @@ void UcbDeleteRequest::deserialize(carbon::CarbonProtocolReader& reader) {
 
     switch (fieldId) {
       case -1: {
-        reader.readField(ucacheBenchRequestCommon, fieldType);
+        reader.readField(*self.ucacheBenchReplyCommon_ref(), fieldType);
         break;
       }
       case 1: {
-        reader.readField(key_ref(), fieldType);
+        reader.readField(self.result_ref(), fieldType);
         break;
       }
       case 2: {
-        reader.readField(flags_ref(), fieldType);
+        reader.readField(self.flags_ref(), fieldType);
+        break;
+      }
+      case 3: {
+        reader.readField(self.message_ref(), fieldType);
+        break;
+      }
+      case 4: {
+        reader.readField(self.appSpecificErrorCode_ref(), fieldType);
         break;
       }
       default: {
@@ -276,44 +345,7 @@ void UcbDeleteRequest::deserialize(carbon::CarbonProtocolReader& reader) {
 }
 
 void UcbDeleteReply::deserialize(carbon::CarbonProtocolReader& reader) {
-  reader.readStructBegin();
-  while (true) {
-    const auto pr = reader.readFieldHeader();
-    const auto fieldType = pr.first;
-    const auto fieldId = pr.second;
-
-    if (fieldType == carbon::FieldType::Stop) {
-      break;
-    }
-
-    switch (fieldId) {
-      case -1: {
-        reader.readField(ucacheBenchReplyCommon, fieldType);
-        break;
-      }
-      case 1: {
-        reader.readField(result_ref(), fieldType);
-        break;
-      }
-      case 2: {
-        reader.readField(flags_ref(), fieldType);
-        break;
-      }
-      case 3: {
-        reader.readField(message_ref(), fieldType);
-        break;
-      }
-      case 4: {
-        reader.readField(appSpecificErrorCode_ref(), fieldType);
-        break;
-      }
-      default: {
-        reader.skip(fieldType);
-        break;
-      }
-    }
-  }
-  reader.readStructEnd();
+  facebook::ucachebench::thrift::deserialize(*this, reader);
 }
 } // namespace thrift
 } // namespace ucachebench


### PR DESCRIPTION
Summary:
`cpp.methods` is being deprecated, with the suggested replacement being free functions taking the object as a parameter.

Modify the Carbon IDL C++ code generator to produce free function overloads
for all methods injected via cpp.methods (serialize, deserialize, visitFields,
foreachMember). Member methods become thin wrappers that delegate to the free
functions, which contain the actual implementation.

Free function definitions go in -inl.h files (serialize, visitFields,
foreachMember as templates; deserialize as inline). The .cpp files now only
contain the thin delegating member method for deserialize.

Key implementation details:
- Parameterized _gen_write(), _gen_visit_statement(), _gen_visit_fields_body()
  with prefix/member_access params for free function generation
- Added _gen_deserialize_free_fn() and _gen_deserialize_cases() to StructImpl
  and UnionImpl for inline deserialize free functions in -inl.h
- Simplified StructCpp/StructThriftCpp/UnionCpp/UnionThriftCpp to thin
  delegating wrappers
- Use *self.xxx_ref() public accessors in free functions instead of direct
  private member access for thrift mixin members
- Handle empty struct edge cases (unused self param, always-named visitor param)

Differential Revision: D93677112


