### PR TITLE
Allow alternative artifacts basepath for read-only installations

### DIFF
--- a/benchpress/cli/commands/install.py
+++ b/benchpress/cli/commands/install.py
@@ -12,6 +12,7 @@ import os
 import click
 from benchpress.lib.job import get_target_jobs
 from benchpress.lib.util import (
+    get_artifacts_dir,
     initialize_env_vars,
     install_benchmark,
     install_tool,
@@ -46,7 +47,8 @@ class InstallCommand(BenchpressCommand):
 
     def run(self, args, jobs):
         jobs = get_target_jobs(jobs, args.jobs)
-        install_log = open("install.log", "w")
+        install_log_path = os.path.join(get_artifacts_dir(), "install.log")
+        install_log = open(install_log_path, "w")
         for job in jobs.values():
             if not job.install_script:
                 msg = "{} does not have install script, try running without install it"

--- a/benchpress/cli/commands/run.py
+++ b/benchpress/cli/commands/run.py
@@ -19,7 +19,7 @@ from benchpress.lib.history import History
 from benchpress.lib.hook_factory import HookFactory
 from benchpress.lib.job import get_target_jobs
 from benchpress.lib.reporter_factory import ReporterFactory
-from benchpress.lib.util import verify_install
+from benchpress.lib.util import get_artifacts_dir, verify_install
 
 from .command import BenchpressCommand
 
@@ -224,11 +224,16 @@ class RunCommand(BenchpressCommand):
                 logger.warning("Hooks globally disabled as requested")
             else:
                 job.start_hooks()
-            metrics_dir = f"benchmark_metrics_{job.uuid}"
+            metrics_dir = os.path.join(
+                get_artifacts_dir(), f"benchmark_metrics_{job.uuid}"
+            )
             now = datetime.now()
             date = now.strftime("%Y%m%d_%H%M")
             symlink = job.name + "_timestamp:" + date + "_" + job.uuid
-            os.symlink(metrics_dir, f"benchmark_metrics_{symlink}")
+            symlink_path = os.path.join(
+                get_artifacts_dir(), f"benchmark_metrics_{symlink}"
+            )
+            os.symlink(metrics_dir, symlink_path)
             sys_specs_dict["run_id"] = job.uuid
             sys_specs_dict["timestamp"] = job.timestamp
 

--- a/benchpress/cli/main.py
+++ b/benchpress/cli/main.py
@@ -25,7 +25,7 @@ from benchpress.lib.job import Job, JobSuiteBuilder
 from benchpress.lib.job_listing import create_job_listing
 from benchpress.lib.reporter import JSONFileReporter, ScoreReporter, StdoutReporter
 from benchpress.lib.reporter_factory import ReporterFactory
-from benchpress.lib.util import generate_run_id, generate_timestamp
+from benchpress.lib.util import generate_run_id, generate_timestamp, set_artifacts_dir
 from benchpress.plugins.hooks import user_script
 
 from .commands.clean import CleanCommand
@@ -222,6 +222,15 @@ def setup_parser():
         default="./results",
         help="directory to load/store results",
     )
+    parser.add_argument(
+        "--artifacts-dir",
+        type=str,
+        default=None,
+        dest="artifacts_dir",
+        help="Directory to write artifacts (benchmark_metrics, logs, etc.). "
+        "Defaults to BENCHPRESS_ROOT. Useful for read-only installations. "
+        "Can also be set via BENCHPRESS_ARTIFACTS_DIR env var.",
+    )
     parser.add_argument("--verbose", "-v", action="count", default=0)
     parser.add_argument("--version", action="version", version=f"{PROJECT} {VERSION}")
 
@@ -351,6 +360,16 @@ def main(args=sys.argv[1:]):
 
     parser = setup_parser()
     args = parser.parse_args(args)
+
+    # Set up artifacts directory from CLI flag or environment variable
+    artifacts_dir = args.artifacts_dir or os.environ.get("BENCHPRESS_ARTIFACTS_DIR")
+    if artifacts_dir:
+        set_artifacts_dir(artifacts_dir)
+        logging_config.reconfigure_log_path(artifacts_dir)
+
+    # If results path is relative, resolve it relative to artifacts dir
+    if artifacts_dir and not os.path.isabs(args.results):
+        args.results = os.path.join(os.path.abspath(artifacts_dir), args.results)
 
     conf = load_config(args)
 

--- a/benchpress/lib/util.py
+++ b/benchpress/lib/util.py
@@ -26,8 +26,32 @@ BENCHMARKS_ROOT = "benchmarks"
 # This is used to resolve relative paths for scripts and tracking files
 BENCHPRESS_ROOT = os.path.dirname(os.path.realpath(sys.argv[0]))
 
-# Path to the benchmark installs tracking file
-BENCHMARK_INSTALLS_FILE = os.path.join(BENCHPRESS_ROOT, "benchmark_installs.txt")
+# Alternative base path for writing artifacts (benchmark_metrics, logs, etc.)
+# When set, all writable artifacts are redirected to this directory instead of
+# BENCHPRESS_ROOT. This is necessary for read-only installations (e.g. fbpkg
+# mounted in TW containers).
+_artifacts_dir: typing.Optional[str] = None
+
+
+def get_artifacts_dir() -> str:
+    """Return the directory for writing artifacts.
+
+    Defaults to BENCHPRESS_ROOT if not explicitly set via set_artifacts_dir().
+    """
+    return _artifacts_dir if _artifacts_dir is not None else BENCHPRESS_ROOT
+
+
+def set_artifacts_dir(path: str) -> None:
+    """Set the artifacts output directory. Creates it if it doesn't exist."""
+    global _artifacts_dir
+    abs_path = os.path.abspath(path)
+    os.makedirs(abs_path, exist_ok=True)
+    _artifacts_dir = abs_path
+
+
+def get_benchmark_installs_file() -> str:
+    """Return the path to the benchmark installs tracking file."""
+    return os.path.join(get_artifacts_dir(), "benchmark_installs.txt")
 
 
 def resolve_script_path(script_path: str) -> str:
@@ -80,8 +104,9 @@ def issue_background_command(cmd, stdout, stderr, env=None):
 def install_list_contains(installer_name: str) -> bool:
     if not installer_name:
         return True
-    if os.path.exists(BENCHMARK_INSTALLS_FILE):
-        with open(BENCHMARK_INSTALLS_FILE, "r") as benchmark_installs:
+    installs_file = get_benchmark_installs_file()
+    if os.path.exists(installs_file):
+        with open(installs_file, "r") as benchmark_installs:
             for benchmark_install in benchmark_installs:
                 if installer_name.strip() == benchmark_install.strip():
                     return True
@@ -90,16 +115,17 @@ def install_list_contains(installer_name: str) -> bool:
 
 def install_list_append(installer_name: str):
     if not install_list_contains(installer_name):
-        with open(BENCHMARK_INSTALLS_FILE, "a") as installs_file:
+        with open(get_benchmark_installs_file(), "a") as installs_file:
             # Note: we could os.path.expandvars() to match the echo approach
             installs_file.write(installer_name + "\n")
 
 
 def install_list_remove(installer_name: str):
-    if os.path.exists(BENCHMARK_INSTALLS_FILE):
-        with open(BENCHMARK_INSTALLS_FILE, "r") as benchmark_installs_fp:
+    installs_file = get_benchmark_installs_file()
+    if os.path.exists(installs_file):
+        with open(installs_file, "r") as benchmark_installs_fp:
             lines = benchmark_installs_fp.readlines()
-        with open(BENCHMARK_INSTALLS_FILE, "w") as benchmark_installs_fp:
+        with open(installs_file, "w") as benchmark_installs_fp:
             for line in lines:
                 if line.strip() != installer_name.strip():
                     benchmark_installs_fp.write(line)
@@ -110,7 +136,7 @@ def verify_install(job) -> bool:
     If the yaml file provided install markers, any marker being missing will
     lead to this function returning False. Assuming no markers are provided,
     this function checks installed.txt for a record of the install script
-    being run. The actual binary is allways checked for existance.
+    being run. The actual binary is allways checked for existence.
 
     Arguments
         - job is a Benchpress Job. Class is defined in lib/job.py
@@ -189,7 +215,9 @@ def install_tool(tool_name):
 
 
 def create_benchmark_metrics_dir(run_id):
-    benchmark_metrics_dir = "benchmark_metrics_{}".format(run_id)
+    benchmark_metrics_dir = os.path.join(
+        get_artifacts_dir(), "benchmark_metrics_{}".format(run_id)
+    )
     try:
         os.mkdir(benchmark_metrics_dir)
     except OSError as exc:
@@ -206,14 +234,14 @@ def clean_benchmark(clean_script, install_script):
     clean_benchmark_proc = subprocess.Popen(clean_benchmark_cmd, shell=False)
     clean_benchmark_proc.wait()
     if clean_benchmark_proc.returncode == 0:
-        if os.path.exists(BENCHMARK_INSTALLS_FILE):
-            with open(BENCHMARK_INSTALLS_FILE, "r") as benchmark_installs_fp:
+        installs_file = get_benchmark_installs_file()
+        if os.path.exists(installs_file):
+            with open(installs_file, "r") as benchmark_installs_fp:
                 lines = benchmark_installs_fp.readlines()
-            with open(BENCHMARK_INSTALLS_FILE, "w") as benchmark_installs_fp:
+            with open(installs_file, "w") as benchmark_installs_fp:
                 for line in lines:
                     if line.strip("\n") != install_script:
                         benchmark_installs_fp.write(line)
-                benchmark_installs_fp.close()
 
 
 def clean_tool(tool_name):

--- a/benchpress/logging_config.py
+++ b/benchpress/logging_config.py
@@ -31,3 +31,15 @@ def create_logger():
     root.addHandler(handler)
     root.addHandler(stream_handler)
     return root
+
+
+def reconfigure_log_path(artifacts_dir: str):
+    """Reconfigure the file handler to write benchpress.log to the artifacts directory."""
+    global handler
+    new_path = os.path.join(artifacts_dir, "benchpress.log")
+    new_handler = logging.handlers.WatchedFileHandler(new_path)
+    new_handler.setFormatter(formatter)
+    root = logging.getLogger()
+    root.removeHandler(handler)
+    root.addHandler(new_handler)
+    handler = new_handler

--- a/benchpress/plugins/hooks/copy.py
+++ b/benchpress/plugins/hooks/copy.py
@@ -10,9 +10,9 @@ import glob
 import logging
 import os
 import shutil
-import sys
 
 from benchpress.lib.hook import Hook
+from benchpress.lib.util import get_artifacts_dir
 
 logger = logging.getLogger(__name__)
 
@@ -23,10 +23,6 @@ class CopyMoveHook(Hook):
     Options are a dictionary of 'before' and 'after' lists with a string for
     each paths to copy.
     """
-
-    def __init__(self):
-        # Path to directory of benchpress_cli.py
-        self.basepath = os.path.dirname(os.path.abspath(sys.argv[0]))
 
     @staticmethod
     def do_copy_or_move(sources, dest, move=False):
@@ -50,13 +46,13 @@ class CopyMoveHook(Hook):
                 logger.warning(f"Could not copy {src}.")
 
     def before_job(self, opts, job):
-        destdir = self.basepath + "/benchmark_metrics_" + job.uuid
+        destdir = os.path.join(get_artifacts_dir(), "benchmark_metrics_" + job.uuid)
         is_move = True if "is_move" in opts and opts["is_move"] else False
         if "before" in opts:
             self.do_copy_or_move(opts["before"], destdir, is_move)
 
     def after_job(self, opts, job):
-        destdir = self.basepath + "/benchmark_metrics_" + job.uuid
+        destdir = os.path.join(get_artifacts_dir(), "benchmark_metrics_" + job.uuid)
         is_move = True if "is_move" in opts and opts["is_move"] else False
         if "after" in opts:
             self.do_copy_or_move(opts["after"], destdir, is_move)

--- a/benchpress/plugins/hooks/perf.py
+++ b/benchpress/plugins/hooks/perf.py
@@ -8,11 +8,11 @@
 
 import logging
 import os
-import sys
 import traceback
 
 from benchpress.lib import open_source
 from benchpress.lib.hook import Hook
+from benchpress.lib.util import get_artifacts_dir
 
 from .perf_monitors import (
     cpufreq_cpuinfo,
@@ -28,8 +28,6 @@ from .perf_monitors import (
 
 if not open_source:
     from .perf_monitors.fb_power import monitor as fb_power
-
-BP_BASEPATH = os.path.dirname(os.path.abspath(sys.argv[0]))
 
 DEFAULT_OPTIONS = {
     "mpstat": {
@@ -79,7 +77,9 @@ class Perf(Hook):
             if key in opts:
                 self.opts[key].update(opts[key])
 
-        self.benchmark_metrics_dir = BP_BASEPATH + f"/benchmark_metrics_{job.uuid}"
+        self.benchmark_metrics_dir = os.path.join(
+            get_artifacts_dir(), f"benchmark_metrics_{job.uuid}"
+        )
         if not os.path.isdir(self.benchmark_metrics_dir):
             os.mkdir(self.benchmark_metrics_dir)
 

--- a/benchpress/plugins/hooks/perf_monitors/__init__.py
+++ b/benchpress/plugins/hooks/perf_monitors/__init__.py
@@ -11,18 +11,19 @@ import logging
 import os
 import signal
 import subprocess
-import sys
 import threading
+
+from benchpress.lib.util import get_artifacts_dir
 
 
 logger = logging.getLogger(__name__)
-# Path to directory of benchpress_cli.py
-BP_BASEPATH = os.path.dirname(os.path.abspath(sys.argv[0]))
 
 
 class Monitor:
     def gen_path(self, filename):
-        return BP_BASEPATH + f"/benchmark_metrics_{self.job_uuid}/{filename}"
+        return os.path.join(
+            get_artifacts_dir(), f"benchmark_metrics_{self.job_uuid}", filename
+        )
 
     def __init__(self, interval, name, job_uuid):
         """Initialize some common parameters and storage variables"""

--- a/benchpress/plugins/hooks/perf_monitors/topdown.py
+++ b/benchpress/plugins/hooks/perf_monitors/topdown.py
@@ -13,8 +13,9 @@ import subprocess
 
 import numpy as np
 import pandas as pd
+from benchpress.lib.util import BENCHPRESS_ROOT, get_artifacts_dir
 
-from . import BP_BASEPATH, logger, Monitor
+from . import logger, Monitor
 
 
 def get_cpuinfo():
@@ -149,14 +150,18 @@ class IntelPerfSpect(Monitor):
         super(IntelPerfSpect, self).__init__(interval, "perfspect", job_uuid)
         self.mux_interval_msecs = mux_interval_msecs
         if perfspect_path is None:
-            self.perfspect_path = os.path.join(BP_BASEPATH, "perfspect")
+            self.perfspect_path = os.path.join(BENCHPRESS_ROOT, "perfspect")
         else:
             self.perfspect_path = perfspect_path
         self.collect_output_path = os.path.join(
-            BP_BASEPATH, "benchmark_metrics_" + self.job_uuid, "perf-collect.csv"
+            get_artifacts_dir(),
+            "benchmark_metrics_" + self.job_uuid,
+            "perf-collect.csv",
         )
         self.postprocess_output_path = os.path.join(
-            BP_BASEPATH, "benchmark_metrics_" + self.job_uuid, "topdown-intel.csv"
+            get_artifacts_dir(),
+            "benchmark_metrics_" + self.job_uuid,
+            "topdown-intel.csv",
         )
         if os.path.exists(
             os.path.join(self.perfspect_path, "perf-collect")
@@ -227,14 +232,16 @@ class IntelPerfSpect3(Monitor):
         super(IntelPerfSpect3, self).__init__(interval, "perfspect3", job_uuid)
         self.mux_interval_msecs = mux_interval_msecs
         if perfspect_path is None:
-            self.perfspect_path = os.path.join(BP_BASEPATH, "perfspect")
+            self.perfspect_path = os.path.join(BENCHPRESS_ROOT, "perfspect")
         else:
             self.perfspect_path = perfspect_path
         self.collect_output_path = os.path.join(
-            BP_BASEPATH, "benchmark_metrics_" + self.job_uuid
+            get_artifacts_dir(), "benchmark_metrics_" + self.job_uuid
         )
         self.postprocess_output_path = os.path.join(
-            BP_BASEPATH, "benchmark_metrics_" + self.job_uuid, "topdown-intel.sys.csv"
+            get_artifacts_dir(),
+            "benchmark_metrics_" + self.job_uuid,
+            "topdown-intel.sys.csv",
         )
         if os.path.exists(os.path.join(self.perfspect_path, "perfspect")):
             self.supported = True
@@ -293,7 +300,7 @@ class BasePerfUtil(Monitor):
     ):
         super(BasePerfUtil, self).__init__(interval, name, job_uuid)
         if perfutils_path is None:
-            self.perfutils_path = os.path.join(BP_BASEPATH, "perfutils")
+            self.perfutils_path = os.path.join(BENCHPRESS_ROOT, "perfutils")
         else:
             self.perfutil_path = perfutils_path
         self.perf_collect_script_name = perf_collect_script_name
@@ -302,10 +309,14 @@ class BasePerfUtil(Monitor):
             list(perf_postproc_args) if perf_postproc_args else []
         )
         self.postprocess_timeseries_output_path = os.path.join(
-            BP_BASEPATH, "benchmark_metrics_" + self.job_uuid, f"{name}-timeseries.csv"
+            get_artifacts_dir(),
+            "benchmark_metrics_" + self.job_uuid,
+            f"{name}-timeseries.csv",
         )
         self.postprocess_summary_output_path = os.path.join(
-            BP_BASEPATH, "benchmark_metrics_" + self.job_uuid, f"{name}-summary.csv"
+            get_artifacts_dir(),
+            "benchmark_metrics_" + self.job_uuid,
+            f"{name}-summary.csv",
         )
 
     def run(self):
@@ -631,7 +642,7 @@ class DummyPerfUtil:
 
 
 def choose_perfspect():
-    perfspect_dir = os.path.join(BP_BASEPATH, "perfspect")
+    perfspect_dir = os.path.join(BENCHPRESS_ROOT, "perfspect")
     perfspect3_bin = os.path.join(perfspect_dir, "perfspect")
     perfspect1_bin1 = os.path.join(perfspect_dir, "perf-collect")
     perfspect1_bin2 = os.path.join(perfspect_dir, "perf-postprocess")


### PR DESCRIPTION
Summary:
Adds --artifacts-dir CLI flag and BENCHPRESS_ARTIFACTS_DIR env var support so
benchpress can write artifacts (benchmark_metrics, logs, install tracking) to
a user-specified directory instead of BENCHPRESS_ROOT. This is needed for
running DCPerf on TW containers where the fbpkg mount is read-only.

When set, all artifact writes (benchmark_metrics_<run_id>/ dirs, benchpress.log,
install.log, benchmark_installs.txt, result records, symlinks) go to the
specified directory. Script resolution (finding install/run/clean scripts) still
uses BENCHPRESS_ROOT. Default behavior is unchanged when neither flag nor env
var is provided.

Also consolidates the duplicate BP_BASEPATH definitions in perf hooks into
the centralized get_artifacts_dir() API from util.py.

Differential Revision: D95804538


