### PR TITLE
Add post-processing and integrate fb_power into perf hooks

### DIFF
--- a/benchpress/plugins/hooks/perf.py
+++ b/benchpress/plugins/hooks/perf.py
@@ -27,7 +27,7 @@ from .perf_monitors import (
 )
 
 if not open_source:
-    from .perf_monitors.fb_power import monitor as fb_power
+    from .perf_monitors import fb_power
 
 DEFAULT_OPTIONS = {
     "mpstat": {
@@ -48,7 +48,7 @@ DEFAULT_OPTIONS = {
 }
 
 if not open_source:
-    DEFAULT_OPTIONS["fb_power"] = {"interval": 1}
+    DEFAULT_OPTIONS["fb_power"] = {"interval": 10, "post_process": True}
 
 AVAIL_MONITORS = {
     "mpstat": mpstat.MPStat,


### PR DESCRIPTION
Summary:
The diff stack enables power-telemetry tracing for Benchpress plugins and supports the following platforms: **T1_CPL, T1_MLN, T1_BGM, T1_TRN, and T11_GRC_ARM**.

- **Task:** T248954685  
- **Claude CLI prompts:**  
  - `design.md` (P2203208599)  
  - `implementation.md` (P2203210057)  
- **Related older diffs:**  
  - D73953894  
  - D92542871  

**Summary**  
Adds **post-processing** to the `fb_power` monitor and integrates it with **perf hooks**. The post-processing engine reads `power.csv` and computes results using **platform-specific sensor mappings**.

**Changes**
- Add `fb_power/post_process.py` with `PowerPostProcessor`
- Extend `constants.py` with per-platform sensor mapping config
- Update `perf.py` to pass `post_process` to `fb_power`
- Update `BUCK` to include `post_process.py`
- Export `PowerPostProcessor` from `__init__.py`

Differential Revision: D94542927


