### PR TITLE
Fix misc bugs in schbench, syscall, health_check, memcached_bench, and common utils

### DIFF
--- a/packages/common/diagnosis_utils.py
+++ b/packages/common/diagnosis_utils.py
@@ -136,6 +136,7 @@ class DiagnosisRecorder:
                 # Double-check locking pattern
                 if cls._instance is None:
                     # Check environment variable for cross-process file sharing
+                    env_file_path = None
                     if not shared_file_path:
                         env_file_path = os.environ.get("DIAGNOSIS_FILE_PATH")
                         if env_file_path:

--- a/packages/health_check/cleanup_health_check.sh
+++ b/packages/health_check/cleanup_health_check.sh
@@ -4,8 +4,8 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-BPKGS_HEATH_ROOT="$(dirname "$(readlink -f "$0")")" # Path to dir with this file.
-BENCHPRESS_ROOT="$(readlink -f "$BPKGS_HEATH_ROOT/../..")"
+BPKGS_HEALTH_ROOT="$(dirname "$(readlink -f "$0")")" # Path to dir with this file.
+BENCHPRESS_ROOT="$(readlink -f "$BPKGS_HEALTH_ROOT/../..")"
 HEALTH_ROOT="${BENCHPRESS_ROOT}/benchmarks/health_check"
 
 rm -rf "$HEALTH_ROOT"

--- a/packages/health_check/install_health_check.sh
+++ b/packages/health_check/install_health_check.sh
@@ -7,8 +7,8 @@ set -Eeuo pipefail
 
 ##################### SYS CONFIG AND DEPS #########################
 
-BPKGS_HEATH_ROOT="$(dirname "$(readlink -f "$0")")" # Path to dir with this file.
-BENCHPRESS_ROOT="$(readlink -f "$BPKGS_HEATH_ROOT/../..")"
+BPKGS_HEALTH_ROOT="$(dirname "$(readlink -f "$0")")" # Path to dir with this file.
+BENCHPRESS_ROOT="$(readlink -f "$BPKGS_HEALTH_ROOT/../..")"
 HEALTH_ROOT="${BENCHPRESS_ROOT}/benchmarks/health_check"
 
 # Determine OS version

--- a/packages/schbench/install_schbench.sh
+++ b/packages/schbench/install_schbench.sh
@@ -1,4 +1,10 @@
 #!/bin/bash
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+set -euo pipefail
+
 PKG_SCHBENCH_ROOT="$(dirname "$(readlink -f "$0")")" # Path to dir with this file.
 
 rm -rf build
@@ -9,7 +15,7 @@ pushd build
     git clone https://kernel.googlesource.com/pub/scm/linux/kernel/git/mason/schbench
 
     pushd schbench
-        make -j"${BP_CPUS}"
+        make -j"${BP_CPUS:-$(nproc)}"
         # move the binary to the install dir
         install -m755 -D schbench "${PKG_SCHBENCH_ROOT}/bin/schbench"
     popd
@@ -18,4 +24,4 @@ popd
 # destroy the build directory
 rm -rf build
 
-echo "shcbench installed to ${PKG_SCHBENCH_ROOT}/bin/schbench"
+echo "schbench installed to ${PKG_SCHBENCH_ROOT}/bin/schbench"

--- a/packages/syscall/install_syscall.sh
+++ b/packages/syscall/install_syscall.sh
@@ -20,4 +20,5 @@ fi
 
 # Syscall system microbenchmarks
 pushd "$PKG_SYSCALL_ROOT"
-make
+make -j"$(nproc)"
+popd


### PR DESCRIPTION
Summary:
Fixes assorted bugs across smaller benchmark packages including typos, missing error handling, and an UnboundLocalError.

This diff:
- schbench: Add set -euo pipefail, copyright header, nproc fallback for make -j, fix "shcbench" typo.
- syscall: Add missing popd after pushd/make, add -j parallelism to make.
- health_check: Fix BPKGS_HEATH_ROOT typo to BPKGS_HEALTH_ROOT (install + cleanup).
- common/diagnosis_utils.py: Initialize env_file_path before conditional block to prevent UnboundLocalError when shared_file_path is provided.
- memcached_bench: Fix insecure `curl http://` to `curl -fL https://` for memcached download.

Differential Revision: D95510161


