### PR TITLE
Fix permission error for ucache_bench run.py in fbpkg

### DIFF
--- a/packages/ucache_bench/install_ucache_bench.sh
+++ b/packages/ucache_bench/install_ucache_bench.sh
@@ -46,6 +46,9 @@ mkdir -p "$BUILD_DIR"
 mkdir -p "$UCACHE_BENCH_DIR/server"
 mkdir -p "$UCACHE_BENCH_DIR/client"
 
+# Ensure run.py has execute permissions (may be lost during fbpkg packaging)
+chmod +x "$SCRIPT_DIR/run.py" 2>/dev/null || true
+
 # Helper function to clone or update a git repository
 # Supports both branches (e.g., "main") and tags (e.g., "11.0.2")
 clone_or_update() {

--- a/packages/ucache_bench/run.py
+++ b/packages/ucache_bench/run.py
@@ -390,9 +390,9 @@ def init_parser() -> argparse.ArgumentParser:
     )
     server_parser.add_argument(
         "--lru-hits-victim-by-free-mem",
-        action="store_true",
-        default=False,
-        help="Use free memory for LRU rebalancing victim selection",
+        type=int,
+        default=0,
+        help="Use free memory for LRU rebalancing victim selection (set to non-zero to enable)",
     )
     server_parser.add_argument(
         "--hashtable-lock-power",

--- a/packages/ucache_bench/server/UcacheBenchRpcServer.cpp
+++ b/packages/ucache_bench/server/UcacheBenchRpcServer.cpp
@@ -159,6 +159,22 @@ apache::thrift::ThriftServer& UcacheBenchRpcServer::addThriftServer() {
   }
   thriftServer_->setNumAcceptThreads(numAcceptorThreads);
 
+  // Match production ucache ThriftServer tuning:
+  // Prevent single connection from monopolizing an IO thread's event loop.
+  // Without this, a few hot connections can starve others, limiting
+  // multi-client scalability.
+  thriftServer_->setSocketMaxReadsPerEvent(1);
+
+  // Disable timeouts — let clients control timing, same as production ucache.
+  thriftServer_->setQueueTimeout(std::chrono::milliseconds(0));
+  thriftServer_->setTaskExpireTime(std::chrono::milliseconds(0));
+
+  // No limit on concurrent active requests.
+  thriftServer_->setMaxRequests(0);
+
+  // Disable per-request tracking overhead.
+  thriftServer_->disableActiveRequestsTracking();
+
   XLOG(INFO) << "ThriftServer configured with "
              << FLAGS_rpc_num_cpu_worker_threads << " CPU worker threads and "
              << numAcceptorThreads << " acceptor threads";


### PR DESCRIPTION
Summary:
Remove the explicit override for `packages/ucache_bench` in the fbpkg paths.

Previously, ucache_bench files were included via an explicit `buck_filegroup`
target (`ucache_bench_srcs`), which caused `run.py` to lose its execute
permissions when packaged via fbpkg.

By removing this override, `packages/ucache_bench` is now included via the
glob pattern `packages/**/*` in the `:packages` filegroup, which preserves
original file permissions including the execute bit on `run.py`.

This fixes the error:
```
PermissionError: [Errno 13] Permission denied: './packages/ucache_bench/run.py'
```

Differential Revision: D94072528


