### PR TITLE
Configuration for stress-ng based CPU micro benchmark

### DIFF
--- a/packages/cdn_bench/micro_cpu/cleanup_cpu_micro.sh
+++ b/packages/cdn_bench/micro_cpu/cleanup_cpu_micro.sh
@@ -15,9 +15,9 @@ LINUX_DIST_ID="$(awk -F "=" '/^ID=/ {print $2}' /etc/os-release | tr -d '"')"
 ##########################################
 echo "Removing prerequisite packages..."
 if [ "$LINUX_DIST_ID" = "ubuntu" ]; then
-  apt remove -y sysbench
+  apt remove -y stress-ng
 elif [ "$LINUX_DIST_ID" = "centos" ]; then
-  dnf remove -y sysbench
+  dnf remove -y stress-ng
 fi
 
 cd "$CPU_MICRO_DIR" || exit 1
@@ -28,8 +28,15 @@ if [ -f cpu_run.log ]; then
   rm -f cpu_run.log
 fi
 
+# Remove YAML metrics file
+if [ -f stress_ng_metrics.yaml ]; then
+  echo "Removing stress_ng_metrics.yaml..."
+  rm -f stress_ng_metrics.yaml
+fi
+
 # Remove any other log files
 echo "Removing any other log files..."
 rm -f ./*.log
+rm -f ./*.yaml
 
 echo "Cleanup complete!"

--- a/packages/cdn_bench/micro_cpu/install_cpu_micro.sh
+++ b/packages/cdn_bench/micro_cpu/install_cpu_micro.sh
@@ -13,9 +13,9 @@ LINUX_DIST_ID="$(awk -F "=" '/^ID=/ {print $2}' /etc/os-release | tr -d '"')"
 ##########################################
 echo "Installing prerequisite packages..."
 if [ "$LINUX_DIST_ID" = "ubuntu" ]; then
-  apt install -y sysbench numactl linux-tools-common
+  apt install -y stress-ng numactl linux-tools-common
 elif [ "$LINUX_DIST_ID" = "centos" ]; then
-  dnf install -y sysbench numactl kernel-tools
+  dnf install -y stress-ng numactl kernel-tools
 fi
 
 echo "Installation complete!"

--- a/packages/cdn_bench/micro_cpu/run.sh
+++ b/packages/cdn_bench/micro_cpu/run.sh
@@ -3,11 +3,11 @@
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
-
 set -Eeuo pipefail
 
-CPU_MICRO_DIR="$(dirname "$(readlink -f "$0")")"
+CPU_MICRO_DIR="$(dirname "$(realpath "$0")")"
 LOG_FILE="${CPU_MICRO_DIR}/cpu_run.log"
+YAML_FILE="${CPU_MICRO_DIR}/stress_ng_metrics.yaml"
 
 # Redirect all output to both console and log file
 exec > >(tee -a "$LOG_FILE") 2>&1
@@ -15,69 +15,46 @@ exec > >(tee -a "$LOG_FILE") 2>&1
 # Clear log file at start
 true > "$LOG_FILE"
 
-# Output benchmark type identifier for parser
 echo "CPU"
+echo "Running CPU Micro"
 
 # Default values
-TEST_TYPE="cpu"
-CPU_MAX_PRIME=10000
-THREADS=0
-TIME=60
-MEMORY_BLOCK_SIZE="4K"
-MEMORY_TOTAL_SIZE="100G"
-MEMORY_OPER="read"
-MEMORY_ACCESS_MODE="seq"
+STRESSOR="cpu"
+WORKERS=0
+TIMEOUT=60
+CPU_METHOD="all"
+MATRIX_SIZE=128
+VM_BYTES="256M"
 GOVERNOR="performance"
+TASKSET=""
+VERIFY=0
+AGGRESSIVE=0
 
-# Parse arguments
-while [[ $# -gt 0 ]]; do
-    case $1 in
-        --test-type=*)
-            TEST_TYPE="${1#*=}"
-            shift
-            ;;
-        --cpu-max-prime=*)
-            CPU_MAX_PRIME="${1#*=}"
-            shift
-            ;;
-        --threads=*)
-            THREADS="${1#*=}"
-            shift
-            ;;
-        --time=*)
-            TIME="${1#*=}"
-            shift
-            ;;
-        --memory-block-size=*)
-            MEMORY_BLOCK_SIZE="${1#*=}"
-            shift
-            ;;
-        --memory-total-size=*)
-            MEMORY_TOTAL_SIZE="${1#*=}"
-            shift
-            ;;
-        --memory-oper=*)
-            MEMORY_OPER="${1#*=}"
-            shift
-            ;;
-        --memory-access-mode=*)
-            MEMORY_ACCESS_MODE="${1#*=}"
-            shift
-            ;;
-        --governor=*)
-            GOVERNOR="${1#*=}"
-            shift
-            ;;
-        *)
-            echo "Unknown option: $1"
-            exit 1
-            ;;
+# Parse command line arguments (--option=value format)
+for arg in "$@"; do
+    case "$arg" in
+        --stressor=*) STRESSOR="${arg#*=}" ;;
+        --workers=*) WORKERS="${arg#*=}" ;;
+        --timeout=*) TIMEOUT="${arg#*=}" ;;
+        --cpu-method=*) CPU_METHOD="${arg#*=}" ;;
+        --matrix-size=*) MATRIX_SIZE="${arg#*=}" ;;
+        --vm-bytes=*) VM_BYTES="${arg#*=}" ;;
+        --governor=*) GOVERNOR="${arg#*=}" ;;
+        --taskset=*) TASKSET="${arg#*=}" ;;
+        --verify=*) VERIFY="${arg#*=}" ;;
+        --aggressive=*) AGGRESSIVE="${arg#*=}" ;;
     esac
 done
 
-# If threads is 0 or empty, use nproc (auto-detect)
-if [[ "$THREADS" == "0" || -z "$THREADS" ]]; then
-    THREADS=$(nproc)
+# If workers is 0 or empty, use nproc (auto-detect)
+if [[ "$WORKERS" == "0" || -z "$WORKERS" ]]; then
+    WORKERS=$(nproc)
+fi
+
+# Check stress-ng availability
+if ! command -v stress-ng &> /dev/null; then
+    echo "ERROR: stress-ng is not installed. Run install_cpu_micro.sh first."
+    exit 1
 fi
 
 # Set CPU governor for consistent results
@@ -85,140 +62,188 @@ echo "====================================================================="
 echo "CPU Governor Configuration"
 echo "====================================================================="
 if command -v cpupower &> /dev/null; then
-    echo "Setting CPU governor to: $GOVERNOR"
-    sudo cpupower frequency-set -g "$GOVERNOR" 2>/dev/null || echo "Warning: Could not set CPU governor (requires root)"
+    echo "Setting CPU governor to: ${GOVERNOR}"
+    sudo cpupower frequency-set -g "${GOVERNOR}" 2>/dev/null || echo "Warning: Could not set CPU governor (requires root)"
     cpupower frequency-info 2>/dev/null | grep -E 'governor|driver' || true
 else
     echo "cpupower not available - skipping governor configuration"
 fi
 echo ""
 
-# Check sysbench availability
-if ! command -v sysbench &> /dev/null; then
-    echo "ERROR: sysbench not found. Please install sysbench."
-    exit 1
-fi
-
-echo "Sysbench version: $(sysbench --version)"
+# Collect system metadata before benchmark
+echo "====================================================================="
+echo "CPU Micro Benchmark (stress-ng)"
+echo "====================================================================="
+echo "Script: $0"
+echo "Execution Date: $(date '+%Y-%m-%d %H:%M:%S')"
+echo "stress-ng Version: $(stress-ng --version 2>&1 | head -1)"
 echo ""
 
-# Run the appropriate benchmark
 echo "====================================================================="
-echo "Running Sysbench Benchmark"
+echo "System Information"
 echo "====================================================================="
+echo "Hostname: $(hostname)"
+echo "Kernel: $(uname -r)"
+echo "Architecture: $(uname -m)"
+echo "CPU Model: $(grep -m1 'model name' /proc/cpuinfo | cut -d: -f2 | xargs)"
+echo "Physical Cores: $(grep -c '^processor' /proc/cpuinfo)"
+echo "NUMA Nodes: $(ls -d /sys/devices/system/node/node* 2>/dev/null | wc -l)"
+echo ""
 
-case $TEST_TYPE in
+# CPU frequency info
+echo "====================================================================="
+echo "CPU Frequency Information"
+echo "====================================================================="
+if command -v cpupower &> /dev/null; then
+    cpupower frequency-info 2>/dev/null | grep -E 'current CPU|hardware limits|governor' || true
+else
+    cat /proc/cpuinfo | grep -m1 'cpu MHz' || true
+fi
+echo ""
+
+echo "====================================================================="
+echo "Configuration"
+echo "====================================================================="
+echo "Stressor: ${STRESSOR}"
+echo "Workers: ${WORKERS}"
+echo "Timeout: ${TIMEOUT}s"
+case "$STRESSOR" in
     cpu)
-        echo "Test: CPU"
-        echo "Parameters:"
-        echo "  - cpu-max-prime: $CPU_MAX_PRIME"
-        echo "  - threads: $THREADS"
-        echo "  - time: $TIME seconds"
-        echo ""
-        sysbench cpu \
-            --cpu-max-prime="$CPU_MAX_PRIME" \
-            --threads="$THREADS" \
-            --time="$TIME" \
-            run
+        echo "CPU Method: ${CPU_METHOD}"
         ;;
-    memory)
-        echo "Test: Memory"
-        echo "Parameters:"
-        echo "  - memory-block-size: $MEMORY_BLOCK_SIZE"
-        echo "  - memory-total-size: $MEMORY_TOTAL_SIZE"
-        echo "  - memory-oper: $MEMORY_OPER"
-        echo "  - memory-access-mode: $MEMORY_ACCESS_MODE"
-        echo "  - threads: $THREADS"
-        echo ""
-        sysbench memory \
-            --memory-block-size="$MEMORY_BLOCK_SIZE" \
-            --memory-total-size="$MEMORY_TOTAL_SIZE" \
-            --memory-oper="$MEMORY_OPER" \
-            --memory-access-mode="$MEMORY_ACCESS_MODE" \
-            --threads="$THREADS" \
-            run
+    matrix)
+        echo "Matrix Size: ${MATRIX_SIZE}"
         ;;
-    cdn_edge)
-        echo "Test: CDN Edge Host Profile"
-        echo "Parameters:"
-        echo "  - cpu-max-prime: 5000 (small working sets)"
-        echo "  - threads: $THREADS"
-        echo "  - time: $TIME seconds"
-        echo ""
-        sysbench cpu \
-            --cpu-max-prime=5000 \
-            --threads="$THREADS" \
-            --time="$TIME" \
-            run
+    vm)
+        echo "VM Bytes: ${VM_BYTES}"
         ;;
-    read_optimized)
-        echo "Test: Read-Optimized Drives Profile"
-        echo "Parameters:"
-        echo "  - memory-block-size: 4K"
-        echo "  - memory-total-size: 100G"
-        echo "  - memory-oper: read"
-        echo "  - memory-access-mode: $MEMORY_ACCESS_MODE"
-        echo "  - threads: $THREADS"
-        echo ""
-        sysbench memory \
-            --memory-block-size=4K \
-            --memory-total-size=100G \
-            --memory-oper=read \
-            --memory-access-mode="$MEMORY_ACCESS_MODE" \
-            --threads="$THREADS" \
-            run
+esac
+[[ -n "${TASKSET}" ]] && echo "Taskset: ${TASKSET}"
+[[ "${VERIFY}" == "1" ]] && echo "Verify: enabled"
+[[ "${AGGRESSIVE}" == "1" ]] && echo "Aggressive: enabled"
+echo ""
+
+# Build stress-ng args
+STRESS_ARGS=(
+    "--timeout" "${TIMEOUT}s"
+    "--metrics-brief"
+    "--yaml" "${YAML_FILE}"
+    "--times"
+)
+
+# Add stressor-specific arguments
+case "$STRESSOR" in
+    cpu)
+        STRESS_ARGS+=("--cpu" "${WORKERS}")
+        [[ -n "${CPU_METHOD}" ]] && STRESS_ARGS+=("--cpu-method" "${CPU_METHOD}")
         ;;
-    caching)
-        echo "Test: Large Caching Machines Profile"
-        echo "Parameters:"
-        echo "  - memory-block-size: 64 (small blocks)"
-        echo "  - memory-total-size: 50G"
-        echo "  - memory-access-mode: rnd (random)"
-        echo "  - threads: $THREADS"
-        echo ""
-        sysbench memory \
-            --memory-block-size=64 \
-            --memory-total-size=50G \
-            --memory-access-mode=rnd \
-            --threads="$THREADS" \
-            run
+    cache)
+        STRESS_ARGS+=("--cache" "${WORKERS}")
         ;;
-    object_storage)
-        echo "Test: Object Storage Profile"
-        echo "Parameters:"
-        echo "  - cpu-max-prime: 20000 (large primes)"
-        echo "  - threads: $THREADS"
-        echo "  - time: $TIME seconds"
-        echo ""
-        sysbench cpu \
-            --cpu-max-prime=20000 \
-            --threads="$THREADS" \
-            --time="$TIME" \
-            run
+    matrix)
+        STRESS_ARGS+=("--matrix" "${WORKERS}")
+        STRESS_ARGS+=("--matrix-size" "${MATRIX_SIZE}")
         ;;
-    networking)
-        echo "Test: High Networking Workloads Profile"
-        echo "Parameters:"
-        echo "  - cpu-max-prime: 3000 (small tasks)"
-        echo "  - threads: $THREADS"
-        echo "  - time: $TIME seconds"
-        echo ""
-        sysbench cpu \
-            --cpu-max-prime=3000 \
-            --threads="$THREADS" \
-            --time="$TIME" \
-            run
+    vecmath)
+        STRESS_ARGS+=("--vecmath" "${WORKERS}")
+        ;;
+    vecwide)
+        STRESS_ARGS+=("--vecwide" "${WORKERS}")
+        ;;
+    bsearch)
+        STRESS_ARGS+=("--bsearch" "${WORKERS}")
+        ;;
+    qsort)
+        STRESS_ARGS+=("--qsort" "${WORKERS}")
+        ;;
+    zlib)
+        STRESS_ARGS+=("--zlib" "${WORKERS}")
+        ;;
+    stream)
+        STRESS_ARGS+=("--stream" "${WORKERS}")
+        ;;
+    vm)
+        STRESS_ARGS+=("--vm" "${WORKERS}")
+        STRESS_ARGS+=("--vm-bytes" "${VM_BYTES}")
         ;;
     *)
-        echo "ERROR: Unknown test type: $TEST_TYPE"
-        echo "Valid options: cpu, memory, cdn_edge, read_optimized, caching, object_storage, networking"
+        echo "ERROR: Unknown stressor type: ${STRESSOR}"
+        echo "Valid options: cpu, cache, matrix, vecmath, vecwide, bsearch, qsort, zlib, stream, vm"
         exit 1
         ;;
 esac
 
+# Add optional flags
+[[ "${VERIFY}" == "1" ]] && STRESS_ARGS+=("--verify")
+[[ "${AGGRESSIVE}" == "1" ]] && STRESS_ARGS+=("--aggressive")
+[[ -n "${TASKSET}" ]] && STRESS_ARGS+=("--taskset" "${TASKSET}")
+
+# Run stress-ng benchmark
+echo "====================================================================="
+echo "Running stress-ng Benchmark"
+echo "====================================================================="
+echo "Command: stress-ng ${STRESS_ARGS[*]}"
 echo ""
+
+stress-ng "${STRESS_ARGS[@]}"
+STRESS_EXIT_CODE=$?
+
+echo ""
+
+# Output YAML metrics for parser consumption
+echo "====================================================================="
+echo "YAML Metrics Output"
+echo "====================================================================="
+if [[ -f "${YAML_FILE}" ]]; then
+    echo "BEGIN_STRESS_NG_YAML"
+    cat "${YAML_FILE}"
+    echo "END_STRESS_NG_YAML"
+else
+    echo "Warning: YAML metrics file not found at ${YAML_FILE}"
+fi
+echo ""
+
+# Post-benchmark metrics
+echo "====================================================================="
+echo "Post-Benchmark Metrics"
+echo "====================================================================="
+
+# CPU frequency after test
+echo "CPU Frequency (post-test):"
+if command -v cpupower &> /dev/null; then
+    cpupower frequency-info 2>/dev/null | grep -E 'current CPU' || true
+else
+    cat /proc/cpuinfo | grep -m1 'cpu MHz' || true
+fi
+echo ""
+
+# Memory status
+echo "Memory Status:"
+free -h
+echo ""
+
+# Thermal status
+echo "Thermal Status:"
+if [[ -d /sys/class/thermal ]]; then
+    for zone in /sys/class/thermal/thermal_zone*; do
+        if [[ -f "${zone}/type" ]] && [[ -f "${zone}/temp" ]]; then
+            ZONE_TYPE=$(cat "${zone}/type" 2>/dev/null)
+            ZONE_TEMP=$(cat "${zone}/temp" 2>/dev/null)
+            if [[ -n "${ZONE_TEMP}" ]]; then
+                echo "  ${ZONE_TYPE}: $((ZONE_TEMP / 1000))C"
+            fi
+        fi
+    done
+else
+    echo "  No thermal zones found"
+fi
+echo ""
+
 echo "====================================================================="
 echo "Benchmark Execution Complete"
 echo "====================================================================="
-echo "Log File: $LOG_FILE"
+echo "Exit Code: ${STRESS_EXIT_CODE}"
+echo "Log File: ${LOG_FILE}"
 echo ""
+
+exit "${STRESS_EXIT_CODE}"


### PR DESCRIPTION
Summary: Swapping sysbench to stress-ng for the CPU microbenchmark. stress-ng gives us richer stressor coverage (cpu, cache, matrix, vecmath) which is more suitable for CDN CPU qualification. Parser and runbook update to follow

Differential Revision: D94836042


