### PR TITLE
Fix ai_wdl sub-benchmark consistency and error handling

### DIFF
--- a/packages/ai_wdl/chm/install_chm.sh
+++ b/packages/ai_wdl/chm/install_chm.sh
@@ -140,7 +140,7 @@ build_folly() {
   # Clone specific version of Folly with all submodules
   git clone -b $FOLLY_VERSION --recursive https://github.com/facebook/folly.git folly-${FOLLY_VERSION}
 
-  pushd folly-${FOLLY_VERSION}
+  pushd folly-${FOLLY_VERSION} || exit 1
   # Install system dependencies required by Folly
   sudo ./build/fbcode_builder/getdeps.py install-system-deps --recursive
   # Build Folly with system packages allowed and using our build directory

--- a/packages/ai_wdl/deser/install_deser.sh
+++ b/packages/ai_wdl/deser/install_deser.sh
@@ -142,7 +142,7 @@ build_folly() {
   # Clone specific version of Folly with all submodules
   git clone -b $FOLLY_VERSION --recursive https://github.com/facebook/folly.git folly-${FOLLY_VERSION}
 
-  pushd folly-${FOLLY_VERSION}
+  pushd folly-${FOLLY_VERSION} || exit 1
   # Install system dependencies required by Folly
   sudo ./build/fbcode_builder/getdeps.py install-system-deps --recursive
   # Build Folly with system packages allowed and using our build directory

--- a/packages/ai_wdl/fbgemm/install_fbgemm_bench.sh
+++ b/packages/ai_wdl/fbgemm/install_fbgemm_bench.sh
@@ -815,7 +815,7 @@ setup_directories() {
   # Change the current directory to the build directory
   # pushd saves the current directory on a stack so we can return to it later with popd
   echo "[SETUP] Changing to build directory..."
-  pushd build || exist
+  pushd build || exit 1
 
   echo "[SETUP] Directory setup complete."
 }
@@ -915,7 +915,7 @@ clone_fbgemm_repo() {
   echo "#!/bin/bash" > fbgemm_${FBGEMM_VERSION}/.github/scripts/fbgemm_gpu_postbuild.bash
 
   # Change the current directory to the FBGEMM GPU directory
-  pushd fbgemm_${FBGEMM_VERSION}/fbgemm_gpu || exist
+  pushd fbgemm_${FBGEMM_VERSION}/fbgemm_gpu || exit 1
 
   echo "[SETUP] FBGEMM repository setup complete."
 }
@@ -1034,7 +1034,7 @@ install_fbgemm() {
   # Return to the previous directory (outside of fbgemm_gpu)
   # This restores the directory we were in before entering fbgemm_gpu
   echo "[BUILD] Returning to previous directory..."
-  cd .. || exist
+  cd .. || exit 1
 
   echo "[BUILD] FBGEMM installation complete."
 }
@@ -1045,7 +1045,7 @@ cleanup() {
 
   # This restores the directory we were in before entering the build directory
   echo "[CLEANUP] Returning to original directory..."
-  popd || exist
+  popd || exit 1
 
   # Remove the build directory to clean up after the build process
   # This saves disk space by removing intermediate build files

--- a/packages/ai_wdl/rebatch/install_rebatch.sh
+++ b/packages/ai_wdl/rebatch/install_rebatch.sh
@@ -6,7 +6,7 @@
 set -Eeuo pipefail
 
 ##################### SYS CONFIG AND DEPS #########################
-BPKGS_REBATCH_ROOT="$(pwd)/packages/ai_wdl/rebatch"
+BPKGS_REBATCH_ROOT="$(cd "$(dirname "$(readlink -f "$0")")" && pwd -P)"
 BENCHPRESS_ROOT="$(readlink -f "$BPKGS_REBATCH_ROOT/../../..")"
 BENCHMARK_ROOT="${BENCHPRESS_ROOT}/benchmarks"
 

--- a/packages/ai_wdl/type_conversion/install_type_conversion.sh
+++ b/packages/ai_wdl/type_conversion/install_type_conversion.sh
@@ -6,7 +6,7 @@
 set -Eeuo pipefail
 
 ##################### SYS CONFIG AND DEPS #########################
-BPKGS_TYPE_CONVERSION_ROOT="$(pwd)/packages/ai_wdl/type_conversion"
+BPKGS_TYPE_CONVERSION_ROOT="$(cd "$(dirname "$(readlink -f "$0")")" && pwd -P)"
 BENCHPRESS_ROOT="$(readlink -f "$BPKGS_TYPE_CONVERSION_ROOT/../../..")"
 BENCHMARK_ROOT="${BENCHPRESS_ROOT}/benchmarks"
 


### PR DESCRIPTION
Summary:
Fixes error handling and path resolution issues across ai_wdl sub-benchmarks (fbgemm, rebatch, type_conversion, chm, deser).

This diff:
- Fix `|| exist` typos to `|| exit 1` in install_fbgemm_bench.sh (4 occurrences). Typo causes silent failure when pushd fails.
- Fix hardcoded $(pwd)-based paths in rebatch and type_conversion install scripts. Replace with dirname/readlink pattern so scripts work when invoked from any directory.
- Add `|| exit 1` to pushd in chm and deser install scripts to fail fast if folly directory doesn't exist.

Differential Revision: D95510128


