### PR TITLE
Remove injected member functions from codegen

### DIFF
--- a/packages/ucache_bench/protocol/gen/UcacheBench.thrift
+++ b/packages/ucache_bench/protocol/gen/UcacheBench.thrift
@@ -24,61 +24,16 @@ namespace cpp2 facebook.ucachebench.thrift
 namespace py3 facebook.ucachebench.thrift
 namespace hack ucachebench
 
-@thrift.DeprecatedUnvalidatedAnnotations{
-  items = {
-    "cpp.methods": "
-  template <class V>
-  void visitFields(V&& v);
-  template <class V>
-  void visitFields(V&& v) const;
-
-  template <class Writer>
-  void serialize(Writer&& writer) const;
-
-  void deserialize(carbon::CarbonProtocolReader& reader);
-
-"
-  },
-}
 struct UcacheBenchRequestCommon {
   1: optional i64 productId
   2: optional string bucketId
-}
-@thrift.DeprecatedUnvalidatedAnnotations{
-  items = {
-    "cpp.methods": "
-  template <class V>
-  void visitFields(V&& v);
-  template <class V>
-  void visitFields(V&& v) const;
-
-  template <class Writer>
-  void serialize(Writer&& writer) const;
-
-  void deserialize(carbon::CarbonProtocolReader& reader);
-
-"
-  },
 }
 struct UcacheBenchReplyCommon {
   1: carbon.ui32 replySourceBitMask
 }
 @thrift.DeprecatedUnvalidatedAnnotations{
   items = {
-    "cpp.methods": "
-  template <class V>
-  void visitFields(V&& v);
-  template <class V>
-  void visitFields(V&& v) const;
-
-  template <class Writer>
-  void serialize(Writer&& writer) const;
-
-  void deserialize(carbon::CarbonProtocolReader& reader);
-
-",
-"cpp.virtual": "1"
-
+    "cpp.virtual": "1"
   },
 }
 struct UcbGetRequest {
@@ -89,20 +44,7 @@ struct UcbGetRequest {
 }
 @thrift.DeprecatedUnvalidatedAnnotations{
   items = {
-    "cpp.methods": "
-  template <class V>
-  void visitFields(V&& v);
-  template <class V>
-  void visitFields(V&& v) const;
-
-  template <class Writer>
-  void serialize(Writer&& writer) const;
-
-  void deserialize(carbon::CarbonProtocolReader& reader);
-
-",
-"cpp.virtual": "1"
-
+    "cpp.virtual": "1"
   },
 }
 struct UcbGetReply {
@@ -117,20 +59,7 @@ struct UcbGetReply {
 }
 @thrift.DeprecatedUnvalidatedAnnotations{
   items = {
-    "cpp.methods": "
-  template <class V>
-  void visitFields(V&& v);
-  template <class V>
-  void visitFields(V&& v) const;
-
-  template <class Writer>
-  void serialize(Writer&& writer) const;
-
-  void deserialize(carbon::CarbonProtocolReader& reader);
-
-",
-"cpp.virtual": "1"
-
+    "cpp.virtual": "1"
   },
 }
 struct UcbSetRequest {
@@ -143,20 +72,7 @@ struct UcbSetRequest {
 }
 @thrift.DeprecatedUnvalidatedAnnotations{
   items = {
-    "cpp.methods": "
-  template <class V>
-  void visitFields(V&& v);
-  template <class V>
-  void visitFields(V&& v) const;
-
-  template <class Writer>
-  void serialize(Writer&& writer) const;
-
-  void deserialize(carbon::CarbonProtocolReader& reader);
-
-",
-"cpp.virtual": "1"
-
+    "cpp.virtual": "1"
   },
 }
 struct UcbSetReply {
@@ -170,20 +86,7 @@ struct UcbSetReply {
 }
 @thrift.DeprecatedUnvalidatedAnnotations{
   items = {
-    "cpp.methods": "
-  template <class V>
-  void visitFields(V&& v);
-  template <class V>
-  void visitFields(V&& v) const;
-
-  template <class Writer>
-  void serialize(Writer&& writer) const;
-
-  void deserialize(carbon::CarbonProtocolReader& reader);
-
-",
-"cpp.virtual": "1"
-
+    "cpp.virtual": "1"
   },
 }
 struct UcbDeleteRequest {
@@ -194,20 +97,7 @@ struct UcbDeleteRequest {
 }
 @thrift.DeprecatedUnvalidatedAnnotations{
   items = {
-    "cpp.methods": "
-  template <class V>
-  void visitFields(V&& v);
-  template <class V>
-  void visitFields(V&& v) const;
-
-  template <class Writer>
-  void serialize(Writer&& writer) const;
-
-  void deserialize(carbon::CarbonProtocolReader& reader);
-
-",
-"cpp.virtual": "1"
-
+    "cpp.virtual": "1"
   },
 }
 struct UcbDeleteReply {

--- a/packages/ucache_bench/protocol/gen/UcacheBenchMessages-inl.h
+++ b/packages/ucache_bench/protocol/gen/UcacheBenchMessages-inl.h
@@ -26,11 +26,6 @@ void serialize(const UcacheBenchRequestCommon& self, Writer&& writer) {
   writer.writeStructEnd();
 }
 
-template <class Writer>
-void UcacheBenchRequestCommon::serialize(Writer&& writer) const {
-  facebook::ucachebench::thrift::serialize(*this, std::forward<Writer>(writer));
-}
-
 template <class V>
 void visitFields(UcacheBenchRequestCommon& self, V&& v) {
   if (!v.visitField(1, "productId", self.productId_ref())) {
@@ -51,27 +46,12 @@ void visitFields(const UcacheBenchRequestCommon& self, V&& v) {
   }
 }
 
-template <class V>
-void UcacheBenchRequestCommon::visitFields(V&& v) {
-  facebook::ucachebench::thrift::visitFields(*this, std::forward<V>(v));
-}
-
-template <class V>
-void UcacheBenchRequestCommon::visitFields(V&& v) const {
-  facebook::ucachebench::thrift::visitFields(*this, std::forward<V>(v));
-}
-
 template <class Writer>
 void serialize(const UcacheBenchReplyCommon& self, Writer&& writer) {
   writer.writeStructBegin();
   writer.writeField(1 /* field id */, self.replySourceBitMask_ref());
   writer.writeFieldStop();
   writer.writeStructEnd();
-}
-
-template <class Writer>
-void UcacheBenchReplyCommon::serialize(Writer&& writer) const {
-  facebook::ucachebench::thrift::serialize(*this, std::forward<Writer>(writer));
 }
 
 template <class V>
@@ -88,16 +68,6 @@ void visitFields(const UcacheBenchReplyCommon& self, V&& v) {
   }
 }
 
-template <class V>
-void UcacheBenchReplyCommon::visitFields(V&& v) {
-  facebook::ucachebench::thrift::visitFields(*this, std::forward<V>(v));
-}
-
-template <class V>
-void UcacheBenchReplyCommon::visitFields(V&& v) const {
-  facebook::ucachebench::thrift::visitFields(*this, std::forward<V>(v));
-}
-
 template <class Writer>
 void serialize(const UcbGetRequest& self, Writer&& writer) {
   writer.writeStructBegin();
@@ -106,11 +76,6 @@ void serialize(const UcbGetRequest& self, Writer&& writer) {
   writer.writeField(2 /* field id */, self.flags_ref());
   writer.writeFieldStop();
   writer.writeStructEnd();
-}
-
-template <class Writer>
-void UcbGetRequest::serialize(Writer&& writer) const {
-  facebook::ucachebench::thrift::serialize(*this, std::forward<Writer>(writer));
 }
 
 template <class V>
@@ -145,16 +110,6 @@ void visitFields(const UcbGetRequest& self, V&& v) {
   }
 }
 
-template <class V>
-void UcbGetRequest::visitFields(V&& v) {
-  facebook::ucachebench::thrift::visitFields(*this, std::forward<V>(v));
-}
-
-template <class V>
-void UcbGetRequest::visitFields(V&& v) const {
-  facebook::ucachebench::thrift::visitFields(*this, std::forward<V>(v));
-}
-
 template <class Writer>
 void serialize(const UcbGetReply& self, Writer&& writer) {
   writer.writeStructBegin();
@@ -167,11 +122,6 @@ void serialize(const UcbGetReply& self, Writer&& writer) {
   writer.writeField(6 /* field id */, self.exptime_ref());
   writer.writeFieldStop();
   writer.writeStructEnd();
-}
-
-template <class Writer>
-void UcbGetReply::serialize(Writer&& writer) const {
-  facebook::ucachebench::thrift::serialize(*this, std::forward<Writer>(writer));
 }
 
 template <class V>
@@ -230,16 +180,6 @@ void visitFields(const UcbGetReply& self, V&& v) {
   }
 }
 
-template <class V>
-void UcbGetReply::visitFields(V&& v) {
-  facebook::ucachebench::thrift::visitFields(*this, std::forward<V>(v));
-}
-
-template <class V>
-void UcbGetReply::visitFields(V&& v) const {
-  facebook::ucachebench::thrift::visitFields(*this, std::forward<V>(v));
-}
-
 template <class Writer>
 void serialize(const UcbSetRequest& self, Writer&& writer) {
   writer.writeStructBegin();
@@ -250,11 +190,6 @@ void serialize(const UcbSetRequest& self, Writer&& writer) {
   writer.writeField(4 /* field id */, self.value_ref());
   writer.writeFieldStop();
   writer.writeStructEnd();
-}
-
-template <class Writer>
-void UcbSetRequest::serialize(Writer&& writer) const {
-  facebook::ucachebench::thrift::serialize(*this, std::forward<Writer>(writer));
 }
 
 template <class V>
@@ -301,16 +236,6 @@ void visitFields(const UcbSetRequest& self, V&& v) {
   }
 }
 
-template <class V>
-void UcbSetRequest::visitFields(V&& v) {
-  facebook::ucachebench::thrift::visitFields(*this, std::forward<V>(v));
-}
-
-template <class V>
-void UcbSetRequest::visitFields(V&& v) const {
-  facebook::ucachebench::thrift::visitFields(*this, std::forward<V>(v));
-}
-
 template <class Writer>
 void serialize(const UcbSetReply& self, Writer&& writer) {
   writer.writeStructBegin();
@@ -322,11 +247,6 @@ void serialize(const UcbSetReply& self, Writer&& writer) {
   writer.writeField(5 /* field id */, self.appSpecificErrorCode_ref());
   writer.writeFieldStop();
   writer.writeStructEnd();
-}
-
-template <class Writer>
-void UcbSetReply::serialize(Writer&& writer) const {
-  facebook::ucachebench::thrift::serialize(*this, std::forward<Writer>(writer));
 }
 
 template <class V>
@@ -379,16 +299,6 @@ void visitFields(const UcbSetReply& self, V&& v) {
   }
 }
 
-template <class V>
-void UcbSetReply::visitFields(V&& v) {
-  facebook::ucachebench::thrift::visitFields(*this, std::forward<V>(v));
-}
-
-template <class V>
-void UcbSetReply::visitFields(V&& v) const {
-  facebook::ucachebench::thrift::visitFields(*this, std::forward<V>(v));
-}
-
 template <class Writer>
 void serialize(const UcbDeleteRequest& self, Writer&& writer) {
   writer.writeStructBegin();
@@ -397,11 +307,6 @@ void serialize(const UcbDeleteRequest& self, Writer&& writer) {
   writer.writeField(2 /* field id */, self.flags_ref());
   writer.writeFieldStop();
   writer.writeStructEnd();
-}
-
-template <class Writer>
-void UcbDeleteRequest::serialize(Writer&& writer) const {
-  facebook::ucachebench::thrift::serialize(*this, std::forward<Writer>(writer));
 }
 
 template <class V>
@@ -436,16 +341,6 @@ void visitFields(const UcbDeleteRequest& self, V&& v) {
   }
 }
 
-template <class V>
-void UcbDeleteRequest::visitFields(V&& v) {
-  facebook::ucachebench::thrift::visitFields(*this, std::forward<V>(v));
-}
-
-template <class V>
-void UcbDeleteRequest::visitFields(V&& v) const {
-  facebook::ucachebench::thrift::visitFields(*this, std::forward<V>(v));
-}
-
 template <class Writer>
 void serialize(const UcbDeleteReply& self, Writer&& writer) {
   writer.writeStructBegin();
@@ -456,11 +351,6 @@ void serialize(const UcbDeleteReply& self, Writer&& writer) {
   writer.writeField(4 /* field id */, self.appSpecificErrorCode_ref());
   writer.writeFieldStop();
   writer.writeStructEnd();
-}
-
-template <class Writer>
-void UcbDeleteReply::serialize(Writer&& writer) const {
-  facebook::ucachebench::thrift::serialize(*this, std::forward<Writer>(writer));
 }
 
 template <class V>
@@ -505,16 +395,6 @@ void visitFields(const UcbDeleteReply& self, V&& v) {
   if (!v.visitField(4, "appSpecificErrorCode", *self.appSpecificErrorCode_ref())) {
     return;
   }
-}
-
-template <class V>
-void UcbDeleteReply::visitFields(V&& v) {
-  facebook::ucachebench::thrift::visitFields(*this, std::forward<V>(v));
-}
-
-template <class V>
-void UcbDeleteReply::visitFields(V&& v) const {
-  facebook::ucachebench::thrift::visitFields(*this, std::forward<V>(v));
 }
 } // namespace thrift
 } // namespace ucachebench

--- a/packages/ucache_bench/protocol/gen/UcacheBenchMessagesThrift.cpp
+++ b/packages/ucache_bench/protocol/gen/UcacheBenchMessagesThrift.cpp
@@ -49,10 +49,6 @@ void deserialize(UcacheBenchRequestCommon& self, carbon::CarbonProtocolReader& r
   reader.readStructEnd();
 }
 
-void UcacheBenchRequestCommon::deserialize(carbon::CarbonProtocolReader& reader) {
-  facebook::ucachebench::thrift::deserialize(*this, reader);
-}
-
 void deserialize(UcacheBenchReplyCommon& self, carbon::CarbonProtocolReader& reader) {
   reader.readStructBegin();
   while (true) {
@@ -76,10 +72,6 @@ void deserialize(UcacheBenchReplyCommon& self, carbon::CarbonProtocolReader& rea
     }
   }
   reader.readStructEnd();
-}
-
-void UcacheBenchReplyCommon::deserialize(carbon::CarbonProtocolReader& reader) {
-  facebook::ucachebench::thrift::deserialize(*this, reader);
 }
 
 void deserialize(UcbGetRequest& self, carbon::CarbonProtocolReader& reader) {
@@ -113,10 +105,6 @@ void deserialize(UcbGetRequest& self, carbon::CarbonProtocolReader& reader) {
     }
   }
   reader.readStructEnd();
-}
-
-void UcbGetRequest::deserialize(carbon::CarbonProtocolReader& reader) {
-  facebook::ucachebench::thrift::deserialize(*this, reader);
 }
 
 void deserialize(UcbGetReply& self, carbon::CarbonProtocolReader& reader) {
@@ -168,10 +156,6 @@ void deserialize(UcbGetReply& self, carbon::CarbonProtocolReader& reader) {
   reader.readStructEnd();
 }
 
-void UcbGetReply::deserialize(carbon::CarbonProtocolReader& reader) {
-  facebook::ucachebench::thrift::deserialize(*this, reader);
-}
-
 void deserialize(UcbSetRequest& self, carbon::CarbonProtocolReader& reader) {
   reader.readStructBegin();
   while (true) {
@@ -211,10 +195,6 @@ void deserialize(UcbSetRequest& self, carbon::CarbonProtocolReader& reader) {
     }
   }
   reader.readStructEnd();
-}
-
-void UcbSetRequest::deserialize(carbon::CarbonProtocolReader& reader) {
-  facebook::ucachebench::thrift::deserialize(*this, reader);
 }
 
 void deserialize(UcbSetReply& self, carbon::CarbonProtocolReader& reader) {
@@ -262,10 +242,6 @@ void deserialize(UcbSetReply& self, carbon::CarbonProtocolReader& reader) {
   reader.readStructEnd();
 }
 
-void UcbSetReply::deserialize(carbon::CarbonProtocolReader& reader) {
-  facebook::ucachebench::thrift::deserialize(*this, reader);
-}
-
 void deserialize(UcbDeleteRequest& self, carbon::CarbonProtocolReader& reader) {
   reader.readStructBegin();
   while (true) {
@@ -297,10 +273,6 @@ void deserialize(UcbDeleteRequest& self, carbon::CarbonProtocolReader& reader) {
     }
   }
   reader.readStructEnd();
-}
-
-void UcbDeleteRequest::deserialize(carbon::CarbonProtocolReader& reader) {
-  facebook::ucachebench::thrift::deserialize(*this, reader);
 }
 
 void deserialize(UcbDeleteReply& self, carbon::CarbonProtocolReader& reader) {
@@ -342,10 +314,6 @@ void deserialize(UcbDeleteReply& self, carbon::CarbonProtocolReader& reader) {
     }
   }
   reader.readStructEnd();
-}
-
-void UcbDeleteReply::deserialize(carbon::CarbonProtocolReader& reader) {
-  facebook::ucachebench::thrift::deserialize(*this, reader);
 }
 } // namespace thrift
 } // namespace ucachebench


### PR DESCRIPTION
Summary:
Remove the injected serialize/deserialize/visitFields member function
declarations and definitions from Carbon-generated structs. All call sites
now use the free function equivalents.

Changes:
- cppgen.py: Delete member function declaration helpers, definition generators,
  and template placeholders for serialize/deserialize/visitFields. Make
  cpp.methods annotation block conditional (only emitted when there are
  actual annotations like cpp.virtual or custom_comparator).
- Regenerate all 27 IDL output files.

Differential Revision: D94292034


