### PR TITLE
let ThreadPoolExecutor observer callbacks be noexcept

### DIFF
--- a/packages/ucache_bench/server/UcacheBenchRpcServer.cpp
+++ b/packages/ucache_bench/server/UcacheBenchRpcServer.cpp
@@ -224,7 +224,7 @@ void UcacheBenchRpcServer::start(
         std::function<void()> cleanup)
         : threadInit_(std::move(init)), threadCleanup_(std::move(cleanup)) {}
 
-    void registerEventBase(folly::EventBase& evb) override {
+    void registerEventBase(folly::EventBase& evb) noexcept override {
       // Initialize fiber context for this thread
       UcacheBenchIOThreadContext::init(evb);
 
@@ -233,7 +233,7 @@ void UcacheBenchRpcServer::start(
       }
     }
 
-    void unregisterEventBase(folly::EventBase& evb) override {
+    void unregisterEventBase(folly::EventBase& evb) noexcept override {
       if (threadCleanup_) {
         threadCleanup_();
       }


### PR DESCRIPTION
Summary: If observer callbacks were permitted to fail, then the behavior being observed would have to handle that failure. But that can get complicated. Easier to require observer callbacks not to fail.

Reviewed By: iahs, ot

Differential Revision: D96358302


