### PR TITLE
Fix django_workload siege install path and cleanup robustness

### DIFF
--- a/packages/django_workload/cleanup_django_workload.sh
+++ b/packages/django_workload/cleanup_django_workload.sh
@@ -3,6 +3,7 @@
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
+set -euo pipefail
 
 DJANGO_PKG_ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")" &>/dev/null && pwd -P)
 BENCHPRESS_ROOT="$(readlink -f "${DJANGO_PKG_ROOT}/../..")"
@@ -15,4 +16,4 @@ pkill java || true
 # Kill memcache processes
 pkill memcache || true
 # Kill uWSGI master process
-kill $(ps aux | grep -i '[u]wsgi master' | awk '{print $2}') || true
+pkill -f uwsgi || true

--- a/packages/django_workload/install_siege.sh
+++ b/packages/django_workload/install_siege.sh
@@ -38,7 +38,7 @@ git clone "$SIEGE_GIT_REPO"
 cd siege/
 git checkout "$SIEGE_GIT_RELEASE_TAG"
 ./utils/bootstrap
-./configure
+./configure --prefix="${SIEGE_INSTALLATION_PREFIX}"
 make -j4
 make install
 cd ../../


### PR DESCRIPTION
Summary:
Fixes siege installation path mismatch and fragile process cleanup in django_workload.

This diff:
- Add --prefix to siege's ./configure so the binary installs to SIEGE_INSTALLATION_PREFIX (where the idempotency check looks for it), fixing re-install failures.
- Replace fragile `kill $(ps aux | grep uwsgi | awk)` with `pkill -f uwsgi || true` in cleanup script.
- Add `set -euo pipefail` to cleanup script.

Differential Revision: D95510173


