### PR TITLE
Fix video_transcode_bench error handling and OOM risk

### DIFF
--- a/packages/video_transcode_bench/install_video_transcode_bench.sh
+++ b/packages/video_transcode_bench/install_video_transcode_bench.sh
@@ -66,6 +66,10 @@ if ! [ -f "/usr/local/bin/cmake" ]; then
      ln -s /usr/bin/cmake /usr/local/bin/cmake
 fi
 
+# Source OOM-safe build parallelism helper
+source "$(dirname "$0")/../common/get_build_parallelism.sh"
+NUM_BUILD_JOBS=${NUM_BUILD_JOBS:-$(get_build_parallelism)}
+
 ##################### BUILD AND INSTALL FUNCTIONS #########################
 
 clone()
@@ -92,11 +96,11 @@ build_x264()
 {
     lib='x264'
     pushd "${FFMPEG_SOURCE}"
-    clone $lib || echo "Failed to clone $lib"
+    clone "$lib" || { echo "ERROR: Failed to clone $lib"; exit 1; }
     cd "$lib" || exit
     mkdir -p _build && cd _build || exit
     CC="clang" CXX="clang++" ../configure --prefix="${FFMPEG_BUILD}" --enable-static --extra-cflags="${platform_cc_flags}"
-    make -j "$(nproc)" && make install -j "$(nproc)"
+    make -j "${NUM_BUILD_JOBS}" && make install -j "${NUM_BUILD_JOBS}"
     popd || exit
 }
 
@@ -104,11 +108,11 @@ build_svtav1()
 {
     lib='SVT-AV1'
     pushd "${FFMPEG_SOURCE}"
-    clone $lib || echo "Failed to clone $lib"
+    clone "$lib" || { echo "ERROR: Failed to clone $lib"; exit 1; }
     cd "$lib" || exit
     mkdir -p _build && cd _build || exit
     CC="clang" CXX="clang++" cmake .. -G"Unix Makefiles" -DCMAKE_INSTALL_PREFIX="${FFMPEG_BUILD}" -DCMAKE_BUILD_TYPE=Release
-    make -j "$(nproc)" && make install -j "$(nproc)"
+    make -j "${NUM_BUILD_JOBS}" && make install -j "${NUM_BUILD_JOBS}"
     popd
 }
 
@@ -116,7 +120,7 @@ build_aom()
 {
     lib='aom'
     pushd "${FFMPEG_SOURCE}"
-    clone $lib || echo "Failed to clone $lib"
+    clone "$lib" || { echo "ERROR: Failed to clone $lib"; exit 1; }
     cd "$lib" || exit
     mkdir -p _build && cd _build || exit
     if [ "$ARCH" = "x86_64" ]; then
@@ -124,7 +128,7 @@ build_aom()
     else
         cmake .. -G"Unix Makefiles" -DCMAKE_INSTALL_PREFIX="${FFMPEG_BUILD}"  -DBUILD_SHARED_LIBS=off -DCMAKE_BUILD_TYPE=Release -DAOM_TARGET_CPU=arm64
     fi
-    make -j "$(nproc)" && make install -j "$(nproc)"
+    make -j "${NUM_BUILD_JOBS}" && make install -j "${NUM_BUILD_JOBS}"
     popd || exit
 }
 
@@ -132,10 +136,10 @@ build_vmaf()
 {
     lib='vmaf'
     pushd "${FFMPEG_SOURCE}"
-    clone $lib || echo "Failed to clone $lib"
+    clone "$lib" || { echo "ERROR: Failed to clone $lib"; exit 1; }
     cd "$lib/libvmaf" || exit
     meson setup _build --prefix="${FFMPEG_BUILD}" --default-library static --buildtype release
-    ninja -vC _build install -j "$(nproc)"
+    ninja -vC _build install -j "${NUM_BUILD_JOBS}"
     popd || exit
 }
 
@@ -143,7 +147,7 @@ build_ffmpeg()
 {
     pushd "${FFMPEG_SOURCE}"
     lib='ffmpeg'
-    clone $lib || echo "Failed to clone $lib"
+    clone "$lib" || { echo "ERROR: Failed to clone $lib"; exit 1; }
     cd "$lib" || exit
     git apply "${BPKGS_FFMPEG_ROOT}/0001-ffmpeg.patch"
     mkdir -p _build && cd _build || exit
@@ -183,7 +187,7 @@ build_ffmpeg()
 
     fi
 
-    make -j "$(nproc)" && make install -j "$(nproc)"
+    make -j "${NUM_BUILD_JOBS}" && make install -j "${NUM_BUILD_JOBS}"
     popd || exit
 }
 

--- a/packages/video_transcode_bench/run.sh
+++ b/packages/video_transcode_bench/run.sh
@@ -80,6 +80,12 @@ main() {
     local sampling_seed
     sampling_seed=1000
 
+    local lp
+    lp=1
+
+    local procs
+    procs=-1
+
     sleep_before_perf=60
 
     # Create a backup of generate_commands_all.py before making any changes, to restore it later and avoid replicating changes for susequent runs
@@ -242,10 +248,6 @@ main() {
 
     # Use the Python script to modify generate_commands_all.py
     python3 ./modify_generate_commands_all.py --sample-rate ${sample_rate} --sampling-seed ${sampling_seed} --lp-number "${lp_number}" --num-pool "${num_pool}" --range "${range}" --encoder $encoder
-    if [ $? -ne 0 ]; then
-        benchreps_tell_state "Error configuring script!"
-        exit 1
-    fi
     # create a copy of generate_commands_all.py to generate_commands_all.debug.py for debugging purposes
     cp ${FFMPEG_ROOT}/generate_commands_all.py ${FFMPEG_ROOT}/generate_commands_all.debug.py
     #generate commands


### PR DESCRIPTION
Summary:
Fixes error-swallowing patterns and uninitialized variables in video_transcode_bench.

This diff:
- Replace `clone $lib || echo "Failed"` with `clone "$lib" || { echo "ERROR: ..."; exit 1; }` (5 instances). The || echo pattern swallows errors under set -e, allowing the script to continue in a broken state.
- Source get_build_parallelism.sh and replace `make/ninja -j "$(nproc)"` with OOM-safe NUM_BUILD_JOBS.
- Initialize `lp=1` and `procs=-1` in run.sh to prevent unbound variable errors.
- Remove unreachable `if [ $? -ne 0 ]` block (dead code under set -e).

Differential Revision: D95510166


