### PR TITLE
Parser for stress-ng CPU micro, cleanup script, and BUCK dep fix

### DIFF
--- a/benchpress/plugins/parsers/cdn_bench.py
+++ b/benchpress/plugins/parsers/cdn_bench.py
@@ -540,11 +540,19 @@ class CDNBenchParser(Parser):
 
     def _parse_cpu_metrics(self, stdout: List[str], metrics: Dict[str, Any]) -> None:
         """
-        Parse CPU/Memory benchmark output from sysbench.
+        Parse CPU benchmark output from stress-ng.
+        Extracts metrics from inline YAML output and metrics-brief table.
         Args:
-            stdout: stdout lines from sysbench benchmark execution
+            stdout: stdout lines from stress-ng benchmark execution
             metrics: dictionary to store metrics
         """
+        self._parse_cpu_config(stdout, metrics)
+        self._parse_cpu_metrics_brief(stdout, metrics)
+        self._parse_cpu_yaml(stdout, metrics)
+        self._parse_cpu_times(stdout, metrics)
+
+    def _parse_cpu_config(self, stdout: List[str], metrics: Dict[str, Any]) -> None:
+        """Parse configuration and system info from stress-ng run output."""
         current_section = ""
 
         for line in stdout:
@@ -553,163 +561,237 @@ class CDNBenchParser(Parser):
             # Track sections
             if "CPU Governor Configuration" in line_stripped:
                 current_section = "governor"
-            elif "Running Sysbench Benchmark" in line_stripped:
-                current_section = "benchmark"
-            elif "CPU speed:" in line_stripped:
-                current_section = "cpu_speed"
-            elif "Latency (ms):" in line_stripped:
-                current_section = "latency"
-            elif "Threads fairness:" in line_stripped:
-                current_section = "fairness"
-            elif line_stripped.startswith("General statistics:"):
-                current_section = "general"
+            elif "System Information" in line_stripped:
+                current_section = "sysinfo"
+            elif "Configuration" in line_stripped and "===" in line:
+                current_section = "config"
+            elif "Running stress-ng" in line_stripped:
+                current_section = "running"
+            elif "Post-Benchmark" in line_stripped:
+                current_section = "post"
 
             # Parse governor info
             if current_section == "governor":
                 if "Setting CPU governor to:" in line_stripped:
                     metrics["cpu_governor"] = line_stripped.split(":")[-1].strip()
 
-            # Parse benchmark configuration
-            if current_section == "benchmark":
-                if line_stripped.startswith("Test:"):
-                    metrics["test_type"] = line_stripped.split(":", 1)[-1].strip()
-                elif line_stripped.startswith("- cpu-max-prime:"):
+            # Parse system info
+            if current_section == "sysinfo":
+                if line_stripped.startswith("Hostname:"):
+                    metrics["hostname"] = line_stripped.split(":", 1)[-1].strip()
+                elif line_stripped.startswith("Kernel:"):
+                    metrics["kernel_version"] = line_stripped.split(":", 1)[-1].strip()
+                elif line_stripped.startswith("Architecture:"):
+                    metrics["architecture"] = line_stripped.split(":", 1)[-1].strip()
+                elif line_stripped.startswith("CPU Model:"):
+                    metrics["cpu_model"] = line_stripped.split(":", 1)[-1].strip()
+                elif line_stripped.startswith("Physical Cores:"):
                     try:
-                        metrics["cpu_max_prime"] = int(
+                        metrics["physical_cores"] = int(
                             line_stripped.split(":", 1)[-1].strip()
                         )
                     except ValueError:
                         pass
-                elif line_stripped.startswith("- threads:"):
+                elif line_stripped.startswith("NUMA Nodes:"):
                     try:
-                        metrics["threads"] = int(
+                        metrics["numa_nodes"] = int(
                             line_stripped.split(":", 1)[-1].strip()
                         )
                     except ValueError:
                         pass
-                elif line_stripped.startswith("- time:"):
+
+            # Parse configuration
+            if current_section == "config":
+                if line_stripped.startswith("Stressor:"):
+                    metrics["stressor"] = line_stripped.split(":", 1)[-1].strip()
+                elif line_stripped.startswith("Workers:"):
+                    try:
+                        metrics["workers"] = int(
+                            line_stripped.split(":", 1)[-1].strip()
+                        )
+                    except ValueError:
+                        pass
+                elif line_stripped.startswith("Timeout:"):
                     match = re.search(r"(\d+)", line_stripped)
                     if match:
-                        metrics["time_secs"] = int(match.group(1))
-                elif line_stripped.startswith("- memory-block-size:"):
-                    metrics["memory_block_size"] = line_stripped.split(":", 1)[
-                        -1
-                    ].strip()
-                elif line_stripped.startswith("- memory-total-size:"):
-                    metrics["memory_total_size"] = line_stripped.split(":", 1)[
-                        -1
-                    ].strip()
-                elif line_stripped.startswith("- memory-oper:"):
-                    metrics["memory_oper"] = line_stripped.split(":", 1)[-1].strip()
-                elif line_stripped.startswith("- memory-access-mode:"):
-                    metrics["memory_access_mode"] = line_stripped.split(":", 1)[
-                        -1
-                    ].strip()
-
-            # Parse sysbench version
-            if line_stripped.startswith("Sysbench version:"):
-                metrics["sysbench_version"] = line_stripped.split(":", 1)[-1].strip()
-
-            # Parse number of threads from sysbench output
-            if "Number of threads:" in line_stripped:
-                try:
-                    metrics["num_threads"] = int(line_stripped.split(":")[-1].strip())
-                except ValueError:
-                    pass
-
-            # Parse CPU speed metrics
-            if current_section == "cpu_speed":
-                if "events per second:" in line_stripped:
+                        metrics["timeout_secs"] = int(match.group(1))
+                elif line_stripped.startswith("CPU Method:"):
+                    metrics["cpu_method"] = line_stripped.split(":", 1)[-1].strip()
+                elif line_stripped.startswith("Matrix Size:"):
                     try:
-                        metrics["cpu_events_per_sec"] = float(
-                            line_stripped.split(":")[-1].strip()
+                        metrics["matrix_size"] = int(
+                            line_stripped.split(":", 1)[-1].strip()
                         )
                     except ValueError:
                         pass
 
-            # Parse latency metrics (for both CPU and memory tests)
-            if current_section == "latency":
-                if line_stripped.startswith("min:"):
-                    try:
-                        metrics["latency_min_ms"] = float(
-                            line_stripped.split(":")[-1].strip()
-                        )
-                    except ValueError:
-                        pass
-                elif line_stripped.startswith("avg:"):
-                    try:
-                        metrics["latency_avg_ms"] = float(
-                            line_stripped.split(":")[-1].strip()
-                        )
-                    except ValueError:
-                        pass
-                elif line_stripped.startswith("max:"):
-                    try:
-                        metrics["latency_max_ms"] = float(
-                            line_stripped.split(":")[-1].strip()
-                        )
-                    except ValueError:
-                        pass
-                elif "95th percentile:" in line_stripped:
-                    try:
-                        metrics["latency_p95_ms"] = float(
-                            line_stripped.split(":")[-1].strip()
-                        )
-                    except ValueError:
-                        pass
-                elif line_stripped.startswith("sum:"):
-                    try:
-                        metrics["latency_sum_ms"] = float(
-                            line_stripped.split(":")[-1].strip()
-                        )
-                    except ValueError:
-                        pass
+            # Parse stress-ng version
+            if line_stripped.startswith("stress-ng Version:"):
+                metrics["stress_ng_version"] = line_stripped.split(":", 1)[-1].strip()
+            elif line_stripped.startswith("Execution Date:"):
+                metrics["execution_date"] = line_stripped.split(":", 1)[-1].strip()
 
-            # Parse general statistics
-            if current_section == "general":
-                if "total time:" in line_stripped:
-                    match = re.search(r"([\d.]+)s", line_stripped)
-                    if match:
-                        metrics["total_time_secs"] = float(match.group(1))
-                elif "total number of events:" in line_stripped:
-                    try:
-                        metrics["total_events"] = int(
-                            line_stripped.split(":")[-1].strip()
-                        )
-                    except ValueError:
-                        pass
+    def _parse_cpu_metrics_brief(
+        self, stdout: List[str], metrics: Dict[str, Any]
+    ) -> None:
+        """Parse stress-ng --metrics-brief table output.
 
-            # Parse threads fairness metrics
-            if current_section == "fairness":
-                if "events (avg/stddev):" in line_stripped:
-                    match = re.search(r"([\d.]+)/([\d.]+)", line_stripped)
-                    if match:
-                        metrics["fairness_events_avg"] = float(match.group(1))
-                        metrics["fairness_events_stddev"] = float(match.group(2))
-                elif "execution time (avg/stddev):" in line_stripped:
-                    match = re.search(r"([\d.]+)/([\d.]+)", line_stripped)
-                    if match:
-                        metrics["fairness_time_avg_secs"] = float(match.group(1))
-                        metrics["fairness_time_stddev_secs"] = float(match.group(2))
+        Expected format (from stderr, captured via 2>&1):
+        stress-ng: info: [...] stressor  bogo ops real time ...
+        stress-ng: info: [...] cpu       8640000    60.00 ...
+        """
+        for line in stdout:
+            line_stripped = line.strip()
 
-            # Parse memory throughput (for memory tests)
-            # Format: "102400.00 MiB transferred (1706.49 MiB/sec)"
-            if "MiB transferred" in line_stripped:
+            # Match metrics-brief data lines
+            # Format: stress-ng: info:  [PID] <stressor> <bogo_ops> <real_time>
+            #         <usr_time> <sys_time> <bogo_ops_rt> <bogo_ops_ust> <cpu_pct>
+            brief_match = re.search(
+                r"stress-ng:\s+info:\s+\[\d+\]\s+"
+                r"(\w+)\s+"
+                r"(\d+)\s+"
+                r"([\d.]+)\s+"
+                r"([\d.]+)\s+"
+                r"([\d.]+)\s+"
+                r"([\d.]+)\s+"
+                r"([\d.]+)\s+"
+                r"([\d.]+)",
+                line_stripped,
+            )
+            if brief_match:
+                stressor_name = brief_match.group(1)
+                # Skip header lines
+                if stressor_name in ("stressor", "info"):
+                    continue
+                metrics["brief_stressor"] = stressor_name
+                metrics["brief_bogo_ops"] = int(brief_match.group(2))
+                metrics["brief_real_time_secs"] = float(brief_match.group(3))
+                metrics["brief_usr_time_secs"] = float(brief_match.group(4))
+                metrics["brief_sys_time_secs"] = float(brief_match.group(5))
+                metrics["brief_bogo_ops_per_sec_real"] = float(brief_match.group(6))
+                metrics["brief_bogo_ops_per_sec_usr_sys"] = float(brief_match.group(7))
+                metrics["brief_cpu_used_per_instance_pct"] = float(brief_match.group(8))
+
+            # Parse successful run completion
+            if "successful run completed in" in line_stripped:
+                match = re.search(r"completed in ([\d.]+)s", line_stripped)
+                if match:
+                    metrics["total_run_time_secs"] = float(match.group(1))
+
+    def _parse_cpu_yaml(self, stdout: List[str], metrics: Dict[str, Any]) -> None:
+        """Parse stress-ng YAML output block delimited by markers."""
+        import yaml
+
+        full_output = "\n".join(stdout)
+
+        # Extract YAML block between markers
+        yaml_start = full_output.find("BEGIN_STRESS_NG_YAML")
+        yaml_end = full_output.find("END_STRESS_NG_YAML")
+
+        if yaml_start == -1 or yaml_end == -1:
+            return
+
+        # Skip the marker line itself
+        yaml_start = full_output.index("\n", yaml_start) + 1
+        yaml_str = full_output[yaml_start:yaml_end].strip()
+
+        if not yaml_str:
+            return
+
+        try:
+            data = yaml.safe_load(yaml_str)
+            if not isinstance(data, dict) or "stress-ng" not in data:
+                return
+
+            stress_data = data["stress-ng"]
+
+            if "system-info" in stress_data:
+                self._extract_yaml_sysinfo(stress_data["system-info"], metrics)
+            if "metrics" in stress_data:
+                self._extract_yaml_stressor_metrics(stress_data["metrics"], metrics)
+            if "times" in stress_data and isinstance(stress_data["times"], dict):
+                if "run-time" in stress_data["times"]:
+                    metrics["yaml_run_time_secs"] = float(
+                        stress_data["times"]["run-time"]
+                    )
+
+        except yaml.YAMLError as e:
+            logger.warning(f"Failed to parse stress-ng YAML output: {e}")
+        except Exception as e:
+            logger.warning(f"Error parsing stress-ng YAML metrics: {e}")
+
+    def _extract_yaml_sysinfo(
+        self, sysinfo: Dict[str, Any], metrics: Dict[str, Any]
+    ) -> None:
+        """Extract system-info fields from stress-ng YAML."""
+        if "stress-ng-version" in sysinfo:
+            metrics["stress_ng_version"] = str(sysinfo["stress-ng-version"])
+        if "num-cpus-online" in sysinfo:
+            metrics["yaml_cpus_online"] = int(sysinfo["num-cpus-online"])
+        if "compiler" in sysinfo:
+            metrics["compiler"] = str(sysinfo["compiler"])
+
+    def _extract_yaml_stressor_metrics(
+        self, stressor_metrics: List[Dict[str, Any]], metrics: Dict[str, Any]
+    ) -> None:
+        """Extract per-stressor metrics from stress-ng YAML."""
+        yaml_metric_map = {
+            "bogo-ops": ("bogo_ops", int),
+            "bogo-ops-per-second-usr-sys-time": ("bogo_ops_per_sec_usr_sys", float),
+            "bogo-ops-per-second-real-time": ("bogo_ops_per_sec_real", float),
+            "wall-clock-time": ("wall_clock_time_secs", float),
+            "user-time": ("user_time_secs", float),
+            "system-time": ("system_time_secs", float),
+            "cpu-usage-per-instance": ("cpu_usage_per_instance_pct", float),
+        }
+        for entry in stressor_metrics:
+            if not isinstance(entry, dict):
+                continue
+            metrics["yaml_stressor"] = entry.get("stressor", "unknown")
+            for yaml_key, (metric_name, converter) in yaml_metric_map.items():
+                if yaml_key in entry:
+                    metrics[metric_name] = converter(entry[yaml_key])
+
+    def _parse_cpu_times(self, stdout: List[str], metrics: Dict[str, Any]) -> None:
+        """Parse stress-ng --times output for time breakdown."""
+        for line in stdout:
+            line_stripped = line.strip()
+
+            # Parse times output lines like:
+            # stress-ng: info: [PID]   4320.00s available CPU time
+            # stress-ng: info: [PID]   4319.78s user time   ( 99.99%)
+            # stress-ng: info: [PID]      0.22s system time (  0.01%)
+
+            if "available CPU time" in line_stripped:
+                match = re.search(r"([\d.]+)s\s+available CPU time", line_stripped)
+                if match:
+                    metrics["available_cpu_time_secs"] = float(match.group(1))
+
+            elif "user time" in line_stripped and "stress-ng" in line_stripped:
                 match = re.search(
-                    r"([\d.]+)\s+MiB transferred\s+\(([\d.]+)\s+MiB/sec\)",
-                    line_stripped,
+                    r"([\d.]+)s\s+user time\s+\(\s*([\d.]+)%\)", line_stripped
                 )
                 if match:
-                    metrics["memory_transferred_mib"] = float(match.group(1))
-                    metrics["memory_throughput_mib_per_sec"] = float(match.group(2))
+                    metrics["times_user_secs"] = float(match.group(1))
+                    metrics["times_user_pct"] = float(match.group(2))
 
-            # Parse memory operations per second
-            # Format: "Total operations: 26214400 (436889.96 per second)"
-            if "Total operations:" in line_stripped:
+            elif "system time" in line_stripped and "stress-ng" in line_stripped:
                 match = re.search(
-                    r"Total operations:\s*(\d+)\s*\(([\d.]+)\s*per second\)",
-                    line_stripped,
+                    r"([\d.]+)s\s+system time\s+\(\s*([\d.]+)%\)", line_stripped
                 )
                 if match:
-                    metrics["memory_total_ops"] = int(match.group(1))
-                    metrics["memory_ops_per_sec"] = float(match.group(2))
+                    metrics["times_system_secs"] = float(match.group(1))
+                    metrics["times_system_pct"] = float(match.group(2))
+
+            elif "total time" in line_stripped and "stress-ng" in line_stripped:
+                match = re.search(
+                    r"([\d.]+)s\s+total time\s+\(\s*([\d.]+)%\)", line_stripped
+                )
+                if match:
+                    metrics["times_total_secs"] = float(match.group(1))
+                    metrics["times_total_pct"] = float(match.group(2))
+
+            elif "stressors started" in line_stripped:
+                match = re.search(r"(\d+)\s+stressors started", line_stripped)
+                if match:
+                    metrics["stressors_started"] = int(match.group(1))

--- a/packages/cdn_bench/micro_cpu/README.md
+++ b/packages/cdn_bench/micro_cpu/README.md
@@ -1,6 +1,6 @@
 # CPU Micro Benchmark (micro_cpu)
 
-CPU and memory microbenchmarking using sysbench. This benchmark evaluates CPU and memory subsystem performance for various Edge workload profiles including CDN edge hosts, caching machines, object storage, and high networking workloads.
+CPU microbenchmarking using stress-ng. This benchmark evaluates CPU subsystem performance using a wide range of stressors for HPC CPU qualification, including compute, cache hierarchy, vectorization, and branch prediction workloads.
 
 ## Table of Contents
 
@@ -19,9 +19,9 @@ CPU and memory microbenchmarking using sysbench. This benchmark evaluates CPU an
 - Linux (Ubuntu or CentOS/RHEL)
 - Root or sudo access (for CPU governor control)
 
-Verify sysbench is available:
+Verify stress-ng is available:
 ```bash
-sysbench --version
+stress-ng --version
 ```
 
 ---
@@ -39,7 +39,7 @@ sudo ./packages/cdn_bench/micro_cpu/install_cpu_micro.sh
 ```
 
 **What gets installed:**
-- `sysbench` - Multi-threaded benchmark tool
+- `stress-ng` - System stress testing tool with 300+ stressors
 - `cpupower` - CPU frequency scaling control (kernel-tools)
 - `numactl` - NUMA topology utilities
 
@@ -50,7 +50,7 @@ sudo ./packages/cdn_bench/micro_cpu/install_cpu_micro.sh
 ### Basic Usage
 
 ```bash
-# Run with default settings (cpu test, 10000 primes, all threads)
+# Run with default settings (cpu stressor, all methods, all threads, 60s)
 sudo ./benchpress_cli.py -b ehw run micro_cpu
 ```
 
@@ -59,24 +59,27 @@ sudo ./benchpress_cli.py -b ehw run micro_cpu
 Override default parameters using the `-o` flag with the format `"micro_cpu:<args>"`:
 
 ```bash
-# CDN Edge workload (small primes, latency-sensitive)
-sudo ./benchpress_cli.py -b ehw -o "micro_cpu:--test-type=cdn_edge --time=60" run
+# CPU stressor with specific method
+sudo ./benchpress_cli.py -b ehw -o "micro_cpu:--stressor=cpu --cpu-method=matrixprod --timeout=120" run
 
-# Memory test with random access
-sudo ./benchpress_cli.py -b ehw -o "micro_cpu:--test-type=memory --memory-access-mode=rnd --memory-block-size=64" run
+# Matrix stressor for SIMD/vectorization testing
+sudo ./benchpress_cli.py -b ehw -o "micro_cpu:--stressor=matrix --matrix-size=256 --timeout=60" run
 
-# Object storage profile (large primes)
-sudo ./benchpress_cli.py -b ehw -o "micro_cpu:--test-type=object_storage --threads=32" run
+# Cache hierarchy testing
+sudo ./benchpress_cli.py -b ehw -o "micro_cpu:--stressor=cache --workers=0 --timeout=120" run
+
+# Vector math stressor
+sudo ./benchpress_cli.py -b ehw -o "micro_cpu:--stressor=vecmath --timeout=60" run
 
 # Full example with multiple parameters
-sudo ./benchpress_cli.py -b ehw -o "micro_cpu:--test-type=cpu --cpu-max-prime=20000 --threads=16 --time=120 --governor=performance" run
+sudo ./benchpress_cli.py -b ehw -o "micro_cpu:--stressor=cpu --cpu-method=all --workers=16 --timeout=120 --governor=performance --verify=1" run
 ```
 
 ---
 
 ## Cleanup
 
-Reset CPU governor to default:
+Remove artifacts and reset state:
 
 ```bash
 # Via Benchpress
@@ -90,147 +93,147 @@ sudo ./packages/cdn_bench/micro_cpu/cleanup_cpu_micro.sh
 
 ## Parameter Reference
 
-### Test Configuration
+### Core Configuration
 
 | Parameter | Description | Default | Example Values |
 |-----------|-------------|---------|----------------|
-| `test_type` | Workload profile to run | `cpu` | `cpu`, `memory`, `cdn_edge`, `read_optimized`, `caching`, `object_storage`, `networking` |
-| `threads` | Number of worker threads | `0` (auto = nproc) | `1`, `8`, `16`, `32` |
-| `time` | Test duration (seconds) | `60` | `30`, `60`, `120`, `300` |
+| `stressor` | Stressor type to run | `cpu` | `cpu`, `cache`, `matrix`, `vecmath`, `vecwide`, `bsearch`, `qsort`, `zlib`, `stream` |
+| `workers` | Number of worker instances | `0` (auto = nproc) | `1`, `8`, `16`, `32` |
+| `timeout` | Test duration (seconds) | `60` | `30`, `60`, `120`, `300` |
 | `governor` | CPU frequency governor | `performance` | `performance`, `ondemand`, `powersave` |
 
-### CPU Test Parameters
+### CPU Stressor Parameters
 
 | Parameter | Description | Default | Example Values |
 |-----------|-------------|---------|----------------|
-| `cpu_max_prime` | Upper limit for prime number generation | `10000` | `3000`, `5000`, `10000`, `20000` |
+| `cpu_method` | CPU stressor method | `all` | `all`, `ackermann`, `bitops`, `callfunc`, `cdouble`, `cfloat`, `matrixprod`, `prime`, `queens`, `fft`, `pi` |
 
-### Memory Test Parameters
+### Matrix Stressor Parameters
 
 | Parameter | Description | Default | Example Values |
 |-----------|-------------|---------|----------------|
-| `memory_block_size` | Memory block size per operation | `4K` | `64`, `4K`, `1M` |
-| `memory_total_size` | Total memory to transfer | `100G` | `10G`, `50G`, `100G`, `200G` |
-| `memory_oper` | Memory operation type | `read` | `read`, `write` |
-| `memory_access_mode` | Memory access pattern | `seq` | `seq`, `rnd` |
+| `matrix_size` | Matrix dimensions (NxN) | `128` | `64`, `128`, `256`, `512` |
+
+### VM Stressor Parameters
+
+| Parameter | Description | Default | Example Values |
+|-----------|-------------|---------|----------------|
+| `vm_bytes` | Memory allocation per worker | `256M` | `64M`, `256M`, `1G`, `4G` |
+
+### Advanced Parameters
+
+| Parameter | Description | Default | Example Values |
+|-----------|-------------|---------|----------------|
+| `taskset` | CPU affinity mask | *(none)* | `0-7`, `0,2,4,6` |
+| `verify` | Verify stressor computations | `0` | `0`, `1` |
+| `aggressive` | Enable aggressive mode (maximize stress) | `0` | `0`, `1` |
 
 ---
 
 ## Common Workloads
 
-### 1. CDN Edge Host
+### 1. General HPC CPU Qualification
 
-Simulates edge request processing: many small requests, branchy code, high syscall rate, latency-sensitive.
+Full CPU stressor sweep across all methods - the default for qualifying new CPUs.
 
 ```bash
-sudo ./benchpress_cli.py -b ehw -o "micro_cpu:--test-type=cdn_edge --time=60" run
+sudo ./benchpress_cli.py -b ehw -o "micro_cpu:--stressor=cpu --cpu-method=all --timeout=120" run
 ```
 
 **What to look at:**
-- `events/sec` → throughput capacity
-- `avg / p95 latency` → tail latency sensitivity
-- Scaling when threads > physical cores
+- `bogo_ops_per_sec_real_time` - throughput capacity
+- `cpu_usage_per_instance` - efficiency per core
+- Consistency across methods
 
-> 💡 Uses small primes (5000) to approximate request-heavy edge logic.
+### 2. CDN Edge Host
 
-### 2. Read-Optimized Drives
-
-For search indexes, analytics reads — CPU doing checksums, decompression, parsing.
+Simulates edge request processing: branchy code, high syscall rate, latency-sensitive.
 
 ```bash
-sudo ./benchpress_cli.py -b ehw -o "micro_cpu:--test-type=read_optimized --memory-access-mode=seq" run
+sudo ./benchpress_cli.py -b ehw -o "micro_cpu:--stressor=cpu --cpu-method=callfunc --timeout=60" run
 ```
 
-**With random access:**
+**With branch prediction stress:**
 ```bash
-sudo ./benchpress_cli.py -b ehw -o "micro_cpu:--test-type=read_optimized --memory-access-mode=rnd" run
-```
-
-**What to look at:**
-- `MiB/sec` → raw bandwidth
-- Cross-socket scaling → NUMA effects
-- Consistency under load
-
-### 3. Large Caching Machines
-
-For Redis/Memcached-style behavior: hot data in memory, pointer chasing, small ops.
-
-```bash
-sudo ./benchpress_cli.py -b ehw -o "micro_cpu:--test-type=caching" run
-```
-
-**Single-thread latency probe:**
-```bash
-sudo ./benchpress_cli.py -b ehw -o "micro_cpu:--test-type=caching --threads=1" run
+sudo ./benchpress_cli.py -b ehw -o "micro_cpu:--stressor=bsearch --timeout=60" run
 ```
 
 **What to look at:**
-- Single-thread bandwidth → core quality
-- Multi-thread scaling → cache coherence & memory subsystem
-- Variance between runs
+- Throughput under function call overhead
+- Branch prediction efficiency (via perf hooks)
+- Scaling when workers > physical cores
 
-### 4. Object Storage / Large File Server
+### 3. Cache Hierarchy Testing
 
-For large buffers, checksums, encryption, compression — throughput over latency.
+Evaluate L1/L2/L3 cache performance and coherence.
 
 ```bash
-sudo ./benchpress_cli.py -b ehw -o "micro_cpu:--test-type=object_storage --time=120" run
-```
-
-**Memory streaming variant:**
-```bash
-sudo ./benchpress_cli.py -b ehw -o "micro_cpu:--test-type=memory --memory-block-size=1M --memory-total-size=200G" run
+sudo ./benchpress_cli.py -b ehw -o "micro_cpu:--stressor=cache --timeout=120" run
 ```
 
 **What to look at:**
-- Sustained throughput
-- Power/thermal throttling over time
-- SMT benefit (hyperthreading on vs off)
+- Cache miss rates (via perfstat hook)
+- Performance degradation across NUMA boundaries
+- Impact of cache size on throughput
 
-### 5. High Networking Workloads
+### 4. SIMD / Vectorization
 
-For load balancers, proxies, L4/L7 boxes — packet processing, high syscall rate.
+Test vector processing capability with matrix and vector math stressors.
 
 ```bash
-sudo ./benchpress_cli.py -b ehw -o "micro_cpu:--test-type=networking --time=60" run
+sudo ./benchpress_cli.py -b ehw -o "micro_cpu:--stressor=matrix --matrix-size=256 --timeout=60" run
 ```
 
-**Test under-subscribed cores (scaling behavior):**
+**Vector math variant:**
 ```bash
-sudo ./benchpress_cli.py -b ehw -o "micro_cpu:--test-type=networking --threads=8" run
+sudo ./benchpress_cli.py -b ehw -o "micro_cpu:--stressor=vecmath --timeout=60" run
 ```
 
 **What to look at:**
-- Diminishing returns at high thread counts
-- Latency spikes
-- SMT behavior
+- FLOPS throughput
+- SIMD utilization (via perf counters)
+- Scaling with matrix size
+
+### 5. Compression Workloads
+
+For storage/networking hosts doing inline compression.
+
+```bash
+sudo ./benchpress_cli.py -b ehw -o "micro_cpu:--stressor=zlib --timeout=120" run
+```
+
+**What to look at:**
+- Compression throughput
+- Memory bandwidth utilization
+- CPU utilization patterns
 
 ### 6. Quick System Validation
 
 Fast sanity check before deeper testing:
 
 ```bash
-sudo ./benchpress_cli.py -b ehw -o "micro_cpu:--test-type=cpu --cpu-max-prime=5000 --time=30" run
+sudo ./benchpress_cli.py -b ehw -o "micro_cpu:--stressor=cpu --cpu-method=matrixprod --timeout=30" run
 ```
 
 ---
 
 ## Workload Selection Guide
 
-| System Type | Test Type | Key Parameters | Primary Metric |
-|-------------|-----------|----------------|----------------|
-| CDN Edge | `cdn_edge` | Small primes (5000), high threads | events/sec, p95 latency |
-| Read-optimized SSD | `read_optimized` | 4K blocks, sequential | MiB/sec |
-| Cache nodes | `caching` | 64B blocks, random | bandwidth, variance |
-| Object storage | `object_storage` | Large primes (20000) | sustained throughput |
-| Networking | `networking` | Small primes (3000) | scaling, latency |
+| System Type | Stressor | Key Parameters | Primary Metric |
+|-------------|----------|----------------|----------------|
+| HPC qualification | `cpu` | `cpu-method=all`, long timeout | bogo-ops/sec across methods |
+| CDN Edge | `cpu`/`bsearch` | `cpu-method=callfunc` | throughput, branch misses |
+| Cache-heavy | `cache` | default | cache miss rates |
+| SIMD/Vector | `matrix`/`vecmath` | `matrix-size=256` | bogo-ops/sec, FLOPS |
+| Compression | `zlib` | default | throughput |
+| Sorting/search | `qsort`/`bsearch` | default | ops/sec, branch prediction |
 
 ---
 
 ## Output Files
 
 Results are collected in:
-- `packages/cdn_bench/micro_cpu/cpu_run.log` — sysbench output
+- `packages/cdn_bench/micro_cpu/cpu_run.log` - stress-ng output + YAML metrics
 
 With perf hooks enabled:
 - `perfstat` with CPU events (instructions, cycles, cache, branches)
@@ -245,14 +248,14 @@ With perf hooks enabled:
 chmod +x ./packages/cdn_bench/micro_cpu/run.sh
 ```
 
-### sysbench Not Found
+### stress-ng Not Found
 Install manually:
 ```bash
 # RHEL/CentOS
-sudo dnf install sysbench
+sudo dnf install stress-ng
 
 # Ubuntu/Debian
-sudo apt-get install sysbench
+sudo apt-get install stress-ng
 ```
 
 ### Cannot Set CPU Governor
@@ -281,11 +284,14 @@ lscpu
 
 # 3. Verify NUMA configuration
 numactl --hardware
+
+# 4. Check stress-ng available stressors
+stress-ng --stressors
 ```
 
 ---
 
 ## See Also
 
-- [Sysbench GitHub](https://github.com/akopytov/sysbench)
-- [Sysbench Documentation](https://github.com/akopytov/sysbench#readme)
+- [stress-ng Project](https://github.com/ColinIanKing/stress-ng)
+- [stress-ng Man Page](https://manpages.ubuntu.com/manpages/jammy/man1/stress-ng.1.html)

--- a/packages/cdn_bench/micro_cpu/cleanup_cpu_micro.sh
+++ b/packages/cdn_bench/micro_cpu/cleanup_cpu_micro.sh
@@ -15,9 +15,9 @@ LINUX_DIST_ID="$(awk -F "=" '/^ID=/ {print $2}' /etc/os-release | tr -d '"')"
 ##########################################
 echo "Removing prerequisite packages..."
 if [ "$LINUX_DIST_ID" = "ubuntu" ]; then
-  apt remove -y sysbench
+  apt remove -y stress-ng
 elif [ "$LINUX_DIST_ID" = "centos" ]; then
-  dnf remove -y sysbench
+  dnf remove -y stress-ng
 fi
 
 cd "$CPU_MICRO_DIR" || exit 1
@@ -28,8 +28,15 @@ if [ -f cpu_run.log ]; then
   rm -f cpu_run.log
 fi
 
+# Remove YAML metrics file
+if [ -f stress_ng_metrics.yaml ]; then
+  echo "Removing stress_ng_metrics.yaml..."
+  rm -f stress_ng_metrics.yaml
+fi
+
 # Remove any other log files
 echo "Removing any other log files..."
 rm -f ./*.log
+rm -f ./*.yaml
 
 echo "Cleanup complete!"

--- a/packages/cdn_bench/micro_cpu/install_cpu_micro.sh
+++ b/packages/cdn_bench/micro_cpu/install_cpu_micro.sh
@@ -13,9 +13,9 @@ LINUX_DIST_ID="$(awk -F "=" '/^ID=/ {print $2}' /etc/os-release | tr -d '"')"
 ##########################################
 echo "Installing prerequisite packages..."
 if [ "$LINUX_DIST_ID" = "ubuntu" ]; then
-  apt install -y sysbench numactl linux-tools-common
+  apt install -y stress-ng numactl linux-tools-common
 elif [ "$LINUX_DIST_ID" = "centos" ]; then
-  dnf install -y sysbench numactl kernel-tools
+  dnf install -y stress-ng numactl kernel-tools
 fi
 
 echo "Installation complete!"

--- a/packages/cdn_bench/micro_cpu/run.sh
+++ b/packages/cdn_bench/micro_cpu/run.sh
@@ -3,11 +3,11 @@
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
-
 set -Eeuo pipefail
 
-CPU_MICRO_DIR="$(dirname "$(readlink -f "$0")")"
+CPU_MICRO_DIR="$(dirname "$(realpath "$0")")"
 LOG_FILE="${CPU_MICRO_DIR}/cpu_run.log"
+YAML_FILE="${CPU_MICRO_DIR}/stress_ng_metrics.yaml"
 
 # Redirect all output to both console and log file
 exec > >(tee -a "$LOG_FILE") 2>&1
@@ -15,69 +15,46 @@ exec > >(tee -a "$LOG_FILE") 2>&1
 # Clear log file at start
 true > "$LOG_FILE"
 
-# Output benchmark type identifier for parser
 echo "CPU"
+echo "Running CPU Micro"
 
 # Default values
-TEST_TYPE="cpu"
-CPU_MAX_PRIME=10000
-THREADS=0
-TIME=60
-MEMORY_BLOCK_SIZE="4K"
-MEMORY_TOTAL_SIZE="100G"
-MEMORY_OPER="read"
-MEMORY_ACCESS_MODE="seq"
+STRESSOR="cpu"
+WORKERS=0
+TIMEOUT=60
+CPU_METHOD="all"
+MATRIX_SIZE=128
+VM_BYTES="256M"
 GOVERNOR="performance"
+TASKSET=""
+VERIFY=0
+AGGRESSIVE=0
 
-# Parse arguments
-while [[ $# -gt 0 ]]; do
-    case $1 in
-        --test-type=*)
-            TEST_TYPE="${1#*=}"
-            shift
-            ;;
-        --cpu-max-prime=*)
-            CPU_MAX_PRIME="${1#*=}"
-            shift
-            ;;
-        --threads=*)
-            THREADS="${1#*=}"
-            shift
-            ;;
-        --time=*)
-            TIME="${1#*=}"
-            shift
-            ;;
-        --memory-block-size=*)
-            MEMORY_BLOCK_SIZE="${1#*=}"
-            shift
-            ;;
-        --memory-total-size=*)
-            MEMORY_TOTAL_SIZE="${1#*=}"
-            shift
-            ;;
-        --memory-oper=*)
-            MEMORY_OPER="${1#*=}"
-            shift
-            ;;
-        --memory-access-mode=*)
-            MEMORY_ACCESS_MODE="${1#*=}"
-            shift
-            ;;
-        --governor=*)
-            GOVERNOR="${1#*=}"
-            shift
-            ;;
-        *)
-            echo "Unknown option: $1"
-            exit 1
-            ;;
+# Parse command line arguments (--option=value format)
+for arg in "$@"; do
+    case "$arg" in
+        --stressor=*) STRESSOR="${arg#*=}" ;;
+        --workers=*) WORKERS="${arg#*=}" ;;
+        --timeout=*) TIMEOUT="${arg#*=}" ;;
+        --cpu-method=*) CPU_METHOD="${arg#*=}" ;;
+        --matrix-size=*) MATRIX_SIZE="${arg#*=}" ;;
+        --vm-bytes=*) VM_BYTES="${arg#*=}" ;;
+        --governor=*) GOVERNOR="${arg#*=}" ;;
+        --taskset=*) TASKSET="${arg#*=}" ;;
+        --verify=*) VERIFY="${arg#*=}" ;;
+        --aggressive=*) AGGRESSIVE="${arg#*=}" ;;
     esac
 done
 
-# If threads is 0 or empty, use nproc (auto-detect)
-if [[ "$THREADS" == "0" || -z "$THREADS" ]]; then
-    THREADS=$(nproc)
+# If workers is 0 or empty, use nproc (auto-detect)
+if [[ "$WORKERS" == "0" || -z "$WORKERS" ]]; then
+    WORKERS=$(nproc)
+fi
+
+# Check stress-ng availability
+if ! command -v stress-ng &> /dev/null; then
+    echo "ERROR: stress-ng is not installed. Run install_cpu_micro.sh first."
+    exit 1
 fi
 
 # Set CPU governor for consistent results
@@ -85,140 +62,188 @@ echo "====================================================================="
 echo "CPU Governor Configuration"
 echo "====================================================================="
 if command -v cpupower &> /dev/null; then
-    echo "Setting CPU governor to: $GOVERNOR"
-    sudo cpupower frequency-set -g "$GOVERNOR" 2>/dev/null || echo "Warning: Could not set CPU governor (requires root)"
+    echo "Setting CPU governor to: ${GOVERNOR}"
+    sudo cpupower frequency-set -g "${GOVERNOR}" 2>/dev/null || echo "Warning: Could not set CPU governor (requires root)"
     cpupower frequency-info 2>/dev/null | grep -E 'governor|driver' || true
 else
     echo "cpupower not available - skipping governor configuration"
 fi
 echo ""
 
-# Check sysbench availability
-if ! command -v sysbench &> /dev/null; then
-    echo "ERROR: sysbench not found. Please install sysbench."
-    exit 1
-fi
-
-echo "Sysbench version: $(sysbench --version)"
+# Collect system metadata before benchmark
+echo "====================================================================="
+echo "CPU Micro Benchmark (stress-ng)"
+echo "====================================================================="
+echo "Script: $0"
+echo "Execution Date: $(date '+%Y-%m-%d %H:%M:%S')"
+echo "stress-ng Version: $(stress-ng --version 2>&1 | head -1)"
 echo ""
 
-# Run the appropriate benchmark
 echo "====================================================================="
-echo "Running Sysbench Benchmark"
+echo "System Information"
 echo "====================================================================="
+echo "Hostname: $(hostname)"
+echo "Kernel: $(uname -r)"
+echo "Architecture: $(uname -m)"
+echo "CPU Model: $(grep -m1 'model name' /proc/cpuinfo | cut -d: -f2 | xargs)"
+echo "Physical Cores: $(grep -c '^processor' /proc/cpuinfo)"
+echo "NUMA Nodes: $(ls -d /sys/devices/system/node/node* 2>/dev/null | wc -l)"
+echo ""
 
-case $TEST_TYPE in
+# CPU frequency info
+echo "====================================================================="
+echo "CPU Frequency Information"
+echo "====================================================================="
+if command -v cpupower &> /dev/null; then
+    cpupower frequency-info 2>/dev/null | grep -E 'current CPU|hardware limits|governor' || true
+else
+    cat /proc/cpuinfo | grep -m1 'cpu MHz' || true
+fi
+echo ""
+
+echo "====================================================================="
+echo "Configuration"
+echo "====================================================================="
+echo "Stressor: ${STRESSOR}"
+echo "Workers: ${WORKERS}"
+echo "Timeout: ${TIMEOUT}s"
+case "$STRESSOR" in
     cpu)
-        echo "Test: CPU"
-        echo "Parameters:"
-        echo "  - cpu-max-prime: $CPU_MAX_PRIME"
-        echo "  - threads: $THREADS"
-        echo "  - time: $TIME seconds"
-        echo ""
-        sysbench cpu \
-            --cpu-max-prime="$CPU_MAX_PRIME" \
-            --threads="$THREADS" \
-            --time="$TIME" \
-            run
+        echo "CPU Method: ${CPU_METHOD}"
         ;;
-    memory)
-        echo "Test: Memory"
-        echo "Parameters:"
-        echo "  - memory-block-size: $MEMORY_BLOCK_SIZE"
-        echo "  - memory-total-size: $MEMORY_TOTAL_SIZE"
-        echo "  - memory-oper: $MEMORY_OPER"
-        echo "  - memory-access-mode: $MEMORY_ACCESS_MODE"
-        echo "  - threads: $THREADS"
-        echo ""
-        sysbench memory \
-            --memory-block-size="$MEMORY_BLOCK_SIZE" \
-            --memory-total-size="$MEMORY_TOTAL_SIZE" \
-            --memory-oper="$MEMORY_OPER" \
-            --memory-access-mode="$MEMORY_ACCESS_MODE" \
-            --threads="$THREADS" \
-            run
+    matrix)
+        echo "Matrix Size: ${MATRIX_SIZE}"
         ;;
-    cdn_edge)
-        echo "Test: CDN Edge Host Profile"
-        echo "Parameters:"
-        echo "  - cpu-max-prime: 5000 (small working sets)"
-        echo "  - threads: $THREADS"
-        echo "  - time: $TIME seconds"
-        echo ""
-        sysbench cpu \
-            --cpu-max-prime=5000 \
-            --threads="$THREADS" \
-            --time="$TIME" \
-            run
+    vm)
+        echo "VM Bytes: ${VM_BYTES}"
         ;;
-    read_optimized)
-        echo "Test: Read-Optimized Drives Profile"
-        echo "Parameters:"
-        echo "  - memory-block-size: 4K"
-        echo "  - memory-total-size: 100G"
-        echo "  - memory-oper: read"
-        echo "  - memory-access-mode: $MEMORY_ACCESS_MODE"
-        echo "  - threads: $THREADS"
-        echo ""
-        sysbench memory \
-            --memory-block-size=4K \
-            --memory-total-size=100G \
-            --memory-oper=read \
-            --memory-access-mode="$MEMORY_ACCESS_MODE" \
-            --threads="$THREADS" \
-            run
+esac
+[[ -n "${TASKSET}" ]] && echo "Taskset: ${TASKSET}"
+[[ "${VERIFY}" == "1" ]] && echo "Verify: enabled"
+[[ "${AGGRESSIVE}" == "1" ]] && echo "Aggressive: enabled"
+echo ""
+
+# Build stress-ng args
+STRESS_ARGS=(
+    "--timeout" "${TIMEOUT}s"
+    "--metrics-brief"
+    "--yaml" "${YAML_FILE}"
+    "--times"
+)
+
+# Add stressor-specific arguments
+case "$STRESSOR" in
+    cpu)
+        STRESS_ARGS+=("--cpu" "${WORKERS}")
+        [[ -n "${CPU_METHOD}" ]] && STRESS_ARGS+=("--cpu-method" "${CPU_METHOD}")
         ;;
-    caching)
-        echo "Test: Large Caching Machines Profile"
-        echo "Parameters:"
-        echo "  - memory-block-size: 64 (small blocks)"
-        echo "  - memory-total-size: 50G"
-        echo "  - memory-access-mode: rnd (random)"
-        echo "  - threads: $THREADS"
-        echo ""
-        sysbench memory \
-            --memory-block-size=64 \
-            --memory-total-size=50G \
-            --memory-access-mode=rnd \
-            --threads="$THREADS" \
-            run
+    cache)
+        STRESS_ARGS+=("--cache" "${WORKERS}")
         ;;
-    object_storage)
-        echo "Test: Object Storage Profile"
-        echo "Parameters:"
-        echo "  - cpu-max-prime: 20000 (large primes)"
-        echo "  - threads: $THREADS"
-        echo "  - time: $TIME seconds"
-        echo ""
-        sysbench cpu \
-            --cpu-max-prime=20000 \
-            --threads="$THREADS" \
-            --time="$TIME" \
-            run
+    matrix)
+        STRESS_ARGS+=("--matrix" "${WORKERS}")
+        STRESS_ARGS+=("--matrix-size" "${MATRIX_SIZE}")
         ;;
-    networking)
-        echo "Test: High Networking Workloads Profile"
-        echo "Parameters:"
-        echo "  - cpu-max-prime: 3000 (small tasks)"
-        echo "  - threads: $THREADS"
-        echo "  - time: $TIME seconds"
-        echo ""
-        sysbench cpu \
-            --cpu-max-prime=3000 \
-            --threads="$THREADS" \
-            --time="$TIME" \
-            run
+    vecmath)
+        STRESS_ARGS+=("--vecmath" "${WORKERS}")
+        ;;
+    vecwide)
+        STRESS_ARGS+=("--vecwide" "${WORKERS}")
+        ;;
+    bsearch)
+        STRESS_ARGS+=("--bsearch" "${WORKERS}")
+        ;;
+    qsort)
+        STRESS_ARGS+=("--qsort" "${WORKERS}")
+        ;;
+    zlib)
+        STRESS_ARGS+=("--zlib" "${WORKERS}")
+        ;;
+    stream)
+        STRESS_ARGS+=("--stream" "${WORKERS}")
+        ;;
+    vm)
+        STRESS_ARGS+=("--vm" "${WORKERS}")
+        STRESS_ARGS+=("--vm-bytes" "${VM_BYTES}")
         ;;
     *)
-        echo "ERROR: Unknown test type: $TEST_TYPE"
-        echo "Valid options: cpu, memory, cdn_edge, read_optimized, caching, object_storage, networking"
+        echo "ERROR: Unknown stressor type: ${STRESSOR}"
+        echo "Valid options: cpu, cache, matrix, vecmath, vecwide, bsearch, qsort, zlib, stream, vm"
         exit 1
         ;;
 esac
 
+# Add optional flags
+[[ "${VERIFY}" == "1" ]] && STRESS_ARGS+=("--verify")
+[[ "${AGGRESSIVE}" == "1" ]] && STRESS_ARGS+=("--aggressive")
+[[ -n "${TASKSET}" ]] && STRESS_ARGS+=("--taskset" "${TASKSET}")
+
+# Run stress-ng benchmark
+echo "====================================================================="
+echo "Running stress-ng Benchmark"
+echo "====================================================================="
+echo "Command: stress-ng ${STRESS_ARGS[*]}"
 echo ""
+
+stress-ng "${STRESS_ARGS[@]}"
+STRESS_EXIT_CODE=$?
+
+echo ""
+
+# Output YAML metrics for parser consumption
+echo "====================================================================="
+echo "YAML Metrics Output"
+echo "====================================================================="
+if [[ -f "${YAML_FILE}" ]]; then
+    echo "BEGIN_STRESS_NG_YAML"
+    cat "${YAML_FILE}"
+    echo "END_STRESS_NG_YAML"
+else
+    echo "Warning: YAML metrics file not found at ${YAML_FILE}"
+fi
+echo ""
+
+# Post-benchmark metrics
+echo "====================================================================="
+echo "Post-Benchmark Metrics"
+echo "====================================================================="
+
+# CPU frequency after test
+echo "CPU Frequency (post-test):"
+if command -v cpupower &> /dev/null; then
+    cpupower frequency-info 2>/dev/null | grep -E 'current CPU' || true
+else
+    cat /proc/cpuinfo | grep -m1 'cpu MHz' || true
+fi
+echo ""
+
+# Memory status
+echo "Memory Status:"
+free -h
+echo ""
+
+# Thermal status
+echo "Thermal Status:"
+if [[ -d /sys/class/thermal ]]; then
+    for zone in /sys/class/thermal/thermal_zone*; do
+        if [[ -f "${zone}/type" ]] && [[ -f "${zone}/temp" ]]; then
+            ZONE_TYPE=$(cat "${zone}/type" 2>/dev/null)
+            ZONE_TEMP=$(cat "${zone}/temp" 2>/dev/null)
+            if [[ -n "${ZONE_TEMP}" ]]; then
+                echo "  ${ZONE_TYPE}: $((ZONE_TEMP / 1000))C"
+            fi
+        fi
+    done
+else
+    echo "  No thermal zones found"
+fi
+echo ""
+
 echo "====================================================================="
 echo "Benchmark Execution Complete"
 echo "====================================================================="
-echo "Log File: $LOG_FILE"
+echo "Exit Code: ${STRESS_EXIT_CODE}"
+echo "Log File: ${LOG_FILE}"
 echo ""
+
+exit "${STRESS_EXIT_CODE}"


### PR DESCRIPTION
Summary: Rewrote the CPU parser to handle stress-ng output instead of sysbench. Parser now extracts metrics from three sources: the run script's configuration/sysinfo output, stress-ng's --metrics-brief table, and the inline YAML block.

Differential Revision: D94836108


