### PR TITLE
Rename GFLOPS metric to remove comma from column name

### DIFF
--- a/perfutils/generate_arm_perf_report.py
+++ b/perfutils/generate_arm_perf_report.py
@@ -324,7 +324,7 @@ def gflops(grouped_df):
     flop_sum_series = fp_fixed_series + fp_scale_series
     gflops_series = flop_sum_series.div(duration_series / 10**9) / 10**9
     return {
-        "name": "GFLOPS (any precision, incl SVE)",
+        "name": "GFLOPS (any precision incl SVE)",
         "series": gflops_series,
     }
 


### PR DESCRIPTION
Summary: The nv-perf-collector metric "GFLOPS (any precision, incl SVE)" contains a comma in the column name. When perfpub's sample_avg_from_csv() outputs this via pandas to_csv(header=False), the comma is not quoted, producing a line like "GFLOPS (any precision, incl SVE),1.234". The downstream split(",") in process_metrics then crashes with "ValueError: too many values to unpack" because it finds 3 comma-separated pieces instead of 2. Fix by removing the comma from the metric name: "GFLOPS (any precision incl SVE)".

Reviewed By: YifanYuan3

Differential Revision: D94975234


