### PR TITLE
Migrate cpp.type/cpp.template inline annotations to @cpp.Type

### DIFF
--- a/packages/feedsim/third_party/src/workloads/ranking/if/CMakeLists.txt
+++ b/packages/feedsim/third_party/src/workloads/ranking/if/CMakeLists.txt
@@ -6,4 +6,5 @@ thrift_library(
     "${CMAKE_CURRENT_LIST_DIR}" # Directory where thrift file lives
     "${CMAKE_CURRENT_LIST_DIR}" # Directory where thrift objects will be built
     "ranking/if"
+    THRIFT_INCLUDE_DIRECTORIES ${FBTHRIFT_INCLUDE_DIR}
 )

--- a/packages/feedsim/third_party/src/workloads/ranking/if/ranking.thrift
+++ b/packages/feedsim/third_party/src/workloads/ranking/if/ranking.thrift
@@ -1,5 +1,7 @@
 namespace cpp2 ranking
 
+include "thrift/annotation/cpp.thrift"
+
 cpp_include "folly/small_vector.h"
 cpp_include "folly/container/F14Map.h"
 
@@ -72,14 +74,14 @@ struct Action {
   4: i64 actorID;
 }
 
-typedef list<i64> (cpp.type = "folly::small_vector<int64_t, 8>") SmallListI64
-typedef map<i16, i64> (cpp.template = "folly::F14FastMap") RankingPayloadIntMap
-typedef map<i16, string> (
-  cpp.template = "folly::F14FastMap",
-) RankingPayloadStringMap
-typedef map<i16, SmallListI64> (
-  cpp.template = "folly::F14FastMap",
-) RankingPayloadVecMap
+@cpp.Type{name = "folly::small_vector<int64_t, 8>"}
+typedef list<i64> SmallListI64
+@cpp.Type{template = "folly::F14FastMap"}
+typedef map<i16, i64> RankingPayloadIntMap
+@cpp.Type{template = "folly::F14FastMap"}
+typedef map<i16, string> RankingPayloadStringMap
+@cpp.Type{template = "folly::F14FastMap"}
+typedef map<i16, SmallListI64> RankingPayloadVecMap
 
 struct RankingObject {
   1: i64 objectID;


### PR DESCRIPTION
Summary: Migrate inline `(cpp.type = "...")` and `(cpp.template = "...")` annotations on typedefs to `cpp.Type{name = "..."}` and `cpp.Type{template = "..."}` structured annotations in 2 feedsim ranking thrift files.

Differential Revision: D94698697


