### PR TITLE
Add FBPower monitor class and read_sensors

### DIFF
--- a/benchpress/plugins/hooks/perf.py
+++ b/benchpress/plugins/hooks/perf.py
@@ -11,6 +11,7 @@ import os
 import sys
 import traceback
 
+from benchpress.lib import open_source
 from benchpress.lib.hook import Hook
 
 from .perf_monitors import (
@@ -24,6 +25,9 @@ from .perf_monitors import (
     topdown,
     vmstat,
 )
+
+if not open_source:
+    from .perf_monitors.fb_power import monitor as fb_power
 
 BP_BASEPATH = os.path.dirname(os.path.abspath(sys.argv[0]))
 
@@ -45,6 +49,9 @@ DEFAULT_OPTIONS = {
     "vmstat": {"interval": 5},
 }
 
+if not open_source:
+    DEFAULT_OPTIONS["fb_power"] = {"interval": 1}
+
 AVAIL_MONITORS = {
     "mpstat": mpstat.MPStat,
     "cpufreq_scaling": cpufreq_scaling.CPUFreq,
@@ -56,6 +63,9 @@ AVAIL_MONITORS = {
     "power": power.Power,
     "vmstat": vmstat.VMStat,
 }
+
+if not open_source:
+    AVAIL_MONITORS["fb_power"] = fb_power.FBPower
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
Summary:
The diff stack enables power-telemetry tracing for Benchpress plugins and supports the following platforms: **T1_CPL, T1_MLN, T1_BGM, T1_TRN, and T11_GRC_ARM**.

- **Task:** T248954685  
- **Claude CLI prompts:**  
  - `design.md` (P2203208599)  
  - `implementation.md` (P2203210057)  
- **Related older diffs:**  
  - D73953894  
  - D92542871  


### FBPower Monitor Class and `read_sensors`

- **Added FBPower monitor class** to **monitor power sensors**  
  - Files:
    - `fbcode/cea/chips/benchpress/benchpress/plugins/hooks/perf.py`
    - `fbcode/cea/chips/benchpress/benchpress/plugins/hooks/perf_monitors/fb_power/__init__.py`
    - `fbcode/cea/chips/benchpress/benchpress/plugins/hooks/perf_monitors/fb_power/monitor.py`

- **Updated BUCK build** to include the **additional targets** required by the new monitor components.

Differential Revision: D94542928


