### PR TITLE
Fix GFlops calculation in ARM perf report — remove erroneous 1e9 duration divisor

### DIFF
--- a/perfutils/generate_arm_perf_report.py
+++ b/perfutils/generate_arm_perf_report.py
@@ -322,7 +322,7 @@ def gflops(grouped_df):
     fp_fixed_series.index = duration_series.index
 
     flop_sum_series = fp_fixed_series + fp_scale_series
-    gflops_series = flop_sum_series.div(duration_series / 10**9) / 10**9
+    gflops_series = flop_sum_series.div(duration_series) / 10**9
     return {
         "name": "GFLOPS (any precision incl SVE)",
         "series": gflops_series,
@@ -336,7 +336,7 @@ def sve_gflops(grouped_df):
 
     fp_scale_series.index = duration_series.index
 
-    sve_gflops_series = fp_scale_series.div(duration_series / 10**9) / 10**9
+    sve_gflops_series = fp_scale_series.div(duration_series) / 10**9
     return {
         "name": "SVE GFLOPS (any precision)",
         "series": sve_gflops_series,


### PR DESCRIPTION
Summary:
`generate_arm_perf_report.py` calculates GFlops as
`flops / (duration / 1e9) / 1e9`. The `get_duration_series()` function returns
timestamp differences already in seconds, so dividing by 1e9 treats seconds as
nanoseconds and inflates results by 10^9.

Fix: `flops / duration / 1e9` — divide by duration (seconds) to get FLOPS,
then by 1e9 to get GFLOPS. Same fix for both `gflops()` and `sve_gflops()`.

Reviewed By: YifanYuan3

Differential Revision: D95473367


