### PR TITLE
Update wget commands to use ftpmirror.gnu.org

### DIFF
--- a/packages/feedsim/alternative_install_feedsim_aws.sh
+++ b/packages/feedsim/alternative_install_feedsim_aws.sh
@@ -60,7 +60,7 @@ cd "${FEEDSIM_THIRD_PARTY_SRC}"
 
 # Installing gengetopt
 if ! [ -d "gengetopt-2.23" ]; then
-    wget "https://ftp.gnu.org/gnu/gengetopt/gengetopt-2.23.tar.xz"
+    wget "https://ftpmirror.gnu.org/gnu/gengetopt/gengetopt-2.23.tar.xz"
     tar -xf "gengetopt-2.23.tar.xz"
     cd "gengetopt-2.23"
     ./configure

--- a/packages/feedsim/install_feedsim.sh
+++ b/packages/feedsim/install_feedsim.sh
@@ -85,7 +85,7 @@ export PATH="${FEEDSIM_THIRD_PARTY_SRC}/cmake-3.14.5/staging/bin:${PATH}"
 
 # Installing gengetopt
 if ! [ -d "gengetopt-2.23" ]; then
-    wget "https://ftp.gnu.org/gnu/gengetopt/gengetopt-2.23.tar.xz"
+    wget "https://ftpmirror.gnu.org/gnu/gengetopt/gengetopt-2.23.tar.xz"
     tar -xf "gengetopt-2.23.tar.xz"
     cd "gengetopt-2.23"
     ./configure

--- a/packages/feedsim/install_feedsim_aarch64.sh
+++ b/packages/feedsim/install_feedsim_aarch64.sh
@@ -57,7 +57,7 @@ cd "${FEEDSIM_THIRD_PARTY_SRC}"
 
 # Installing gengetopt
 if ! [ -d "gengetopt-2.23" ]; then
-    wget "https://ftp.gnu.org/gnu/gengetopt/gengetopt-2.23.tar.xz"
+    wget "https://ftpmirror.gnu.org/gnu/gengetopt/gengetopt-2.23.tar.xz"
     tar -xf "gengetopt-2.23.tar.xz"
     cd "gengetopt-2.23"
     ./configure

--- a/packages/feedsim/install_feedsim_aarch64_ubuntu.sh
+++ b/packages/feedsim/install_feedsim_aarch64_ubuntu.sh
@@ -58,7 +58,7 @@ cd "${FEEDSIM_THIRD_PARTY_SRC}"
 
 # Installing gengetopt
 if ! [ -d "gengetopt-2.23" ]; then
-    wget "https://ftp.gnu.org/gnu/gengetopt/gengetopt-2.23.tar.xz"
+    wget "https://ftpmirror.gnu.org/gnu/gengetopt/gengetopt-2.23.tar.xz"
     tar -xf "gengetopt-2.23.tar.xz"
     cd "gengetopt-2.23"
     ./configure

--- a/packages/feedsim/install_feedsim_x86_64_ubuntu.sh
+++ b/packages/feedsim/install_feedsim_x86_64_ubuntu.sh
@@ -79,7 +79,7 @@ export PATH="${FEEDSIM_THIRD_PARTY_SRC}/cmake-3.14.5/staging/bin:${PATH}"
 
 # Installing gengetopt
 if ! [ -d "gengetopt-2.23" ]; then
-    wget "https://ftp.gnu.org/gnu/gengetopt/gengetopt-2.23.tar.xz"
+    wget "https://ftpmirror.gnu.org/gnu/gengetopt/gengetopt-2.23.tar.xz"
     tar -xf "gengetopt-2.23.tar.xz"
     cd "gengetopt-2.23"
     ./configure

--- a/packages/feedsim/third_party/src/scripts/install_centos8_deps.sh
+++ b/packages/feedsim/third_party/src/scripts/install_centos8_deps.sh
@@ -11,7 +11,7 @@ dnf install -y cmake ninja-build flex bison git texinfo \
 
 
 # gengetopt
-curl $(fwdproxy-config curl) -O https://ftp.gnu.org/gnu/gengetopt/gengetopt-2.23.tar.xz
+curl $(fwdproxy-config curl) -O https://ftpmirror.gnu.org/gnu/gengetopt/gengetopt-2.23.tar.xz
 tar -xf gengetopt-2.23.tar.xz
 cd gengetopt-2.23
 ./configure


### PR DESCRIPTION
I have seen at least one CI/CD server use these scripts which can create increased load on the community ftp.gnu.org server. This patch replaces the link to the main server with the ftp mirror network which should result in faster download speeds and increased uptime for the main server.