### PR TITLE
Add pytorch_gemm_gpuless benchmark to DCPerf AI suite (#542)

### DIFF
--- a/benchpress/config/benchmarks_ai.yml
+++ b/benchpress/config/benchmarks_ai.yml
@@ -65,6 +65,16 @@ adsim:
     - target_latency_msec
     - target_latency_percentile
 
+pytorch_gemm_gpuless:
+  parser: pytorch_gemm_gpuless
+  install_script: ./packages/ai_wdl/pytorch_gemm_gpuless/install_pytorch_gemm_gpuless.sh
+  cleanup_script: ./packages/ai_wdl/pytorch_gemm_gpuless/cleanup_pytorch_gemm_gpuless.sh
+  path: ./benchmarks/ai_wdl/pytorch_gemm_gpuless/run.sh
+  metrics:
+    - wall_time_per_call_us
+    - host_overhead_per_call_us
+    - simulated_tflops
+
 type_conversion:
   parser: type_conversion
   install_script: ./packages/ai_wdl/type_conversion/install_type_conversion.sh

--- a/benchpress/config/jobs_ai.yml
+++ b/benchpress/config/jobs_ai.yml
@@ -340,3 +340,75 @@
   description: Benchmark for common AI data type conversion
   args:
     - '--benchmark_format=json'
+
+- benchmark: pytorch_gemm_gpuless
+  name: pytorch_gemm_gpuless_stage1
+  description: GPU-less torch.mm dispatch overhead via TorchDispatchMode (no CUDA needed).
+  args:
+    - stage1
+    - '-m {m}'
+    - '-n {n}'
+    - '-k {k}'
+    - '-t {dtype}'
+    - '--steps {steps}'
+    - '--warmups {warmups}'
+    - '--gpu-model {gpu_model}'
+    - '--efficiency {efficiency}'
+    - '--no-sleep'
+  vars:
+    - 'm=1024'
+    - 'n=1024'
+    - 'k=1024'
+    - 'dtype=bfloat16'
+    - 'steps=1000000'
+    - 'warmups=10000'
+    - 'gpu_model=gb200'
+    - 'efficiency=0.5'
+
+- benchmark: pytorch_gemm_gpuless
+  name: pytorch_gemm_gpuless_stage2_nosleep
+  description: GPU-less torch.mm full host-side overhead via mock_cuda (requires libcuda.so.1).
+  args:
+    - stage2
+    - '-m {m}'
+    - '-n {n}'
+    - '-k {k}'
+    - '-t {dtype}'
+    - '--steps {steps}'
+    - '--warmups {warmups}'
+    - '--gpu-model {gpu_model}'
+    - '--efficiency {efficiency}'
+    - '--no-sleep'
+  vars:
+    - 'm=1024'
+    - 'n=1024'
+    - 'k=1024'
+    - 'dtype=bfloat16'
+    - 'steps=1000000'
+    - 'warmups=10000'
+    - 'gpu_model=gb200'
+    - 'efficiency=0.5'
+
+- benchmark: pytorch_gemm_gpuless
+  name: pytorch_gemm_gpuless_stage2_spin
+  description: GPU-less torch.mm with spin delay (simulates GPU latency via clock_gettime polling).
+  args:
+    - stage2
+    - '-m {m}'
+    - '-n {n}'
+    - '-k {k}'
+    - '-t {dtype}'
+    - '--steps {steps}'
+    - '--warmups {warmups}'
+    - '--gpu-model {gpu_model}'
+    - '--efficiency {efficiency}'
+    - '--delay-mode spin'
+  vars:
+    - 'm=1024'
+    - 'n=1024'
+    - 'k=1024'
+    - 'dtype=bfloat16'
+    - 'steps=1000000'
+    - 'warmups=10000'
+    - 'gpu_model=gb200'
+    - 'efficiency=0.5'

--- a/benchpress/plugins/parsers/__init__.py
+++ b/benchpress/plugins/parsers/__init__.py
@@ -42,6 +42,7 @@ from .multichase_pingpong import MultichasePingpongParser
 from .multichase_pointer import MultichasePointerParser
 from .nginx_wrk_bench import NginxWrkParser
 from .nnpi_net4 import NNPINet4Parser
+from .pytorch_gemm_gpuless import PytorchGemmGpulessParser
 from .rebatch import RebatchParser
 from .returncode import ReturncodeParser
 from .schbench import SchbenchParser
@@ -116,6 +117,7 @@ def register_parsers(factory):
     factory.register("adsim", AdSimParser)
     factory.register("cdn_bench", CDNBenchParser)
     factory.register("type_conversion", TypeConversionParser)
+    factory.register("pytorch_gemm_gpuless", PytorchGemmGpulessParser)
     factory.register("xsbench", XSBenchParser)
     if not open_source:
         factory.register("hackperf", HackperfParser)

--- a/benchpress/plugins/parsers/pytorch_gemm_gpuless.py
+++ b/benchpress/plugins/parsers/pytorch_gemm_gpuless.py
@@ -1,0 +1,49 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-unsafe
+import re
+
+from benchpress.lib.parser import Parser
+
+
+class PytorchGemmGpulessParser(Parser):
+    """Parser for pytorch_gemm_gpuless benchmark output.
+
+    Extracts metrics from both Stage 1 (TorchDispatchMode) and
+    Stage 2 (mock_cuda) output formats:
+      Wall time / call:       13.730 us
+      Host overhead / call:   13.730 us
+      Simulated TF/s:         156.440000
+    """
+
+    def parse(self, stdout, stderr, returncode):
+        metrics = {}
+
+        for line in stdout:
+            line = line.strip()
+
+            m = re.search(r"Wall\s+time\s*/\s*call:\s+([\d.]+)\s*us", line)
+            if m:
+                metrics["wall_time_per_call_us"] = float(m.group(1))
+                continue
+
+            m = re.search(r"Host\s+overhead\s*/\s*call:\s+([\d.]+)\s*us", line)
+            if m:
+                metrics["host_overhead_per_call_us"] = float(m.group(1))
+                continue
+
+            m = re.search(r"Simulated\s+TF/s:\s+([\d.]+)", line)
+            if m:
+                metrics["simulated_tflops"] = float(m.group(1))
+                continue
+
+            m = re.search(r"Simulated\s+GPU\s*/\s*call:\s+([\d.]+)\s*us", line)
+            if m:
+                metrics["simulated_gpu_per_call_us"] = float(m.group(1))
+                continue
+
+        return metrics

--- a/packages/ai_wdl/pytorch_gemm_gpuless/README.md
+++ b/packages/ai_wdl/pytorch_gemm_gpuless/README.md
@@ -1,0 +1,62 @@
+# pytorch_gemm_gpuless
+
+GPU-less `torch.mm` micro-benchmark that measures host-side dispatch overhead
+without requiring a GPU. Designed for analyzing CPU frontend bottlenecks
+(BTB/L1I capacity) on Neoverse V2 (GB200/GB300) and AMD Zen4.
+
+## Stages
+
+| Stage | What it Measures | Requirements |
+|-------|-----------------|--------------|
+| 1 (`TorchDispatchMode`) | Python dispatch overhead | Any machine |
+| 2 (`mock_cuda`) | Full host-side overhead (C++ + CUDA driver API) | CUDA drivers (libcuda.so.1) |
+
+Stage 2 requires NVIDIA driver userspace libraries (`cuda-compat` package).
+No GPU hardware is needed — only the driver shared library for function table
+patching. The install script auto-detects and installs `cuda-compat` if
+available via package manager.
+
+## Installation
+
+```bash
+./benchpress -b ai install pytorch_gemm_gpuless_stage1
+./benchpress -b ai install pytorch_gemm_gpuless_stage2_nosleep
+```
+
+The install script will:
+- Detect CUDA driver availability
+- Install PyTorch CUDA (if drivers present) or PyTorch CPU (if not)
+- Build C extensions (nop_delay, mock_cuda) via setuptools
+- Stage 2 jobs will error at runtime if CUDA drivers are missing
+
+## Run
+
+```bash
+# Stage 1 — pure host dispatch overhead (any machine)
+./benchpress -b ai run pytorch_gemm_gpuless_stage1
+
+# Stage 2 — full C++ dispatch overhead (requires CUDA drivers)
+./benchpress -b ai run pytorch_gemm_gpuless_stage2_nosleep
+./benchpress -b ai run pytorch_gemm_gpuless_stage2_spin
+```
+
+## Metrics
+
+| Metric | Unit | Description |
+|--------|------|-------------|
+| `wall_time_per_call_us` | microseconds | Total wall time per torch.mm call |
+| `host_overhead_per_call_us` | microseconds | Host dispatch overhead per call |
+| `simulated_tflops` | TF/s | Simulated throughput |
+
+## Sample Output
+
+```json
+{
+  "benchmark_name": "pytorch_gemm_gpuless_stage1",
+  "metrics": {
+    "wall_time_per_call_us": 76.196,
+    "host_overhead_per_call_us": 76.196,
+    "simulated_tflops": 28.183608
+  }
+}
+```

--- a/packages/ai_wdl/pytorch_gemm_gpuless/cleanup_pytorch_gemm_gpuless.sh
+++ b/packages/ai_wdl/pytorch_gemm_gpuless/cleanup_pytorch_gemm_gpuless.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+AI_BENCH_ROOT="$(dirname "$(readlink -f "$0")")"
+BENCHPRESS_ROOT="$(readlink -f "$AI_BENCH_ROOT/../../..")"
+BENCHMARKS_DIR="${BENCHPRESS_ROOT}/benchmarks/ai_wdl/pytorch_gemm_gpuless"
+
+rm -rf "$BENCHMARKS_DIR"

--- a/packages/ai_wdl/pytorch_gemm_gpuless/install_pytorch_gemm_gpuless.sh
+++ b/packages/ai_wdl/pytorch_gemm_gpuless/install_pytorch_gemm_gpuless.sh
@@ -1,0 +1,388 @@
+#!/bin/bash
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+set -Eeuo pipefail
+
+################################################################################
+# Global Configuration
+################################################################################
+
+BENCHMARKS_DIR="$(pwd)/benchmarks/ai_wdl/pytorch_gemm_gpuless"
+MINICONDA_PREFIX="$(pwd)/build/miniconda"
+BUILD_ENV=pytorch_gemm_gpuless_env
+PYTHON_VERSION=3.13
+
+# Source directory (co-located with this script)
+SCRIPT_DIR="$(cd "$(dirname "$(readlink -f "$0")")" && pwd -P)"
+PROJECT_SRC="${SCRIPT_DIR}/src"
+
+# Platform detection
+KERN_NAME="$(uname -s)"
+MACHINE_NAME="$(uname -m)"
+PLATFORM_NAME="${KERN_NAME}-${MACHINE_NAME}"
+
+# Detected at runtime
+HAS_CUDA_DRIVER=false
+CUDA_COMPAT_DIR=""
+
+################################################################################
+# Utility Functions
+################################################################################
+
+log_info() { echo "[$(date '+%H:%M:%S')] $*"; }
+
+exec_with_retries() {
+  local max_retries="$1"
+  shift
+  local delay_secs=2
+  for i in $(seq 0 "$max_retries"); do
+    echo "[EXEC] [ATTEMPT ${i}/${max_retries}] $*"
+    if "$@"; then
+      return 0
+    fi
+    echo "[EXEC] [ATTEMPT ${i}/${max_retries}] Failed."
+    if [ "$i" -ne "$max_retries" ]; then
+      sleep $delay_secs
+    fi
+  done
+  echo "[EXEC] Command failed after $((max_retries + 1)) attempts; aborting."
+  return 1
+}
+
+################################################################################
+# CUDA Driver Detection
+################################################################################
+
+detect_cuda_driver() {
+  log_info "Detecting CUDA driver..."
+
+  # Check if libcuda.so.1 is already on the system
+  if ldconfig -p 2>/dev/null | grep -q "libcuda.so.1"; then
+    HAS_CUDA_DRIVER=true
+    log_info "Found libcuda.so.1 via ldconfig."
+    return
+  fi
+
+  # Check common cuda-compat locations
+  for dir in /usr/local/cuda-13.*/compat /usr/local/cuda/compat /usr/lib64; do
+    if [ -f "${dir}/libcuda.so.1" ]; then
+      HAS_CUDA_DRIVER=true
+      CUDA_COMPAT_DIR="${dir}"
+      log_info "Found libcuda.so.1 at ${dir}"
+      return
+    fi
+  done
+
+  log_info "No CUDA driver found. Checking if cuda-compat is installable..."
+
+  # Try to install cuda-compat (NVIDIA driver userspace libs, no kernel module)
+  local installed=false
+  if command -v dnf &>/dev/null; then
+    # Find latest cuda-compat-13 package
+    local pkg
+    pkg=$(dnf list available 2>/dev/null | grep "cuda-compat-13" | tail -1 | awk '{print $1}') || true
+    if [ -n "$pkg" ]; then
+      log_info "Installing ${pkg}..."
+      if dnf install -y "$pkg" 2>&1; then
+        installed=true
+      fi
+    fi
+  elif command -v apt-get &>/dev/null; then
+    if apt-get install -y cuda-compat 2>/dev/null; then
+      installed=true
+    fi
+  fi
+
+  if $installed; then
+    # Re-scan for the installed library
+    for dir in /usr/local/cuda-13.*/compat /usr/local/cuda/compat; do
+      if [ -f "${dir}/libcuda.so.1" ]; then
+        HAS_CUDA_DRIVER=true
+        CUDA_COMPAT_DIR="${dir}"
+        log_info "Installed cuda-compat, found libcuda.so.1 at ${dir}"
+        return
+      fi
+    done
+  fi
+
+  log_info "No CUDA driver available. Stage 2 will not be supported on this machine."
+  log_info "Stage 1 (TorchDispatchMode) will work without CUDA."
+}
+
+################################################################################
+# Miniconda Setup
+################################################################################
+
+setup_miniconda() {
+  log_info "Setting up Miniconda at ${MINICONDA_PREFIX}..."
+
+  if [ -f "${MINICONDA_PREFIX}/bin/conda" ]; then
+    log_info "Removing existing Miniconda installation..."
+    rm -rf "${MINICONDA_PREFIX}"
+  fi
+
+  mkdir -p "${MINICONDA_PREFIX}"
+  wget -q "https://repo.anaconda.com/miniconda/Miniconda3-latest-${PLATFORM_NAME}.sh" -O miniconda.sh
+  bash miniconda.sh -b -p "${MINICONDA_PREFIX}" -u
+  rm -f miniconda.sh
+
+  eval "$("${MINICONDA_PREFIX}/bin/conda" shell.bash hook)"
+  export PATH="${MINICONDA_PREFIX}/bin:${PATH}"
+  export CONDA="${MINICONDA_PREFIX}"
+
+  conda update -n base -c conda-forge -y conda
+  conda tos accept --override-channels --channel https://repo.anaconda.com/pkgs/main 2>/dev/null || true
+  conda tos accept --override-channels --channel https://repo.anaconda.com/pkgs/r 2>/dev/null || true
+
+  log_info "Miniconda setup complete."
+}
+
+setup_conda_environment() {
+  log_info "Creating conda environment ${BUILD_ENV} (Python ${PYTHON_VERSION})..."
+  local conda_prefix
+  conda_prefix=$(conda run -n base printenv CONDA_PREFIX)
+  rm -rf "${conda_prefix}/envs/${BUILD_ENV}"
+
+  exec_with_retries 3 conda create -y -n "${BUILD_ENV}" -c conda-forge python="${PYTHON_VERSION}"
+  exec_with_retries 3 conda run -n "${BUILD_ENV}" pip install --upgrade pip
+  log_info "Conda environment ready."
+}
+
+################################################################################
+# PyTorch Installation
+################################################################################
+
+install_pytorch() {
+  if $HAS_CUDA_DRIVER; then
+    log_info "Installing PyTorch with CUDA support from conda-forge..."
+    # Find the latest CUDA PyTorch build available for this platform
+    # CONDA_OVERRIDE_CUDA bypasses the __cuda virtual package check
+    CONDA_OVERRIDE_CUDA=13.0 exec_with_retries 3 conda install \
+      -n "${BUILD_ENV}" -c conda-forge -y "pytorch>=2.9=cuda*"
+
+    log_info "Verifying PyTorch CUDA installation..."
+    conda run -n "${BUILD_ENV}" python -c \
+      "import torch; print(f'PyTorch {torch.__version__}, CUDA: {torch.version.cuda}')"
+  else
+    log_info "Installing PyTorch CPU from PyPI..."
+    conda run -n "${BUILD_ENV}" pip install --pre torch \
+      --index-url https://download.pytorch.org/whl/cpu/
+
+    log_info "Verifying PyTorch CPU installation..."
+    conda run -n "${BUILD_ENV}" python -c \
+      "import torch; print(f'PyTorch {torch.__version__} (CPU)')"
+  fi
+
+  log_info "PyTorch installation complete."
+}
+
+################################################################################
+# Build C Extensions
+################################################################################
+
+build_extensions() {
+  log_info "Building C extensions..."
+  local build_dir
+  build_dir=$(mktemp -d)
+
+  # Copy C/C++ source files
+  cp "${PROJECT_SRC}/nop_delay.cpp" "${build_dir}/"
+  cp "${PROJECT_SRC}/mock_cuda.cpp" "${build_dir}/"
+  cp "${PROJECT_SRC}/mock_cuda.h" "${build_dir}/"
+  cp "${PROJECT_SRC}/init.cpp" "${build_dir}/"
+
+  # Create setup.py for building extensions
+  cat > "${build_dir}/setup.py" << 'SETUP_EOF'
+from setuptools import setup, Extension
+
+nop_delay_ext = Extension(
+    "_nop_delay_C",
+    sources=["nop_delay.cpp"],
+    extra_compile_args=["-O2", "-std=c++17"],
+)
+
+mock_cuda_ext = Extension(
+    "_mock_cuda_C",
+    sources=["init.cpp", "mock_cuda.cpp"],
+    extra_compile_args=["-O2", "-std=c++17"],
+    libraries=["dl"],
+)
+
+setup(
+    name="pytorch_gemm_gpuless_extensions",
+    ext_modules=[nop_delay_ext, mock_cuda_ext],
+)
+SETUP_EOF
+
+  # Build extensions
+  cd "${build_dir}"
+  conda run -n "${BUILD_ENV}" python setup.py build_ext --inplace
+
+  # Copy built .so files to benchmark directory
+  cp "${build_dir}"/_nop_delay_C*.so "${BENCHMARKS_DIR}/"
+  cp "${build_dir}"/_mock_cuda_C*.so "${BENCHMARKS_DIR}/"
+
+  # Clean up
+  rm -rf "${build_dir}"
+  log_info "C extensions built and installed."
+}
+
+################################################################################
+# Copy Python Sources
+################################################################################
+
+copy_sources() {
+  log_info "Copying Python source files..."
+
+  local src="${PROJECT_SRC}"
+
+  local py_files=(
+    stage1_benchmark.py
+    stage2_benchmark.py
+    stage1_dispatch_mode.py
+    gpu_timing_model.py
+    nop_delay.py
+    mock_cuda_guard.py
+  )
+
+  for f in "${py_files[@]}"; do
+    if [ ! -f "${src}/${f}" ]; then
+      echo "[WARN] Source file not found: ${src}/${f}"
+      continue
+    fi
+    cp "${src}/${f}" "${BENCHMARKS_DIR}/${f}"
+  done
+
+  log_info "Source files copied."
+}
+
+################################################################################
+# Create Launcher Script
+################################################################################
+
+create_launcher() {
+  log_info "Creating launcher script..."
+
+  # Write CUDA capability marker for the launcher
+  if $HAS_CUDA_DRIVER; then
+    echo "cuda" > "${BENCHMARKS_DIR}/.cuda_support"
+    if [ -n "${CUDA_COMPAT_DIR}" ]; then
+      echo "${CUDA_COMPAT_DIR}" > "${BENCHMARKS_DIR}/.cuda_compat_dir"
+    fi
+  else
+    echo "cpu" > "${BENCHMARKS_DIR}/.cuda_support"
+  fi
+
+  cat > "${BENCHMARKS_DIR}/run.sh" << 'LAUNCHER_EOF'
+#!/bin/bash
+# Usage: ./run.sh <stage1|stage2> [args...]
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../../.." && pwd)"
+
+BUILD_ENV="pytorch_gemm_gpuless_env"
+MINICONDA="${REPO_ROOT}/build/miniconda"
+
+# Activate conda
+eval "$("${MINICONDA}/bin/conda" shell.bash hook)"
+conda activate "${BUILD_ENV}"
+
+# Add benchmark dir to PYTHONPATH so local imports work
+export PYTHONPATH="${SCRIPT_DIR}:${PYTHONPATH:-}"
+
+# Add cuda-compat to LD_LIBRARY_PATH if needed
+if [ -f "${SCRIPT_DIR}/.cuda_compat_dir" ]; then
+  CUDA_COMPAT_DIR="$(cat "${SCRIPT_DIR}/.cuda_compat_dir")"
+  export LD_LIBRARY_PATH="${CUDA_COMPAT_DIR}:${LD_LIBRARY_PATH:-}"
+fi
+
+STAGE="$1"
+shift || true
+
+case "$STAGE" in
+  stage1)
+    exec python "${SCRIPT_DIR}/stage1_benchmark.py" "$@"
+    ;;
+  stage2)
+    # Check if CUDA driver is available
+    CUDA_SUPPORT="$(cat "${SCRIPT_DIR}/.cuda_support" 2>/dev/null || echo cpu)"
+    if [ "$CUDA_SUPPORT" != "cuda" ]; then
+      echo "ERROR: Stage 2 requires CUDA drivers (libcuda.so.1)."
+      echo "This machine was installed without CUDA support."
+      echo "Stage 2 needs: NVIDIA driver userspace libs (cuda-compat package)."
+      echo "Use stage1 for CPU-only machines."
+      exit 1
+    fi
+    exec python "${SCRIPT_DIR}/stage2_benchmark.py" "$@"
+    ;;
+  *)
+    echo "Usage: $0 <stage1|stage2> [benchmark args...]"
+    echo ""
+    echo "  stage1  -- TorchDispatchMode interception (any machine, no CUDA needed)"
+    echo "  stage2  -- mock_cuda driver patching (requires CUDA drivers)"
+    echo ""
+    echo "Common args:"
+    echo "  -m M -n N -k K    Matrix dimensions (default: 1024)"
+    echo "  -t DTYPE           float32, float16, bfloat16 (default: bfloat16)"
+    echo "  --steps N          Timed iterations (default: 100)"
+    echo "  --warmups N        Warmup iterations (default: 10)"
+    echo "  --no-sleep         Disable simulated GPU delay"
+    echo "  --gpu-model MODEL  gb200, gb300, h100 (default: gb200)"
+    exit 1
+    ;;
+esac
+LAUNCHER_EOF
+
+  chmod +x "${BENCHMARKS_DIR}/run.sh"
+  log_info "Launcher script created."
+}
+
+################################################################################
+# Main
+################################################################################
+
+main() {
+  echo "################################################################################"
+  echo "# pytorch_gemm_gpuless Installation"
+  echo "# $(date)"
+  echo "################################################################################"
+
+  # Verify source files exist
+  if [ ! -f "${PROJECT_SRC}/stage1_benchmark.py" ]; then
+    echo "[ERROR] Source files not found at ${PROJECT_SRC}"
+    echo "[ERROR] Expected co-located src/ directory next to install script."
+    exit 1
+  fi
+
+  mkdir -p "${BENCHMARKS_DIR}"
+
+  detect_cuda_driver
+  setup_miniconda
+  setup_conda_environment
+  install_pytorch
+  copy_sources
+  build_extensions
+  create_launcher
+
+  echo "################################################################################"
+  echo "# Installation Complete"
+  echo "#"
+  if $HAS_CUDA_DRIVER; then
+    echo "# CUDA drivers detected — both stage1 and stage2 available."
+    echo "#"
+    echo "# Run: ./benchmarks/ai_wdl/pytorch_gemm_gpuless/run.sh stage1 --no-sleep --steps 1000000"
+    echo "# Run: ./benchmarks/ai_wdl/pytorch_gemm_gpuless/run.sh stage2 --no-sleep --steps 1000000"
+  else
+    echo "# CPU-only mode — stage1 available, stage2 requires CUDA drivers."
+    echo "#"
+    echo "# Run: ./benchmarks/ai_wdl/pytorch_gemm_gpuless/run.sh stage1 --no-sleep --steps 1000000"
+  fi
+  echo "#"
+  echo "# $(date)"
+  echo "################################################################################"
+}
+
+main

--- a/packages/ai_wdl/pytorch_gemm_gpuless/src/gpu_timing_model.py
+++ b/packages/ai_wdl/pytorch_gemm_gpuless/src/gpu_timing_model.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""GPU latency simulation model for GPU-less GEMM benchmarking.
+
+Computes the expected GPU execution time for matrix multiply operations
+based on theoretical peak throughput and an efficiency factor.
+"""
+
+from dataclasses import dataclass
+from enum import Enum
+
+
+class GPUVariant(Enum):
+    """Supported GPU variants with their BF16 dense peak TFLOPS."""
+
+    GB200 = "gb200"
+    GB300 = "gb300"
+    H100 = "h100"
+
+
+# Peak BF16 dense TFLOPS for each GPU variant
+_PEAK_TFLOPS: dict[GPUVariant, float] = {
+    GPUVariant.GB200: 2250.0,
+    GPUVariant.GB300: 2250.0,  # Same Blackwell die as GB200
+    GPUVariant.H100: 1979.0,
+}
+
+# Minimum latency floor in seconds
+_MIN_LATENCY_S: float = 0
+
+
+@dataclass
+class GPUTimingConfig:
+    """Configuration for GPU latency simulation.
+
+    Args:
+        variant: GPU variant to simulate.
+        efficiency: Fraction of peak throughput achieved (0.0-1.0).
+            Typical values: 0.3-0.7 depending on problem size.
+    """
+
+    variant: GPUVariant = GPUVariant.GB200
+    efficiency: float = 0.5
+
+    def __post_init__(self) -> None:
+        if not 0.0 < self.efficiency <= 1.0:
+            raise ValueError(f"efficiency must be in (0.0, 1.0], got {self.efficiency}")
+
+    @property
+    def peak_tflops(self) -> float:
+        return _PEAK_TFLOPS[self.variant]
+
+
+def compute_mm_latency(m: int, n: int, k: int, config: GPUTimingConfig) -> float:
+    """Compute simulated GPU latency for a matrix multiply (M x K) @ (K x N).
+
+    Formula: latency = 2*M*N*K / (peak_tflops * efficiency * 1e12)
+    The result is floored at 5 microseconds to account for kernel launch overhead.
+
+    Args:
+        m: Number of rows of the output matrix.
+        n: Number of columns of the output matrix.
+        k: Shared dimension (inner dimension).
+        config: GPU timing configuration.
+
+    Returns:
+        Simulated latency in seconds.
+    """
+    flops = 2.0 * m * n * k
+    throughput = config.peak_tflops * config.efficiency * 1e12
+    latency = flops / throughput
+    return max(latency, _MIN_LATENCY_S)
+
+
+def variant_from_str(name: str) -> GPUVariant:
+    """Parse a GPU variant name string (case-insensitive).
+
+    Args:
+        name: One of "gb200", "gb300", "h100".
+
+    Returns:
+        The corresponding GPUVariant enum member.
+
+    Raises:
+        ValueError: If the name is not recognized.
+    """
+    try:
+        return GPUVariant(name.lower())
+    except ValueError:
+        valid = ", ".join(v.value for v in GPUVariant)
+        raise ValueError(f"Unknown GPU variant '{name}'. Valid options: {valid}")

--- a/packages/ai_wdl/pytorch_gemm_gpuless/src/init.cpp
+++ b/packages/ai_wdl/pytorch_gemm_gpuless/src/init.cpp
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+// init.cpp — Python module definition for _mock_cuda_C extension.
+
+#include <Python.h>
+#include "mock_cuda.h"
+
+static PyMethodDef _mock_cuda_C_methods[] = {
+    {"patch_mock_cuda",
+     patch_mock_cuda,
+     METH_NOARGS,
+     "Patch libcuda.so.1 function table for mocking."},
+    {"enable_mock_cuda",
+     enable_mock_cuda,
+     METH_NOARGS,
+     "Enable CUDA mocking (thread-local)."},
+    {"disable_mock_cuda",
+     disable_mock_cuda,
+     METH_NOARGS,
+     "Disable CUDA mocking (thread-local)."},
+    {NULL, NULL, 0, NULL}};
+
+static struct PyModuleDef _mock_cuda_C_module = {
+    PyModuleDef_HEAD_INIT,
+    "_mock_cuda_C",
+    "CUDA driver function table patching for GPU-less benchmarking.",
+    -1,
+    _mock_cuda_C_methods};
+
+PyMODINIT_FUNC PyInit__mock_cuda_C(void) {
+  return PyModule_Create(&_mock_cuda_C_module);
+}

--- a/packages/ai_wdl/pytorch_gemm_gpuless/src/mock_cuda.cpp
+++ b/packages/ai_wdl/pytorch_gemm_gpuless/src/mock_cuda.cpp
@@ -1,0 +1,799 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+// mock_cuda.cpp — Patches libcuda.so.1 function table for GPU-less
+// benchmarking.
+//
+// Based on Monarch's mock_cuda (D67496828) with updated pattern matching for
+// NVIDIA driver 580.x+. See docs/driver_binary_analysis.md for details.
+//
+// Supports both x86_64 and aarch64 architectures:
+//
+// x86_64: Functions use cmpl with immediate 0x321cba00, then call/jmpq through
+//   a RIP-relative function table pointer. We scan for the magic bytes
+//   00 ba 1c 32, then for ff 15 (call) or ff 25 (jmpq).
+//
+// aarch64: Functions load 0x321cba00 via MOVZ+MOVK instructions, then use
+//   ADRP+LDR to load the function pointer from a page-relative table, followed
+//   by BLR for the indirect call. We scan for MOVZ Wn,#0xba00 + MOVK
+//   Wn,#0x321c,LSL#16, then find B.EQ + ADRP + LDR + BLR.
+
+// @lint-ignore-every CLANGSECURITY facebook-security-vulnerable-memcpy
+// @lint-ignore-every CLANGTIDY clang-diagnostic-unused-parameter
+#include <Python.h>
+#include <assert.h>
+#include <dlfcn.h>
+#include <stdint.h>
+#include <atomic>
+#include <cstddef>
+#include <cstring>
+#include <mutex>
+#include <optional>
+#include <random>
+#include <stdexcept>
+#include <string>
+#include <unordered_map>
+#include <unordered_set>
+
+namespace {
+
+// Maximum bytes to scan from function start when looking for patterns.
+constexpr size_t SCAN_LIMIT = 128;
+// Maximum number of 4-byte ARM instructions to scan.
+constexpr size_t ARM_INSN_LIMIT = SCAN_LIMIT / 4;
+
+#if defined(__x86_64__)
+
+// --- x86_64 pattern matching ---
+
+// The magic deinitialization check value as raw bytes (little-endian
+// immediate).
+const uint8_t MAGIC_BYTES[] = {0x00, 0xBA, 0x1C, 0x32};
+
+// Opcode for indirect call through RIP-relative address: call *off(%rip)
+const uint8_t CALL_INDIRECT[] = {0xFF, 0x15};
+
+// Opcode for indirect jump through RIP-relative address: jmpq *off(%rip)
+// Used by older driver versions.
+const uint8_t JMPQ_INDIRECT[] = {0xFF, 0x25};
+
+// Extract the function table entry address from an x86_64 CUDA driver function.
+//
+// Scans for the magic value 0x321cba00 as raw bytes, then for the first
+// indirect call (ff 15) or jump (ff 25), and decodes the RIP-relative offset.
+std::optional<void*> extractCallTarget(const uint8_t* functionBytes) {
+  // Step 1: Find the magic value within the scan limit
+  int magicOffset = -1;
+  for (size_t i = 0; i + sizeof(MAGIC_BYTES) <= SCAN_LIMIT; ++i) {
+    if (std::memcmp(functionBytes + i, MAGIC_BYTES, sizeof(MAGIC_BYTES)) == 0) {
+      magicOffset = static_cast<int>(i);
+      break;
+    }
+  }
+  if (magicOffset < 0) {
+    return std::nullopt;
+  }
+
+  // Step 2: Find the first indirect call (ff 15) or jump (ff 25) after the
+  // magic
+  size_t searchStart = magicOffset + sizeof(MAGIC_BYTES);
+  for (size_t i = searchStart; i + 6 <= SCAN_LIMIT; ++i) {
+    bool isCall =
+        std::memcmp(functionBytes + i, CALL_INDIRECT, sizeof(CALL_INDIRECT)) ==
+        0;
+    bool isJmpq =
+        std::memcmp(functionBytes + i, JMPQ_INDIRECT, sizeof(JMPQ_INDIRECT)) ==
+        0;
+    if (isCall || isJmpq) {
+      // Step 3: Decode the 32-bit RIP-relative offset
+      int32_t ripRelativeOffset;
+      std::memcpy(&ripRelativeOffset, functionBytes + i + 2, sizeof(int32_t));
+
+      // The RIP-relative offset is relative to the end of the instruction
+      // (instruction address + 6 bytes for the full ff 15/25 XX XX XX XX)
+      uintptr_t instructionAddress =
+          reinterpret_cast<uintptr_t>(functionBytes) + i;
+      uintptr_t targetAddress = instructionAddress + 6 + ripRelativeOffset;
+      return reinterpret_cast<void*>(targetAddress);
+    }
+  }
+  return std::nullopt;
+}
+
+#elif defined(__aarch64__)
+
+// --- aarch64 pattern matching ---
+//
+// On ARM64, the magic 0x321cba00 is loaded via two instructions:
+//   MOVZ Wn, #0xba00            → encodes as 0x52974000 | Rd
+//   MOVK Wn, #0x321c, LSL #16  → encodes as 0x72a64380 | Rd
+//
+// After a CMP + B.EQ (deinitialization check), the function table entry
+// is loaded via:
+//   ADRP Xq, #page_offset      → page-relative address of table
+//   LDR  Xq, [Xq, #offset]     → load function pointer from table
+//   BLR  Xq                     → indirect call
+//
+// The function table address = (ADRP_PC & ~0xFFF) + (ADRP_imm << 12) +
+// LDR_offset
+
+// Instruction masks and expected values
+// Instruction masks: mask out only Rd (low 5 bits) to match any register
+constexpr uint32_t MOV_RD_MASK = 0xFFFFFFE0;
+// MOVZ Wn, #0xba00, LSL #0: sf=0, opc=10, hw=00, imm16=0xba00
+// 0_10_100101_00_1011101000000000_ddddd
+constexpr uint32_t MOVZ_BA00_BASE = 0x52974000;
+
+constexpr uint32_t MOVK_321C_BASE = 0x72A64380;
+
+// B.EQ: 0101_0100_iiiiiiiiiiiiiiiiiii_0_0000
+constexpr uint32_t BEQ_MASK = 0xFF00001F;
+constexpr uint32_t BEQ_VAL = 0x54000000;
+
+// ADRP: x_ii_10000_iiiiiiiiiiiiiiiiiii_ddddd
+constexpr uint32_t ADRP_MASK = 0x9F000000;
+constexpr uint32_t ADRP_VAL = 0x90000000;
+
+// LDR X (64-bit, unsigned offset): 11_111_00101_iiiiiiiiiiii_nnnnn_ttttt
+constexpr uint32_t LDR_X_MASK = 0xFFC00000;
+constexpr uint32_t LDR_X_VAL = 0xF9400000;
+
+// BLR: 1101_0110_0011_1111_0000_00nn_nnn0_0000
+constexpr uint32_t BLR_MASK = 0xFFFFFC1F;
+constexpr uint32_t BLR_VAL = 0xD63F0000;
+
+// Decode ADRP immediate and compute target page address.
+uintptr_t decodeAdrpTarget(uint32_t insn, uintptr_t pc) {
+  // immhi = bits[23:5], immlo = bits[30:29]
+  uint32_t immhi = (insn >> 5) & 0x7FFFF;
+  uint32_t immlo = (insn >> 29) & 0x3;
+  int64_t imm = static_cast<int64_t>((immhi << 2) | immlo);
+  // Sign-extend from 21 bits
+  if (imm & (1LL << 20)) {
+    imm -= (1LL << 21);
+  }
+  return (pc & ~static_cast<uintptr_t>(0xFFF)) +
+      (static_cast<uintptr_t>(imm) << 12);
+}
+
+// Extract the function table entry address from an aarch64 CUDA driver
+// function.
+std::optional<void*> extractCallTarget(const uint8_t* functionBytes) {
+  const uint32_t* insns = reinterpret_cast<const uint32_t*>(functionBytes);
+
+  // Step 1: Find MOVZ Wn, #0xba00 (the magic value load)
+  int movzIdx = -1;
+  uint32_t movzRd = 0;
+  for (size_t i = 0; i < ARM_INSN_LIMIT; ++i) {
+    if ((insns[i] & MOV_RD_MASK) == MOVZ_BA00_BASE) {
+      movzRd = insns[i] & 0x1F;
+      // Verify MOVK with matching Rd exists nearby (within 8 instructions)
+      for (size_t j = i + 1; j < i + 8 && j < ARM_INSN_LIMIT; ++j) {
+        if ((insns[j] & MOV_RD_MASK) == MOVK_321C_BASE &&
+            (insns[j] & 0x1F) == movzRd) {
+          movzIdx = static_cast<int>(i);
+          break;
+        }
+      }
+      if (movzIdx >= 0) {
+        break;
+      }
+    }
+  }
+  if (movzIdx < 0) {
+    return std::nullopt;
+  }
+
+  // Step 2: Find B.EQ after the MOVZ/MOVK pair
+  int beqIdx = -1;
+  for (size_t i = movzIdx + 2; i < ARM_INSN_LIMIT; ++i) {
+    if ((insns[i] & BEQ_MASK) == BEQ_VAL) {
+      beqIdx = static_cast<int>(i);
+      break;
+    }
+  }
+  if (beqIdx < 0) {
+    return std::nullopt;
+  }
+
+  // Step 3: After B.EQ, find ADRP Xq (loads page of function table)
+  for (size_t i = beqIdx + 1; i < ARM_INSN_LIMIT; ++i) {
+    if ((insns[i] & ADRP_MASK) != ADRP_VAL) {
+      continue;
+    }
+    uint32_t adrpRd = insns[i] & 0x1F;
+    uintptr_t adrpPc = reinterpret_cast<uintptr_t>(functionBytes) + i * 4;
+    uintptr_t pageAddr = decodeAdrpTarget(insns[i], adrpPc);
+
+    // Step 4: Find LDR Xt, [Xq, #offset] where Xq matches ADRP Rd
+    for (size_t j = i + 1; j < i + 8 && j < ARM_INSN_LIMIT; ++j) {
+      if ((insns[j] & LDR_X_MASK) != LDR_X_VAL) {
+        continue;
+      }
+      uint32_t ldrRn = (insns[j] >> 5) & 0x1F;
+      if (ldrRn != adrpRd) {
+        continue;
+      }
+      uint32_t ldrImm12 = (insns[j] >> 10) & 0xFFF;
+      uint32_t ldrOffset = ldrImm12 * 8; // 64-bit LDR scales by 8
+      uint32_t ldrRt = insns[j] & 0x1F;
+
+      // Step 5: Verify BLR Xt follows (within a few instructions)
+      for (size_t k = j + 1; k < j + 8 && k < ARM_INSN_LIMIT; ++k) {
+        if ((insns[k] & BLR_MASK) == BLR_VAL) {
+          uint32_t blrRn = (insns[k] >> 5) & 0x1F;
+          if (blrRn == ldrRt) {
+            uintptr_t tableAddr = pageAddr + ldrOffset;
+            return reinterpret_cast<void*>(tableAddr);
+          }
+        }
+      }
+      // Even without BLR confirmation, if ADRP+LDR pattern matches
+      // and it's the first one after B.EQ, trust it
+      uintptr_t tableAddr = pageAddr + ldrOffset;
+      return reinterpret_cast<void*>(tableAddr);
+    }
+  }
+  return std::nullopt;
+}
+
+#else
+#error "mock_cuda: unsupported architecture (need x86_64 or aarch64)"
+#endif
+
+// Swap the function pointer at the table entry with our replacement.
+// Returns the original function pointer that was in the table.
+std::optional<void*> swapCallTarget(void* functionAddr, void* newTarget) {
+  uint8_t* functionBytes = reinterpret_cast<uint8_t*>(functionAddr);
+  auto targetAddressOpt = extractCallTarget(functionBytes);
+  if (!targetAddressOpt) {
+    return std::nullopt;
+  }
+  std::atomic<void*>* atomicTargetAddress =
+      reinterpret_cast<std::atomic<void*>*>(*targetAddressOpt);
+  return atomicTargetAddress->exchange(newTarget);
+}
+
+// --- Function list and mock implementations ---
+// Mirrors Monarch's FORALL_FUNCTIONS macro from D67496828.
+
+#define FORALL_FUNCTIONS(_)      \
+  _(cuGetProcAddress)            \
+  _(cuInit)                      \
+  _(cuDriverGetVersion)          \
+  _(cuDeviceGetCount)            \
+  _(cuDeviceGet)                 \
+  _(cuDeviceGetAttribute)        \
+  _(cuDeviceGetName)             \
+  _(cuDeviceTotalMem)            \
+  _(cuLaunchKernel)              \
+  _(cuMemcpyDtoHAsync)           \
+  _(cuMemcpyHtoDAsync)           \
+  _(cuMemsetD8Async)             \
+  _(cuLaunchKernelEx)            \
+  _(cuMemAlloc)                  \
+  _(cuMemFree)                   \
+  _(cuMemcpyDtoDAsync)           \
+  _(cuPointerGetAttribute)       \
+  _(cuGetProcAddress_v2)         \
+  _(cuMemCreate)                 \
+  _(cuMemAddressReserve)         \
+  _(cuMemMap)                    \
+  _(cuMemSetAccess)              \
+  _(cuMemcpyAsync)               \
+  _(cuMemRelease)                \
+  _(cuMemUnmap)                  \
+  _(cuMemAddressFree)            \
+  _(cuMemRetainAllocationHandle) \
+  _(cuMemGetAddressRange)
+
+// Each function can have up to MAX_VERSIONS entries in the driver's function
+// table (different entries for different CUDA API versions returned by
+// cuGetProcAddress). We need a separate mock for each version so that
+// RETURN_REAL_IF_UNMOCKED can call back to the correct real function.
+constexpr int MAX_VERSIONS = 4;
+
+#define CREATE_REALS(fn)                     \
+  void* real_##fn[MAX_VERSIONS] = {nullptr}; \
+  extern void* ps_##fn[];
+
+FORALL_FUNCTIONS(CREATE_REALS)
+#undef CREATE_REALS
+
+// --- CUDA type definitions (minimal, matching driver API) ---
+
+using CUresult = int;
+using CUdevice = int;
+using CUmemGenericAllocationHandle = unsigned long long;
+using CUcontext = struct CUctx_st*;
+using CUfunction = struct CUfunc_st*;
+using CUstream = struct CUstream_st*;
+struct CUlaunchConfig;
+struct CUmemAllocationProp;
+struct CUmemAccessDesc;
+
+enum CUpointer_attribute {
+  CU_POINTER_ATTRIBUTE_CONTEXT = 1,
+  CU_POINTER_ATTRIBUTE_MEMORY_TYPE = 2,
+  CU_POINTER_ATTRIBUTE_DEVICE_POINTER = 3,
+  CU_POINTER_ATTRIBUTE_HOST_POINTER = 4,
+  CU_POINTER_ATTRIBUTE_P2P_TOKENS = 5,
+  CU_POINTER_ATTRIBUTE_SYNC_MEMOPS = 6,
+  CU_POINTER_ATTRIBUTE_BUFFER_ID = 7,
+  CU_POINTER_ATTRIBUTE_IS_MANAGED = 8,
+  CU_POINTER_ATTRIBUTE_DEVICE_ORDINAL = 9,
+  CU_POINTER_ATTRIBUTE_IS_LEGACY_CUDA_IPC_CAPABLE = 10,
+  CU_POINTER_ATTRIBUTE_RANGE_START_ADDR = 11,
+  CU_POINTER_ATTRIBUTE_RANGE_SIZE = 12,
+  CU_POINTER_ATTRIBUTE_MAPPED = 13,
+  CU_POINTER_ATTRIBUTE_ALLOWED_HANDLE_TYPES = 14,
+  CU_POINTER_ATTRIBUTE_IS_GPU_DIRECT_RDMA_CAPABLE = 15,
+  CU_POINTER_ATTRIBUTE_ACCESS_FLAGS = 16,
+  CU_POINTER_ATTRIBUTE_MEMPOOL_HANDLE = 17,
+  CU_POINTER_ATTRIBUTE_MAPPING_SIZE = 18,
+  CU_POINTER_ATTRIBUTE_MAPPING_BASE_ADDR = 19,
+  CU_POINTER_ATTRIBUTE_MEMORY_BLOCK_ID = 20
+};
+
+// Thread-local mock toggle. When true, intercepted CUDA calls return
+// success immediately without doing real GPU work. When false, they
+// forward to the real driver function.
+thread_local std::atomic<bool> mockCudaEnabled = false;
+
+#define RETURN_REAL_IF_UNMOCKED(fn, ...)                      \
+  if (!mockCudaEnabled.load()) {                              \
+    return ((decltype(&p_##fn<N>))real_##fn[N])(__VA_ARGS__); \
+  }
+
+// --- Mock function implementations ---
+// Each is a template parameterized by version index N, so different
+// driver table entries can call back to the correct real function.
+
+// GPU-less init mocks: return success with fake device info
+template <int N>
+CUresult p_cuInit(unsigned int flags) {
+  RETURN_REAL_IF_UNMOCKED(cuInit, flags);
+  return 0; // CUDA_SUCCESS
+}
+
+template <int N>
+CUresult p_cuDriverGetVersion(int* version) {
+  RETURN_REAL_IF_UNMOCKED(cuDriverGetVersion, version);
+  *version = 13500; // Report high driver version
+  return 0;
+}
+
+template <int N>
+CUresult p_cuDeviceGetCount(int* count) {
+  RETURN_REAL_IF_UNMOCKED(cuDeviceGetCount, count);
+  *count = 1;
+  return 0;
+}
+
+template <int N>
+CUresult p_cuDeviceGet(CUdevice* device, int ordinal) {
+  RETURN_REAL_IF_UNMOCKED(cuDeviceGet, device, ordinal);
+  *device = 0;
+  return 0;
+}
+
+template <int N>
+CUresult p_cuDeviceGetAttribute(int* value, int attribute, CUdevice dev) {
+  RETURN_REAL_IF_UNMOCKED(cuDeviceGetAttribute, value, attribute, dev);
+  // Return reasonable defaults for common attributes
+  switch (attribute) {
+    case 1:
+      *value = 1024;
+      break; // MAX_THREADS_PER_BLOCK
+    case 14:
+      *value = 32;
+      break; // WARP_SIZE
+    case 21:
+      *value = 9;
+      break; // COMPUTE_CAPABILITY_MAJOR
+    case 22:
+      *value = 0;
+      break; // COMPUTE_CAPABILITY_MINOR
+    case 30:
+      *value = 132;
+      break; // MULTIPROCESSOR_COUNT
+    case 75:
+      *value = 9;
+      break; // COMPUTE_CAPABILITY_MAJOR (alt)
+    case 76:
+      *value = 0;
+      break; // COMPUTE_CAPABILITY_MINOR (alt)
+    default:
+      *value = 0;
+      break;
+  }
+  return 0;
+}
+
+template <int N>
+CUresult p_cuDeviceGetName(char* name, int len, CUdevice dev) {
+  RETURN_REAL_IF_UNMOCKED(cuDeviceGetName, name, len, dev);
+  snprintf(name, len, "Mock CUDA Device (GPU-less benchmark)");
+  return 0;
+}
+
+template <int N>
+CUresult p_cuDeviceTotalMem(size_t* bytes, CUdevice dev) {
+  RETURN_REAL_IF_UNMOCKED(cuDeviceTotalMem, bytes, dev);
+  *bytes = 80ULL * 1024 * 1024 * 1024; // 80 GB
+  return 0;
+}
+
+template <int N>
+CUresult p_cuLaunchKernel(
+    CUfunction f,
+    unsigned int gridDimX,
+    unsigned int gridDimY,
+    unsigned int gridDimZ,
+    unsigned int blockDimX,
+    unsigned int blockDimY,
+    unsigned int blockDimZ,
+    unsigned int sharedMemBytes,
+    CUstream hStream,
+    void** kernelParams,
+    void** extra) {
+  RETURN_REAL_IF_UNMOCKED(
+      cuLaunchKernel,
+      f,
+      gridDimX,
+      gridDimY,
+      gridDimZ,
+      blockDimX,
+      blockDimY,
+      blockDimZ,
+      sharedMemBytes,
+      hStream,
+      kernelParams,
+      extra);
+  return 0;
+}
+
+std::mutex lockMemAddr;
+size_t memAddr = static_cast<size_t>(1UL << 48);
+
+template <int N>
+CUresult p_cuMemAlloc(CUdevice** dptr, size_t bytesize) {
+  RETURN_REAL_IF_UNMOCKED(cuMemAlloc, dptr, bytesize);
+  std::lock_guard<std::mutex> guard(lockMemAddr);
+  memAddr -= bytesize;
+  memAddr -= memAddr % 8;
+  *dptr = reinterpret_cast<CUdevice*>(memAddr);
+  return 0;
+}
+
+template <int N>
+CUresult p_cuMemFree(CUdevice* dptr) {
+  RETURN_REAL_IF_UNMOCKED(cuMemFree, dptr);
+  return 0;
+}
+
+template <int N>
+CUresult p_cuMemcpyDtoDAsync(
+    CUdevice* dstDevice,
+    CUdevice* srcDevice,
+    size_t ByteCount,
+    CUstream hStream) {
+  RETURN_REAL_IF_UNMOCKED(
+      cuMemcpyDtoDAsync, dstDevice, srcDevice, ByteCount, hStream);
+  return 0;
+}
+
+template <int N>
+CUresult p_cuLaunchKernelEx(
+    const CUlaunchConfig* config,
+    CUfunction f,
+    void** kernelParams,
+    void** extra) {
+  RETURN_REAL_IF_UNMOCKED(cuLaunchKernelEx, config, f, kernelParams, extra);
+  return 0;
+}
+
+template <int N>
+CUresult p_cuMemcpyDtoHAsync(
+    void* dstHost,
+    CUdevice* srcDevice,
+    size_t ByteCount,
+    CUstream hStream) {
+  RETURN_REAL_IF_UNMOCKED(
+      cuMemcpyDtoHAsync, dstHost, srcDevice, ByteCount, hStream);
+  return 0;
+}
+
+template <int N>
+CUresult p_cuMemcpyHtoDAsync(
+    CUdevice* dstDevice,
+    const void* srcHost,
+    size_t ByteCount,
+    CUstream hStream) {
+  RETURN_REAL_IF_UNMOCKED(
+      cuMemcpyHtoDAsync, dstDevice, srcHost, ByteCount, hStream);
+  return 0;
+}
+
+template <int N>
+CUresult p_cuMemsetD8Async(
+    CUdevice* dstDevice,
+    unsigned char uc,
+    size_t M,
+    CUstream hStream) {
+  RETURN_REAL_IF_UNMOCKED(cuMemsetD8Async, dstDevice, uc, M, hStream);
+  return 0;
+}
+
+template <int N>
+CUresult p_cuPointerGetAttribute(
+    void* data,
+    CUpointer_attribute attribute,
+    CUdevice* ptr) {
+  RETURN_REAL_IF_UNMOCKED(cuPointerGetAttribute, data, attribute, ptr);
+  return 0;
+}
+
+namespace {
+std::random_device _rd;
+std::mt19937_64 _gen(_rd());
+std::uniform_int_distribution<uint64_t> _dis;
+
+uint64_t randUint64_t() {
+  return _dis(_gen);
+}
+} // namespace
+
+template <int N>
+CUresult p_cuMemCreate(
+    CUmemGenericAllocationHandle* handle,
+    size_t size,
+    const CUmemAllocationProp* prop,
+    unsigned long long flags) {
+  RETURN_REAL_IF_UNMOCKED(cuMemCreate, handle, size, prop, flags);
+  *handle = randUint64_t();
+  return 0;
+}
+
+template <int N>
+CUresult p_cuMemRelease(CUmemGenericAllocationHandle handle) {
+  RETURN_REAL_IF_UNMOCKED(cuMemRelease, handle);
+  return 0;
+}
+
+static std::unordered_map<CUdevice*, size_t> ptrToSize;
+
+template <int N>
+CUresult p_cuMemAddressReserve(
+    CUdevice** ptr,
+    size_t size,
+    size_t alignment,
+    CUdevice* addr,
+    unsigned long long flags) {
+  RETURN_REAL_IF_UNMOCKED(
+      cuMemAddressReserve, ptr, size, alignment, addr, flags);
+  std::lock_guard<std::mutex> guard(lockMemAddr);
+  memAddr -= size;
+  size_t offset = memAddr % (alignment ? alignment : 8);
+  memAddr -= offset;
+  *ptr = reinterpret_cast<CUdevice*>(memAddr);
+  ptrToSize[*ptr] = size + offset;
+  return 0;
+}
+
+template <int N>
+CUresult p_cuMemMap(
+    CUdevice* ptr,
+    size_t size,
+    size_t offset,
+    CUmemGenericAllocationHandle handle,
+    unsigned long long flags) {
+  RETURN_REAL_IF_UNMOCKED(cuMemMap, ptr, size, offset, handle, flags);
+  return 0;
+}
+
+template <int N>
+CUresult p_cuMemUnmap(CUdevice* ptr, size_t size) {
+  RETURN_REAL_IF_UNMOCKED(cuMemUnmap, ptr, size);
+  return 0;
+}
+
+template <int N>
+CUresult p_cuMemSetAccess(
+    CUdevice* ptr,
+    size_t size,
+    const CUmemAccessDesc* desc,
+    size_t count) {
+  RETURN_REAL_IF_UNMOCKED(cuMemSetAccess, ptr, size, desc, count);
+  return 0;
+}
+
+template <int N>
+CUresult p_cuMemcpyAsync(
+    CUdevice* dst,
+    CUdevice* src,
+    size_t ByteCount,
+    CUstream hStream) {
+  RETURN_REAL_IF_UNMOCKED(cuMemcpyAsync, dst, src, ByteCount, hStream);
+  return 0;
+}
+
+template <int N>
+CUresult p_cuMemAddressFree(CUdevice* ptr, size_t size) {
+  RETURN_REAL_IF_UNMOCKED(cuMemAddressFree, ptr, size);
+  return 0;
+}
+
+template <int N>
+CUresult p_cuMemRetainAllocationHandle(
+    CUmemGenericAllocationHandle* handle,
+    void* addr) {
+  RETURN_REAL_IF_UNMOCKED(cuMemRetainAllocationHandle, handle, addr);
+  return 0;
+}
+
+template <int N>
+CUresult
+p_cuMemGetAddressRange(CUdevice** pbase, size_t* psize, CUdevice* dptr) {
+  RETURN_REAL_IF_UNMOCKED(cuMemGetAddressRange, pbase, psize, dptr);
+  auto it = ptrToSize.find(dptr);
+  if (it != ptrToSize.end()) {
+    if (pbase) {
+      *pbase = dptr;
+    }
+    if (psize) {
+      *psize = it->second;
+    }
+    return 0;
+  } else {
+    for (const auto& entry : ptrToSize) {
+      CUdevice* base = entry.first;
+      size_t size = entry.second;
+      if (dptr >= base &&
+          dptr < reinterpret_cast<CUdevice*>(
+                     reinterpret_cast<char*>(base) + size)) {
+        if (pbase) {
+          *pbase = base;
+        }
+        if (psize) {
+          *psize = size;
+        }
+        return 0;
+      }
+    }
+    return 1; // CUDA_ERROR_INVALID_VALUE
+  }
+}
+
+// --- Patching infrastructure ---
+
+std::unordered_set<void*> patched;
+std::mutex patchedMutex;
+
+void doPatch(const char* name, void** realFns, void* toPatch, void** ourFns) {
+  std::lock_guard<std::mutex> guard(patchedMutex);
+  if (patched.count(toPatch)) {
+    return;
+  }
+  patched.emplace(toPatch);
+  for (size_t i = 0; i < MAX_VERSIONS; ++i) {
+    if (realFns[i] == nullptr) {
+      auto result = swapCallTarget(toPatch, ourFns[i]);
+      if (!result) {
+        throw std::runtime_error(
+            std::string("Failed to patch CUDA function: ") + name +
+            " (incompatible libcuda.so.1 binary layout)");
+      }
+      realFns[i] = *result;
+      return;
+    }
+  }
+  throw std::runtime_error(
+      std::string("Too many versions for function: ") + name +
+      " (increase MAX_VERSIONS)");
+}
+
+#define CREATE_PATCH(fn)                    \
+  if (symbol == #fn) {                      \
+    doPatch(#fn, real_##fn, *pfn, ps_##fn); \
+    return r;                               \
+  }
+
+// cuGetProcAddress intercepts: when the runtime asks the driver for a function
+// pointer, we patch the returned pointer to point to our mock instead.
+template <int N>
+CUresult p_cuGetProcAddress(
+    const char* symbol_,
+    void** pfn,
+    int cudaVersion,
+    uint64_t flags,
+    void* symbolStatus);
+
+template <int N>
+CUresult p_cuGetProcAddress_v2(
+    const char* symbol_,
+    void** pfn,
+    int cudaVersion,
+    uint64_t flags,
+    void* symbolStatus) {
+  auto r = ((decltype(&p_cuGetProcAddress_v2<N>))real_cuGetProcAddress_v2[N])(
+      symbol_, pfn, cudaVersion, flags, symbolStatus);
+  std::string symbol = symbol_;
+  FORALL_FUNCTIONS(CREATE_PATCH)
+  return r;
+}
+
+template <int N>
+CUresult p_cuGetProcAddress(
+    const char* symbol_,
+    void** pfn,
+    int cudaVersion,
+    uint64_t flags,
+    void* symbolStatus) {
+  auto r = ((decltype(&p_cuGetProcAddress<N>))real_cuGetProcAddress[N])(
+      symbol_, pfn, cudaVersion, flags, symbolStatus);
+  std::string symbol = symbol_;
+  FORALL_FUNCTIONS(CREATE_PATCH)
+  return r;
+}
+
+// Instantiate the 4 versioned patch arrays for each function.
+#define DEFINE_PATCHES(fn) \
+  void* ps_##fn[] = {      \
+      (void*)p_##fn<0>, (void*)p_##fn<1>, (void*)p_##fn<2>, (void*)p_##fn<3>};
+
+FORALL_FUNCTIONS(DEFINE_PATCHES)
+
+void install() {
+  void* dl = dlopen("libcuda.so.1", RTLD_NOW);
+  if (!dl) {
+    throw std::runtime_error(
+        std::string("Failed to load libcuda.so.1: ") + dlerror());
+  }
+
+#define REDIRECT_FUNCTION(fn)                                            \
+  {                                                                      \
+    void* sym = dlsym(dl, #fn);                                          \
+    if (!sym) {                                                          \
+      throw std::runtime_error(std::string("Symbol not found: ") + #fn); \
+    }                                                                    \
+    doPatch(#fn, real_##fn, sym, ps_##fn);                               \
+  }
+
+  FORALL_FUNCTIONS(REDIRECT_FUNCTION)
+}
+
+} // namespace
+
+// --- Python API ---
+
+PyObject* enable_mock_cuda(PyObject*, PyObject*) {
+  mockCudaEnabled = true;
+  Py_RETURN_NONE;
+}
+
+PyObject* disable_mock_cuda(PyObject*, PyObject*) {
+  mockCudaEnabled = false;
+  Py_RETURN_NONE;
+}
+
+PyObject* patch_mock_cuda(PyObject*, PyObject*) {
+  try {
+    install();
+    Py_RETURN_NONE;
+  } catch (const std::runtime_error& e) {
+    PyErr_SetString(PyExc_RuntimeError, e.what());
+    return nullptr;
+  } catch (const std::exception& e) {
+    PyErr_SetString(PyExc_Exception, e.what());
+    return nullptr;
+  } catch (...) {
+    PyErr_SetString(PyExc_Exception, "Unknown error during CUDA patching");
+    return nullptr;
+  }
+}

--- a/packages/ai_wdl/pytorch_gemm_gpuless/src/mock_cuda.h
+++ b/packages/ai_wdl/pytorch_gemm_gpuless/src/mock_cuda.h
@@ -1,0 +1,16 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+// mock_cuda.h — Python-callable C functions for CUDA driver mocking.
+
+#pragma once
+#include <Python.h>
+
+PyObject* patch_mock_cuda(PyObject*, PyObject*);
+PyObject* enable_mock_cuda(PyObject*, PyObject*);
+PyObject* disable_mock_cuda(PyObject*, PyObject*);

--- a/packages/ai_wdl/pytorch_gemm_gpuless/src/mock_cuda_guard.py
+++ b/packages/ai_wdl/pytorch_gemm_gpuless/src/mock_cuda_guard.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Python wrapper for our custom mock_cuda C++ extension.
+
+Provides mock_cuda_guard() context manager that patches libcuda.so.1's
+function table so CUDA driver calls return success instantly without
+GPU work. Compatible with NVIDIA driver 580.x+.
+
+See docs/driver_binary_analysis.md for details on the binary patching.
+"""
+
+from contextlib import contextmanager
+from typing import Generator, Optional
+from unittest.mock import patch
+
+import _mock_cuda_C as _C
+import torch
+
+# Patch at import time — installs our mock functions into
+# libcuda.so.1's function table. The mocks are disabled by default
+# (they forward to the real functions). Call enable_mock_cuda() to
+# activate the no-op behavior.
+_C.patch_mock_cuda()
+
+_mock_cuda_stream: Optional[torch.cuda.Stream] = None
+_has_real_gpu: Optional[bool] = None
+
+
+def _detect_real_gpu() -> bool:
+    """Check if a real GPU is available (cached)."""
+    global _has_real_gpu
+    if _has_real_gpu is None:
+        try:
+            _has_real_gpu = torch.cuda.device_count() > 0
+        except Exception:
+            _has_real_gpu = False
+    return _has_real_gpu
+
+
+def _get_mock_cuda_stream() -> torch.cuda.Stream:
+    global _mock_cuda_stream
+    if _mock_cuda_stream is None:
+        _mock_cuda_stream = torch.cuda.Stream()
+    return _mock_cuda_stream
+
+
+def _fake_lazy_init() -> None:
+    """No-op replacement for torch.cuda._lazy_init on GPU-less machines."""
+    pass
+
+
+@contextmanager
+def mock_cuda_guard() -> Generator[None, None, None]:
+    """Context manager that enables CUDA mocking.
+
+    All CUDA driver calls within the context return success instantly
+    without performing GPU work. Memory allocations return fake pointers
+    in the address space above 1UL << 48.
+
+    On machines with a real GPU, uses a dedicated CUDA stream.
+    On GPU-less machines, monkey-patches PyTorch's CUDA initialization
+    to bypass device count checks.
+    """
+    has_gpu = _detect_real_gpu()
+
+    if has_gpu:
+        # Normal path: use a dedicated stream on real GPU machines
+        try:
+            with torch.cuda.stream(_get_mock_cuda_stream()):
+                _C.enable_mock_cuda()
+                yield
+        finally:
+            _C.disable_mock_cuda()
+    else:
+        # GPU-less path: patch PyTorch's CUDA init to skip device checks
+        patches = [
+            patch("torch.cuda._lazy_init", _fake_lazy_init),
+            patch("torch.cuda.device_count", return_value=1),
+            patch("torch.cuda.is_available", return_value=True),
+        ]
+        try:
+            for p in patches:
+                p.start()
+            _C.enable_mock_cuda()
+            yield
+        finally:
+            _C.disable_mock_cuda()
+            for p in reversed(patches):
+                p.stop()
+
+
+def mock_cuda() -> None:
+    """Enable CUDA mocking (thread-local)."""
+    _C.enable_mock_cuda()
+
+
+def unmock_cuda() -> None:
+    """Disable CUDA mocking (thread-local)."""
+    _C.disable_mock_cuda()

--- a/packages/ai_wdl/pytorch_gemm_gpuless/src/nop_delay.cpp
+++ b/packages/ai_wdl/pytorch_gemm_gpuless/src/nop_delay.cpp
@@ -1,0 +1,145 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+// nop_delay.cpp — High-precision delay via NOP spin loops.
+//
+// nanosleep() has ~30-50 us minimum overhead due to kernel scheduling.
+// For simulating GPU compute latencies of ~14 us, we need sub-microsecond
+// precision. This module provides:
+//
+//   calibrate(duration_ms) → nops_per_ns
+//     Runs a NOP loop for the given duration, measures with CLOCK_MONOTONIC,
+//     and returns the number of NOPs per nanosecond on this CPU.
+//
+//   nop_delay_ns(nanos, nops_per_ns)
+//     Executes the computed number of NOPs to busy-wait for the given duration.
+//
+// Works on both x86_64 and aarch64.
+
+// @lint-ignore-every CLANGTIDY clang-diagnostic-unused-parameter
+#include <Python.h>
+#include <stdint.h>
+#include <time.h>
+
+namespace {
+
+static inline void execute_nops(uint64_t count) {
+  for (uint64_t i = 0; i < count; ++i) {
+    __asm__ volatile("nop");
+  }
+}
+
+static inline uint64_t clock_ns() {
+  struct timespec ts;
+  clock_gettime(CLOCK_MONOTONIC, &ts);
+  return static_cast<uint64_t>(ts.tv_sec) * 1000000000ULL +
+      static_cast<uint64_t>(ts.tv_nsec);
+}
+
+} // namespace
+
+// calibrate(duration_ms: float) -> float
+//   Runs NOPs for duration_ms milliseconds and returns nops_per_ns.
+static PyObject* py_calibrate(PyObject* self, PyObject* args) {
+  double duration_ms;
+  if (!PyArg_ParseTuple(args, "d", &duration_ms)) {
+    return nullptr;
+  }
+
+  uint64_t duration_ns = static_cast<uint64_t>(duration_ms * 1e6);
+  uint64_t total_nops = 0;
+
+  // Run NOP batches until we've consumed the calibration duration.
+  // Use batches to amortize the clock_gettime overhead.
+  constexpr uint64_t BATCH = 100000;
+  uint64_t start = clock_ns();
+  uint64_t target = start + duration_ns;
+
+  while (true) {
+    execute_nops(BATCH);
+    total_nops += BATCH;
+    if (clock_ns() >= target) {
+      break;
+    }
+  }
+
+  uint64_t elapsed = clock_ns() - start;
+  double nops_per_ns =
+      static_cast<double>(total_nops) / static_cast<double>(elapsed);
+
+  return PyFloat_FromDouble(nops_per_ns);
+}
+
+// nop_delay_ns(nanos: float, nops_per_ns: float) -> None
+//   Executes NOPs to busy-wait for approximately `nanos` nanoseconds.
+static PyObject* py_nop_delay_ns(PyObject* self, PyObject* args) {
+  double nanos;
+  double nops_per_ns;
+  if (!PyArg_ParseTuple(args, "dd", &nanos, &nops_per_ns)) {
+    return nullptr;
+  }
+
+  uint64_t count = static_cast<uint64_t>(nanos * nops_per_ns);
+  execute_nops(count);
+
+  Py_RETURN_NONE;
+}
+
+// spin_delay_ns(nanos: float) -> None
+//   Spin-waits by polling clock_gettime(CLOCK_MONOTONIC) in a tight loop.
+//   Much fewer instructions than NOP loops — ~500 iterations for 14 us
+//   vs millions of NOPs. The VDSO clock read fits in 2-3 cache lines,
+//   so icache/dcache pollution is minimal. This closely mimics what the
+//   CUDA driver does during cudaDeviceSynchronize (spin-polling).
+static PyObject* py_spin_delay_ns(PyObject* self, PyObject* args) {
+  double nanos;
+  if (!PyArg_ParseTuple(args, "d", &nanos)) {
+    return nullptr;
+  }
+
+  const uint64_t target = clock_ns() + static_cast<uint64_t>(nanos);
+  while (clock_ns() < target) {
+    // Yield to prevent starving sibling SMT threads (NOP on non-SMT cores).
+#if defined(__aarch64__)
+    __asm__ volatile("yield");
+#elif defined(__x86_64__)
+    __asm__ volatile("pause");
+#endif
+  }
+
+  Py_RETURN_NONE;
+}
+
+static PyMethodDef nop_delay_methods[] = {
+    {"calibrate",
+     py_calibrate,
+     METH_VARARGS,
+     "calibrate(duration_ms) -> nops_per_ns. "
+     "Runs NOPs for duration_ms and returns NOPs per nanosecond."},
+    {"nop_delay_ns",
+     py_nop_delay_ns,
+     METH_VARARGS,
+     "nop_delay_ns(nanos, nops_per_ns) -> None. "
+     "Busy-waits for approximately nanos nanoseconds using NOP instructions."},
+    {"spin_delay_ns",
+     py_spin_delay_ns,
+     METH_VARARGS,
+     "spin_delay_ns(nanos) -> None. "
+     "Spin-waits by polling clock_gettime. Minimal instruction pollution."},
+    {NULL, NULL, 0, NULL}};
+
+static struct PyModuleDef nop_delay_module = {
+    PyModuleDef_HEAD_INIT,
+    "_nop_delay_C",
+    "High-precision NOP-based delay for GPU latency simulation.",
+    -1,
+    nop_delay_methods};
+
+PyMODINIT_FUNC PyInit__nop_delay_C(void) {
+  return PyModule_Create(&nop_delay_module);
+}

--- a/packages/ai_wdl/pytorch_gemm_gpuless/src/nop_delay.py
+++ b/packages/ai_wdl/pytorch_gemm_gpuless/src/nop_delay.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""High-precision delay for GPU latency simulation.
+
+nanosleep() has ~30-50 us minimum overhead due to kernel scheduling.
+For simulating GPU compute latencies (e.g. 14 us for 1024^3 GEMM on GB200),
+we need sub-microsecond precision.
+
+Two modes:
+  NopTimer  — NOP spin loop, requires calibration.  High instruction count.
+  SpinTimer — clock_gettime spin loop, no calibration.  Minimal instruction
+              pollution (~500 clock reads for 14 us vs millions of NOPs).
+              Closer to real CUDA driver spin-wait behaviour.
+
+Usage:
+    timer = SpinTimer()       # preferred — low instruction overhead
+    timer.delay_ns(14000)     # 14 us delay
+
+    timer = NopTimer()        # legacy — high instruction overhead
+    timer.delay_ns(14000)
+"""
+
+import _nop_delay_C as _C
+
+
+class NopTimer:
+    """High-precision delay timer using NOP spin loops.
+
+    Calibrates at construction time by running NOPs for `calibration_ms`
+    milliseconds and measuring throughput.
+
+    Warning: injects millions of trivially-decoded NOP instructions that
+    artificially lower cache MPKI and inflate Retiring%.  Prefer SpinTimer
+    when collecting perf counters.
+    """
+
+    def __init__(self, calibration_ms: float = 100.0) -> None:
+        self.nops_per_ns: float = _C.calibrate(calibration_ms)
+
+    def delay_ns(self, nanos: float) -> None:
+        """Busy-wait for approximately `nanos` nanoseconds."""
+        if nanos > 0:
+            _C.nop_delay_ns(nanos, self.nops_per_ns)
+
+    def delay_s(self, seconds: float) -> None:
+        """Busy-wait for approximately `seconds` seconds."""
+        self.delay_ns(seconds * 1e9)
+
+
+class SpinTimer:
+    """High-precision delay by spin-polling clock_gettime(CLOCK_MONOTONIC).
+
+    No calibration needed.  Executes very few instructions per iteration
+    (~one VDSO call + compare + branch), so icache/dcache pollution is
+    minimal.  This closely mimics the CUDA driver's spin-wait during
+    cudaDeviceSynchronize.
+    """
+
+    def delay_ns(self, nanos: float) -> None:
+        """Busy-wait for approximately `nanos` nanoseconds."""
+        if nanos > 0:
+            _C.spin_delay_ns(nanos)
+
+    def delay_s(self, seconds: float) -> None:
+        """Busy-wait for approximately `seconds` seconds."""
+        self.delay_ns(seconds * 1e9)

--- a/packages/ai_wdl/pytorch_gemm_gpuless/src/stage1_benchmark.py
+++ b/packages/ai_wdl/pytorch_gemm_gpuless/src/stage1_benchmark.py
@@ -1,0 +1,173 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Stage 1: GPU-less GEMM benchmark via TorchDispatchMode interception.
+
+Measures the Python-level dispatch overhead of torch.mm by intercepting
+aten.mm at the TorchDispatchMode level. Optionally simulates GPU latency
+to mimic real execution timing.
+
+Key mode: --no-sleep disables simulated delay to measure pure host-side
+dispatch overhead, which is the primary metric for BTB analysis.
+
+Runs on any machine — no GPU or CUDA drivers needed.
+"""
+
+import argparse
+import sys
+import time
+
+import torch
+from gpu_timing_model import GPUTimingConfig, variant_from_str
+from nop_delay import NopTimer
+from stage1_dispatch_mode import GpulessMmMode
+from torch.profiler import profile, ProfilerActivity
+
+
+_DTYPE_MAP = {
+    "float32": torch.float32,
+    "float16": torch.float16,
+    "bfloat16": torch.bfloat16,
+}
+
+
+def parse_args() -> argparse.Namespace:
+    p = argparse.ArgumentParser(
+        description="GPU-less GEMM benchmark (Stage 1: TorchDispatchMode)"
+    )
+    p.add_argument("-m", "--msize", type=int, default=1024, help="M dimension")
+    p.add_argument("-n", "--nsize", type=int, default=1024, help="N dimension")
+    p.add_argument("-k", "--ksize", type=int, default=1024, help="K dimension")
+    p.add_argument(
+        "-t",
+        "--dtype",
+        type=str,
+        default="bfloat16",
+        choices=list(_DTYPE_MAP.keys()),
+        help="Data type (default: bfloat16)",
+    )
+    p.add_argument("--steps", type=int, default=100, help="Number of timed iterations")
+    p.add_argument(
+        "--warmups", type=int, default=10, help="Number of warmup iterations"
+    )
+    p.add_argument(
+        "--gpu-model",
+        type=str,
+        default="gb200",
+        help="GPU variant to simulate: gb200, gb300, h100 (default: gb200)",
+    )
+    p.add_argument(
+        "--efficiency",
+        type=float,
+        default=0.5,
+        help="GPU efficiency factor 0.0-1.0 (default: 0.5)",
+    )
+    p.add_argument(
+        "--no-sleep",
+        action="store_true",
+        help="Disable simulated GPU delay — measures pure host dispatch overhead",
+    )
+    p.add_argument(
+        "--trace",
+        type=str,
+        default=None,
+        metavar="PATH",
+        help="Export PyTorch profiler trace to file (Chrome/Perfetto .json or .json.gz)",
+    )
+    return p.parse_args()
+
+
+def run_benchmark(args: argparse.Namespace) -> None:
+    m, n, k = args.msize, args.nsize, args.ksize
+    dtype = _DTYPE_MAP[args.dtype]
+
+    variant = variant_from_str(args.gpu_model)
+    config = GPUTimingConfig(variant=variant, efficiency=args.efficiency)
+
+    nop_timer = None
+    if not args.no_sleep:
+        print("Calibrating NOP timer...", flush=True)
+        nop_timer = NopTimer(calibration_ms=200)
+        print(f"  NOP rate: {nop_timer.nops_per_ns:.3f} nops/ns")
+
+    mode = GpulessMmMode(config=config, sleep=not args.no_sleep, nop_timer=nop_timer)
+
+    # Create input tensors on CPU
+    a = torch.randn(m, k, dtype=dtype, device="cpu")
+    b = torch.randn(k, n, dtype=dtype, device="cpu")
+
+    flops_per_call = 2.0 * m * n * k
+
+    # Warmup phase
+    with mode:
+        for _ in range(args.warmups):
+            torch.mm(a, b)
+    mode.stats.reset()
+
+    # Measured phase
+    with mode:
+        prof_ctx = profile(activities=[ProfilerActivity.CPU]) if args.trace else None
+        if prof_ctx is not None:
+            prof_ctx.__enter__()
+        t0 = time.perf_counter()
+        for _ in range(args.steps):
+            torch.mm(a, b)
+        t1 = time.perf_counter()
+        if prof_ctx is not None:
+            prof_ctx.__exit__(None, None, None)
+
+    wall_time = t1 - t0
+    calls = mode.stats.call_count
+    simulated_gpu_time = mode.stats.total_simulated_time_s
+
+    if calls == 0:
+        print("ERROR: No GEMM calls intercepted", file=sys.stderr)
+        sys.exit(1)
+
+    wall_per_call = wall_time / calls
+    simulated_per_call = simulated_gpu_time / calls
+
+    if args.no_sleep:
+        host_overhead_per_call = wall_per_call
+    else:
+        host_overhead_per_call = wall_per_call - simulated_per_call
+
+    simulated_tfs = flops_per_call * calls / wall_time / 1e12 if wall_time > 0 else 0.0
+
+    # Report
+    print(f"{'=' * 60}")
+    print("Stage 1: GPU-less GEMM Benchmark (TorchDispatchMode)")
+    print(f"{'=' * 60}")
+    print(f"  Matrix:       ({m} x {k}) @ ({k} x {n})")
+    print(f"  Dtype:        {args.dtype}")
+    print(f"  GPU model:    {args.gpu_model} (efficiency={args.efficiency})")
+    print(f"  Sleep:        {'disabled (--no-sleep)' if args.no_sleep else 'enabled'}")
+    print(f"  Steps:        {args.steps}  (warmups: {args.warmups})")
+    print(f"{'=' * 60}")
+    print(f"  Total wall time:        {wall_time * 1e3:12.3f} ms")
+    print(f"  Wall time / call:       {wall_per_call * 1e6:12.3f} us")
+    if not args.no_sleep:
+        print(f"  Simulated GPU / call:   {simulated_per_call * 1e6:12.3f} us")
+    print(f"  Host overhead / call:   {host_overhead_per_call * 1e6:12.3f} us")
+    print(f"  Simulated TF/s:         {simulated_tfs:12.6f}")
+    print(f"  Intercepted calls:      {calls}")
+    for op_name, count in sorted(mode.stats.per_op_counts.items()):
+        print(f"    {op_name}: {count}")
+    print(f"{'=' * 60}")
+
+    if args.trace and prof_ctx is not None:
+        prof_ctx.export_chrome_trace(args.trace)
+        print(f"  Trace exported to: {args.trace}")
+
+
+def main() -> None:
+    args = parse_args()
+    run_benchmark(args)
+
+
+if __name__ == "__main__":
+    main()

--- a/packages/ai_wdl/pytorch_gemm_gpuless/src/stage1_dispatch_mode.py
+++ b/packages/ai_wdl/pytorch_gemm_gpuless/src/stage1_dispatch_mode.py
@@ -1,0 +1,132 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""TorchDispatchMode-based interception of GEMM ops for GPU-less benchmarking.
+
+Intercepts aten.mm, aten.addmm, and aten.bmm at the Python dispatch level,
+optionally simulating GPU latency. Returns correctly-shaped CPU tensors
+without performing actual computation.
+
+Pattern follows _FlopCounterMode in caffe2/torch/utils/flop_counter.py.
+"""
+
+import time
+from dataclasses import dataclass, field
+from typing import Optional
+
+import torch
+from gpu_timing_model import compute_mm_latency, GPUTimingConfig
+from nop_delay import NopTimer
+from torch.utils._python_dispatch import TorchDispatchMode
+
+
+@dataclass
+class GpulessMmStats:
+    """Accumulated statistics from intercepted GEMM operations."""
+
+    call_count: int = 0
+    total_simulated_time_s: float = 0.0
+    per_op_counts: dict[str, int] = field(default_factory=dict)
+
+    def reset(self) -> None:
+        self.call_count = 0
+        self.total_simulated_time_s = 0.0
+        self.per_op_counts.clear()
+
+    def record(self, op_name: str, simulated_latency_s: float) -> None:
+        self.call_count += 1
+        self.total_simulated_time_s += simulated_latency_s
+        self.per_op_counts[op_name] = self.per_op_counts.get(op_name, 0) + 1
+
+
+# Ops we intercept
+_INTERCEPTED_OPS = frozenset(
+    {
+        torch.ops.aten.mm.default,
+        torch.ops.aten.addmm.default,
+        torch.ops.aten.bmm.default,
+    }
+)
+
+
+class GpulessMmMode(TorchDispatchMode):
+    """Intercepts GEMM ops, returns zero tensors, optionally simulates GPU latency.
+
+    Usage:
+        config = GPUTimingConfig(variant=GPUVariant.GB200, efficiency=0.5)
+        mode = GpulessMmMode(config=config, sleep=True)
+        with mode:
+            c = torch.mm(a, b)  # intercepted, returns zeros
+        print(mode.stats)
+
+    Args:
+        config: GPU timing configuration for latency simulation.
+        sleep: If True, delay for the simulated latency duration.
+            Set to False to measure pure host-side dispatch overhead.
+        nop_timer: If provided, use NOP spin loop for delay instead of
+            time.sleep. Required for sub-microsecond precision.
+    """
+
+    def __init__(
+        self,
+        config: GPUTimingConfig | None = None,
+        sleep: bool = True,
+        nop_timer: Optional[NopTimer] = None,
+    ) -> None:
+        super().__init__()
+        self.config = config or GPUTimingConfig()
+        self.sleep = sleep
+        self.nop_timer = nop_timer
+        self.stats = GpulessMmStats()
+
+    def __torch_dispatch__(self, func, types, args=(), kwargs=None):
+        kwargs = kwargs if kwargs else {}
+
+        if func not in _INTERCEPTED_OPS:
+            return func(*args, **kwargs)
+
+        # Compute output shape and latency based on which op we intercepted
+        if func is torch.ops.aten.mm.default:
+            a, b = args[0], args[1]
+            m, k = a.shape
+            _, n = b.shape
+            out_shape = (m, n)
+            dtype = a.dtype
+            op_name = "aten.mm"
+
+        elif func is torch.ops.aten.addmm.default:
+            # addmm(bias, input, weight) -> bias + input @ weight
+            a, b = args[1], args[2]
+            m, k = a.shape
+            _, n = b.shape
+            out_shape = (m, n)
+            dtype = a.dtype
+            op_name = "aten.addmm"
+
+        elif func is torch.ops.aten.bmm.default:
+            a, b = args[0], args[1]
+            batch, m, k = a.shape
+            _, _, n = b.shape
+            out_shape = (batch, m, n)
+            dtype = a.dtype
+            op_name = "aten.bmm"
+
+        else:
+            # Should not reach here given _INTERCEPTED_OPS check above
+            return func(*args, **kwargs)
+
+        # Compute simulated latency
+        latency = compute_mm_latency(m, n, k, self.config)
+        self.stats.record(op_name, latency)
+
+        if self.sleep:
+            if self.nop_timer is not None:
+                self.nop_timer.delay_s(latency)
+            else:
+                time.sleep(latency)
+
+        return torch.zeros(out_shape, dtype=dtype, device="cpu")

--- a/packages/ai_wdl/pytorch_gemm_gpuless/src/stage2_benchmark.py
+++ b/packages/ai_wdl/pytorch_gemm_gpuless/src/stage2_benchmark.py
@@ -1,0 +1,184 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Stage 2: GPU-less GEMM benchmark via mock_cuda.
+
+Measures the full host-side overhead of torch.mm including C++ dispatch,
+cuBLAS wrapper code, and CUDA driver API call overhead — everything except
+actual GPU kernel execution.
+
+Patches the function table in libcuda.so.1 so all CUDA driver calls
+(cuLaunchKernel, cuMemAlloc, etc.) return success instantly without GPU work.
+
+Requires: CUDA drivers installed (libcuda.so.1 must be present), but no GPU.
+"""
+
+import argparse
+import time
+
+import torch
+from gpu_timing_model import compute_mm_latency, GPUTimingConfig, variant_from_str
+from mock_cuda_guard import mock_cuda_guard
+from nop_delay import NopTimer, SpinTimer
+from torch.profiler import profile, ProfilerActivity
+
+
+_DTYPE_MAP = {
+    "float32": torch.float32,
+    "float16": torch.float16,
+    "bfloat16": torch.bfloat16,
+}
+
+
+def parse_args() -> argparse.Namespace:
+    p = argparse.ArgumentParser(
+        description="GPU-less GEMM benchmark (Stage 2: mock_cuda)"
+    )
+    p.add_argument("-m", "--msize", type=int, default=1024, help="M dimension")
+    p.add_argument("-n", "--nsize", type=int, default=1024, help="N dimension")
+    p.add_argument("-k", "--ksize", type=int, default=1024, help="K dimension")
+    p.add_argument(
+        "-t",
+        "--dtype",
+        type=str,
+        default="bfloat16",
+        choices=list(_DTYPE_MAP.keys()),
+        help="Data type (default: bfloat16)",
+    )
+    p.add_argument("--steps", type=int, default=100, help="Number of timed iterations")
+    p.add_argument(
+        "--warmups", type=int, default=10, help="Number of warmup iterations"
+    )
+    p.add_argument(
+        "--gpu-model",
+        type=str,
+        default="gb200",
+        help="GPU variant to simulate: gb200, gb300, h100 (default: gb200)",
+    )
+    p.add_argument(
+        "--efficiency",
+        type=float,
+        default=0.5,
+        help="GPU efficiency factor 0.0-1.0 (default: 0.5)",
+    )
+    p.add_argument(
+        "--no-sleep",
+        action="store_true",
+        help="Disable simulated GPU delay — measures pure host dispatch overhead",
+    )
+    p.add_argument(
+        "--delay-mode",
+        type=str,
+        default="nop",
+        choices=["nop", "spin"],
+        help="Delay method: nop = NOP spin loop (default), "
+        "spin = clock_gettime spin (minimal instruction pollution)",
+    )
+    p.add_argument(
+        "--trace",
+        type=str,
+        default=None,
+        metavar="PATH",
+        help="Export PyTorch profiler trace to file (Chrome/Perfetto .json or .json.gz)",
+    )
+    return p.parse_args()
+
+
+def run_benchmark(args: argparse.Namespace) -> None:
+    m, n, k = args.msize, args.nsize, args.ksize
+    dtype = _DTYPE_MAP[args.dtype]
+    flops_per_call = 2.0 * m * n * k
+
+    variant = variant_from_str(args.gpu_model)
+    config = GPUTimingConfig(variant=variant, efficiency=args.efficiency)
+    simulated_latency = compute_mm_latency(m, n, k, config)
+    simulated_latency_ns = simulated_latency * 1e9
+    do_sleep = not args.no_sleep
+
+    delay_timer = None
+    if do_sleep:
+        if args.delay_mode == "spin":
+            delay_timer = SpinTimer()
+            print("Using spin delay (clock_gettime polling)", flush=True)
+        else:
+            print("Calibrating NOP timer...", flush=True)
+            nop_timer = NopTimer(calibration_ms=200)
+            print(f"  NOP rate: {nop_timer.nops_per_ns:.3f} nops/ns")
+            delay_timer = nop_timer
+
+    with mock_cuda_guard():
+        # Create CUDA tensors (backed by fake memory under mock)
+        a = torch.randn(m, k, dtype=dtype, device="cuda:0")
+        b = torch.randn(k, n, dtype=dtype, device="cuda:0")
+
+        # Warmup
+        for _ in range(args.warmups):
+            torch.mm(a, b)
+            if do_sleep and delay_timer is not None:
+                delay_timer.delay_ns(simulated_latency_ns)
+        torch.cuda.synchronize()  # no-op under mock
+
+        # Measured phase
+        activities = [ProfilerActivity.CPU, ProfilerActivity.CUDA]
+        prof_ctx = profile(activities=activities) if args.trace else None
+        if prof_ctx is not None:
+            prof_ctx.__enter__()
+        t0 = time.perf_counter()
+        for _ in range(args.steps):
+            torch.mm(a, b)
+            if do_sleep and delay_timer is not None:
+                delay_timer.delay_ns(simulated_latency_ns)
+        torch.cuda.synchronize()  # no-op under mock
+        t1 = time.perf_counter()
+        if prof_ctx is not None:
+            prof_ctx.__exit__(None, None, None)
+
+    wall_time = t1 - t0
+    wall_per_call = wall_time / args.steps
+    total_simulated_gpu_time = simulated_latency * args.steps
+
+    if args.no_sleep:
+        host_overhead_per_call = wall_per_call
+    else:
+        host_overhead_per_call = wall_per_call - simulated_latency
+
+    tfs = flops_per_call * args.steps / wall_time / 1e12 if wall_time > 0 else 0.0
+
+    # Report
+    print(f"{'=' * 60}")
+    print("Stage 2: GPU-less GEMM Benchmark (mock_cuda)")
+    print(f"{'=' * 60}")
+    print(f"  Matrix:       ({m} x {k}) @ ({k} x {n})")
+    print(f"  Dtype:        {args.dtype}")
+    print(f"  GPU model:    {args.gpu_model} (efficiency={args.efficiency})")
+    if args.no_sleep:
+        sleep_str = "disabled (--no-sleep)"
+    else:
+        sleep_str = f"enabled ({args.delay_mode})"
+    print(f"  Sleep:        {sleep_str}")
+    print(f"  Steps:        {args.steps}  (warmups: {args.warmups})")
+    print(f"{'=' * 60}")
+    print(f"  Total wall time:        {wall_time * 1e3:12.3f} ms")
+    print(f"  Wall time / call:       {wall_per_call * 1e6:12.3f} us")
+    if not args.no_sleep:
+        print(f"  Simulated GPU / call:   {simulated_latency * 1e6:12.3f} us")
+    print(f"  Host overhead / call:   {host_overhead_per_call * 1e6:12.3f} us")
+    print(f"  Simulated TF/s:         {tfs:12.6f}")
+    print(f"{'=' * 60}")
+
+    if args.trace and prof_ctx is not None:
+        prof_ctx.export_chrome_trace(args.trace)
+        print(f"  Trace exported to: {args.trace}")
+
+
+def main() -> None:
+    args = parse_args()
+    run_benchmark(args)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Summary:

OSS build recipe and benchpress integration for the GPU-less torch.mm
micro-benchmark. Measures host-side dispatch overhead of torch.mm without
requiring a GPU — for analyzing CPU frontend bottlenecks (BTB/L1I capacity)
on Neoverse V2 and AMD Zen4.

Package contents:
- install_pytorch_gemm_gpuless.sh: Auto-detects CUDA drivers, installs
  PyTorch CUDA (via conda-forge) or CPU accordingly, builds C extensions
- cleanup_pytorch_gemm_gpuless.sh: Remove installed benchmarks
- src/: 6 Python + 4 C/C++ source files with local imports
- PytorchGemmGpulessParser: Extracts wall_time_per_call_us,
  host_overhead_per_call_us, simulated_tflops from benchmark stdout

Three job configs:
- pytorch_gemm_gpuless_stage1: Python dispatch overhead (any machine)
- pytorch_gemm_gpuless_stage2_nosleep: Full host overhead via mock_cuda
- pytorch_gemm_gpuless_stage2_spin: With spin delay simulating GPU latency

CUDA driver handling:
- Install script detects libcuda.so.1 or installs cuda-compat package
- If CUDA drivers present: installs PyTorch CUDA, both stages available
- If no CUDA drivers: installs PyTorch CPU, stage2 blocked at runtime
  with clear error message directing user to install cuda-compat
- mock_cuda.cpp extended with cuInit/cuDeviceGetCount/cuDeviceGet/
  cuDeviceGetAttribute/cuDeviceGetName/cuDeviceTotalMem/cuDriverGetVersion
  mocks for GPU-less machine support

Reviewed By: pranaykoka

Differential Revision: D97787215
