### PR TITLE
Improve memory benchmark to use openmp and nthreads for memory ops

### DIFF
--- a/packages/cdn_bench/micro_mem/README.md
+++ b/packages/cdn_bench/micro_mem/README.md
@@ -1,111 +1,237 @@
-# Runbook: Using STREAM Benchmark via DCPerf
-
-This runbook provides step-by-step instructions for running the STREAM memory
-bandwidth benchmark using the **DCPerf** integration. It assumes that **DCPerf**
-is already installed on your system.
-
----
+# Memory Micro Benchmark Runbook
 
 ## Overview
 
-**STREAM** is a widely used tool for measuring sustainable memory bandwidth.
-With its integration into DCPerf, you can now install, run, and clean the STREAM
-benchmark using simle benchpress CLI commands.
+**STREAM** is a widely used tool for measuring sustainable memory bandwidth. This benchmark uses OpenMP parallelization to saturate all memory channels and provides accurate full-system memory bandwidth measurements.
 
-This runbook covers:
-
-- Installing the STREAM benchmark
-- Running the benchmark and collecting metrics
-- Cleaning up after benchmark runs
-- Troubleshooting common issues
-- Useful references
+The benchmark automatically:
+- Compiles STREAM with `-O3 -fopenmp` for optimal parallelization
+- Uses all available CPU threads via `OMP_NUM_THREADS`
+- Applies NUMA interleaving via `numactl --interleave=all` for optimal memory access
 
 ---
 
 ## Quick Start
 
-### 1. **Install the Memory Microbenchmark**
+### 1. Install the Memory Microbenchmark
 
 ```bash
 sudo ./benchpress_cli.py -b ehw install micro_mem
 ```
 
-- This command installs the benchmark and all required dependencies.
+This installs:
+- GCC compiler
+- numactl (for NUMA optimization)
+- Required perf tools
 
 ---
 
-### 2. **Run the Memory Microbenchmark**
+### 2. Run the Memory Microbenchmark
+
+**Recommended command for 100G NIC servers (large L3 cache):**
 
 ```bash
-sudo ./benchpress_cli.py -b ehw -o "micro_mem:<STREAM_ARRAY_SIZE> <NTIMES>" run
+sudo ./benchpress_cli.py -b ehw -o "micro_mem:500000000 100" run micro_mem
 ```
 
-- Replace `<STREAM_ARRAY_SIZE>` with the desired array size (e.g., `100000000`).
-- Replace `<NTIMES>` with the number of iterations (e.g., `2`).
+**Parameters:**
+- `500000000` - Array size (500M elements = ~11 GiB working set)
+- `100` - Number of iterations
 
-**Example:**
+**For maximum accuracy (production benchmarking):**
 
 ```bash
-sudo ./benchpress_cli.py -b ehw -o "micro_mem:100000000 2" run
+sudo ./benchpress_cli.py -b ehw -o "micro_mem:1000000000 100" run micro_mem
 ```
 
-- This will execute the STREAM benchmark and collect system metrics (including
-  cache misses, memory usage, and more).
-- Results and logs are automatically saved and summarized.
+- `1000000000` - 1B elements = ~22 GiB working set (recommended for 336 MiB L3 cache systems)
 
 ---
 
-### 3. **Cleanup After Benchmark Runs**
+## Parameter Selection Guide
+
+### Array Size (STREAM_ARRAY_SIZE)
+
+The array size **must be much larger than L3 cache** to ensure cache misses and accurate memory bandwidth measurement.
+
+| System L3 Cache | Minimum Array Size | Recommended | Working Set |
+|-----------------|-------------------|-------------|-------------|
+| 96 MiB | 100M | **500M** | ~11 GiB |
+| 336 MiB | 200M | **1B** | ~22 GiB |
+
+**Formula:** Working Set = ARRAY_SIZE × 8 bytes × 3 arrays
+
+**⚠️ Avoid small array sizes:**
 
 ```bash
-sudo ./benchpress_cli.py -b ehw clean micro_mem
+# BAD: 20M elements = ~457 MiB, barely exceeds L3 cache
+sudo ./benchpress_cli.py -b ehw -o "micro_mem:20000000 5" run micro_mem
+
+# GOOD: 500M elements = ~11 GiB, properly stresses memory
+sudo ./benchpress_cli.py -b ehw -o "micro_mem:500000000 100" run micro_mem
 ```
 
-- This command removes the binaries, and log files from your environment.
-- It also cleans up any dependencies installed for the micro_mem job.
+### NTIMES (Iterations)
+
+- **Minimum:** 10 iterations
+- **Recommended:** 100 iterations for stable results
+- Higher values reduce variance in reported bandwidth
 
 ---
 
-## Parameter Selection
+## OpenMP Parallelization
 
-- **STREAM_ARRAY_SIZE**: Should be much larger than the lowest-level cache
-  (recommend at least 4x larger). This ensures a high cache miss rate and
-  accurate bandwidth measurement.
-- **NTIMES**: Number of iterations for each kernel. The best result from any
-  iteration is reported.
+The benchmark automatically configures OpenMP for optimal performance:
+
+| Setting | Value | Purpose |
+|---------|-------|---------|
+| `OMP_NUM_THREADS` | $(nproc) | Uses all available CPUs |
+| `OMP_PROC_BIND` | spread | Distributes threads across cores |
+| `OMP_PLACES` | threads | Binds to hardware threads |
+
+### NUMA Optimization
+
+The benchmark uses `numactl --interleave=all` to:
+- Distribute memory allocations across all NUMA nodes
+- Maximize aggregate memory bandwidth
+- Avoid NUMA locality bottlenecks
+
+---
+
+## Expected Results
+
+### Properly Parallelized STREAM (with this fix)
+
+| System | Memory Config | Expected Triad | Efficiency |
+|--------|---------------|----------------|------------|
+| 64-core, 8-channel DDR5-5600 | 358 GB/s theoretical | **~250-280 GB/s** | 70-78% |
+| 64-core, 8-channel DDR5-6400 | 410 GB/s theoretical | **~290-320 GB/s** | 70-78% |
+
+### Single-Threaded STREAM (old behavior)
+
+| System | Expected Triad | Issue |
+|--------|----------------|-------|
+| Any | ~15 GB/s | Only uses 1 memory channel |
+
+If you see ~15 GB/s, the benchmark is not properly parallelized.
 
 ---
 
 ## Output and Metrics
 
-After running the benchmark, you will see an output that includes the usual
-STREAM report and an additional results report gathered and parsed by DCPerf. In
-addition additional metrics and system specs will be persisted via the perf hook
-in the benchmark*metrics*<run_id> directory.
+### Results Directory
 
-### Vendor Addendum
+After a run, results are stored in `benchmark_metrics_<uuid>/`:
 
-We urge you to run the microbenchmark with additional perf parameters to capture
-metrics of interest
+```text
+benchmark_metrics_<uuid>/
+├── micro_mem_metrics_<timestamp>_iter_None.json    # Parsed metrics
+├── micro_mem_system_specs_<timestamp>.json         # System specifications
+├── stream_run.log                                   # Full STREAM output log
+├── perf-stat.csv                                    # Performance counters
+├── vmstat.csv                                       # Virtual memory stats
+├── mpstat.csv                                       # CPU statistics
+└── mem-stat.csv                                     # Memory statistics
+```
+
+### Key Metrics
+
+| Metric | Description | Unit |
+|--------|-------------|------|
+| `copy_best_MBps` | Best Copy bandwidth | MB/s |
+| `scale_best_MBps` | Best Scale bandwidth | MB/s |
+| `add_best_MBps` | Best Add bandwidth | MB/s |
+| `triad_best_MBps` | Best Triad bandwidth (most important) | MB/s |
+| `triad_avg_MBps` | Average Triad bandwidth | MB/s |
+
+### Why Triad is Most Important
+
+| Operation | Formula | Memory Ops | Bytes/Element |
+|-----------|---------|------------|---------------|
+| Copy | c[i] = a[i] | 1 read, 1 write | 16 |
+| Scale | b[i] = scalar × c[i] | 1 read, 1 write | 16 |
+| Add | c[i] = a[i] + b[i] | 2 reads, 1 write | 24 |
+| **Triad** | a[i] = b[i] + scalar × c[i] | 2 reads, 1 write | 24 |
+
+Triad combines multiply-add with multiple memory streams, reflecting real workloads.
+
+---
+
+## Cleanup
+
+```bash
+sudo ./benchpress_cli.py -b ehw clean micro_mem
+```
+
+This removes binaries, logs, and temporary files.
+
+---
+
+## Troubleshooting
+
+### Low Bandwidth (~15 GB/s instead of ~250+ GB/s)
+
+**Cause:** OpenMP not working properly.
+
+**Check:**
+```bash
+# Verify OpenMP threads
+OMP_DISPLAY_ENV=true ./stream
+```
+
+**Solution:** Ensure `libomp` or `libgomp` is installed:
+```bash
+# CentOS/RHEL
+dnf install -y libgomp
+
+# Ubuntu
+apt install -y libomp-dev
+```
+
+### "numactl not found" Warning
+
+**Solution:**
+```bash
+# CentOS/RHEL
+dnf install -y numactl
+
+# Ubuntu
+apt install -y numactl
+```
+
+### Out of Memory
+
+**Cause:** Array size too large for available RAM.
+
+**Solution:** Reduce array size. Working set should be < 50% of total RAM.
+
+### Permission Denied
+
+Run with `sudo` for perf counter access.
+
+---
+
+## Vendor Addendum
+
+For detailed performance analysis, run with additional perf events:
 
 ```json
 {
   "perf": {
     "perfstat": {
       "additional_events": [
-        "branch-misses",
-        "branches",
-        "cpu-cycles",
+        "cache-references",
+        "cache-misses",
+        "LLC-load-misses",
+        "LLC-store-misses",
         "dTLB-load-misses",
-        "dTLB-loads",
-        "dTLB-store-misses",
-        "dTLB-stores",
-        "L1-dcache-loads",
-        "L1-dcache-stores",
-        "ref-cycles"
+        "dTLB-store-misses"
       ]
     },
     "vmstat": {
+      "interval": 1
+    },
+    "mpstat": {
       "interval": 1
     }
   }
@@ -114,32 +240,8 @@ metrics of interest
 
 ---
 
-## Troubleshooting
-
-- **Permission denied:** Ensure you are running commands with `sudo`.
-
-- **Missing dependencies:** The install command will attempt to install `gcc`,
-  `make`, `perf`, and `wget` automatically. If you encounter issues, manually
-  install these packages.
-
-- **Benchmark crashes or hangs:** Reduce `STREAM_ARRAY_SIZE` if you encounter
-  out-of-memory errors. Monitor system resources with `htop` or `free -h`.
-
-- **No output or missing logs:** Check the output directory for logs. Ensure
-  both stdout and stderr are being captured.
-
-- **Cleanup issues:** If files remain after cleanup, manually remove any
-  lingering binaries or logs in the micro_mem directory.
-
----
-
 ## References
 
 - [STREAM Benchmark Homepage](https://www.cs.virginia.edu/stream/)
-- [DCPerf Documentation](https://github.com/facebookresearch/DCPerf/blob/main/README.md)
-
----
-
-```
-
-```
+- [OpenMP Best Practices](https://www.openmp.org/resources/)
+- [NUMA Memory Policies](https://man7.org/linux/man-pages/man8/numactl.8.html)

--- a/packages/cdn_bench/micro_mem/run.sh
+++ b/packages/cdn_bench/micro_mem/run.sh
@@ -19,15 +19,24 @@ BIN="stream"
 # Change to mem_micro directory
 cd "$MEM_MICRO_DIR" || exit 1
 
-# Compile the STREAM benchmark
-echo "Compiling $SRC with stream array size = $ARRAY_SIZE and iterations =$NTIMES..."
-gcc -O -mcmodel=large -DSTREAM_ARRAY_SIZE="$ARRAY_SIZE" -DNTIMES="$NTIMES" "$SRC" -o "$BIN"
+# Detect number of physical cores for OpenMP
+NUM_THREADS=$(nproc)
+echo "Detected $NUM_THREADS available CPUs for OpenMP parallelization"
+
+# Compile the STREAM benchmark with OpenMP support
+echo "Compiling $SRC with OpenMP, stream array size = $ARRAY_SIZE and iterations = $NTIMES..."
+gcc -O3 -fopenmp -mcmodel=large -DSTREAM_ARRAY_SIZE="$ARRAY_SIZE" -DNTIMES="$NTIMES" "$SRC" -o "$BIN"
 
 # Check compilation success
 if [[ ! -x "$BIN" ]]; then
   echo "ERROR: Compilation failed or binary not found!"
   exit 1
 fi
+
+# Set OpenMP environment variables for optimal performance
+export OMP_NUM_THREADS="$NUM_THREADS"
+export OMP_PROC_BIND=spread
+export OMP_PLACES=threads
 
 # Collect system metadata before benchmark
 echo "MEM"
@@ -39,12 +48,25 @@ echo "Execution Date: $(date '+%Y-%m-%d %H:%M:%S')"
 echo "Arguments Passed:"
 echo "  - STREAM_ARRAY_SIZE: $ARRAY_SIZE"
 echo "  - NTIMES: $NTIMES"
+echo "OpenMP Configuration:"
+echo "  - OMP_NUM_THREADS: $OMP_NUM_THREADS"
+echo "  - OMP_PROC_BIND: $OMP_PROC_BIND"
+echo "  - OMP_PLACES: $OMP_PLACES"
 echo "====================================================================="
-./"$BIN" 2>&1
+
+# Run STREAM with NUMA interleaving for optimal memory access
+if command -v numactl &> /dev/null; then
+  echo "Running with numactl --interleave=all for NUMA optimization"
+  numactl --interleave=all ./"$BIN" 2>&1
+else
+  echo "WARNING: numactl not found, running without NUMA optimization"
+  ./"$BIN" 2>&1
+fi
 echo ""
 
 # Get memory information
-echo "Total Memory: $(free -h | awk '/^Mem:/ {print $2}')\n"
+echo "Total Memory: $(free -h | awk '/^Mem:/ {print $2}')"
+printf "\n"
 echo "====================================================================="
 echo "Memory Configuration"
 echo "====================================================================="


### PR DESCRIPTION
Summary: OpenMP enablement for stream to parallelize system-memory bandwidth operations to get real signals.,

Differential Revision: D94947279


