### PR TITLE
Apply cachelib_num_shards config to CacheAllocator (#518)

### DIFF
--- a/packages/ucache_bench/server/UcacheBenchServer.cpp
+++ b/packages/ucache_bench/server/UcacheBenchServer.cpp
@@ -45,6 +45,11 @@ void UcacheBenchServer::setupCacheLib() {
   cacheConfig.setAccessConfig(
       {config_.hash_power, config_.hashtable_lock_power});
 
+  // Configure number of CacheLib shards if specified
+  if (config_.cachelib_num_shards > 0) {
+    cacheConfig.setNumShards(config_.cachelib_num_shards);
+  }
+
   // Generate alloc sizes (factor 1.25, min allocation size)
   // This provides a good distribution of allocation classes for cache items
   // Max alloc size increased to 64KB to support production traffic distribution


### PR DESCRIPTION
Summary:

The cachelib_num_shards parameter was parsed from gflags and stored in
UcacheBenchConfig but never actually applied to the CacheAllocator::Config.
This meant the config value was silently ignored and CacheLib used its
default of 8192 shards.

Now call setNumShards() when cachelib_num_shards > 0, allowing the
benchmark to match production shard counts for more accurate CPU
utilization profiling.

Differential Revision: D96087814


