### PR TITLE
Fix infinite loop in CPU frequency estimation benchmark

### DIFF
--- a/packages/health_check/freq_est.c
+++ b/packages/health_check/freq_est.c
@@ -230,7 +230,7 @@ int main(int argc, char* argv[]) {
       "adcs %1, %1, xzr \n\t"
       "adcs %1, %1, xzr \n\t"
       "adcs %1, %1, xzr \n\t"
-      "b.ne 1b \n\t" // Branch if loop counter != 0
+      "cbnz %0, 1b \n\t" // Branch if loop counter != 0 (flag-independent)
       : "+r"(loop_count), "+r"(start_val) // Inputs/Outputs
       :
       : "cc", "memory" // Clobbers


### PR DESCRIPTION
Summary:
The benchmark was hanging because `b.ne` checks the Z flag, but the 100 `adcs` instructions overwrite the flags set by `subs`. This means the branch was checking if `start_val` is zero (from the last `adcs`) instead of the loop counter.

Since `start_val` is a random non-zero value that only gets incremented, it never becomes zero, causing an infinite loop.

Fix: Use `cbnz` (Compare and Branch if Not Zero) which directly tests the loop counter register without depending on flags.

Differential Revision: D94513551


