### PR TITLE
Expose job and benchmark config files to DC Perf (#554)

### DIFF
--- a/benchpress/config/__init__.py
+++ b/benchpress/config/__init__.py
@@ -70,11 +70,11 @@ if not open_source:
     register_benchmark_suite("internal")
     register_benchmark_suite("wdl_v1")
     register_benchmark_suite("v1")
-    register_benchmark_suite("ehw")
 
 register_benchmark_suite("wdl")
 register_benchmark_suite("system")
 register_benchmark_suite("ai")
+register_benchmark_suite("ehw")
 
 
 class BenchpressConfig:


### PR DESCRIPTION
Summary:

All cdn_bench source files and READMEs are included, the config files need to be added(or in this case exposed)

Differential Revision: D99336502


