### PR TITLE
Fix admin server socket timeout dropping clients

### DIFF
--- a/packages/ucache_bench/server/UcacheBenchAdminServer.cpp
+++ b/packages/ucache_bench/server/UcacheBenchAdminServer.cpp
@@ -213,9 +213,14 @@ void UcacheBenchAdminServer::serverLoop() {
       continue;
     }
 
-    // Set receive timeout on client socket to prevent indefinite blocking
+    // Set receive timeout on client socket.
+    // Must be long enough to cover warmup + benchmark phases, since the client
+    // won't send the next command (WARMUP_DONE / BENCHMARK_DONE) until its
+    // current phase finishes. A too-short timeout causes recv() to return -1,
+    // which handleClient() interprets as a closed connection, dropping the
+    // socket before the client can report phase completion.
     struct timeval tv;
-    tv.tv_sec = 5;
+    tv.tv_sec = timeoutSeconds_ > 0 ? timeoutSeconds_ : 7200;
     tv.tv_usec = 0;
     if (setsockopt(clientSocket, SOL_SOCKET, SO_RCVTIMEO, &tv, sizeof(tv)) <
         0) {


### PR DESCRIPTION
Summary:
The admin server's `SO_RCVTIMEO` was hardcoded to 5 seconds, but clients don't send their next command (`WARMUP_DONE`) until the warmup phase finishes (typically 1000+ seconds). After 5 seconds of inactivity, `recv()` timed out and `handleClient()` exited the read loop, closing the client socket. When clients later tried to report warmup completion, the connection was already dead, so `warmupCompleteClients_` stayed at 0 and the server hit its coordination timeout without ever starting the benchmark phase — resulting in no metrics being reported.

Fix: use `timeoutSeconds_` (the overall coordination timeout, e.g. 3600s) as the socket recv timeout instead of the hardcoded 5 seconds, so handler threads stay alive for the entire benchmark lifecycle.

Reviewed By: excelle08

Differential Revision: D94508544


