### PR TITLE
Fix unrealistic QPS in server-aggregated results

### DIFF
--- a/benchpress/plugins/parsers/ucache_bench.py
+++ b/benchpress/plugins/parsers/ucache_bench.py
@@ -138,13 +138,20 @@ class UcacheBenchParser(Parser):
         if total_ops_match:
             metrics["total_operations"] = int(total_ops_match.group(1))
 
-        # Parse QPS
-        qps_match = re.search(r"QPS:\s+([\d.]+)", output)
+        # Parse QPS from the "Performance:" section of the final results block.
+        # Must be anchored to "Performance:" to avoid matching periodic stats
+        # lines like "[Server BENCHMARK] ... | QPS: ... |" which appear earlier
+        # in the output and can contain transient spike values.
+        qps_match = re.search(r"Performance:\s*\n\s*QPS:\s+([\d.]+)", output, re.DOTALL)
         if qps_match:
             metrics["qps"] = float(qps_match.group(1))
 
-        # Parse hit ratio
-        hit_ratio_match = re.search(r"Hit Ratio:\s+([\d.]+)%", output)
+        # Parse hit ratio from the "Performance:" section for the same reason
+        hit_ratio_match = re.search(
+            r"Performance:\s*\n\s*QPS:\s+[\d.]+\s*\n\s*Hit Ratio:\s+([\d.]+)%",
+            output,
+            re.DOTALL,
+        )
         if hit_ratio_match:
             metrics["hit_ratio_percent"] = float(hit_ratio_match.group(1))
 

--- a/packages/ucache_bench/server/UcacheBenchServer.cpp
+++ b/packages/ucache_bench/server/UcacheBenchServer.cpp
@@ -524,12 +524,16 @@ void UcacheBenchServer::periodicStatsLoop(uint32_t intervalSec) {
       continue;
     }
 
-    // Reset snapshot on phase transition
+    // Reset snapshot on phase transition and skip this iteration.
+    // Without the continue, intervalElapsed would be nearly zero (since
+    // prevTime was just set) while totalOps could already have accumulated
+    // operations, producing an astronomically high intervalQps spike.
     if (phase != prevPhase) {
       prevTotalOps = 0;
       prevTime = std::chrono::steady_clock::now();
       phaseStartTime = prevTime;
       prevPhase = phase;
+      continue;
     }
 
     const PhaseMetrics& metrics =


### PR DESCRIPTION
Summary:
The periodic stats reporting (D94508507) introduced a bug that caused
unrealistically high QPS values (e.g., 527 trillion) in benchmark reports.

Two issues combined to cause this:

1. **Phase transition QPS spike (C++)**: In `periodicStatsLoop`, when a phase
   transition occurs (e.g., WARMUP → BENCHMARK), the code resets `prevTime` to
   `now()` but then falls through to compute `intervalQps`. Since `prevTime`
   was just set nanoseconds ago, `intervalElapsed ≈ 0`, but `totalOps` has
   already accumulated operations since the actual phase change. This produces
   `intervalQps = accumulated_ops / ~0 = astronomically high value`.

   Fix: Add `continue` after the phase transition reset so the first stats
   print happens on the next interval with a proper time delta.

2. **Parser matches wrong QPS line (Python)**: The parser used
   `re.search(r"QPS:\s+([\d.]+)", output)` which matches the *first* "QPS:"
   in the entire output. The periodic stats lines (with the bogus spike from
   bug #1) appear before the final results block, so the parser picked up the
   wrong value.

   Fix: Anchor the regex to the "Performance:" section header that only
   appears in the final `UCACHEBENCH SERVER RESULTS` block.

Differential Revision: D96071356


