### PR TITLE
Running mm-mem standalone inside benchpress

### DIFF
--- a/benchpress/config/jobs.yml
+++ b/benchpress/config/jobs.yml
@@ -1457,6 +1457,49 @@
       args:
         - '-r client'
 
+- benchmark: health_check
+  name: mm_mem
+  description: Standalone run for mm-mem memory latency and bandwidth benchmark
+  args:
+    - '-b mm-mem'
+    - '--'
+    - '{extra_args}'
+  vars:
+    - 'extra_args='
+
+- benchmark: health_check
+  name: mm_mem_peak_bw
+  description: Run mm-mem peak bandwidth and memcpy benchmark
+  args:
+    - '-b mm-mem'
+    - '--'
+    - '--test bandwidth'
+    - '{extra_args}'
+  vars:
+    - 'extra_args='
+
+- benchmark: health_check
+  name: mm_mem_idle_latency
+  description: Run mm-mem idle latency benchmark
+  args:
+    - '-b mm-mem'
+    - '--'
+    - '--test idle_latency'
+    - '{extra_args}'
+  vars:
+    - 'extra_args='
+
+- benchmark: health_check
+  name: mm_mem_loaded_latency
+  description: Run mm-mem loaded latency benchmark
+  args:
+    - '-b mm-mem'
+    - '--'
+    - '--test loaded_latency'
+    - '{extra_args}'
+  vars:
+    - 'extra_args='
+
 - benchmark: sleep
   name: sleep
   description: >

--- a/packages/health_check/run.sh
+++ b/packages/health_check/run.sh
@@ -11,17 +11,21 @@ set -Eeo pipefail
 HEALTH_ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")" &>/dev/null && pwd -P)
 show_help() {
 cat <<EOF
-Usage: ${0##*/} [-h] [-r server|client] [-c clients]
+Usage: ${0##*/} [-h] [-r server|client] [-c clients] [-b benchmark] [-- extra_args]
     -h, --help        Display this help and exit
     -r, --role        Specify role (server or client)
     -c, --clients     Specify clients
+    -b, --benchmark   Specify sub-benchmark to run (default: all)
+                      Options: all, mm-mem
+    Extra arguments after -- are passed to the sub-benchmark
 EOF
 }
 
 # Parse command-line options using getopt
-TEMP=$(getopt -o hr:c: --long help,role:,clients: -- "$@")
+TEMP=$(getopt -o hr:c:b: --long help,role:,clients:,benchmark: -- "$@")
 # Set positional parameters to parsed options
 eval set -- "$TEMP"
+benchmark="all"
 while true; do
   case "$1" in
     -h | --help)
@@ -36,12 +40,25 @@ while true; do
       clients="$2"
       shift 2
       ;;
+    -b | --benchmark)
+      benchmark="$2"
+      shift 2
+      ;;
     --)
       shift
       break
       ;;
   esac
 done
+# Remaining arguments after -- are passed through to the sub-benchmark
+extra_args="$*"
+
+# Run a specific sub-benchmark standalone (no role required)
+if [ "$benchmark" = "mm-mem" ]; then
+  # shellcheck disable=SC2086
+  python3 "$HEALTH_ROOT"/mm-mem/scripts/run_cpu_micro.py $extra_args
+  exit 0
+fi
 
 if [ "$role" = "client" ]; then
   iperf3 -s &


### PR DESCRIPTION
Summary:
**Running mm-mem Standalone Inside Benchpress**
=============================================

### Summary

This diff introduces changes to enable running mm-mem standalone inside benchpress. It modifies the `run.sh` script to accept additional arguments for specifying the sub-benchmark to run and extra arguments. Furthermore, it adds new job configurations to the `jobs.yml` file for running mm-mem memory latency and bandwidth benchmark, as well as mm-mem peak bandwidth and memcpy benchmark.

### Key Changes

* Modified `run.sh` script to accept `-b` and `extra_args` options for specifying sub-benchmark and extra arguments, respectively.
* Added three new job configurations to `jobs.yml` for running mm-mem benchmarks:
	+ `mm_mem`: standalone run for mm-mem memory latency and bandwidth benchmark.
	+ `mm_mem_peak_bw`: run mm-mem peak bandwidth and memcpy benchmark.
	+ `mm_mem_idle_latency`: run mm-mem idle latency benchmark (description incomplete in the diff).

Differential Revision: D96207367


