### PR TITLE
Fix bugs and refactor benchmark dispatch logic

### DIFF
--- a/packages/wdl_bench/aggregate_result.py
+++ b/packages/wdl_bench/aggregate_result.py
@@ -11,16 +11,24 @@ import sys
 
 import parse_line
 
-sum_c = {}
+
+def main() -> None:
+    if len(sys.argv) != 2:
+        print("Usage: aggregate_result.py <benchmark_name>")
+        sys.exit(1)
+
+    benchmark_name = sys.argv[1]
+    sum_c = {}
+    parser = parse_line.get_parser(benchmark_name)
+
+    for n in glob.glob("output_file_*"):
+        with open(n) as f:
+            parser(f, sum_c)
+
+    out_file_name = "out_" + benchmark_name + ".json"
+    with open(out_file_name, "w") as f:
+        json.dump(sum_c, f, indent=4, sort_keys=True)
 
 
-for n in glob.glob("output_file_*"):
-    with open(n) as f:
-        if sys.argv[1] == "lzbench":
-            parse_line.parse_line_lzbench(f, sum_c)
-        else:
-            parse_line.parse_line(f, sum_c)
-
-out_file_name = "out_" + sys.argv[1] + ".json"
-with open(out_file_name, "w") as f:
-    json.dump(sum_c, f, indent=4, sort_keys=True)
+if __name__ == "__main__":
+    main()

--- a/packages/wdl_bench/common.sh
+++ b/packages/wdl_bench/common.sh
@@ -14,6 +14,12 @@ ARMPL_VERSION="26.01"
 # Determine OS version
 LINUX_DIST_ID="$(awk -F "=" '/^ID=/ {print $2}' /etc/os-release | tr -d '"')"
 
+BREPS_LFILE=/tmp/wdl_log.txt
+
+benchreps_tell_state() {
+    date +"%Y-%m-%d_%T ${1}" >> "$BREPS_LFILE"
+}
+
 has_real_conda() {
     # 1. Check if 'conda' command exists at all
     if ! command -v conda >/dev/null 2>&1; then

--- a/packages/wdl_bench/compare_results.py
+++ b/packages/wdl_bench/compare_results.py
@@ -157,6 +157,14 @@ def extract_default_results(data: dict[str, Any]) -> dict[str, float]:
     return results
 
 
+_EXTRACTOR_REGISTRY = {
+    "xxhash_benchmark": extract_xxhash_results,
+    "bench-memcmp": extract_memcmp_timings_for_compare,
+    "benchsleef": extract_sleef_results,
+    "concurrency_concurrent_hash_map_bench": extract_concurrent_hash_map_results,
+}
+
+
 def compare_results(
     data1: dict[str, Any],
     data2: dict[str, Any],
@@ -173,21 +181,9 @@ def compare_results(
     Returns:
         List of tuples (benchmark_name, value1, value2, ratio) sorted by ratio (high to low)
     """
-    if benchmark_type == "xxhash_benchmark":
-        results1 = extract_xxhash_results(data1)
-        results2 = extract_xxhash_results(data2)
-    elif benchmark_type == "bench-memcmp":
-        results1 = extract_memcmp_timings_for_compare(data1)
-        results2 = extract_memcmp_timings_for_compare(data2)
-    elif benchmark_type == "benchsleef":
-        results1 = extract_sleef_results(data1)
-        results2 = extract_sleef_results(data2)
-    elif benchmark_type == "concurrency_concurrent_hash_map_bench":
-        results1 = extract_concurrent_hash_map_results(data1)
-        results2 = extract_concurrent_hash_map_results(data2)
-    else:
-        results1 = extract_default_results(data1)
-        results2 = extract_default_results(data2)
+    extractor = _EXTRACTOR_REGISTRY.get(benchmark_type, extract_default_results)
+    results1 = extractor(data1)
+    results2 = extractor(data2)
 
     comparisons = []
     common_keys = set(results1.keys()) & set(results2.keys())
@@ -197,14 +193,7 @@ def compare_results(
         val2 = results2[key]
 
         if val2 != 0:
-            # For concurrency_concurrent_hash_map_bench, higher is better (throughput)
-            # so we invert the ratio to show speedup consistently
-            if benchmark_type == "concurrency_concurrent_hash_map_bench":
-                ratio = val1 / val2
-            else:
-                # For timing-based benchmarks, lower is better
-                # ratio > 1 means file2 is faster
-                ratio = val1 / val2
+            ratio = val1 / val2
             comparisons.append((key, val1, val2, ratio))
 
     # Sort by ratio from high to low
@@ -280,8 +269,8 @@ def main() -> None:
             f"# Comparison: {os.path.basename(file1)} vs {os.path.basename(file2)}\n"
         )
         f.write(f"# Benchmark type: {benchmark_type}\n")
-        f.write(f"# Ratio = file1 / file2\n")
-        f.write(f"# Sorted from high to low ratio\n")
+        f.write("# Ratio = file1 / file2\n")
+        f.write("# Sorted from high to low ratio\n")
         f.write("#\n")
         f.write(f"# {'Benchmark':<80} {'File1':>15} {'File2':>15} {'Ratio':>10}\n")
         f.write(f"# {'-' * 80} {'-' * 15} {'-' * 15} {'-' * 10}\n")

--- a/packages/wdl_bench/convert.py
+++ b/packages/wdl_bench/convert.py
@@ -10,31 +10,24 @@ import sys
 
 import parse_line
 
-sum_c = {}
 
-input_file_name = "out_" + sys.argv[1] + ".txt"
+def main() -> None:
+    if len(sys.argv) != 2:
+        print("Usage: convert.py <benchmark_name>")
+        sys.exit(1)
+
+    benchmark_name = sys.argv[1]
+    input_file_name = "out_" + benchmark_name + ".txt"
+    sum_c = {}
+
+    parser = parse_line.get_parser(benchmark_name)
+    with open(input_file_name) as f:
+        parser(f, sum_c)
+
+    out_file_name = "out_" + benchmark_name + ".json"
+    with open(out_file_name, "w") as f:
+        json.dump(sum_c, f, indent=4, sort_keys=True)
 
 
-with open(input_file_name) as f:
-    if sys.argv[1] == "concurrency_concurrent_hash_map_bench":
-        parse_line.parse_line_chm(f, sum_c)
-    elif sys.argv[1] == "lzbench":
-        parse_line.parse_line_lzbench(f, sum_c)
-    elif sys.argv[1] == "openssl":
-        parse_line.parse_line_openssl(f, sum_c)
-    elif sys.argv[1] == "vdso_bench":
-        parse_line.parse_line_vdso_bench(f, sum_c)
-    elif sys.argv[1] == "libaegis_benchmark":
-        parse_line.parse_line_libaegis_benchmark(f, sum_c)
-    elif sys.argv[1] == "xxhash_benchmark":
-        parse_line.parse_line_xxhash_benchmark(f, sum_c)
-    elif sys.argv[1] == "container_hash_maps_bench":
-        parse_line.parse_line_container_hash_maps_bench(f, sum_c)
-    elif sys.argv[1] == "erasure_code_perf":
-        parse_line.parse_line_erasure_code_perf(f, sum_c)
-    else:
-        parse_line.parse_line(f, sum_c)
-
-out_file_name = "out_" + sys.argv[1] + ".json"
-with open(out_file_name, "w") as f:
-    json.dump(sum_c, f, indent=4, sort_keys=True)
+if __name__ == "__main__":
+    main()

--- a/packages/wdl_bench/install_wdl_bench.sh
+++ b/packages/wdl_bench/install_wdl_bench.sh
@@ -291,16 +291,14 @@ build_libaegis()
     pushd "${WDL_SOURCE}"
     clone $lib || echo "Failed to clone $lib"
     if [ "$ARCH" = "aarch64" ]; then
-        # shellcheck disable=SC2046
-        curl $(get_curl_proxy_args) -O https://ziglang.org/download/0.15.2/zig-aarch64-linux-0.15.2.tar.xz
-        tar xvf zig-aarch64-linux-0.15.2.tar.xz
-        mv zig-aarch64-linux-0.15.2 zig
+        zig_arch="aarch64"
     else
-        # shellcheck disable=SC2046
-        curl $(get_curl_proxy_args) -O https://ziglang.org/download/0.15.2/zig-x86_64-linux-0.15.2.tar.xz
-        tar xvf zig-x86_64-linux-0.15.2.tar.xz
-        mv zig-x86_64-linux-0.15.2 zig
+        zig_arch="x86_64"
     fi
+    # shellcheck disable=SC2046
+    curl $(get_curl_proxy_args) -O "https://ziglang.org/download/0.15.2/zig-${zig_arch}-linux-0.15.2.tar.xz"
+    tar xvf "zig-${zig_arch}-linux-0.15.2.tar.xz"
+    mv "zig-${zig_arch}-linux-0.15.2" zig
     cd "$lib" || exit
     ../zig/zig build -Drelease -Dfavor-performance -Dwith-benchmark
     cp ./zig-out/bin/benchmark "${WDL_ROOT}/libaegis_benchmark" || exit
@@ -439,7 +437,7 @@ build_stdcpp()
 
 build_gemm()
 {
-    lib='gemm_bench'
+    gemm_lib='gemm_bench'
     pushd "$WDL_BUILD"
     source /etc/profile.d/modules.sh
     if [ "$ARCH" = "aarch64" ]; then
@@ -460,9 +458,8 @@ build_gemm()
         fi
         module use apl/modulefiles
         module load "armpl/${ARMPL_VERSION}.0_gcc"
-        lib='gemm_bench' # reset lib to gemm_bench
-        cmake -S "$BPKGS_WDL_ROOT/$lib" -B "$lib-build" -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_RPATH="${ARMPL_LIBRARIES};${WDL_BUILD}/acl/lib64;${WDL_BUILD}/acl/lib" -DCMAKE_CXX_FLAGS="-I${WDL_BUILD}/acl/include -L ${WDL_BUILD}/acl/lib64 -L ${WDL_BUILD}/acl/lib" && cmake --build "$lib-build"
-        cp "$lib-build/$lib" "${WDL_ROOT}/" || exit 1
+        cmake -S "$BPKGS_WDL_ROOT/$gemm_lib" -B "$gemm_lib-build" -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_RPATH="${ARMPL_LIBRARIES};${WDL_BUILD}/acl/lib64;${WDL_BUILD}/acl/lib" -DCMAKE_CXX_FLAGS="-I${WDL_BUILD}/acl/include -L ${WDL_BUILD}/acl/lib64 -L ${WDL_BUILD}/acl/lib" && cmake --build "$gemm_lib-build"
+        cp "$gemm_lib-build/$gemm_lib" "${WDL_ROOT}/" || exit 1
     else
         cpu_vendor=$(grep -m 1 'vendor_id' /proc/cpuinfo | awk '{print $3}')
         # shellcheck disable=SC2046,SC2086
@@ -486,26 +483,24 @@ build_gemm()
             conda env remove -n "$AOCL_BUILD_ENV" -y
         )
         cd .. || exit
-        lib='gemm_bench' # reset lib to gemm_bench
-        cmake -S "$BPKGS_WDL_ROOT/$lib" -B "$lib-build-onemkl" -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_RPATH="${MKLROOT}/lib" && cmake --build "$lib-build-onemkl"
-        cmake -S "$BPKGS_WDL_ROOT/$lib" -B "$lib-build-aocl" -DCMAKE_BUILD_TYPE=Release -DCPU_VENDOR=AMD -DCMAKE_INSTALL_RPATH="${WDL_BUILD}/aocl/lib" -DCMAKE_CXX_FLAGS="-I${WDL_BUILD}/aocl/include -L ${WDL_BUILD}/aocl/lib" && cmake --build "$lib-build-aocl"
+        cmake -S "$BPKGS_WDL_ROOT/$gemm_lib" -B "$gemm_lib-build-onemkl" -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_RPATH="${MKLROOT}/lib" && cmake --build "$gemm_lib-build-onemkl"
+        cmake -S "$BPKGS_WDL_ROOT/$gemm_lib" -B "$gemm_lib-build-aocl" -DCMAKE_BUILD_TYPE=Release -DCPU_VENDOR=AMD -DCMAKE_INSTALL_RPATH="${WDL_BUILD}/aocl/lib" -DCMAKE_CXX_FLAGS="-I${WDL_BUILD}/aocl/include -L ${WDL_BUILD}/aocl/lib" && cmake --build "$gemm_lib-build-aocl"
         if [[ "$cpu_vendor" == "GenuineIntel" ]]; then
             echo "CPU is Intel"
-            cp "$lib-build-onemkl/$lib" "${WDL_ROOT}/" || exit 1
+            cp "$gemm_lib-build-onemkl/$gemm_lib" "${WDL_ROOT}/" || exit 1
         elif [[ "$cpu_vendor" == "AuthenticAMD" ]]; then
             echo "CPU is AMD"
-            cp "$lib-build-aocl/$lib" "${WDL_ROOT}/" || exit 1
+            cp "$gemm_lib-build-aocl/$gemm_lib" "${WDL_ROOT}/" || exit 1
         else
             echo "Unknown CPU vendor: $cpu_vendor"
         fi
     fi
-    cmake -S "$BPKGS_WDL_ROOT/$lib" -B "$lib-build-openblas" -DCMAKE_BUILD_TYPE=Release -DUSE_OPENBLAS=ON && cmake --build "$lib-build-openblas"
+    cmake -S "$BPKGS_WDL_ROOT/$gemm_lib" -B "$gemm_lib-build-openblas" -DCMAKE_BUILD_TYPE=Release -DUSE_OPENBLAS=ON && cmake --build "$gemm_lib-build-openblas"
     clone onednn || echo "Failed to clone onednn"
     cd onednn || exit
     cmake -S . -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX="${WDL_BUILD}/onednn" && cmake --build build --config release --target install -- -j"$(nproc)"
     cd .. || exit
-    lib='gemm_bench' # reset lib to gemm_bench
-    cmake -S "$BPKGS_WDL_ROOT/$lib" -B "$lib-build-onednn" -DCMAKE_BUILD_TYPE=Release -DUSE_ONEDNN=ON -DCMAKE_INSTALL_RPATH="${WDL_BUILD}/onednn/lib;${WDL_BUILD}/onednn/lib64" -DCMAKE_CXX_FLAGS="-I${WDL_BUILD}/onednn/include -L ${WDL_BUILD}/onednn/lib -L ${WDL_BUILD}/onednn/lib64" && cmake --build "$lib-build-onednn"
+    cmake -S "$BPKGS_WDL_ROOT/$gemm_lib" -B "$gemm_lib-build-onednn" -DCMAKE_BUILD_TYPE=Release -DUSE_ONEDNN=ON -DCMAKE_INSTALL_RPATH="${WDL_BUILD}/onednn/lib;${WDL_BUILD}/onednn/lib64" -DCMAKE_CXX_FLAGS="-I${WDL_BUILD}/onednn/include -L ${WDL_BUILD}/onednn/lib -L ${WDL_BUILD}/onednn/lib64" && cmake --build "$gemm_lib-build-onednn"
     module purge
 
     popd || exit

--- a/packages/wdl_bench/parse_line.py
+++ b/packages/wdl_bench/parse_line.py
@@ -7,43 +7,66 @@
 import json
 import re
 
+_TIME_UNIT_RE = re.compile(r"([0-9](n|m|u|f|p)s)|([0-9]s)")
+_HASH_MAP_OPS_RE = re.compile(r"^(Find)|(Insert)|(InsertSqBr)|(Erase)|(Iter)")
+
+_THROUGHPUT_SUFFIX = {
+    "K": 1e3,
+    "M": 1e6,
+    "G": 1e9,
+    "T": 1e12,
+    "m": 1e-3,
+}
+
+_LATENCY_SUFFIX = {
+    "u": 1000,
+    "m": 1000 * 1000,
+}
+
+
+def _parse_throughput(raw: str) -> float:
+    if raw == "Infinity":
+        return float("inf")
+    if raw[-1] in _THROUGHPUT_SUFFIX:
+        return float(raw[:-1]) * _THROUGHPUT_SUFFIX[raw[-1]]
+    return float(raw)
+
+
+def _parse_latency_ns(raw: str) -> int:
+    suffix = raw[-2]
+    value = int(raw[:-2])
+    if suffix in _LATENCY_SUFFIX:
+        return value * _LATENCY_SUFFIX[suffix]
+    return value
+
 
 def parse_line_chm(f, sum_c):
     thread_count = 0
     for line in f:
-        if re.search("threads", line):
+        if "threads" in line:
             thread_count = int(line.split()[1])
-        elif re.search("CHM", line):
+        elif "CHM" in line:
             elements = line.split()
             idx_name = 0
-            for i in range(len(elements)):
-                if re.search("(item)|(empty)", elements[i]):
+            for i, elem in enumerate(elements):
+                if re.search("(item)|(empty)", elem):
                     idx_name = i
 
             bench_name = (
                 str(thread_count) + "threads " + " ".join(elements[: idx_name + 1])
             )
             bench_name = bench_name + ": ns"
-            # max_latency = "".join(elements[idx_name + 1 : idx_name + 3])
             avg_latency = "".join(elements[idx_name + 3 : idx_name + 5])
-            # min_latency = "".join(elements[idx_name + 5 : idx_name + 7])
-
-            if avg_latency[-2] == "u":
-                avg_latency = int(avg_latency[:-2]) * 1000
-            elif avg_latency[-2] == "m":
-                avg_latency = int(avg_latency[:-2]) * 1000 * 1000
-            else:
-                avg_latency = int(avg_latency[:-2])
-            sum_c[bench_name] = avg_latency
+            sum_c[bench_name] = _parse_latency_ns(avg_latency)
 
 
 def find_idx_time(elements):
     has_relative = False
     idx_time = 0
-    for i in range(len(elements)):
-        if re.search("%", elements[i]):
+    for i, elem in enumerate(elements):
+        if "%" in elem:
             has_relative = True
-        if re.search("([0-9](n|m|u|f|p)s)|([0-9]s)", elements[i]):
+        if _TIME_UNIT_RE.search(elem):
             idx_time = i
             break
 
@@ -53,30 +76,16 @@ def find_idx_time(elements):
 def parse_line(f, sum_c):
     for line in f:
         # capture the time unit here (ns, us, ms, s, ps, fs)
-        if re.search("([0-9](n|m|u|f|p)s)|([0-9]s)", line):
+        if _TIME_UNIT_RE.search(line):
             elements = line.split()
             has_relative, idx_time = find_idx_time(elements)
             throughput = elements[idx_time + 1]
-            bench_name = None
             if has_relative:
                 bench_name = " ".join(elements[: idx_time - 1])
             else:
                 bench_name = " ".join(elements[:idx_time])
             bench_name = bench_name + ": iters/s"
-            if throughput[-1] == "K":
-                throughput = float(throughput[:-1]) * 1000
-            elif throughput[-1] == "M":
-                throughput = float(throughput[:-1]) * 1000 * 1000
-            elif throughput[-1] == "G":
-                throughput = float(throughput[:-1]) * 1000 * 1000 * 1000
-            elif throughput[-1] == "T":
-                throughput = float(throughput[:-1]) * 1000 * 1000 * 1000 * 1000
-            elif throughput[-1] == "m":
-                throughput = float(throughput[:-1]) / 1000
-            elif throughput == "Infinity":
-                throughput = float("inf")
-            else:
-                throughput = float(throughput)
+            throughput = _parse_throughput(throughput)
 
             if bench_name not in sum_c:
                 sum_c[bench_name] = 0
@@ -85,11 +94,11 @@ def parse_line(f, sum_c):
 
 def parse_line_lzbench(f, sum_c):
     for line in f:
-        if re.search("datasets", line):
+        if "datasets" in line:
             elements = line.split()
             idx_time = 0
-            for i in range(len(elements)):
-                if re.search("MB", elements[i]):
+            for i, elem in enumerate(elements):
+                if "MB" in elem:
                     idx_time = i
                     break
             throughput_decomp = float(elements[idx_time + 1])
@@ -112,6 +121,9 @@ def parse_line_openssl(f, sum_c):
     last_line = None
     for line in f:
         last_line = line
+
+    if last_line is None:
+        return
 
     elements = last_line.split()
     name = elements[0]
@@ -143,6 +155,7 @@ def parse_line_libaegis_benchmark(f, sum_c):
 
 
 def parse_line_xxhash_benchmark(f, sum_c):
+    current_section = None
     for line in f:
         line = line.strip()
         if not line:
@@ -165,7 +178,7 @@ def parse_line_xxhash_benchmark(f, sum_c):
             current_section = "latency_small_random"
             sum_c[current_section] = {}
         # Parse data lines (format: "xxh3   , value1, value2, ...")
-        elif "," in line and current_section:
+        elif "," in line and current_section is not None:
             parts = [p.strip() for p in line.split(",")]
             if len(parts) > 1:
                 hash_name = parts[0]
@@ -188,7 +201,7 @@ def parse_line_xxhash_benchmark(f, sum_c):
 def parse_line_container_hash_maps_bench(f, sum_c):
     data = json.load(f)
     for k, v in data.items():
-        if re.search("^(Find)|(Insert)|(InsertSqBr)|(Erase)|(Iter)", k):
+        if _HASH_MAP_OPS_RE.search(k):
             sum_c[k] = v
 
 
@@ -199,3 +212,22 @@ def parse_line_erasure_code_perf(f, sum_c):
             name = elements[0]
             value = float(elements[-2])
             sum_c[name + ": MB/s"] = value
+
+
+# Registry mapping benchmark names to parser functions.
+# The default parser (parse_line) is used for benchmarks not listed here.
+PARSER_REGISTRY = {
+    "concurrency_concurrent_hash_map_bench": parse_line_chm,
+    "lzbench": parse_line_lzbench,
+    "openssl": parse_line_openssl,
+    "vdso_bench": parse_line_vdso_bench,
+    "libaegis_benchmark": parse_line_libaegis_benchmark,
+    "xxhash_benchmark": parse_line_xxhash_benchmark,
+    "container_hash_maps_bench": parse_line_container_hash_maps_bench,
+    "erasure_code_perf": parse_line_erasure_code_perf,
+}
+
+
+def get_parser(benchmark_name):
+    """Return the parser function for the given benchmark name."""
+    return PARSER_REGISTRY.get(benchmark_name, parse_line)

--- a/packages/wdl_bench/run.sh
+++ b/packages/wdl_bench/run.sh
@@ -8,17 +8,10 @@ set -Eeo pipefail
 #trap SIGINT SIGTERM ERR EXIT
 
 
-BREPS_LFILE=/tmp/wdl_log.txt
-
-function benchreps_tell_state () {
-    date +"%Y-%m-%d_%T ${1}" >> $BREPS_LFILE
-}
-
-
 # Constants
 WDL_ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")" &>/dev/null && pwd -P)
-WDL_DATASETS="${WDL_ROOT}/datasets"
-WDL_BUILD="${WDL_ROOT}/wdl_build"
+# shellcheck disable=SC1091
+source "$WDL_ROOT"/common.sh
 
 show_help() {
 cat <<EOF
@@ -41,6 +34,8 @@ run_list=""
 
 run_allcore()
 {
+    local -a pids=()
+    local nprocs
     nprocs=$(nproc)
 
     for i in $(seq "$nprocs")
@@ -81,42 +76,42 @@ main() {
     dataset="silesia.tar"
 
 
-    while :; do
-        case $1 in
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
             --output)
+                [[ -n "${2:-}" ]] || { echo "Invalid option: $1 requires an argument" 1>&2; exit 1; }
                 result_filename="$2"
+                shift 2
                 ;;
             --type)
+                [[ -n "${2:-}" ]] || { echo "Invalid option: $1 requires an argument" 1>&2; exit 1; }
                 run_type="$2"
+                shift 2
                 ;;
             --name)
+                [[ -n "${2:-}" ]] || { echo "Invalid option: $1 requires an argument" 1>&2; exit 1; }
                 name="$2"
+                shift 2
                 ;;
             --algo)
+                [[ -n "${2:-}" ]] || { echo "Invalid option: $1 requires an argument" 1>&2; exit 1; }
                 algo="$2"
+                shift 2
                 ;;
             --dataset)
+                [[ -n "${2:-}" ]] || { echo "Invalid option: $1 requires an argument" 1>&2; exit 1; }
                 dataset="$2"
+                shift 2
                 ;;
             -h)
                 show_help >&2
                 exit 1
                 ;;
-            *)  # end of input
-                echo "Unsupported arg $1"
-                break
-        esac
-
-        case $1 in
-            --output|--type|--name|--algo|--dataset)
-                if [ -z "$2" ]; then
-                    echo "Invalid option: $1 requires an argument" 1>&2
-                    exit 1
-                fi
-                shift   # Additional shift for the argument
+            *)
+                echo "Unsupported arg: $1"
+                exit 1
                 ;;
         esac
-        shift
     done
 
 
@@ -163,7 +158,7 @@ main() {
     elif [ "$name" != "none" ]; then
         run_list=$name
         if [ "$name" = "small_locks_benchmark" ] || [ "$name" = "iobuf_benchmark" ]; then
-                "./${name}" --bm_min_iters=1000000 > "out_${benchmark}".txt
+                "./${name}" --bm_min_iters=1000000 > "out_${name}".txt
             else
                 "./${name}"  > "out_${name}".txt
         fi

--- a/packages/wdl_bench/run_prod.sh
+++ b/packages/wdl_bench/run_prod.sh
@@ -8,13 +8,6 @@ set -Eeo pipefail
 #trap SIGINT SIGTERM ERR EXIT
 
 
-BREPS_LFILE=/tmp/wdl_log.txt
-
-function benchreps_tell_state () {
-    date +"%Y-%m-%d_%T ${1}" >> $BREPS_LFILE
-}
-
-
 # Constants
 WDL_ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")" &>/dev/null && pwd -P)
 # shellcheck disable=SC1091
@@ -44,7 +37,10 @@ prod_benchmark_vdso="vdso_bench"
 prod_benchmark_math="benchsleef128 benchsleef256 benchsleef512 gemm_bench"
 prod_benchmark_stdcpp="stdcpp_bench"
 
-prod_benchmarks="memcpy_benchmark memset_benchmark bench-memcmp hash_hash_benchmark xxhash_benchmark lzbench openssl libaegis_benchmark hash_checksum_benchmark  erasure_code_perf random_benchmark concurrency_concurrent_hash_map_bench ProtocolBench VarintUtilsBench container_hash_maps_bench synchronization_small_locks_benchmark synchronization_lifo_sem_bench vdso_bench benchsleef128 benchsleef256 benchsleef512 stdcpp_bench"
+# Compose prod_benchmarks from the category variables above.
+# Note: gemm_bench (in prod_benchmark_math) is excluded from the default prod
+# run because it is architecture-specific and may not always be installed.
+prod_benchmarks="${prod_benchmark_list_mem} ${prod_benchmark_list_hash} ${prod_benchmark_compression} ${prod_benchmark_crypto} ${prod_benchmark_checksum} ${prod_benchmark_rng} ${prod_benchmark_chm} ${prod_benchmark_thrift} ${prod_benchmark_f14} ${prod_benchmark_lock} ${prod_benchmark_vdso} ${prod_benchmark_math% gemm_bench} ${prod_benchmark_stdcpp}"
 
 benchmark_non_json_list=("openssl" "libaegis_benchmark" "lzbench" "vdso_bench" "xxhash_benchmark" "concurrency_concurrent_hash_map_bench" "container_hash_maps_bench" "erasure_code_perf")
 

--- a/packages/wdl_bench/scoring.py
+++ b/packages/wdl_bench/scoring.py
@@ -329,7 +329,7 @@ def compute_gemm_score(sum_baseline: dict[str, Any], sum_c: dict[str, Any]) -> f
     return geomean(current_peak_ops) / geomean(baseline_peak_ops)
 
 
-def compute_memcpy_score(sum_baseline: dict[str, Any], sum_c: dict[str, Any]):
+def compute_memcpy_score(sum_baseline: dict[str, Any], sum_c: dict[str, Any]) -> float:
     scores = []
     for low, high in [
         ("0", "7"),
@@ -354,7 +354,7 @@ def compute_memcpy_score(sum_baseline: dict[str, Any], sum_c: dict[str, Any]):
     return score
 
 
-def compute_memset_score(sum_baseline: dict[str, Any], sum_c: dict[str, Any]):
+def compute_memset_score(sum_baseline: dict[str, Any], sum_c: dict[str, Any]) -> float:
     scores = []
     size = 1
     while size <= 32768:
@@ -385,7 +385,7 @@ def compute_memset_score(sum_baseline: dict[str, Any], sum_c: dict[str, Any]):
     return score
 
 
-def compute_xxhash_score(sum_baseline: dict[str, Any], sum_c: dict[str, Any]):
+def compute_xxhash_score(sum_baseline: dict[str, Any], sum_c: dict[str, Any]) -> float:
     scores = []
     res_large = sum_c["large_inputs"]["xxh3"]
     res_baseline = sum_baseline["large_inputs"]["xxh3"]
@@ -425,60 +425,68 @@ def compute_score_from_rate(
     return score
 
 
+# Registries for score dispatch.
+# Benchmarks with custom scoring functions:
+_CUSTOM_SCORERS: dict[str, Any] = {
+    "memcpy_benchmark": compute_memcpy_score,
+    "memset_benchmark": compute_memset_score,
+    "xxhash_benchmark": compute_xxhash_score,
+    "bench-memcmp": compute_memcmp_score,
+    "stdcpp_bench": compute_stdcpp_score,
+    "gemm_bench": compute_gemm_score,
+}
+
+# Benchmarks scored via compute_score_from_rate:
+_RATE_BASED: set[str] = {
+    "lzbench",
+    "openssl",
+    "erasure_code_perf",
+    "libaegis_benchmark",
+    "vdso_bench",
+}
+
+# Benchmarks scored via compute_score_from_time:
+_TIME_BASED: set[str] = {
+    "hash_hash_benchmark",
+    "hash_checksum_benchmark",
+    "random_benchmark",
+    "concurrency_concurrent_hash_map_bench",
+    "container_hash_maps_bench",
+    "ProtocolBench",
+    "VarintUtilsBench",
+    "synchronization_small_locks_benchmark",
+    "synchronization_lifo_sem_bench",
+}
+
+# Per-benchmark skip sets for rate/time scoring:
+_SKIP_SETS: dict[str, set[str]] = {
+    "vdso_bench": {"CLOCK_BOOTTIME_ALARM: M/s", "CLOCK_REALTIME_ALARM: M/s"},
+}
+
+
 def compute_benchmark_score(
     benchmark_name: str, input_file_name: str, baseline_name: str
 ) -> float:
-    with open(input_file_name) as f:
-        with open(baseline_name) as f_baseline:
-            sum_c = json.load(f)
-            sum_baseline = json.load(f_baseline)
-            if benchmark_name == "memcpy_benchmark":
-                score = compute_memcpy_score(sum_baseline, sum_c)
-            elif benchmark_name == "memset_benchmark":
-                score = compute_memset_score(sum_baseline, sum_c)
-            elif benchmark_name == "xxhash_benchmark":
-                score = compute_xxhash_score(sum_baseline, sum_c)
-            elif benchmark_name.startswith("benchsleef"):
-                score = compute_sleef_score(benchmark_name, sum_baseline, sum_c)
-            elif benchmark_name == "bench-memcmp":
-                score = compute_memcmp_score(sum_baseline, sum_c)
-            elif benchmark_name == "stdcpp_bench":
-                score = compute_stdcpp_score(sum_baseline, sum_c)
-            elif benchmark_name == "gemm_bench":
-                score = compute_gemm_score(sum_baseline, sum_c)
-            elif benchmark_name == "vdso_bench":
-                # Some Linux kernels may not support these clocks, so do not
-                # count them in the score.
-                skip_set = {"CLOCK_BOOTTIME_ALARM: M/s", "CLOCK_REALTIME_ALARM: M/s"}
-                score = compute_score_from_rate(sum_baseline, sum_c, skip_set)
-            elif benchmark_name in {
-                "lzbench",
-                "openssl",
-                "erasure_code_perf",
-                "libaegis_benchmark",
-            }:
-                score = compute_score_from_rate(sum_baseline, sum_c)
-            elif benchmark_name in {
-                "hash_hash_benchmark",
-                "hash_checksum_benchmark",
-                "random_benchmark",
-                "concurrency_concurrent_hash_map_bench",
-                "container_hash_maps_bench",
-                "ProtocolBench",
-                "VarintUtilsBench",
-                "synchronization_small_locks_benchmark",
-                "synchronization_lifo_sem_bench",
-                "benchsleef128",
-            }:
-                score = compute_score_from_time(sum_baseline, sum_c)
-            else:
-                # N.B.: if you add a new benchmark, double-check if the results are time
-                #       or rates. Call compute_score_from_time or compute_score_from_rate
-                #       accordingly.
-                print(
-                    f"{benchmark_name} score: error (unclear if results are time or rates)"
-                )
-                sys.exit(0)  # return 0 so run_prod.sh can continue
+    with open(input_file_name) as f, open(baseline_name) as f_baseline:
+        sum_c = json.load(f)
+        sum_baseline = json.load(f_baseline)
+
+        if benchmark_name in _CUSTOM_SCORERS:
+            score = _CUSTOM_SCORERS[benchmark_name](sum_baseline, sum_c)
+        elif benchmark_name.startswith("benchsleef"):
+            score = compute_sleef_score(benchmark_name, sum_baseline, sum_c)
+        elif benchmark_name in _RATE_BASED:
+            skip_set = _SKIP_SETS.get(benchmark_name)
+            score = compute_score_from_rate(sum_baseline, sum_c, skip_set)
+        elif benchmark_name in _TIME_BASED:
+            score = compute_score_from_time(sum_baseline, sum_c)
+        else:
+            # N.B.: if you add a new benchmark, add it to _CUSTOM_SCORERS,
+            #       _RATE_BASED, or _TIME_BASED above.
+            print(
+                f"{benchmark_name} score: error (unclear if results are time or rates)"
+            )
+            sys.exit(0)  # return 0 so run_prod.sh can continue
 
     return score
 


### PR DESCRIPTION
Summary:
Fix several bugs and reduce maintenance burden in the wdl_bench package by
consolidating duplicated dispatch logic, extracting shared helpers, and
fixing edge-case crashes.

Bug fixes:
- parse_line.py: Fix NameError when comma-line appears before section header
  in xxhash parser (uninitialized current_section)
- parse_line.py: Fix AttributeError in openssl parser when file is empty
  (last_line is None)
- run.sh: Fix unbound variable $benchmark (should be $name) causing crash
  with set -u
- run.sh: Fix arg parsing loop printing spurious "Unsupported arg" on
  exhausted args

Refactoring:
- Add PARSER_REGISTRY + get_parser() in parse_line.py; use in convert.py
  and aggregate_result.py to replace if/elif dispatch chains
- Add _CUSTOM_SCORERS, _RATE_BASED, _TIME_BASED, _SKIP_SETS registries
  in scoring.py to replace 15-branch if/elif
- Add _EXTRACTOR_REGISTRY in compare_results.py
- Extract _parse_throughput() and _parse_latency_ns() helpers
- Replace re.search() with `in` for literal substring checks; compile
  actual regexes at module level
- Replace for-i-in-range-len with enumerate()
- Remove dead benchsleef128 entry (always matched by startswith first)
- Remove dead CHM branch in compare_results.py (identical to default)
- Add main() guards to convert.py and aggregate_result.py
- Add -> float return annotations to 3 scoring functions
- Fix nested with statement in scoring.py
- Move benchreps_tell_state to common.sh; source common.sh from run.sh
- Compose prod_benchmarks from category variables in run_prod.sh
- Simplify zig download in install_wdl_bench.sh (deduplicate arch branches)
- Use dedicated gemm_lib variable in build_gemm() to avoid fragile lib resets

Differential Revision: D94043013


