### PR TITLE
Fix duplicate SCF cycles event in ARM perf report

### DIFF
--- a/perfutils/generate_arm_perf_report.py
+++ b/perfutils/generate_arm_perf_report.py
@@ -53,6 +53,13 @@ def read_csv(perf_csv_file):
         },
         na_values=["<not counted>"],
     )
+    # On some kernels, requesting 'cycles' in system-wide mode (-a) auto-expands
+    # to include uncore PMU cycles (e.g. nvidia_scf_pmu_0/cycles/). When the SCF
+    # memory group also explicitly requests nvidia_scf_pmu_0/cycles/, it appears
+    # twice per interval, causing series length mismatches in derived metrics.
+    # Keep the last occurrence per (timestamp, event_name) since the explicit SCF
+    # group entry appears later and has counter_runtime aligned with other SCF events.
+    df = df.drop_duplicates(subset=["timestamp", "event_name"], keep="last")
     return df
 
 


### PR DESCRIPTION
Summary: On newer kernels (e.g. fbk6+), requesting `cycles` in system-wide perf stat mode (`-a`) auto-expands to include uncore PMU cycles such as `nvidia_scf_pmu_0/cycles/`. Since the SCF local memory group in `collect_nvda_neoversev2_perf_counters.sh` also explicitly requests `nvidia_scf_pmu_0/cycles/`, the event appears twice per interval in the raw perf log. This causes `generate_arm_perf_report.py` to produce series with mismatched lengths when grouping by event name, resulting in a ValueError that silently prevents all derived ARM metrics (TopDown, cache MPKI, TLB, SCF memory bandwidth/latency) from being computed. The fix deduplicates rows by (timestamp, event_name) after CSV read, keeping the last occurrence (the explicit SCF group entry whose counter_runtime is aligned with other SCF events).

Reviewed By: charles-typ

Differential Revision: D93627307


