### PR TITLE
Upgrade to Python 3.14, Cinder 3.14, and add CinderX JIT (#561)

### DIFF
--- a/benchpress/cli/commands/run.py
+++ b/benchpress/cli/commands/run.py
@@ -227,6 +227,10 @@ class RunCommand(BenchpressCommand):
             metrics_dir = os.path.join(
                 get_artifacts_dir(), f"benchmark_metrics_{job.uuid}"
             )
+            # Export metrics dir so benchmark scripts (e.g., run.sh) can write
+            # breakdown.csv directly there, avoiding race conditions when
+            # multiple runs share the same benchmarks/ directory.
+            os.environ["BENCHPRESS_METRICS_DIR"] = metrics_dir
             now = datetime.now()
             date = now.strftime("%Y%m%d_%H%M")
             symlink = job.name + "_timestamp:" + date + "_" + job.uuid

--- a/benchpress/config/benchmarks.yml
+++ b/benchpress/config/benchmarks.yml
@@ -21,6 +21,7 @@ oss_performance_mediawiki:
 
 django_workload:
   parser: django_workload
+  check_returncode: false
   install_script: ./packages/django_workload/install_django_workload.sh
   cleanup_script: ./packages/django_workload/cleanup_django_workload.sh
   install_markers:
@@ -28,8 +29,8 @@ django_workload:
     - ./benchmarks/django_workload/proxygen_binding/proxygen_binding*.so
     - ./benchmarks/django_workload/django-workload/django-workload/django_workload/thrift/build/gen-py3/mock_services/MockAdsService-remote
     - ./benchmarks/django_workload/django-workload/django-workload/django_workload/feed_timeline.py
-    - ./benchmarks/django_workload/django-workload/django-workload/cinder/cinder-build/bin/python3.10
-    - ./benchmarks/django_workload/django-workload/django-workload/Python-3.10.2/python-build/bin/python3.10
+    - ./benchmarks/django_workload/django-workload/django-workload/cinder/cinder-build/bin/python3.14
+    - ./benchmarks/django_workload/django-workload/django-workload/Python-3.14.2/python-build/bin/python3.14
     - ./benchmarks/django_workload/wrk/wrk
     - ./benchmarks/django_workload/apache-cassandra/bin/cassandra
   path: ./benchmarks/django_workload/bin/run.sh

--- a/benchpress/plugins/hooks/copy.py
+++ b/benchpress/plugins/hooks/copy.py
@@ -34,6 +34,12 @@ class CopyMoveHook(Hook):
         if not os.path.isdir(dest):
             os.mkdir(dest)
         for src in expanded_sources:
+            dest_path = os.path.join(dest, os.path.basename(src))
+            if os.path.exists(dest_path):
+                if os.path.isdir(dest_path):
+                    shutil.rmtree(dest_path)
+                else:
+                    os.remove(dest_path)
             if os.path.isfile(src) or os.path.islink(src):
                 if move:
                     shutil.move(src, dest)
@@ -43,7 +49,7 @@ class CopyMoveHook(Hook):
                 if move:
                     shutil.move(src, dest)
                 else:
-                    shutil.copytree(src, dest)
+                    shutil.copytree(src, dest_path)
             else:
                 logger.warning(f"Could not copy {src}.")
 

--- a/benchpress/plugins/parsers/django_workload.py
+++ b/benchpress/plugins/parsers/django_workload.py
@@ -139,6 +139,18 @@ class DjangoWorkloadParser(Parser):
                 has_url_hit_percentages = True
                 continue
 
+            # Stop parsing metrics when we reach the end-of-output markers
+            if has_url_hit_percentages and (
+                "Full wrk output" in dw_line or "Full Siege output" in dw_line
+            ):
+                has_url_hit_percentages = False
+                continue
+
+            # Parse the Interpreter line regardless of section
+            if "Interpreter:" in dw_line and ":" in dw_line:
+                self.parse_dw_key_val(dw_line, dw_metrics)
+                continue
+
             if has_url_hit_percentages and ":" in dw_line:
                 self.parse_dw_key_val(dw_line, dw_metrics)
 

--- a/packages/django_workload/install_django_workload_aarch64.sh
+++ b/packages/django_workload/install_django_workload_aarch64.sh
@@ -40,7 +40,7 @@ dnf groupinstall "Development Tools" -y --exclude="texlive*"
 dnf install -y memcached libmemcached-awesome-devel zlib-devel screen \
     openssl-devel bzip2-devel libffi-devel wget make xz-devel haproxy \
     xxhash-devel perl-FindBin perl-JSON perl-core liburing-devel \
-    ninja-build
+    ninja-build clang libev libev-devel
 
 echo "System dependencies installed successfully"
 
@@ -70,29 +70,21 @@ else
     alias wget='wget --no-clobber'
 fi
 pushd "${DJANGO_WORKLOAD_DEPS}"
-# cassandra_driver-3.29.2-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl
-wget "https://files.pythonhosted.org/packages/cc/60/f8de88175937481be98da88eb88b4fd704093e284e5907775293c496df32/cassandra_driver-3.29.2-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
-# Removed Cython download as it's not needed
 # Django-5.2.tar.gz
 wget "https://files.pythonhosted.org/packages/1b/11/7aff961db37e1ea501a2bb663d27a8ce97f3683b9e5b83d3bfead8b86fa4/django-5.2.3-py3-none-any.whl"
-# django-cassandra-engine-1.6.2.tar.gz
-wget "https://files.pythonhosted.org/packages/1f/5e/438eb7f2d8b8e240701b721a43cb5a20cf970c8e9da8b3770df1de6d7c5b/django-cassandra-engine-1.6.2.tar.gz"
+# Note: django-cassandra-engine is installed directly from PyPI (not pre-downloaded) to avoid poetry build issues
 # django_statsd_mozilla-0.4.0-py3-none-any.whl
 wget "https://files.pythonhosted.org/packages/ac/54/5fa99753dab7ced46129a4c95c777596a2e4094a8b0f65c8764d60d5cff4/django_statsd_mozilla-0.4.0-py3-none-any.whl"
-# numpy-1.26.4-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl
-wget "https://files.pythonhosted.org/packages/fc/a5/4beee6488160798683eed5bdb7eead455892c3b4e1f78d79d8d3f3b084ac/numpy-1.26.4-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
 # psutil-5.8.0.tar.gz
 wget "https://files.pythonhosted.org/packages/e1/b0/7276de53321c12981717490516b7e612364f2cb372ee8901bd4a66a000d7/psutil-5.8.0.tar.gz"
-# pylibmc-1.6.1-cp36-cp36m-manylinux1_x86_64.whl
-wget "https://files.pythonhosted.org/packages/a7/0c/f7a3af34b05c167a69ed1fc330b06b658dac4ab25b8632c52d1022dd5337/pylibmc-1.6.1.tar.gz"
+# pylibmc - installed from GitHub source for Python 3.14 compatibility (see Step 6.3)
 # pytz-2021.1-py2.py3-none-any.whl
 wget "https://files.pythonhosted.org/packages/70/94/784178ca5dd892a98f113cdd923372024dc04b8d40abe77ca76b5fb90ca6/pytz-2021.1-py2.py3-none-any.whl"
 # six-1.16.0-py2.py3-none-any.whl
 wget "https://files.pythonhosted.org/packages/d9/5a/e7c31adbe875f2abbb91bd84cf2dc52d792b5a01506781dbcf25c91daf11/six-1.16.0-py2.py3-none-any.whl"
 # statsd
 wget "https://files.pythonhosted.org/packages/47/33/c824f799128dfcfce2142f18d9bc6c55c46a939f6e4250639134222d99eb/statsd-3.3.0-py2.py3-none-any.whl"
-# uwsgi-2.0.22.tar.gz
-wget "https://files.pythonhosted.org/packages/a7/4e/c4d5559b3504bb65175a759392b03cac04b8771e9a9b14811adf1151f02f/uwsgi-2.0.22.tar.gz"
+# Note: uwsgi is installed directly from PyPI (not pre-downloaded) to ensure proper linking
 # geomet-0.2.1.post1-py3-none-any.whl
 wget "https://files.pythonhosted.org/packages/c9/81/156ca48f950f833ddc392f8e3677ca50a18cb9d5db38ccb4ecea55a9303f/geomet-0.2.1.post1-py3-none-any.whl"
 # click-7.1.2.tar.gz
@@ -219,46 +211,49 @@ popd
 echo "JDK and Cassandra installed successfully"
 
 # =====================================================================
-# Step 4: Build CPython 3.10
+# Step 4: Build CPython 3.14
 # =====================================================================
 echo ""
 echo "====================================================================="
-echo "Step 4: Building CPython 3.10"
+echo "Step 4: Building CPython 3.14"
 echo "====================================================================="
 
 pushd "${DJANGO_SERVER_ROOT}"
 
-# Install python3.10
-if ! [ -d Python-3.10.2 ]; then
-    wget https://www.python.org/ftp/python/3.10.2/Python-3.10.2.tgz
-    tar -xzf Python-3.10.2.tgz
-    cd Python-3.10.2
+# Install python3.14
+if ! [ -d Python-3.14.2 ]; then
+    wget https://www.python.org/ftp/python/3.14.2/Python-3.14.2.tgz
+    tar -xzf Python-3.14.2.tgz
+    cd Python-3.14.2
     ./configure --enable-optimizations --prefix="$(pwd)/python-build" --enable-shared LN="ln -s"
-    make -j"${NUM_BUILD_JOBS}"
+    make -j"${NUM_BUILD_JOBS}" PROFILE_TASK="-m test --pgo --ignore test_generators"
     make install
     cd ../
 fi
 
-CPYTHON_INSTALL_PREFIX="${DJANGO_SERVER_ROOT}/Python-3.10.2/python-build"
+CPYTHON_INSTALL_PREFIX="${DJANGO_SERVER_ROOT}/Python-3.14.2/python-build"
 export LD_LIBRARY_PATH="${CPYTHON_INSTALL_PREFIX}/lib"
 
-echo "CPython 3.10 built successfully"
+echo "CPython 3.14 built successfully"
 
 # =====================================================================
-# Step 5: Build Cinder 3.10
+# Step 5: Build Cinder 3.14
 # =====================================================================
 echo ""
 echo "====================================================================="
-echo "Step 5: Building Cinder 3.10"
+echo "Step 5: Building Cinder 3.14"
 echo "====================================================================="
 
 # Download and build Cinder
+# Using meta/3.14 branch — includes gh-145615 mimalloc page leak fix
+CINDER_COMMIT="7627b90844073b94ef60415ed1f1248837bedef7"
 if ! [ -d "cinder" ]; then
-    git clone -b cinder/3.10 https://github.com/facebookincubator/cinder.git
+    git clone https://github.com/facebookincubator/cinder.git
     pushd cinder
+    git checkout "${CINDER_COMMIT}"
     mkdir -p cinder-build
     ./configure --prefix="$(pwd)/cinder-build" --enable-optimizations --enable-shared LN="ln -s"
-    make -j"${NUM_BUILD_JOBS}"
+    make -j"${NUM_BUILD_JOBS}" PROFILE_TASK="-m test --pgo --ignore test_generators"
     make install
     popd
 fi
@@ -266,7 +261,7 @@ fi
 CINDER_INSTALL_PREFIX="${DJANGO_SERVER_ROOT}/cinder/cinder-build"
 export LD_LIBRARY_PATH="${CINDER_INSTALL_PREFIX}/lib"
 
-echo "Cinder 3.10 built successfully"
+echo "Cinder 3.14 built successfully"
 
 # =====================================================================
 # Step 6: Install Python dependencies in virtual environments
@@ -278,10 +273,56 @@ echo "====================================================================="
 
 # Create virtual environments for both CPython and Cinder
 export LD_LIBRARY_PATH="${CPYTHON_INSTALL_PREFIX}/lib"
-[ ! -d venv_cpython ] && "${CPYTHON_INSTALL_PREFIX}/bin/python3.10" -m venv venv_cpython
+[ ! -d venv_cpython ] && "${CPYTHON_INSTALL_PREFIX}/bin/python3.14" -m venv venv_cpython
 
 export LD_LIBRARY_PATH="${CINDER_INSTALL_PREFIX}/lib"
 [ ! -d venv_cinder ] && "${CINDER_INSTALL_PREFIX}/bin/python3" -m venv venv_cinder
+
+# =====================================================================
+# Step 6.3: Clone pylibmc from GitHub (Python 3.14 compatible)
+# =====================================================================
+echo ""
+echo "====================================================================="
+echo "Step 6.3: Cloning pylibmc from GitHub source"
+echo "====================================================================="
+
+# Clone pylibmc 1.6.1 from GitHub and patch for Python 3.14 compatibility
+# pylibmc trunk has bugs in the refactored _fetch_multi function that cause
+# memcached connection failures after ~2300 requests. Using stable 1.6.1
+# with a minimal setup.py patch (distutils→setuptools, remove "U" mode) instead.
+PYLIBMC_DIR="${DJANGO_SERVER_ROOT}/pylibmc"
+if ! [ -d "${PYLIBMC_DIR}" ]; then
+    cd "${DJANGO_SERVER_ROOT}"
+    git clone https://github.com/lericson/pylibmc.git
+    cd "${PYLIBMC_DIR}"
+    git checkout 1.6.1
+    # Apply Python 3.14 compatibility patch (setup.py: distutils removed in 3.12)
+    patch -p1 < "${BENCHPRESS_ROOT}/packages/django_workload/srcs/patches/pylibmc-1.6.1-py314-compat.patch"
+    echo "Applied pylibmc 1.6.1 Python 3.14 compatibility patch"
+fi
+
+# =====================================================================
+# Step 6.4: Clone cassandra-python-driver from GitHub (setuptools v82 compatible)
+# =====================================================================
+echo ""
+echo "====================================================================="
+echo "Step 6.4: Cloning cassandra-python-driver from GitHub source"
+echo "====================================================================="
+
+# Clone cassandra-python-driver from GitHub
+# PyPI version uses deprecated ez_setup which is incompatible with setuptools v82+
+# Latest trunk removed ez_setup for compatibility
+CASSANDRA_DRIVER_COMMIT="7d8015e3c1cff543a5f64c70cff3e14216e58037"
+CASSANDRA_DRIVER_DIR="${DJANGO_SERVER_ROOT}/cassandra-python-driver"
+if ! [ -d "${CASSANDRA_DRIVER_DIR}" ]; then
+    cd "${DJANGO_SERVER_ROOT}"
+    git clone https://github.com/apache/cassandra-python-driver.git
+    cd cassandra-python-driver
+    git checkout "${CASSANDRA_DRIVER_COMMIT}"
+fi
+
+# Return to DJANGO_SERVER_ROOT before activating virtual environments
+cd "${DJANGO_SERVER_ROOT}"
 
 # Install packages in CPython environment
 set +u
@@ -291,12 +332,37 @@ set -u
 
 export LD_LIBRARY_PATH="${CPYTHON_INSTALL_PREFIX}/lib"
 export CMAKE_LIBRARY_PATH="${CPYTHON_INSTALL_PREFIX}/lib"
-export CPATH="${DJANGO_SERVER_ROOT}/Python-3.10.2/python-build/include:${DJANGO_SERVER_ROOT}/Python-3.10.2/Include"
+export CPATH="${DJANGO_SERVER_ROOT}/Python-3.14.2/python-build/include:${DJANGO_SERVER_ROOT}/Python-3.14.2/Include"
+# Set LIBRARY_PATH and LDFLAGS to ensure packages link against CPython's libpython
+export LIBRARY_PATH="${CPYTHON_INSTALL_PREFIX}/lib"
+export LDFLAGS="-L${CPYTHON_INSTALL_PREFIX}/lib -Wl,-rpath,${CPYTHON_INSTALL_PREFIX}/lib"
+
+# Install pylibmc (required by django-workload)
+cd "${PYLIBMC_DIR}"
+pip3.14 install -e .
+echo "pylibmc installed in CPython venv"
+pip3.14 install pymemcache
+echo "pymemcache installed in CPython venv"
+
+# Install uwsgi directly from PyPI to ensure proper linking with CPython's libpython
+# Use --no-cache-dir to prevent reusing a wheel built for a different Python environment
+pip3.14 install --no-cache-dir uwsgi
+echo "uwsgi installed in CPython venv"
+
+# Install django-cassandra-engine directly from PyPI to avoid poetry build issues
+pip3.14 install django-cassandra-engine
+echo "django-cassandra-engine installed in CPython venv"
 
 # Install dependencies using third_party pip dependencies
-pip3.10 install "django-statsd-mozilla" --no-index --find-links file://"${DJANGO_WORKLOAD_DEPS}"
-pip3.10 install "numpy>=1.19" --no-index --find-links file://"${DJANGO_WORKLOAD_DEPS}"
-pip3.10 install -e . --no-index --find-links file://"${DJANGO_WORKLOAD_DEPS}"
+cd "${DJANGO_SERVER_ROOT}"
+pip3.14 install "django-statsd-mozilla" --no-index --find-links file://"${DJANGO_WORKLOAD_DEPS}"
+# Install cassandra-driver from GitHub source (setuptools v82+ compatible)
+# Disable Cython extension to avoid build issues
+cd "${CASSANDRA_DRIVER_DIR}"
+CASS_DRIVER_NO_CYTHON=1 pip3.14 install -e .
+echo "cassandra-driver installed in CPython venv"
+cd "${DJANGO_SERVER_ROOT}"
+pip3.14 install -e . --no-index --find-links file://"${DJANGO_WORKLOAD_DEPS}"
 
 echo "Dependencies installed in CPython venv"
 
@@ -311,15 +377,68 @@ pushd "${DJANGO_SERVER_ROOT}"
 export CPATH="${DJANGO_SERVER_ROOT}/cinder/cinder-build/include:${DJANGO_SERVER_ROOT}/cinder/Include"
 export LD_LIBRARY_PATH="${CINDER_INSTALL_PREFIX}/lib"
 export CMAKE_LIBRARY_PATH="${CINDER_INSTALL_PREFIX}/lib"
+# Critical: Set LIBRARY_PATH and LDFLAGS to ensure uwsgi links against Cinder's libpython
+# Without these, the linker may find CPython's libpython3.14.so instead
+export LIBRARY_PATH="${CINDER_INSTALL_PREFIX}/lib"
+export LDFLAGS="-L${CINDER_INSTALL_PREFIX}/lib -Wl,-rpath,${CINDER_INSTALL_PREFIX}/lib"
 source ./venv_cinder/bin/activate
 set -u
 
+# Install pylibmc (required by django-workload)
+cd "${PYLIBMC_DIR}"
+pip3.14 install -e .
+echo "pylibmc installed in Cinder venv"
+pip3.14 install pymemcache
+echo "pymemcache installed in Cinder venv"
+
+# Install uwsgi directly from PyPI to ensure proper linking with Cinder's libpython
+# Use --no-cache-dir to prevent reusing a wheel built for a different Python environment
+pip3.14 install --no-cache-dir uwsgi
+echo "uwsgi installed in Cinder venv"
+
+# Install django-cassandra-engine directly from PyPI to avoid poetry build issues
+pip3.14 install django-cassandra-engine
+echo "django-cassandra-engine installed in Cinder venv"
+
 # Install dependencies using third_party pip dependencies
-pip3.10 install "django-statsd-mozilla" --no-index --find-links file://"${DJANGO_WORKLOAD_DEPS}"
-pip3.10 install "numpy>=1.19" --no-index --find-links file://"${DJANGO_WORKLOAD_DEPS}"
-pip3.10 install -e . --no-index --find-links file://"${DJANGO_WORKLOAD_DEPS}"
+cd "${DJANGO_SERVER_ROOT}"
+pip3.14 install "django-statsd-mozilla" --no-index --find-links file://"${DJANGO_WORKLOAD_DEPS}"
+# Install cassandra-driver from GitHub source (setuptools v82+ compatible)
+# Disable Cython extension to avoid build issues
+cd "${CASSANDRA_DRIVER_DIR}"
+CASS_DRIVER_NO_CYTHON=1 pip3.14 install -e .
+echo "cassandra-driver installed in Cinder venv"
+cd "${DJANGO_SERVER_ROOT}"
+pip3.14 install -e . --no-index --find-links file://"${DJANGO_WORKLOAD_DEPS}"
 
 echo "Dependencies installed in Cinder venv"
+
+# =====================================================================
+# Step 6.5: Install CinderX for JIT Support
+# =====================================================================
+echo ""
+echo "====================================================================="
+echo "Step 6.5: Installing CinderX for JIT Support"
+echo "====================================================================="
+
+# Clone and install CinderX for JIT functionality
+CINDERX_COMMIT="6e0472215c9917c2b5c9777dd4702b5d84eb3111"
+if ! [ -d "${DJANGO_SERVER_ROOT}/cinderx" ]; then
+    cd "${DJANGO_SERVER_ROOT}"
+    git clone https://github.com/facebookincubator/cinderx.git
+    cd cinderx
+    git checkout "${CINDERX_COMMIT}"
+fi
+
+# Install CinderX in Cinder virtual environment (already activated)
+cd "${DJANGO_SERVER_ROOT}/cinderx"
+python -m pip install -e .
+
+# Validate CinderX installation
+echo "Validating CinderX installation..."
+python -c "import cinderx; cinderx.init(); assert cinderx.is_initialized(), 'CinderX failed to initialize'; print('CinderX initialized successfully')"
+
+echo "CinderX installed and validated successfully"
 
 deactivate
 popd  # ${DJANGO_SERVER_ROOT}
@@ -513,6 +632,7 @@ export PROXYGEN_INSTALL_DIR="${DJANGO_WORKLOAD_ROOT}/proxygen/staging"
 # Build and install in venv_cpython
 echo ""
 echo "Installing proxygen_binding in venv_cpython..."
+export LD_LIBRARY_PATH="${CPYTHON_INSTALL_PREFIX}/lib"
 cd "${DJANGO_WORKLOAD_ROOT}/proxygen_binding"
 "${DJANGO_SERVER_ROOT}/venv_cpython/bin/python" -m pip install pybind11
 "${DJANGO_SERVER_ROOT}/venv_cpython/bin/python" -m pip install -e .
@@ -521,6 +641,7 @@ echo "proxygen_binding installed in venv_cpython"
 # Build and install in venv_cinder
 echo ""
 echo "Installing proxygen_binding in venv_cinder..."
+export LD_LIBRARY_PATH="${CINDER_INSTALL_PREFIX}/lib"
 cd "${DJANGO_WORKLOAD_ROOT}/proxygen_binding"
 "${DJANGO_SERVER_ROOT}/venv_cinder/bin/python" -m pip install pybind11
 "${DJANGO_SERVER_ROOT}/venv_cinder/bin/python" -m pip install -e .
@@ -535,6 +656,8 @@ echo "Step 9: Generating Code Variants for FeedFlow"
 echo "====================================================================="
 
 # Install jinja2 in venv_cpython
+# Set LD_LIBRARY_PATH for CPython shared library
+export LD_LIBRARY_PATH="${CPYTHON_INSTALL_PREFIX}/lib"
 echo "Installing jinja2 for code generation..."
 "${DJANGO_SERVER_ROOT}/venv_cpython/bin/python" -m pip install jinja2
 

--- a/packages/django_workload/install_django_workload_aarch64_ubuntu22.sh
+++ b/packages/django_workload/install_django_workload_aarch64_ubuntu22.sh
@@ -39,7 +39,7 @@ echo "====================================================================="
 apt install -y memcached libmemcached-dev zlib1g-dev screen \
     python3 python3.10-dev python3.10-venv rpm libffi-dev \
     libssl-dev libcrypt-dev haproxy libxxhash-dev \
-    perl ninja-build
+    perl ninja-build clang libev4 libev-dev
 
 echo "System dependencies installed successfully"
 
@@ -69,31 +69,23 @@ else
     alias wget='wget --no-clobber'
 fi
 pushd "${DJANGO_WORKLOAD_DEPS}"
-# cassandra-driver-3.26_aarch64.whl
-wget "https://files.pythonhosted.org/packages/b5/5e/54c58c98a4eeea12a2fee7220e7ac9e8b021ea5c3d84c84adb9106c4ed43/cassandra_driver-3.26.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
-# Removed Cython download as it's not needed
 # Django-5.2.3-py3-none-any.whl
 wget "https://files.pythonhosted.org/packages/1b/11/7aff961db37e1ea501a2bb663d27a8ce97f3683b9e5b83d3bfead8b86fa4/django-5.2.3-py3-none-any.whl"
 # Dulwich 0.21.2.tar.gz
 wget "https://files.pythonhosted.org/packages/14/a5/cf61f9209d48abf47d48086e0a0388f1030bb5f7cf2661972eee56ccee3d/dulwich-0.21.2.tar.gz"
-# django-cassandra-engine-1.6.2.tar.gz
-wget "https://files.pythonhosted.org/packages/1f/5e/438eb7f2d8b8e240701b721a43cb5a20cf970c8e9da8b3770df1de6d7c5b/django-cassandra-engine-1.6.2.tar.gz"
+# Note: django-cassandra-engine is installed directly from PyPI (not pre-downloaded) to avoid poetry build issues
 # django-statsd-mozilla-0.4.3-py3-none-any.whl
 wget "https://files.pythonhosted.org/packages/ac/54/5fa99753dab7ced46129a4c95c777596a2e4094a8b0f65c8764d60d5cff4/django_statsd_mozilla-0.4.0-py3-none-any.whl"
-# numpy-1.22.1-aarch64.whl
-wget "https://files.pythonhosted.org/packages/d6/ec/a8b5f1b6d00bc4fd1bc91043d5dfb029536ec5c7769588d3f4c982240008/numpy-1.22.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
 # psutil-5.8.0.tar.gz
 wget "https://files.pythonhosted.org/packages/e1/b0/7276de53321c12981717490516b7e612364f2cb372ee8901bd4a66a000d7/psutil-5.8.0.tar.gz"
-# pylibmc-1.6.1.tar.gz
-wget "https://files.pythonhosted.org/packages/a7/0c/f7a3af34b05c167a69ed1fc330b06b658dac4ab25b8632c52d1022dd5337/pylibmc-1.6.1.tar.gz"
+# pylibmc - installed from GitHub source for Python 3.14 compatibility (see Step 6.3)
 # pytz-2021.1-py2.py3-none-any.whl
 wget "https://files.pythonhosted.org/packages/70/94/784178ca5dd892a98f113cdd923372024dc04b8d40abe77ca76b5fb90ca6/pytz-2021.1-py2.py3-none-any.whl"
 # six-1.16.0-py2.py3-none-any.whl
 wget "https://files.pythonhosted.org/packages/d9/5a/e7c31adbe875f2abbb91bd84cf2dc52d792b5a01506781dbcf25c91daf11/six-1.16.0-py2.py3-none-any.whl"
 # statsd-3.3.0-py2.py3-none-any.whl
 wget "https://files.pythonhosted.org/packages/47/33/c824f799128dfcfce2142f18d9bc6c55c46a939f6e4250639134222d99eb/statsd-3.3.0-py2.py3-none-any.whl"
-# uwsgi-2.0.22.tar.gz
-wget "https://files.pythonhosted.org/packages/a7/4e/c4d5559b3504bb65175a759392b03cac04b8771e9a9b14811adf1151f02f/uwsgi-2.0.22.tar.gz"
+# Note: uwsgi is installed directly from PyPI (not pre-downloaded) to ensure proper linking
 # geomet-0.2.1.post1-py3-none-any.whl
 wget "https://files.pythonhosted.org/packages/c9/81/156ca48f950f833ddc392f8e3677ca50a18cb9d5db38ccb4ecea55a9303f/geomet-0.2.1.post1-py3-none-any.whl"
 # click-7.1.2.tar.gz
@@ -223,38 +215,48 @@ popd
 echo "JDK and Cassandra installed successfully"
 
 # =====================================================================
-# Step 4: Build CPython 3.10
+# Step 4: Build CPython 3.14
 # =====================================================================
 echo ""
 echo "====================================================================="
-echo "Step 4: Building CPython 3.10"
+echo "Step 4: Building CPython 3.14"
 echo "====================================================================="
 
 pushd "${DJANGO_SERVER_ROOT}"
 
-# Ubuntu 22 comes with python3.10, so we use system python
-echo "Using system Python 3.10"
+# Install python3.14 from source
+if ! [ -d Python-3.14.2 ]; then
+    wget https://www.python.org/ftp/python/3.14.2/Python-3.14.2.tgz
+    tar -xzf Python-3.14.2.tgz
+    cd Python-3.14.2
+    ./configure --enable-optimizations --prefix="$(pwd)/python-build" --enable-shared LN="ln -s"
+    make -j"${NUM_BUILD_JOBS}"
+    make install
+    cd ../
+fi
 
-# Create directory and symlink so the install marker check passes
-mkdir -p "${DJANGO_SERVER_ROOT}/Python-3.10.2/python-build/bin"
-ln -sf /usr/bin/python3.10 "${DJANGO_SERVER_ROOT}/Python-3.10.2/python-build/bin/python3.10"
+CPYTHON_INSTALL_PREFIX="${DJANGO_SERVER_ROOT}/Python-3.14.2/python-build"
+export LD_LIBRARY_PATH="${CPYTHON_INSTALL_PREFIX}/lib"
 
-echo "CPython 3.10 ready"
+echo "CPython 3.14 built successfully"
 
 # =====================================================================
-# Step 5: Build Cinder 3.10
+# Step 5: Build Cinder 3.14
 # =====================================================================
 echo ""
 echo "====================================================================="
-echo "Step 5: Building Cinder 3.10"
+echo "Step 5: Building Cinder 3.14"
 echo "====================================================================="
 
 # Download and build Cinder
+# Using meta/3.14 branch at a known good commit for reproducibility
+CINDER_COMMIT="04f91c3659d8d2dfe4331a47548316289d2fa3f0"
 if ! [ -d "cinder" ]; then
-    git clone -b cinder/3.10 https://github.com/facebookincubator/cinder.git
+    git clone https://github.com/facebookincubator/cinder.git
     pushd cinder
+    git checkout "${CINDER_COMMIT}"
     mkdir -p cinder-build
-    ./configure --prefix="$(pwd)/cinder-build" --enable-optimizations --enable-shared LN="ln -s"
+    ./configure --prefix="$(pwd)/cinder-build" --enable-profiling --enable-optimizations --enable-shared LN="ln -s"
     make -j"${NUM_BUILD_JOBS}"
     make install
     popd
@@ -263,7 +265,7 @@ fi
 CINDER_INSTALL_PREFIX="${DJANGO_SERVER_ROOT}/cinder/cinder-build"
 export LD_LIBRARY_PATH="${CINDER_INSTALL_PREFIX}/lib"
 
-echo "Cinder 3.10 built successfully"
+echo "Cinder 3.14 built successfully"
 
 # =====================================================================
 # Step 6: Install Python dependencies in virtual environments
@@ -275,11 +277,58 @@ echo "====================================================================="
 
 # Create virtual environments for both CPython and Cinder
 # Create CPython virtual env
-python3.10 -m venv venv_cpython
+export LD_LIBRARY_PATH="${CPYTHON_INSTALL_PREFIX}/lib"
+[ ! -d venv_cpython ] && "${CPYTHON_INSTALL_PREFIX}/bin/python3.14" -m venv venv_cpython
 
 # Create Cinder virtual env
 export LD_LIBRARY_PATH="${CINDER_INSTALL_PREFIX}/lib"
 [ ! -d venv_cinder ] && "${CINDER_INSTALL_PREFIX}/bin/python3" -m venv venv_cinder
+
+# =====================================================================
+# Step 6.3: Clone pylibmc from GitHub (Python 3.14 compatible)
+# =====================================================================
+echo ""
+echo "====================================================================="
+echo "Step 6.3: Cloning pylibmc from GitHub source"
+echo "====================================================================="
+
+# Clone pylibmc 1.6.1 from GitHub and patch for Python 3.14 compatibility
+# pylibmc trunk has bugs in the refactored _fetch_multi function that cause
+# memcached connection failures after ~2300 requests. Using stable 1.6.1
+# with a minimal setup.py patch (distutils→setuptools, remove "U" mode) instead.
+PYLIBMC_DIR="${DJANGO_SERVER_ROOT}/pylibmc"
+if ! [ -d "${PYLIBMC_DIR}" ]; then
+    cd "${DJANGO_SERVER_ROOT}"
+    git clone https://github.com/lericson/pylibmc.git
+    cd "${PYLIBMC_DIR}"
+    git checkout 1.6.1
+    # Apply Python 3.14 compatibility patch (setup.py: distutils removed in 3.12)
+    patch -p1 < "${BENCHPRESS_ROOT}/packages/django_workload/srcs/patches/pylibmc-1.6.1-py314-compat.patch"
+    echo "Applied pylibmc 1.6.1 Python 3.14 compatibility patch"
+fi
+
+# =====================================================================
+# Step 6.4: Clone cassandra-python-driver from GitHub (setuptools v82 compatible)
+# =====================================================================
+echo ""
+echo "====================================================================="
+echo "Step 6.4: Cloning cassandra-python-driver from GitHub source"
+echo "====================================================================="
+
+# Clone cassandra-python-driver from GitHub
+# PyPI version uses deprecated ez_setup which is incompatible with setuptools v82+
+# Latest trunk removed ez_setup for compatibility
+CASSANDRA_DRIVER_COMMIT="7d8015e3c1cff543a5f64c70cff3e14216e58037"
+CASSANDRA_DRIVER_DIR="${DJANGO_SERVER_ROOT}/cassandra-python-driver"
+if ! [ -d "${CASSANDRA_DRIVER_DIR}" ]; then
+    cd "${DJANGO_SERVER_ROOT}"
+    git clone https://github.com/apache/cassandra-python-driver.git
+    cd cassandra-python-driver
+    git checkout "${CASSANDRA_DRIVER_COMMIT}"
+fi
+
+# Return to DJANGO_SERVER_ROOT before activating virtual environments
+cd "${DJANGO_SERVER_ROOT}"
 
 # Install packages in CPython environment
 set +u
@@ -287,10 +336,39 @@ set +u
 source ./venv_cpython/bin/activate
 set -u
 
+export LD_LIBRARY_PATH="${CPYTHON_INSTALL_PREFIX}/lib"
+export CMAKE_LIBRARY_PATH="${CPYTHON_INSTALL_PREFIX}/lib"
+export CPATH="${DJANGO_SERVER_ROOT}/Python-3.14.2/python-build/include:${DJANGO_SERVER_ROOT}/Python-3.14.2/Include"
+# Set LIBRARY_PATH and LDFLAGS to ensure packages link against CPython's libpython
+export LIBRARY_PATH="${CPYTHON_INSTALL_PREFIX}/lib"
+export LDFLAGS="-L${CPYTHON_INSTALL_PREFIX}/lib -Wl,-rpath,${CPYTHON_INSTALL_PREFIX}/lib"
+
+# Install pylibmc (required by django-workload)
+cd "${PYLIBMC_DIR}"
+pip3.14 install -e .
+echo "pylibmc installed in CPython venv"
+pip3.14 install pymemcache
+echo "pymemcache installed in CPython venv"
+
+# Install uwsgi directly from PyPI to ensure proper linking with CPython's libpython
+# Use --no-cache-dir to prevent reusing a wheel built for a different Python environment
+pip3.14 install --no-cache-dir uwsgi
+echo "uwsgi installed in CPython venv"
+
+# Install django-cassandra-engine directly from PyPI to avoid poetry build issues
+pip3.14 install django-cassandra-engine
+echo "django-cassandra-engine installed in CPython venv"
+
 # Install dependencies using third_party pip dependencies
-pip3 install "django-statsd-mozilla" --no-index --find-links file://"${DJANGO_WORKLOAD_DEPS}"
-pip3 install "numpy>=1.19" --no-index --find-links file://"${DJANGO_WORKLOAD_DEPS}"
-pip3 install -e . --no-index --find-links file://"${DJANGO_WORKLOAD_DEPS}"
+cd "${DJANGO_SERVER_ROOT}"
+pip3.14 install "django-statsd-mozilla" --no-index --find-links file://"${DJANGO_WORKLOAD_DEPS}"
+# Install cassandra-driver from GitHub source (setuptools v82+ compatible)
+# Disable Cython extension to avoid build issues
+cd "${CASSANDRA_DRIVER_DIR}"
+CASS_DRIVER_NO_CYTHON=1 pip3.14 install -e .
+echo "cassandra-driver installed in CPython venv"
+cd "${DJANGO_SERVER_ROOT}"
+pip3.14 install -e . --no-index --find-links file://"${DJANGO_WORKLOAD_DEPS}"
 
 echo "Dependencies installed in CPython venv"
 
@@ -305,15 +383,68 @@ pushd "${DJANGO_SERVER_ROOT}"
 export CPATH="${DJANGO_SERVER_ROOT}/cinder/cinder-build/include:${DJANGO_SERVER_ROOT}/cinder/Include"
 export LD_LIBRARY_PATH="${CINDER_INSTALL_PREFIX}/lib"
 export CMAKE_LIBRARY_PATH="${CINDER_INSTALL_PREFIX}/lib"
+# Critical: Set LIBRARY_PATH and LDFLAGS to ensure uwsgi links against Cinder's libpython
+# Without these, the linker may find CPython's libpython3.14.so instead
+export LIBRARY_PATH="${CINDER_INSTALL_PREFIX}/lib"
+export LDFLAGS="-L${CINDER_INSTALL_PREFIX}/lib -Wl,-rpath,${CINDER_INSTALL_PREFIX}/lib"
 source ./venv_cinder/bin/activate
 set -u
 
+# Install pylibmc (required by django-workload)
+cd "${PYLIBMC_DIR}"
+pip3.14 install -e .
+echo "pylibmc installed in Cinder venv"
+pip3.14 install pymemcache
+echo "pymemcache installed in Cinder venv"
+
+# Install uwsgi directly from PyPI to ensure proper linking with Cinder's libpython
+# Use --no-cache-dir to prevent reusing a wheel built for a different Python environment
+pip3.14 install --no-cache-dir uwsgi
+echo "uwsgi installed in Cinder venv"
+
+# Install django-cassandra-engine directly from PyPI to avoid poetry build issues
+pip3.14 install django-cassandra-engine
+echo "django-cassandra-engine installed in Cinder venv"
+
 # Install dependencies using third_party pip dependencies
-pip3 install "django-statsd-mozilla" --no-index --find-links file://"${DJANGO_WORKLOAD_DEPS}"
-pip3 install "numpy>=1.19" --no-index --find-links file://"${DJANGO_WORKLOAD_DEPS}"
-pip3 install -e . --no-index --find-links file://"${DJANGO_WORKLOAD_DEPS}"
+cd "${DJANGO_SERVER_ROOT}"
+pip3.14 install "django-statsd-mozilla" --no-index --find-links file://"${DJANGO_WORKLOAD_DEPS}"
+# Install cassandra-driver from GitHub source (setuptools v82+ compatible)
+# Disable Cython extension to avoid build issues
+cd "${CASSANDRA_DRIVER_DIR}"
+CASS_DRIVER_NO_CYTHON=1 pip3.14 install -e .
+echo "cassandra-driver installed in Cinder venv"
+cd "${DJANGO_SERVER_ROOT}"
+pip3.14 install -e . --no-index --find-links file://"${DJANGO_WORKLOAD_DEPS}"
 
 echo "Dependencies installed in Cinder venv"
+
+# =====================================================================
+# Step 6.5: Install CinderX for JIT Support
+# =====================================================================
+echo ""
+echo "====================================================================="
+echo "Step 6.5: Installing CinderX for JIT Support"
+echo "====================================================================="
+
+# Clone and install CinderX for JIT functionality
+CINDERX_COMMIT="497b2b671a8084345a8288cfbd9995acfab9dfbf"
+if ! [ -d "${DJANGO_SERVER_ROOT}/cinderx" ]; then
+    cd "${DJANGO_SERVER_ROOT}"
+    git clone https://github.com/facebookincubator/cinderx.git
+    cd cinderx
+    git checkout "${CINDERX_COMMIT}"
+fi
+
+# Install CinderX in Cinder virtual environment (already activated)
+cd "${DJANGO_SERVER_ROOT}/cinderx"
+python -m pip install -e .
+
+# Validate CinderX installation
+echo "Validating CinderX installation..."
+python -c "import cinderx; cinderx.init(); assert cinderx.is_initialized(), 'CinderX failed to initialize'; print('CinderX initialized successfully')"
+
+echo "CinderX installed and validated successfully"
 
 deactivate
 popd  # ${DJANGO_SERVER_ROOT}
@@ -507,6 +638,7 @@ export PROXYGEN_INSTALL_DIR="${DJANGO_WORKLOAD_ROOT}/proxygen/staging"
 # Build and install in venv_cpython
 echo ""
 echo "Installing proxygen_binding in venv_cpython..."
+export LD_LIBRARY_PATH="${CPYTHON_INSTALL_PREFIX}/lib"
 cd "${DJANGO_WORKLOAD_ROOT}/proxygen_binding"
 "${DJANGO_SERVER_ROOT}/venv_cpython/bin/python" -m pip install pybind11
 "${DJANGO_SERVER_ROOT}/venv_cpython/bin/python" -m pip install -e .
@@ -515,6 +647,7 @@ echo "proxygen_binding installed in venv_cpython"
 # Build and install in venv_cinder
 echo ""
 echo "Installing proxygen_binding in venv_cinder..."
+export LD_LIBRARY_PATH="${CINDER_INSTALL_PREFIX}/lib"
 cd "${DJANGO_WORKLOAD_ROOT}/proxygen_binding"
 "${DJANGO_SERVER_ROOT}/venv_cinder/bin/python" -m pip install pybind11
 "${DJANGO_SERVER_ROOT}/venv_cinder/bin/python" -m pip install -e .
@@ -529,6 +662,8 @@ echo "Step 9: Generating Code Variants for FeedFlow"
 echo "====================================================================="
 
 # Install jinja2 in venv_cpython
+# Set LD_LIBRARY_PATH for CPython shared library
+export LD_LIBRARY_PATH="${CPYTHON_INSTALL_PREFIX}/lib"
 echo "Installing jinja2 for code generation..."
 "${DJANGO_SERVER_ROOT}/venv_cpython/bin/python" -m pip install jinja2
 

--- a/packages/django_workload/install_django_workload_x86_64_centos9.sh
+++ b/packages/django_workload/install_django_workload_x86_64_centos9.sh
@@ -38,8 +38,9 @@ echo "====================================================================="
 
 dnf groupinstall "Development Tools" -y --exclude="texlive*"
 dnf install -y memcached libmemcached-awesome-devel zlib-devel screen \
-    openssl-devel bzip2-devel libffi-devel wget make haproxy xxhash-devel \
-    perl-FindBin perl-JSON perl-core liburing-devel ninja-build
+    openssl-devel bzip2-devel libffi-devel wget make xz-devel haproxy \
+    xxhash-devel perl-FindBin perl-JSON perl-core liburing-devel \
+    ninja-build clang libev libev-devel
 
 echo "System dependencies installed successfully"
 
@@ -67,21 +68,14 @@ else
     alias wget='wget --no-clobber'
 fi
 pushd "${DJANGO_WORKLOAD_DEPS}"
-# cassandra-driver-3.29.1_x86_64.whl
-wget "https://files.pythonhosted.org/packages/eb/d5/e437271aea182e33db32e0990703b4e0d7025e4fba67829c5fd65dba926a/cassandra_driver-3.29.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
-# Removed Cython download as it's not needed
 # Django-5.2.3-py3-none-any.whl
 wget "https://files.pythonhosted.org/packages/1b/11/7aff961db37e1ea501a2bb663d27a8ce97f3683b9e5b83d3bfead8b86fa4/django-5.2.3-py3-none-any.whl"
-# django-cassandra-engine-1.6.2.tar.gz
-wget "https://files.pythonhosted.org/packages/1f/5e/438eb7f2d8b8e240701b721a43cb5a20cf970c8e9da8b3770df1de6d7c5b/django-cassandra-engine-1.6.2.tar.gz"
+# Note: django-cassandra-engine is installed directly from PyPI (not pre-downloaded) to avoid poetry build issues
 # django_statsd_mozilla-0.4.0-py3-none-any.whl
 wget "https://files.pythonhosted.org/packages/ac/54/5fa99753dab7ced46129a4c95c777596a2e4094a8b0f65c8764d60d5cff4/django_statsd_mozilla-0.4.0-py3-none-any.whl"
-# numpy-1.26.4-x86_64.whl
-wget "https://files.pythonhosted.org/packages/4b/d7/ecf66c1cd12dc28b4040b15ab4d17b773b87fa9d29ca16125de01adb36cd/numpy-1.26.4-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
 # psutil-5.8.0.tar.gz
 wget "https://files.pythonhosted.org/packages/e1/b0/7276de53321c12981717490516b7e612364f2cb372ee8901bd4a66a000d7/psutil-5.8.0.tar.gz"
-# pylibmc-1.6.1-cp36-cp36m-manylinux1_x86_64.whl
-wget "https://files.pythonhosted.org/packages/a7/0c/f7a3af34b05c167a69ed1fc330b06b658dac4ab25b8632c52d1022dd5337/pylibmc-1.6.1.tar.gz"
+# pylibmc - installed from GitHub source for Python 3.14 compatibility (see Step 6.3)
 # pytz-2021.1-py2.py3-none-any.whl
 wget "https://files.pythonhosted.org/packages/70/94/784178ca5dd892a98f113cdd923372024dc04b8d40abe77ca76b5fb90ca6/pytz-2021.1-py2.py3-none-any.whl"
 # six-1.16.0-py2.py3-none-any.whl
@@ -89,8 +83,7 @@ wget "https://files.pythonhosted.org/packages/d9/5a/e7c31adbe875f2abbb91bd84cf2d
 # statsd
 # wget "https://files.pythonhosted.org/packages/2c/a8/714954464435178017e8d2f39ff418e0c9ad4411a416d4acc315298b9cea/statsd-2.1.2.tar.gz"
 wget "https://files.pythonhosted.org/packages/47/33/c824f799128dfcfce2142f18d9bc6c55c46a939f6e4250639134222d99eb/statsd-3.3.0-py2.py3-none-any.whl"
-# uwsgi-2.0.22.tar.gz
-wget "https://files.pythonhosted.org/packages/a7/4e/c4d5559b3504bb65175a759392b03cac04b8771e9a9b14811adf1151f02f/uwsgi-2.0.22.tar.gz"
+# Note: uwsgi is installed directly from PyPI (not pre-downloaded) to ensure proper linking
 # geomet-0.2.1.post1-py3-none-any.whl
 wget "https://files.pythonhosted.org/packages/c9/81/156ca48f950f833ddc392f8e3677ca50a18cb9d5db38ccb4ecea55a9303f/geomet-0.2.1.post1-py3-none-any.whl"
 # click-7.1.2.tar.gz
@@ -217,46 +210,52 @@ popd
 echo "JDK and Cassandra installed successfully"
 
 # =====================================================================
-# Step 4: Build CPython 3.10
+# Step 4: Build CPython 3.14
 # =====================================================================
 echo ""
 echo "====================================================================="
-echo "Step 4: Building CPython 3.10"
+echo "Step 4: Building CPython 3.14"
 echo "====================================================================="
 
 pushd "${DJANGO_SERVER_ROOT}"
 
-# Install python3.10
-if ! [ -d Python-3.10.2 ]; then
-    wget https://www.python.org/ftp/python/3.10.2/Python-3.10.2.tgz
-    tar -xzf Python-3.10.2.tgz
-    cd Python-3.10.2
+# Install python3.14
+if ! [ -d Python-3.14.2 ]; then
+    wget https://www.python.org/ftp/python/3.14.2/Python-3.14.2.tgz
+    tar -xzf Python-3.14.2.tgz
+    cd Python-3.14.2
     ./configure --enable-optimizations --prefix="$(pwd)/python-build" --enable-shared LN="ln -s"
-    make -j"${NUM_BUILD_JOBS}"
+    # Skip test_generators during PGO profiling — test_raise_and_yield_from
+    # fails on some x86 microarchitectures (Cooper Lake, Turin) due to
+    # signal handling timing differences. The test works fine at runtime.
+    make -j"${NUM_BUILD_JOBS}" PROFILE_TASK="-m test --pgo --ignore test_generators"
     make install
     cd ../
 fi
 
-CPYTHON_INSTALL_PREFIX="${DJANGO_SERVER_ROOT}/Python-3.10.2/python-build"
+CPYTHON_INSTALL_PREFIX="${DJANGO_SERVER_ROOT}/Python-3.14.2/python-build"
 export LD_LIBRARY_PATH="${CPYTHON_INSTALL_PREFIX}/lib"
 
-echo "CPython 3.10 built successfully"
+echo "CPython 3.14 built successfully"
 
 # =====================================================================
-# Step 5: Build Cinder 3.10
+# Step 5: Build Cinder 3.14
 # =====================================================================
 echo ""
 echo "====================================================================="
-echo "Step 5: Building Cinder 3.10"
+echo "Step 5: Building Cinder 3.14"
 echo "====================================================================="
 
 # Download and build Cinder
+# Using meta/3.14 branch — includes gh-145615 mimalloc page leak fix
+CINDER_COMMIT="7627b90844073b94ef60415ed1f1248837bedef7"
 if ! [ -d "cinder" ]; then
-    git clone -b cinder/3.10 https://github.com/facebookincubator/cinder.git
+    git clone https://github.com/facebookincubator/cinder.git
     pushd cinder
+    git checkout "${CINDER_COMMIT}"
     mkdir -p cinder-build
     ./configure --prefix="$(pwd)/cinder-build" --enable-optimizations --enable-shared LN="ln -s"
-    make -j"${NUM_BUILD_JOBS}"
+    make -j"${NUM_BUILD_JOBS}" PROFILE_TASK="-m test --pgo --ignore test_generators"
     make install
     popd
 fi
@@ -264,7 +263,7 @@ fi
 CINDER_INSTALL_PREFIX="${DJANGO_SERVER_ROOT}/cinder/cinder-build"
 export LD_LIBRARY_PATH="${CINDER_INSTALL_PREFIX}/lib"
 
-echo "Cinder 3.10 built successfully"
+echo "Cinder 3.14 built successfully"
 
 # =====================================================================
 # Step 6: Install Python dependencies in virtual environments
@@ -276,10 +275,56 @@ echo "====================================================================="
 
 # Create virtual environments for both CPython and Cinder
 export LD_LIBRARY_PATH="${CPYTHON_INSTALL_PREFIX}/lib"
-[ ! -d venv_cpython ] && "${CPYTHON_INSTALL_PREFIX}/bin/python3.10" -m venv venv_cpython
+[ ! -d venv_cpython ] && "${CPYTHON_INSTALL_PREFIX}/bin/python3.14" -m venv venv_cpython
 
 export LD_LIBRARY_PATH="${CINDER_INSTALL_PREFIX}/lib"
 [ ! -d venv_cinder ] && "${CINDER_INSTALL_PREFIX}/bin/python3" -m venv venv_cinder
+
+# =====================================================================
+# Step 6.3: Clone pylibmc from GitHub (Python 3.14 compatible)
+# =====================================================================
+echo ""
+echo "====================================================================="
+echo "Step 6.3: Cloning pylibmc from GitHub source"
+echo "====================================================================="
+
+# Clone pylibmc 1.6.1 from GitHub and patch for Python 3.14 compatibility
+# pylibmc trunk has bugs in the refactored _fetch_multi function that cause
+# memcached connection failures after ~2300 requests. Using stable 1.6.1
+# with a minimal setup.py patch (distutils→setuptools, remove "U" mode) instead.
+PYLIBMC_DIR="${DJANGO_SERVER_ROOT}/pylibmc"
+if ! [ -d "${PYLIBMC_DIR}" ]; then
+    cd "${DJANGO_SERVER_ROOT}"
+    git clone https://github.com/lericson/pylibmc.git
+    cd "${PYLIBMC_DIR}"
+    git checkout 1.6.1
+    # Apply Python 3.14 compatibility patch (setup.py: distutils removed in 3.12)
+    patch -p1 < "${BENCHPRESS_ROOT}/packages/django_workload/srcs/patches/pylibmc-1.6.1-py314-compat.patch"
+    echo "Applied pylibmc 1.6.1 Python 3.14 compatibility patch"
+fi
+
+# =====================================================================
+# Step 6.4: Clone cassandra-python-driver from GitHub (setuptools v82 compatible)
+# =====================================================================
+echo ""
+echo "====================================================================="
+echo "Step 6.4: Cloning cassandra-python-driver from GitHub source"
+echo "====================================================================="
+
+# Clone cassandra-python-driver from GitHub
+# PyPI version uses deprecated ez_setup which is incompatible with setuptools v82+
+# Latest trunk removed ez_setup for compatibility
+CASSANDRA_DRIVER_COMMIT="7d8015e3c1cff543a5f64c70cff3e14216e58037"
+CASSANDRA_DRIVER_DIR="${DJANGO_SERVER_ROOT}/cassandra-python-driver"
+if ! [ -d "${CASSANDRA_DRIVER_DIR}" ]; then
+    cd "${DJANGO_SERVER_ROOT}"
+    git clone https://github.com/apache/cassandra-python-driver.git
+    cd cassandra-python-driver
+    git checkout "${CASSANDRA_DRIVER_COMMIT}"
+fi
+
+# Return to DJANGO_SERVER_ROOT before activating virtual environments
+cd "${DJANGO_SERVER_ROOT}"
 
 # Install packages in CPython environment
 set +u
@@ -289,12 +334,37 @@ set -u
 
 export LD_LIBRARY_PATH="${CPYTHON_INSTALL_PREFIX}/lib"
 export CMAKE_LIBRARY_PATH="${CPYTHON_INSTALL_PREFIX}/lib"
-export CPATH="${DJANGO_SERVER_ROOT}/Python-3.10.2/python-build/include:${DJANGO_SERVER_ROOT}/Python-3.10.2/Include"
+export CPATH="${DJANGO_SERVER_ROOT}/Python-3.14.2/python-build/include:${DJANGO_SERVER_ROOT}/Python-3.14.2/Include"
+# Set LIBRARY_PATH and LDFLAGS to ensure packages link against CPython's libpython
+export LIBRARY_PATH="${CPYTHON_INSTALL_PREFIX}/lib"
+export LDFLAGS="-L${CPYTHON_INSTALL_PREFIX}/lib -Wl,-rpath,${CPYTHON_INSTALL_PREFIX}/lib"
+
+# Install pylibmc (required by django-workload)
+cd "${PYLIBMC_DIR}"
+pip3.14 install -e .
+echo "pylibmc installed in CPython venv"
+pip3.14 install pymemcache
+echo "pymemcache installed in CPython venv"
+
+# Install uwsgi directly from PyPI to ensure proper linking with CPython's libpython
+# Use --no-cache-dir to prevent reusing a wheel built for a different Python environment
+pip3.14 install --no-cache-dir uwsgi
+echo "uwsgi installed in CPython venv"
+
+# Install django-cassandra-engine directly from PyPI to avoid poetry build issues
+pip3.14 install django-cassandra-engine
+echo "django-cassandra-engine installed in CPython venv"
 
 # Install dependencies using third_party pip dependencies
-pip3.10 install "django-statsd-mozilla" --no-index --find-links file://"${DJANGO_WORKLOAD_DEPS}"
-pip3.10 install "numpy>=1.19" --no-index --find-links file://"${DJANGO_WORKLOAD_DEPS}"
-pip3.10 install -e . --no-index --find-links file://"${DJANGO_WORKLOAD_DEPS}"
+cd "${DJANGO_SERVER_ROOT}"
+pip3.14 install "django-statsd-mozilla" --no-index --find-links file://"${DJANGO_WORKLOAD_DEPS}"
+# Install cassandra-driver from GitHub source (setuptools v82+ compatible)
+# Disable Cython extension to avoid build issues
+cd "${CASSANDRA_DRIVER_DIR}"
+CASS_DRIVER_NO_CYTHON=1 pip3.14 install -e .
+echo "cassandra-driver installed in CPython venv"
+cd "${DJANGO_SERVER_ROOT}"
+pip3.14 install -e . --no-index --find-links file://"${DJANGO_WORKLOAD_DEPS}"
 
 echo "Dependencies installed in CPython venv"
 
@@ -308,15 +378,68 @@ pushd "${DJANGO_SERVER_ROOT}"
 export CPATH="${DJANGO_SERVER_ROOT}/cinder/cinder-build/include:${DJANGO_SERVER_ROOT}/cinder/Include"
 export LD_LIBRARY_PATH="${CINDER_INSTALL_PREFIX}/lib"
 export CMAKE_LIBRARY_PATH="${CINDER_INSTALL_PREFIX}/lib"
+# Critical: Set LIBRARY_PATH and LDFLAGS to ensure uwsgi links against Cinder's libpython
+# Without these, the linker may find CPython's libpython3.14.so instead
+export LIBRARY_PATH="${CINDER_INSTALL_PREFIX}/lib"
+export LDFLAGS="-L${CINDER_INSTALL_PREFIX}/lib -Wl,-rpath,${CINDER_INSTALL_PREFIX}/lib"
 source ./venv_cinder/bin/activate
 set -u
 
+# Install pylibmc (required by django-workload)
+cd "${PYLIBMC_DIR}"
+pip3.14 install -e .
+echo "pylibmc installed in Cinder venv"
+pip3.14 install pymemcache
+echo "pymemcache installed in Cinder venv"
+
+# Install uwsgi directly from PyPI to ensure proper linking with Cinder's libpython
+# Use --no-cache-dir to prevent reusing a wheel built for a different Python environment
+pip3.14 install --no-cache-dir uwsgi
+echo "uwsgi installed in Cinder venv"
+
+# Install django-cassandra-engine directly from PyPI to avoid poetry build issues
+pip3.14 install django-cassandra-engine
+echo "django-cassandra-engine installed in Cinder venv"
+
 # Install dependencies using third_party pip dependencies
-pip3.10 install "django-statsd-mozilla" --no-index --find-links file://"${DJANGO_WORKLOAD_DEPS}"
-pip3.10 install "numpy>=1.19" --no-index --find-links file://"${DJANGO_WORKLOAD_DEPS}"
-pip3.10 install -e . --no-index --find-links file://"${DJANGO_WORKLOAD_DEPS}"
+cd "${DJANGO_SERVER_ROOT}"
+pip3.14 install "django-statsd-mozilla" --no-index --find-links file://"${DJANGO_WORKLOAD_DEPS}"
+# Install cassandra-driver from GitHub source (setuptools v82+ compatible)
+# Disable Cython extension to avoid build issues
+cd "${CASSANDRA_DRIVER_DIR}"
+CASS_DRIVER_NO_CYTHON=1 pip3.14 install -e .
+echo "cassandra-driver installed in Cinder venv"
+cd "${DJANGO_SERVER_ROOT}"
+pip3.14 install -e . --no-index --find-links file://"${DJANGO_WORKLOAD_DEPS}"
 
 echo "Dependencies installed in Cinder venv"
+
+# =====================================================================
+# Step 6.5: Install CinderX for JIT Support
+# =====================================================================
+echo ""
+echo "====================================================================="
+echo "Step 6.5: Installing CinderX for JIT Support"
+echo "====================================================================="
+
+# Clone and install CinderX for JIT functionality
+CINDERX_COMMIT="6e0472215c9917c2b5c9777dd4702b5d84eb3111"
+if ! [ -d "${DJANGO_SERVER_ROOT}/cinderx" ]; then
+    cd "${DJANGO_SERVER_ROOT}"
+    git clone https://github.com/facebookincubator/cinderx.git
+    cd cinderx
+    git checkout "${CINDERX_COMMIT}"
+fi
+
+# Install CinderX in Cinder virtual environment (already activated)
+cd "${DJANGO_SERVER_ROOT}/cinderx"
+python -m pip install -e .
+
+# Validate CinderX installation
+echo "Validating CinderX installation..."
+python -c "import cinderx; cinderx.init(); assert cinderx.is_initialized(), 'CinderX failed to initialize'; print('CinderX initialized successfully')"
+
+echo "CinderX installed and validated successfully"
 
 deactivate
 popd  # ${DJANGO_SERVER_ROOT}
@@ -510,6 +633,7 @@ export PROXYGEN_INSTALL_DIR="${DJANGO_WORKLOAD_ROOT}/proxygen/staging"
 # Build and install in venv_cpython
 echo ""
 echo "Installing proxygen_binding in venv_cpython..."
+export LD_LIBRARY_PATH="${CPYTHON_INSTALL_PREFIX}/lib"
 cd "${DJANGO_WORKLOAD_ROOT}/proxygen_binding"
 "${DJANGO_SERVER_ROOT}/venv_cpython/bin/python" -m pip install pybind11
 "${DJANGO_SERVER_ROOT}/venv_cpython/bin/python" -m pip install -e .
@@ -518,6 +642,7 @@ echo "proxygen_binding installed in venv_cpython"
 # Build and install in venv_cinder
 echo ""
 echo "Installing proxygen_binding in venv_cinder..."
+export LD_LIBRARY_PATH="${CINDER_INSTALL_PREFIX}/lib"
 cd "${DJANGO_WORKLOAD_ROOT}/proxygen_binding"
 "${DJANGO_SERVER_ROOT}/venv_cinder/bin/python" -m pip install pybind11
 "${DJANGO_SERVER_ROOT}/venv_cinder/bin/python" -m pip install -e .
@@ -532,6 +657,8 @@ echo "Step 9: Generating Code Variants for FeedFlow"
 echo "====================================================================="
 
 # Install jinja2 in venv_cpython
+# Set LD_LIBRARY_PATH for CPython shared library
+export LD_LIBRARY_PATH="${CPYTHON_INSTALL_PREFIX}/lib"
 echo "Installing jinja2 for code generation..."
 "${DJANGO_SERVER_ROOT}/venv_cpython/bin/python" -m pip install jinja2
 

--- a/packages/django_workload/install_django_workload_x86_64_ubuntu22.sh
+++ b/packages/django_workload/install_django_workload_x86_64_ubuntu22.sh
@@ -39,7 +39,7 @@ echo "====================================================================="
 apt install -y memcached libmemcached-dev zlib1g-dev screen \
     python3 python3.10-dev python3.10-venv rpm libffi-dev \
     libssl-dev libcrypt-dev haproxy libxxhash-dev \
-    perl ninja-build
+    perl liburing-dev ninja-build clang libev4 libev-dev
 
 echo "System dependencies installed successfully"
 
@@ -69,30 +69,23 @@ else
     alias wget='wget --no-clobber'
 fi
 pushd "${DJANGO_WORKLOAD_DEPS}"
-# cassandra-driver-3.29.1_x86_64.whl
-wget "https://files.pythonhosted.org/packages/eb/d5/e437271aea182e33db32e0990703b4e0d7025e4fba67829c5fd65dba926a/cassandra_driver-3.29.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
 # Django-5.2.3-py3-none-any.whl
 wget "https://files.pythonhosted.org/packages/1b/11/7aff961db37e1ea501a2bb663d27a8ce97f3683b9e5b83d3bfead8b86fa4/django-5.2.3-py3-none-any.whl"
 # Dulwich 0.21.2.tar.gz
 wget "https://files.pythonhosted.org/packages/14/a5/cf61f9209d48abf47d48086e0a0388f1030bb5f7cf2661972eee56ccee3d/dulwich-0.21.2.tar.gz"
-# django-cassandra-engine-1.6.2.tar.gz
-wget "https://files.pythonhosted.org/packages/1f/5e/438eb7f2d8b8e240701b721a43cb5a20cf970c8e9da8b3770df1de6d7c5b/django-cassandra-engine-1.6.2.tar.gz"
+# Note: django-cassandra-engine is installed directly from PyPI (not pre-downloaded) to avoid poetry build issues
 # django-statsd-mozilla-0.4.3-py3-none-any.whl
 wget "https://files.pythonhosted.org/packages/ac/54/5fa99753dab7ced46129a4c95c777596a2e4094a8b0f65c8764d60d5cff4/django_statsd_mozilla-0.4.0-py3-none-any.whl"
-# numpy-1.26.4-x86_64.whl
-wget "https://files.pythonhosted.org/packages/4b/d7/ecf66c1cd12dc28b4040b15ab4d17b773b87fa9d29ca16125de01adb36cd/numpy-1.26.4-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
 # psutil-5.8.0.tar.gz
 wget "https://files.pythonhosted.org/packages/e1/b0/7276de53321c12981717490516b7e612364f2cb372ee8901bd4a66a000d7/psutil-5.8.0.tar.gz"
-# pylibmc-1.6.1.tar.gz
-wget "https://files.pythonhosted.org/packages/a7/0c/f7a3af34b05c167a69ed1fc330b06b658dac4ab25b8632c52d1022dd5337/pylibmc-1.6.1.tar.gz"
+# pylibmc - installed from GitHub source for Python 3.14 compatibility (see Step 6.3)
 # pytz-2021.1-py2.py3-none-any.whl
 wget "https://files.pythonhosted.org/packages/70/94/784178ca5dd892a98f113cdd923372024dc04b8d40abe77ca76b5fb90ca6/pytz-2021.1-py2.py3-none-any.whl"
 # six-1.16.0-py2.py3-none-any.whl
 wget "https://files.pythonhosted.org/packages/d9/5a/e7c31adbe875f2abbb91bd84cf2dc52d792b5a01506781dbcf25c91daf11/six-1.16.0-py2.py3-none-any.whl"
 # statsd-3.3.0-py2.py3-none-any.whl
 wget "https://files.pythonhosted.org/packages/47/33/c824f799128dfcfce2142f18d9bc6c55c46a939f6e4250639134222d99eb/statsd-3.3.0-py2.py3-none-any.whl"
-# uwsgi-2.0.22.tar.gz
-wget "https://files.pythonhosted.org/packages/a7/4e/c4d5559b3504bb65175a759392b03cac04b8771e9a9b14811adf1151f02f/uwsgi-2.0.22.tar.gz"
+# Note: uwsgi is installed directly from PyPI (not pre-downloaded) to ensure proper linking
 # geomet-0.2.1.post1-py3-none-any.whl
 wget "https://files.pythonhosted.org/packages/c9/81/156ca48f950f833ddc392f8e3677ca50a18cb9d5db38ccb4ecea55a9303f/geomet-0.2.1.post1-py3-none-any.whl"
 # click-7.1.2.tar.gz
@@ -220,40 +213,54 @@ popd
 echo "JDK and Cassandra installed successfully"
 
 # =====================================================================
-# Step 4: Build CPython 3.10
+# Step 4: Build CPython 3.14
 # =====================================================================
 echo ""
 echo "====================================================================="
-echo "Step 4: Building CPython 3.10"
+echo "Step 4: Building CPython 3.14"
 echo "====================================================================="
 
 pushd "${DJANGO_SERVER_ROOT}"
 
-# Ubuntu 22 comes with python3.10, so we use system python
-echo "Using system Python 3.10"
+# Install python3.14 from source
+if ! [ -d Python-3.14.2 ]; then
+    wget https://www.python.org/ftp/python/3.14.2/Python-3.14.2.tgz
+    tar -xzf Python-3.14.2.tgz
+    cd Python-3.14.2
+    ./configure --enable-optimizations --prefix="$(pwd)/python-build" --enable-shared LN="ln -s"
+    make -j"${NUM_BUILD_JOBS}" PROFILE_TASK="-m test --pgo --ignore test_generators"
+    make install
+    cd ../
+fi
+
+CPYTHON_INSTALL_PREFIX="${DJANGO_SERVER_ROOT}/Python-3.14.2/python-build"
+export LD_LIBRARY_PATH="${CPYTHON_INSTALL_PREFIX}/lib"
 
 
 # Create directory and symlink so the install marker check passes
 mkdir -p "${DJANGO_SERVER_ROOT}/Python-3.10.2/python-build/bin"
 ln -sf /usr/bin/python3.10 "${DJANGO_SERVER_ROOT}/Python-3.10.2/python-build/bin/python3.10"
 
-echo "CPython 3.10 ready"
+echo "CPython 3.14 built successfully"
 
 # =====================================================================
-# Step 5: Build Cinder 3.10
+# Step 5: Build Cinder 3.14
 # =====================================================================
 echo ""
 echo "====================================================================="
-echo "Step 5: Building Cinder 3.10"
+echo "Step 5: Building Cinder 3.14"
 echo "====================================================================="
 
 # Download and build Cinder
+# Using meta/3.14 branch at a known good commit for reproducibility
+CINDER_COMMIT="04f91c3659d8d2dfe4331a47548316289d2fa3f0"
 if ! [ -d "cinder" ]; then
-    git clone -b cinder/3.10 https://github.com/facebookincubator/cinder.git
+    git clone https://github.com/facebookincubator/cinder.git
     pushd cinder
+    git checkout "${CINDER_COMMIT}"
     mkdir -p cinder-build
-    ./configure --prefix="$(pwd)/cinder-build" --enable-optimizations --enable-shared LN="ln -s"
-    make -j"${NUM_BUILD_JOBS}"
+    ./configure --prefix="$(pwd)/cinder-build" --enable-profiling --enable-optimizations --enable-shared LN="ln -s"
+    make -j"${NUM_BUILD_JOBS}" PROFILE_TASK="-m test --pgo --ignore test_generators"
     make install
     popd
 fi
@@ -261,7 +268,7 @@ fi
 CINDER_INSTALL_PREFIX="${DJANGO_SERVER_ROOT}/cinder/cinder-build"
 export LD_LIBRARY_PATH="${CINDER_INSTALL_PREFIX}/lib"
 
-echo "Cinder 3.10 built successfully"
+echo "Cinder 3.14 built successfully"
 
 # =====================================================================
 # Step 6: Install Python dependencies in virtual environments
@@ -273,11 +280,58 @@ echo "====================================================================="
 
 # Create virtual environments for both CPython and Cinder
 # Create CPython virtual env
-python3.10 -m venv venv_cpython
+export LD_LIBRARY_PATH="${CPYTHON_INSTALL_PREFIX}/lib"
+[ ! -d venv_cpython ] && "${CPYTHON_INSTALL_PREFIX}/bin/python3.14" -m venv venv_cpython
 
 # Create Cinder virtual env
 export LD_LIBRARY_PATH="${CINDER_INSTALL_PREFIX}/lib"
 [ ! -d venv_cinder ] && "${CINDER_INSTALL_PREFIX}/bin/python3" -m venv venv_cinder
+
+# =====================================================================
+# Step 6.3: Clone pylibmc from GitHub (Python 3.14 compatible)
+# =====================================================================
+echo ""
+echo "====================================================================="
+echo "Step 6.3: Cloning pylibmc from GitHub source"
+echo "====================================================================="
+
+# Clone pylibmc 1.6.1 from GitHub and patch for Python 3.14 compatibility
+# pylibmc trunk has bugs in the refactored _fetch_multi function that cause
+# memcached connection failures after ~2300 requests. Using stable 1.6.1
+# with a minimal setup.py patch (distutils→setuptools, remove "U" mode) instead.
+PYLIBMC_DIR="${DJANGO_SERVER_ROOT}/pylibmc"
+if ! [ -d "${PYLIBMC_DIR}" ]; then
+    cd "${DJANGO_SERVER_ROOT}"
+    git clone https://github.com/lericson/pylibmc.git
+    cd "${PYLIBMC_DIR}"
+    git checkout 1.6.1
+    # Apply Python 3.14 compatibility patch (setup.py: distutils removed in 3.12)
+    patch -p1 < "${BENCHPRESS_ROOT}/packages/django_workload/srcs/patches/pylibmc-1.6.1-py314-compat.patch"
+    echo "Applied pylibmc 1.6.1 Python 3.14 compatibility patch"
+fi
+
+# =====================================================================
+# Step 6.4: Clone cassandra-python-driver from GitHub (setuptools v82 compatible)
+# =====================================================================
+echo ""
+echo "====================================================================="
+echo "Step 6.4: Cloning cassandra-python-driver from GitHub source"
+echo "====================================================================="
+
+# Clone cassandra-python-driver from GitHub
+# PyPI version uses deprecated ez_setup which is incompatible with setuptools v82+
+# Latest trunk removed ez_setup for compatibility
+CASSANDRA_DRIVER_COMMIT="7d8015e3c1cff543a5f64c70cff3e14216e58037"
+CASSANDRA_DRIVER_DIR="${DJANGO_SERVER_ROOT}/cassandra-python-driver"
+if ! [ -d "${CASSANDRA_DRIVER_DIR}" ]; then
+    cd "${DJANGO_SERVER_ROOT}"
+    git clone https://github.com/apache/cassandra-python-driver.git
+    cd cassandra-python-driver
+    git checkout "${CASSANDRA_DRIVER_COMMIT}"
+fi
+
+# Return to DJANGO_SERVER_ROOT before activating virtual environments
+cd "${DJANGO_SERVER_ROOT}"
 
 # Install packages in CPython environment
 set +u
@@ -285,10 +339,39 @@ set +u
 source ./venv_cpython/bin/activate
 set -u
 
+export LD_LIBRARY_PATH="${CPYTHON_INSTALL_PREFIX}/lib"
+export CMAKE_LIBRARY_PATH="${CPYTHON_INSTALL_PREFIX}/lib"
+export CPATH="${DJANGO_SERVER_ROOT}/Python-3.14.2/python-build/include:${DJANGO_SERVER_ROOT}/Python-3.14.2/Include"
+# Set LIBRARY_PATH and LDFLAGS to ensure packages link against CPython's libpython
+export LIBRARY_PATH="${CPYTHON_INSTALL_PREFIX}/lib"
+export LDFLAGS="-L${CPYTHON_INSTALL_PREFIX}/lib -Wl,-rpath,${CPYTHON_INSTALL_PREFIX}/lib"
+
+# Install pylibmc (required by django-workload)
+cd "${PYLIBMC_DIR}"
+pip3.14 install -e .
+echo "pylibmc installed in CPython venv"
+pip3.14 install pymemcache
+echo "pymemcache installed in CPython venv"
+
+# Install uwsgi directly from PyPI to ensure proper linking with CPython's libpython
+# Use --no-cache-dir to prevent reusing a wheel built for a different Python environment
+pip3.14 install --no-cache-dir uwsgi
+echo "uwsgi installed in CPython venv"
+
+# Install django-cassandra-engine directly from PyPI to avoid poetry build issues
+pip3.14 install django-cassandra-engine
+echo "django-cassandra-engine installed in CPython venv"
+
 # Install dependencies using third_party pip dependencies
-pip3 install "django-statsd-mozilla" --no-index --find-links file://"${DJANGO_WORKLOAD_DEPS}"
-pip3 install "numpy>=1.19" --no-index --find-links file://"${DJANGO_WORKLOAD_DEPS}"
-pip3 install -e . --no-index --find-links file://"${DJANGO_WORKLOAD_DEPS}"
+cd "${DJANGO_SERVER_ROOT}"
+pip3.14 install "django-statsd-mozilla" --no-index --find-links file://"${DJANGO_WORKLOAD_DEPS}"
+# Install cassandra-driver from GitHub source (setuptools v82+ compatible)
+# Disable Cython extension to avoid build issues
+cd "${CASSANDRA_DRIVER_DIR}"
+CASS_DRIVER_NO_CYTHON=1 pip3.14 install -e .
+echo "cassandra-driver installed in CPython venv"
+cd "${DJANGO_SERVER_ROOT}"
+pip3.14 install -e . --no-index --find-links file://"${DJANGO_WORKLOAD_DEPS}"
 
 echo "Dependencies installed in CPython venv"
 
@@ -303,15 +386,68 @@ pushd "${DJANGO_SERVER_ROOT}"
 export CPATH="${DJANGO_SERVER_ROOT}/cinder/cinder-build/include:${DJANGO_SERVER_ROOT}/cinder/Include"
 export LD_LIBRARY_PATH="${CINDER_INSTALL_PREFIX}/lib"
 export CMAKE_LIBRARY_PATH="${CINDER_INSTALL_PREFIX}/lib"
+# Critical: Set LIBRARY_PATH and LDFLAGS to ensure uwsgi links against Cinder's libpython
+# Without these, the linker may find CPython's libpython3.14.so instead
+export LIBRARY_PATH="${CINDER_INSTALL_PREFIX}/lib"
+export LDFLAGS="-L${CINDER_INSTALL_PREFIX}/lib -Wl,-rpath,${CINDER_INSTALL_PREFIX}/lib"
 source ./venv_cinder/bin/activate
 set -u
 
+# Install pylibmc (required by django-workload)
+cd "${PYLIBMC_DIR}"
+pip3.14 install -e .
+echo "pylibmc installed in Cinder venv"
+pip3.14 install pymemcache
+echo "pymemcache installed in Cinder venv"
+
+# Install uwsgi directly from PyPI to ensure proper linking with Cinder's libpython
+# Use --no-cache-dir to prevent reusing a wheel built for a different Python environment
+pip3.14 install --no-cache-dir uwsgi
+echo "uwsgi installed in Cinder venv"
+
+# Install django-cassandra-engine directly from PyPI to avoid poetry build issues
+pip3.14 install django-cassandra-engine
+echo "django-cassandra-engine installed in Cinder venv"
+
 # Install dependencies using third_party pip dependencies
-pip3 install "django-statsd-mozilla" --no-index --find-links file://"${DJANGO_WORKLOAD_DEPS}"
-pip3 install "numpy>=1.19" --no-index --find-links file://"${DJANGO_WORKLOAD_DEPS}"
-pip3 install -e . --no-index --find-links file://"${DJANGO_WORKLOAD_DEPS}"
+cd "${DJANGO_SERVER_ROOT}"
+pip3.14 install "django-statsd-mozilla" --no-index --find-links file://"${DJANGO_WORKLOAD_DEPS}"
+# Install cassandra-driver from GitHub source (setuptools v82+ compatible)
+# Disable Cython extension to avoid build issues
+cd "${CASSANDRA_DRIVER_DIR}"
+CASS_DRIVER_NO_CYTHON=1 pip3.14 install -e .
+echo "cassandra-driver installed in Cinder venv"
+cd "${DJANGO_SERVER_ROOT}"
+pip3.14 install -e . --no-index --find-links file://"${DJANGO_WORKLOAD_DEPS}"
 
 echo "Dependencies installed in Cinder venv"
+
+# =====================================================================
+# Step 6.5: Install CinderX for JIT Support
+# =====================================================================
+echo ""
+echo "====================================================================="
+echo "Step 6.5: Installing CinderX for JIT Support"
+echo "====================================================================="
+
+# Clone and install CinderX for JIT functionality
+CINDERX_COMMIT="497b2b671a8084345a8288cfbd9995acfab9dfbf"
+if ! [ -d "${DJANGO_SERVER_ROOT}/cinderx" ]; then
+    cd "${DJANGO_SERVER_ROOT}"
+    git clone https://github.com/facebookincubator/cinderx.git
+    cd cinderx
+    git checkout "${CINDERX_COMMIT}"
+fi
+
+# Install CinderX in Cinder virtual environment (already activated)
+cd "${DJANGO_SERVER_ROOT}/cinderx"
+python -m pip install -e .
+
+# Validate CinderX installation
+echo "Validating CinderX installation..."
+python -c "import cinderx; cinderx.init(); assert cinderx.is_initialized(), 'CinderX failed to initialize'; print('CinderX initialized successfully')"
+
+echo "CinderX installed and validated successfully"
 
 deactivate
 popd  # ${DJANGO_SERVER_ROOT}
@@ -505,6 +641,7 @@ export PROXYGEN_INSTALL_DIR="${DJANGO_WORKLOAD_ROOT}/proxygen/staging"
 # Build and install in venv_cpython
 echo ""
 echo "Installing proxygen_binding in venv_cpython..."
+export LD_LIBRARY_PATH="${CPYTHON_INSTALL_PREFIX}/lib"
 cd "${DJANGO_WORKLOAD_ROOT}/proxygen_binding"
 "${DJANGO_SERVER_ROOT}/venv_cpython/bin/python" -m pip install pybind11
 "${DJANGO_SERVER_ROOT}/venv_cpython/bin/python" -m pip install -e .
@@ -513,6 +650,7 @@ echo "proxygen_binding installed in venv_cpython"
 # Build and install in venv_cinder
 echo ""
 echo "Installing proxygen_binding in venv_cinder..."
+export LD_LIBRARY_PATH="${CINDER_INSTALL_PREFIX}/lib"
 cd "${DJANGO_WORKLOAD_ROOT}/proxygen_binding"
 "${DJANGO_SERVER_ROOT}/venv_cinder/bin/python" -m pip install pybind11
 "${DJANGO_SERVER_ROOT}/venv_cinder/bin/python" -m pip install -e .
@@ -527,6 +665,8 @@ echo "Step 9: Generating Code Variants for FeedFlow"
 echo "====================================================================="
 
 # Install jinja2 in venv_cpython
+# Set LD_LIBRARY_PATH for CPython shared library
+export LD_LIBRARY_PATH="${CPYTHON_INSTALL_PREFIX}/lib"
 echo "Installing jinja2 for code generation..."
 "${DJANGO_SERVER_ROOT}/venv_cpython/bin/python" -m pip install jinja2
 

--- a/packages/django_workload/srcs/bin/run.sh
+++ b/packages/django_workload/srcs/bin/run.sh
@@ -10,7 +10,7 @@ SCRIPT_ROOT="$(dirname "$(readlink -f "$0")")"
 BENCHPRESS_ROOT="$(readlink -f "${SCRIPT_ROOT}/../../..")"
 DJANGO_PKG_SRC_ROOT="${BENCHPRESS_ROOT}/packages/django_workload/srcs"
 DJANGO_SERVER_ROOT="$(readlink -f "${SCRIPT_ROOT}/../django-workload/django-workload")"
-CPYTHON_PATH="${DJANGO_SERVER_ROOT}/Python-3.10.2/python-build"
+CPYTHON_PATH="${DJANGO_SERVER_ROOT}/Python-3.14.2/python-build"
 CINDER_PATH="${DJANGO_SERVER_ROOT}/cinder/cinder-build"
 MEMCACHED_PID=
 CASSANDRA_PID=
@@ -142,8 +142,27 @@ cleanup() {
   #   echo "$HAPROXY_PIDS" | xargs -r kill -9 2>/dev/null || true
   # fi
 
-  # Stop memcached
-  [ -n "$MEMCACHED_PID" ] && { echo "Stopping memcached"; kill "$MEMCACHED_PID" 2>/dev/null || true; }
+  # Stop memcached using PID file
+  if [ -f memcached.pid ]; then
+    MEMCACHED_PID="$(cat memcached.pid)"
+    echo "Stopping memcached (PID: $MEMCACHED_PID)"
+    kill "$MEMCACHED_PID" 2>/dev/null || true
+
+    # Wait briefly for graceful shutdown
+    sleep 1
+
+    # Force kill if still running
+    if kill -0 "$MEMCACHED_PID" 2>/dev/null; then
+      echo "Force killing memcached (PID: $MEMCACHED_PID)"
+      kill -9 "$MEMCACHED_PID" 2>/dev/null || true
+    fi
+
+    rm -f memcached.pid
+  elif [ -n "$MEMCACHED_PID" ]; then
+    # Fallback to variable if PID file doesn't exist
+    echo "Stopping memcached (PID: $MEMCACHED_PID)"
+    kill "$MEMCACHED_PID" 2>/dev/null || true
+  fi
 
   # Stop Cassandra using PID file
   if [ -f cassandra.pid ]; then
@@ -185,36 +204,18 @@ check_port_available() {
   local port=$1
   local port_name=$2
 
-  # Check for LISTENING sockets only (TIME_WAIT won't appear here)
-  # With SO_REUSEADDR enabled, TIME_WAIT sockets won't prevent binding
-  if ss -tan | grep -q ":${port} "; then
+  # Only check for LISTENING sockets — use ss -tln (not ss -tan which
+  # also matches TIME_WAIT/CLOSE_WAIT sockets that don't block binding).
+  # With SO_REUSEADDR, TIME_WAIT sockets won't prevent binding.
+  local pid=$(ss -tlnp | grep ":${port} " | grep -oP 'pid=\K[0-9]+' | head -1)
+
+  if [ -n "$pid" ]; then
     echo "ERROR: Port ${port} (${port_name}) has an active LISTENING socket!"
-
-    # Check if there's a process associated with this port
-    local pid=$(ss -tlnp | grep ":${port} " | grep -oP 'pid=\K[0-9]+' | head -1)
-
-    if [ -n "$pid" ]; then
-      echo "ERROR: Process with PID ${pid} is actively listening on port ${port}"
-      echo "Process details:"
-      ps -p "$pid" -o pid,cmd 2>/dev/null || echo "  (Process information unavailable)"
-      echo ""
-      echo "To fix this issue:"
-      echo "  1. Kill the process: kill ${pid}"
-      echo "  2. Or choose a different port using -P (base port) or -T (stats port) options"
-    else
-      echo "WARNING: Port ${port} appears to be listening but no process ID found."
-      echo "This is unusual and may indicate a kernel-level issue."
-      echo ""
-      echo "To fix this issue:"
-      echo "  1. Try running the benchmark anyway (SO_REUSEADDR may allow binding)"
-      echo "  2. Or choose a different port using -P (base port) or -T (stats port) options"
-      echo "  3. Or check for zombie processes: ps aux | grep defunct"
-    fi
+    echo "ERROR: Process with PID ${pid} is actively listening on port ${port}"
+    ps -p "$pid" -o pid,cmd 2>/dev/null || true
     return 1
   fi
 
-  # With SO_REUSEADDR enabled, we don't need to check for TIME_WAIT sockets
-  # The kernel will allow us to bind even if old connections are in TIME_WAIT
   return 0
 }
 
@@ -515,15 +516,12 @@ start_django_server() {
   # Export FBTHRIFT_PREFIX for thrift Python bindings
   export FBTHRIFT_PREFIX="${SCRIPT_ROOT}/../proxygen/proxygen/_build/deps"
 
-  # Enable JIT if requested (Cinder on x86 only)
-  if [ "${use_jit}" -gt 0 ] && [ "${interpreter}" = "cinder" ]; then
-    echo "Enabling Cinder JIT..."
-    export PYTHONJIT=1
-    export PYTHONJITWRITEPROFILE=/tmp/cinder-jit.profile
-    export PYTHONJITPROFILEINTERP=1
-    export PYTHONJITPROFILEINTERPPERIOD=10
-    #export PYTHONJITDUMPSTATS=1
-    export PYTHONJITALLSTATICFUNCTIONS=1
+  # Enable JIT if requested (Cinder only)
+  if [ "${use_jit}" -ge 1 ] && [ "${interpreter}" = "cinder" ]; then
+    echo "Enabling Cinder JIT (CinderX)..."
+    export PYTHONJITALL=1
+    export PYTHONJITLOGFILE=/tmp/cinder-jit.log
+    export PYTHONJITDUMPSTATS=1
   fi
 
   # Export FBTHRIFT_PREFIX for thrift Python bindings
@@ -534,6 +532,8 @@ start_django_server() {
   ./django-workload/services/memcached/run-memcached > memcached.log 2>&1 &
 
   MEMCACHED_PID=$!
+  echo "$MEMCACHED_PID" > memcached.pid
+  echo "Started memcached with PID: $MEMCACHED_PID"
 
   # Start django-workload
   # Set the cassandra ip in django config file
@@ -627,6 +627,7 @@ start_client() {
   local server_addr=$5
   local iterations="$6"
   local reps="$7"
+  local server_pid="${8:-}"
 
   # Replace the host in url template to the actual server addr
   CLIENTS_DIR="${SCRIPT_ROOT}/../django-workload/client"
@@ -694,7 +695,15 @@ start_client() {
   echo "Brief warmup delay before starting benchmark..."
   sleep 2
 
+  if [ -n "$server_pid" ]; then
+    log_main_benchmark_start "$BREAKDOWN_FOLDER" "$server_pid"
+  fi
+
   run_benchmark "${num_client_workers}" "${duration}" "${siege_logs_path}" "${urls_path}" "${iterations}" "${reps}"
+
+  if [ -n "$server_pid" ]; then
+    log_main_benchmark_end "$BREAKDOWN_FOLDER" "$server_pid"
+  fi
 }
 
 start_clientserver() {
@@ -742,17 +751,27 @@ start_clientserver() {
   django_server_pid="$server_pid"
 
   log_preprocessing_end "$BREAKDOWN_FOLDER" "$$"
-  log_main_benchmark_start "$BREAKDOWN_FOLDER" "$django_server_pid"
 
-  start_client "${num_client_workers}" "${duration}" "${siege_logs_path}" "${urls_path}" "127.0.0.1" "${iterations}" "${reps}"
+  start_client "${num_client_workers}" "${duration}" "${siege_logs_path}" "${urls_path}" "127.0.0.1" "${iterations}" "${reps}" "${django_server_pid}"
 
-  log_main_benchmark_end "$BREAKDOWN_FOLDER" "$django_server_pid"
   log_postprocessing_start "$BREAKDOWN_FOLDER" "$$"
 
   # Report interpreter type
   echo "Interpreter: ${interpreter}"
 
   log_postprocessing_end "$BREAKDOWN_FOLDER" "$$"
+
+  # Copy breakdown.csv directly to the metrics directory to avoid race
+  # conditions when multiple runs share the same benchmarks/ directory.
+  # BENCHPRESS_METRICS_DIR is set by benchpress before launching run.sh.
+  if [ -n "${BENCHPRESS_METRICS_DIR:-}" ]; then
+    local breakdown_src="${BREAKDOWN_FOLDER}/breakdown.csv"
+    if [ -f "$breakdown_src" ]; then
+      mkdir -p "$BENCHPRESS_METRICS_DIR"
+      cp "$breakdown_src" "$BENCHPRESS_METRICS_DIR/"
+      echo "Copied breakdown.csv to ${BENCHPRESS_METRICS_DIR}/"
+    fi
+  fi
 }
 
 main() {

--- a/packages/django_workload/srcs/django-workload/client/run-siege
+++ b/packages/django_workload/srcs/django-workload/client/run-siege
@@ -8,7 +8,7 @@ import optparse
 import os
 import subprocess
 import re
-import numpy as np
+import statistics
 
 # Concurrent worker count
 WORKERS = 185
@@ -274,8 +274,8 @@ def parse_results(iterations, url_dict, url_target):
         if iterations > 1:
             del url_dict[url][second_idx]
             del url_dict[url][first_idx]
-        arr = np.array(url_dict[url])
-        arr_mean = np.mean(arr) * 100
+        arr = url_dict[url]
+        arr_mean = statistics.mean(arr) * 100 if arr else 0
         print(padding(url, 3), end="")
         print(str(arr_mean) + "%, expected " + str(url_target[url]) + "%")
     print()
@@ -287,13 +287,13 @@ def parse_results(iterations, url_dict, url_target):
 
         print(padding(metric, 5), end="")
 
-        arr = np.array(results[metric])
-        arr_mean = np.mean(arr)
+        arr = results[metric]
+        arr_mean = statistics.mean(arr) if arr else -1
         if arr_mean >= 0:
-            if arr_mean == 0:
+            if arr_mean == 0 or len(arr) < 2:
                 arr_rsd = 0
             else:
-                arr_rsd = np.std(arr) / arr_mean
+                arr_rsd = statistics.stdev(arr) / arr_mean
             print(str(arr_mean) + " " + unit_measures[metric], end="")
             print(" ---- RSD " + str(arr_rsd))
         else:

--- a/packages/django_workload/srcs/django-workload/client/run-wrk
+++ b/packages/django_workload/srcs/django-workload/client/run-wrk
@@ -8,7 +8,7 @@ import optparse
 import os
 import subprocess
 import re
-import numpy as np
+import statistics
 
 # Concurrent worker count
 WORKERS = 185
@@ -347,22 +347,22 @@ def parse_wrk_output(wrk_file):
                     metrics["Shortest transaction"] = float(match.group(1))
 
             elif line.startswith("P50:"):
-                match = re.search(r'([\d.]+)', line)
+                match = re.search(r':\s*([\d.]+)', line)
                 if match:
                     metrics["P50"] = float(match.group(1))
 
             elif line.startswith("P90:"):
-                match = re.search(r'([\d.]+)', line)
+                match = re.search(r':\s*([\d.]+)', line)
                 if match:
                     metrics["P90"] = float(match.group(1))
 
             elif line.startswith("P95:"):
-                match = re.search(r'([\d.]+)', line)
+                match = re.search(r':\s*([\d.]+)', line)
                 if match:
                     metrics["P95"] = float(match.group(1))
 
             elif line.startswith("P99:"):
-                match = re.search(r'([\d.]+)', line)
+                match = re.search(r':\s*([\d.]+)', line)
                 if match:
                     metrics["P99"] = float(match.group(1))
 
@@ -482,8 +482,8 @@ def parse_results(iterations, url_dict, url_target):
         if iterations > 1:
             del base_url_dict[url][second_idx]
             del base_url_dict[url][first_idx]
-        arr = np.array(base_url_dict[url])
-        arr_mean = np.mean(arr) * 100
+        arr = base_url_dict[url]
+        arr_mean = statistics.mean(arr) * 100 if arr else 0
         expected_perc = (base_url_target[url] / total_expected_weight) * 100
         print(padding(url, 3), end="")
         print(str(arr_mean) + "%, expected " + str(expected_perc) + "%")
@@ -497,13 +497,13 @@ def parse_results(iterations, url_dict, url_target):
 
         print(padding(metric, 5), end="")
 
-        arr = np.array(results[metric])
-        arr_mean = np.mean(arr)
+        arr = results[metric]
+        arr_mean = statistics.mean(arr) if arr else -1
         if arr_mean >= 0:
-            if arr_mean == 0:
+            if arr_mean == 0 or len(arr) < 2:
                 arr_rsd = 0
             else:
-                arr_rsd = np.std(arr) / arr_mean
+                arr_rsd = statistics.stdev(arr) / arr_mean
             print(str(arr_mean) + " " + unit_measures[metric], end="")
             print(" ---- RSD " + str(arr_rsd))
         else:

--- a/packages/django_workload/srcs/django-workload/django-workload/django_workload/cache_backend.py
+++ b/packages/django_workload/srcs/django-workload/django-workload/django_workload/cache_backend.py
@@ -1,0 +1,288 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Thread-safe, fault-tolerant memcached cache backend for Django using pylibmc.
+
+pylibmc.Client is NOT thread-safe — concurrent access from multiple threads
+corrupts the memcached protocol stream (interleaved request/response bytes),
+causing ~50% ConnectionError/SocketCreateError/Failure rates.
+
+Django's CacheHandler creates per-thread cache backend instances, so
+instance-level locks don't provide cross-thread protection. This backend
+uses module-level (global) state: one lock and one pylibmc.Client per
+process, shared across all FaultTolerantPyLibMCCache instances. This
+ensures only one thread accesses memcached at a time while keeping
+memory usage minimal (one client per process).
+
+Errors are swallowed and treated as cache misses to prevent cascading
+failures in DjangoBench's multi-threaded Proxygen architecture.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import re
+import threading
+import time
+
+import pylibmc
+from django.core.cache.backends.base import BaseCache, DEFAULT_TIMEOUT
+
+logger = logging.getLogger(__name__)
+
+# How often (seconds) each worker logs its cache stats summary
+_STATS_LOG_INTERVAL = 30
+
+# Module-level globals shared across ALL cache backend instances in a process.
+# Django's CacheHandler creates per-thread instances, but we need ONE lock
+# and ONE client per process to prevent pylibmc protocol corruption.
+_global_lock = threading.Lock()
+_global_client = None
+_global_client_pid = None
+
+
+def _get_client(servers, options):
+    """Get or create the process-wide pylibmc client.
+
+    Must be called while holding _global_lock.
+    """
+    global _global_client, _global_client_pid
+    pid = os.getpid()
+    if _global_client_pid != pid:
+        _global_client = pylibmc.Client(servers, **options)
+        _global_client_pid = pid
+    return _global_client
+
+
+class _CacheStats:
+    """Per-process cache operation counters with periodic logging."""
+
+    def __init__(self):
+        self._lock = threading.Lock()
+        self._pid = os.getpid()
+        self._reset_counters()
+
+    def _reset_counters(self):
+        self._ops = 0
+        self._errors = 0
+        self._error_types = {}  # exception class name -> count
+        self._last_log = time.monotonic()
+
+    def record_success(self):
+        with self._lock:
+            self._maybe_reset_pid()
+            self._ops += 1
+            self._maybe_log()
+
+    def record_error(self, exc):
+        with self._lock:
+            self._maybe_reset_pid()
+            self._ops += 1
+            self._errors += 1
+            name = type(exc).__name__
+            self._error_types[name] = self._error_types.get(name, 0) + 1
+            self._maybe_log()
+
+    def _maybe_reset_pid(self):
+        pid = os.getpid()
+        if self._pid != pid:
+            self._pid = pid
+            self._reset_counters()
+
+    def _maybe_log(self):
+        now = time.monotonic()
+        if now - self._last_log >= _STATS_LOG_INTERVAL:
+            elapsed = now - self._last_log
+            ops, errors = self._ops, self._errors
+            error_types = dict(self._error_types)
+            self._ops = 0
+            self._errors = 0
+            self._error_types = {}
+            self._last_log = now
+            rate = ops / elapsed if elapsed > 0 else 0
+            if errors > 0:
+                logger.warning(
+                    "cache stats [pid=%d] %.0fs: %d ops (%.1f/s), "
+                    "%d errors (%.1f%%) — %s",
+                    self._pid,
+                    elapsed,
+                    ops,
+                    rate,
+                    errors,
+                    100.0 * errors / ops if ops else 0,
+                    ", ".join(f"{k}={v}" for k, v in error_types.items()),
+                )
+            else:
+                logger.info(
+                    "cache stats [pid=%d] %.0fs: %d ops (%.1f/s), 0 errors",
+                    self._pid,
+                    elapsed,
+                    ops,
+                    rate,
+                )
+
+
+_stats = _CacheStats()
+
+
+class FaultTolerantPyLibMCCache(BaseCache):
+    """pylibmc backend that swallows errors and treats them as cache misses.
+
+    Uses module-level lock and client shared across all instances in a
+    process. Django creates per-thread instances, but we bypass that by
+    using global state, ensuring one pylibmc.Client per process.
+    """
+
+    def __init__(self, server, params):
+        super().__init__(params)
+        if isinstance(server, str):
+            self._servers = [s.removeprefix("unix:") for s in re.split("[;,]", server)]
+        else:
+            self._servers = [s.removeprefix("unix:") for s in server]
+        self._options = params.get("OPTIONS") or {}
+
+    @property
+    def _cache(self):
+        return _get_client(self._servers, self._options)
+
+    def get_backend_timeout(self, timeout=DEFAULT_TIMEOUT):
+        if timeout == DEFAULT_TIMEOUT:
+            timeout = self.default_timeout
+        if timeout is None:
+            return 0
+        elif int(timeout) == 0:
+            timeout = -1
+        if timeout > 2592000:
+            import time
+
+            timeout += int(time.time())
+        return int(timeout)
+
+    def make_and_validate_key(self, key, version=None):
+        key = self.make_key(key, version=version)
+        self.validate_key(key)
+        return key
+
+    def add(self, key, value, timeout=DEFAULT_TIMEOUT, version=None):
+        key = self.make_and_validate_key(key, version=version)
+        try:
+            with _global_lock:
+                result = self._cache.add(key, value, self.get_backend_timeout(timeout))
+            _stats.record_success()
+            return result
+        except Exception as e:
+            _stats.record_error(e)
+            return False
+
+    def get(self, key, default=None, version=None):
+        key = self.make_and_validate_key(key, version=version)
+        try:
+            with _global_lock:
+                val = self._cache.get(key)
+            _stats.record_success()
+        except Exception as e:
+            _stats.record_error(e)
+            val = None
+        return val if val is not None else default
+
+    def set(self, key, value, timeout=DEFAULT_TIMEOUT, version=None):
+        key = self.make_and_validate_key(key, version=version)
+        try:
+            with _global_lock:
+                if not self._cache.set(key, value, self.get_backend_timeout(timeout)):
+                    self._cache.delete(key)
+            _stats.record_success()
+        except Exception as e:
+            _stats.record_error(e)
+
+    def touch(self, key, timeout=DEFAULT_TIMEOUT, version=None):
+        key = self.make_and_validate_key(key, version=version)
+        try:
+            with _global_lock:
+                if timeout == 0:
+                    result = self._cache.delete(key)
+                else:
+                    result = self._cache.touch(key, self.get_backend_timeout(timeout))
+            _stats.record_success()
+            return result
+        except Exception as e:
+            _stats.record_error(e)
+            return False
+
+    def delete(self, key, version=None):
+        key = self.make_and_validate_key(key, version=version)
+        try:
+            with _global_lock:
+                result = bool(self._cache.delete(key))
+            _stats.record_success()
+            return result
+        except Exception as e:
+            _stats.record_error(e)
+            return False
+
+    def get_many(self, keys, version=None):
+        key_map = {
+            self.make_and_validate_key(key, version=version): key for key in keys
+        }
+        try:
+            with _global_lock:
+                ret = self._cache.get_multi(key_map.keys())
+            _stats.record_success()
+            return {key_map[k]: v for k, v in ret.items()}
+        except Exception as e:
+            _stats.record_error(e)
+            return {}
+
+    def set_many(self, data, timeout=DEFAULT_TIMEOUT, version=None):
+        safe_data = {}
+        original_keys = {}
+        for key, value in data.items():
+            safe_key = self.make_and_validate_key(key, version=version)
+            safe_data[safe_key] = value
+            original_keys[safe_key] = key
+        try:
+            with _global_lock:
+                failed_keys = self._cache.set_multi(
+                    safe_data, self.get_backend_timeout(timeout)
+                )
+            _stats.record_success()
+            return [original_keys[k] for k in failed_keys]
+        except Exception as e:
+            _stats.record_error(e)
+            return list(data.keys())
+
+    def delete_many(self, keys, version=None):
+        keys = [self.make_and_validate_key(key, version=version) for key in keys]
+        try:
+            with _global_lock:
+                self._cache.delete_multi(keys)
+            _stats.record_success()
+        except Exception as e:
+            _stats.record_error(e)
+
+    def incr(self, key, delta=1, version=None):
+        key = self.make_and_validate_key(key, version=version)
+        try:
+            with _global_lock:
+                if delta < 0:
+                    val = self._cache.decr(key, -delta)
+                else:
+                    val = self._cache.incr(key, delta)
+        except Exception:
+            val = None
+        if val is None:
+            raise ValueError("Key '%s' not found" % key)
+        return val
+
+    def clear(self):
+        try:
+            with _global_lock:
+                self._cache.flush_all()
+        except Exception:
+            pass
+
+    def close(self, **kwargs):
+        pass

--- a/packages/django_workload/srcs/django-workload/django-workload/django_workload/settings.py
+++ b/packages/django_workload/srcs/django-workload/django-workload/django_workload/settings.py
@@ -140,9 +140,12 @@ STATSD_MAXUDPSIZE = 512
 STATSD_IPV6 = False
 
 # Cache configuration
+# Uses ThreadSafePyLibMCCache — one shared pylibmc.Client per worker process,
+# created lazily post-fork via os.getpid(), with a threading.Lock for ASGI
+# thread safety. This avoids both per-thread OOM and pre-fork connection issues.
 CACHES = {
     "default": {
-        "BACKEND": "django.core.cache.backends.memcached.PyLibMCCache",
+        "BACKEND": "django_workload.cache_backend.FaultTolerantPyLibMCCache",
         "LOCATION": "127.0.0.1:11811",
     }
 }

--- a/packages/django_workload/srcs/django-workload/django-workload/start_loadbalanced_server.py
+++ b/packages/django_workload/srcs/django-workload/django-workload/start_loadbalanced_server.py
@@ -121,6 +121,12 @@ class UWSGIManager:
         env["PROXYGEN_THREADS"] = str(self.threads_per_worker)
         env["PYTHONUNBUFFERED"] = "1"
 
+        # Ensure LD_LIBRARY_PATH is set for Python 3.14 shared library
+        # This is critical for uWSGI workers to find libpython3.14.so
+        if "LD_LIBRARY_PATH" in os.environ:
+            env["LD_LIBRARY_PATH"] = os.environ["LD_LIBRARY_PATH"]
+            logger.info(f"Using LD_LIBRARY_PATH: {env['LD_LIBRARY_PATH']}")
+
         # Start uWSGI with config overrides
         # Use --set to override config variables (standard uWSGI way)
         self.uwsgi_process = subprocess.Popen(
@@ -774,6 +780,12 @@ listen stats
 
         env = os.environ.copy()
         env["PYTHONUNBUFFERED"] = "1"  # Disable output buffering
+
+        # Ensure LD_LIBRARY_PATH is set for Python 3.14 shared library
+        # This is critical for uWSGI workers to find libpython3.14.so
+        if "LD_LIBRARY_PATH" in os.environ:
+            env["LD_LIBRARY_PATH"] = os.environ["LD_LIBRARY_PATH"]
+            logger.info(f"Using LD_LIBRARY_PATH: {env['LD_LIBRARY_PATH']}")
 
         # Start worker process
         process = subprocess.Popen(

--- a/packages/django_workload/srcs/django-workload/django-workload/uwsgi.ini
+++ b/packages/django_workload/srcs/django-workload/django-workload/uwsgi.ini
@@ -42,3 +42,7 @@ thunder-lock = True
 stats = 127.0.0.1:9191
 logger = file:django-uwsgi.log
 disable-logging = True
+
+# Python 3.14 shared library path - required for built-in modules (math, _socket, etc.)
+# This must point to the Cinder/CPython lib directory containing libpython3.14.so
+# The actual path is set by the run script via environment variable

--- a/packages/django_workload/srcs/django-workload/services/memcached/run-memcached
+++ b/packages/django_workload/srcs/django-workload/services/memcached/run-memcached
@@ -15,4 +15,12 @@ PORT="${PORT:-11811}"
 # User to run under
 USER="${USER:-memcache}"
 
-/usr/bin/memcached -u "$USER" -m "$MEMORY" -l "$LISTEN" -p "$PORT" -t 16
+# Scale threads to match uWSGI worker count (1 worker = 1 connection).
+# V2 architecture uses per-worker ports, so each worker has an independent
+# memcached connection. Default memcached -t 16 is insufficient when
+# num_workers >> 16 (e.g., 176 on T1_BGM).
+NPROC=$(nproc)
+THREADS=$((NPROC > 16 ? NPROC / 2 : 16))
+MAXCONNS=$((NPROC * 8))
+
+/usr/bin/memcached -u "$USER" -m "$MEMORY" -l "$LISTEN" -p "$PORT" -t "$THREADS" -c "$MAXCONNS"

--- a/packages/django_workload/srcs/patches/pylibmc-1.6.1-py314-compat.patch
+++ b/packages/django_workload/srcs/patches/pylibmc-1.6.1-py314-compat.patch
@@ -1,0 +1,99 @@
+diff --git a/setup.py b/setup.py
+index 9bea257..84b3aeb 100644
+--- a/setup.py
++++ b/setup.py
+@@ -1,11 +1,6 @@
+-from __future__ import print_function
+ import os
+ import sys
+-from distutils.core import setup, Extension
+-
+-# Need an 'open' function that supports the 'encoding' argument:
+-if sys.version_info[0] < 3:
+-    from codecs import open
++from setuptools import setup, Extension
+ 
+ ## Command-line argument parsing
+ 
+@@ -95,9 +90,9 @@ if cmd == "gen-setup":
+         s.write(line + "\n")
+     sys.exit(0)
+ 
+-with open("README.rst", "U", encoding="utf-8") as r:
++with open("README.rst", encoding="utf-8") as r:
+     readme_text = r.read()
+-with open("src/pylibmc-version.h", "U", encoding="utf-8") as r:
++with open("src/pylibmc-version.h", encoding="utf-8") as r:
+     version = r.read().strip().split("\"")[1]
+ 
+ setup(
+diff --git a/src/_pylibmcmodule.c b/src/_pylibmcmodule.c
+index 5324d1d..077f6e2 100644
+--- a/src/_pylibmcmodule.c
++++ b/src/_pylibmcmodule.c
+@@ -1714,7 +1714,7 @@ memcached_return pylibmc_memcached_fetch_multi(memcached_st *mc, pylibmc_mget_re
+ 
+     /* Allocate as much as could possibly be needed, and an extra because of
+      * how libmemcached signals EOF. */
+-    *req.results = PyMem_New(memcached_result_st, req.nkeys + 1);
++    *req.results = PyMem_RawNew(memcached_result_st, req.nkeys + 1);
+ 
+     /* Note that nresults will not be off by one with this because the loops
+      * runs a half pass after the last key has been fetched, thus bumping the
+@@ -1742,7 +1742,7 @@ memcached_return pylibmc_memcached_fetch_multi(memcached_st *mc, pylibmc_mget_re
+                 memcached_result_free(*req.results + *req.nresults);
+             } while ((*req.nresults)--);
+ 
+-            PyMem_Free(*req.results);
++            PyMem_RawDel(*req.results);
+             *req.results = NULL;
+             *req.nresults = 0;
+ 
+@@ -1942,7 +1942,7 @@ memory_cleanup:
+         for (i = 0; i < nresults && results != NULL; i++) {
+             memcached_result_free(results + i);
+         }
+-        PyMem_Free(results);
++        PyMem_RawDel(results);
+     }
+ 
+     /* Not INCREFing because the only two outcomes are NULL and a new dict.
+@@ -2167,7 +2167,7 @@ static PyObject *PylibMC_Client_set_behaviors(PylibMC_Client *self,
+     char *key;
+ 
+     for (b = PylibMC_behaviors; b->name != NULL; b++) {
+-        if (!PyMapping_HasKeyString(behaviors, b->name)) {
++        if (behaviors == Py_None || !PyMapping_HasKeyString(behaviors, b->name)) {
+             continue;
+         } else if ((py_v = PyMapping_GetItemString(behaviors, b->name)) == NULL) {
+             goto error;
+@@ -2197,7 +2197,7 @@ static PyObject *PylibMC_Client_set_behaviors(PylibMC_Client *self,
+     }
+ 
+     for (b = PylibMC_callbacks; b->name != NULL; b++) {
+-        if (!PyMapping_HasKeyString(behaviors, b->name)) {
++        if (behaviors == Py_None || !PyMapping_HasKeyString(behaviors, b->name)) {
+             continue;
+         } else if ((py_v = PyMapping_GetItemString(behaviors, b->name)) == NULL) {
+             goto error;
+diff --git a/src/_pylibmcmodule.h b/src/_pylibmcmodule.h
+index cee9772..d28dec6 100644
+--- a/src/_pylibmcmodule.h
++++ b/src/_pylibmcmodule.h
+@@ -52,6 +52,16 @@
+ typedef ssize_t Py_ssize_t;
+ #endif
+ 
++/* Python 3.4+ PyMem_New/PyMem_Free require the GIL. Use Raw variants for
++ * allocations in GIL-free sections (e.g. inside Py_BEGIN_ALLOW_THREADS). */
++#if PY_VERSION_HEX >= 0x03040000
++#  define PyMem_RawNew(type, nelem) ((type *)PyMem_RawMalloc((nelem)*sizeof(type)))
++#  define PyMem_RawDel(ptr) PyMem_RawFree(ptr)
++#else
++#  define PyMem_RawNew PyMem_New
++#  define PyMem_RawDel(ptr) PyMem_Del(ptr)
++#endif
++
+ /* Server types. */
+ #define PYLIBMC_SERVER_TCP   (1 << 0)
+ #define PYLIBMC_SERVER_UDP   (1 << 1)

--- a/packages/django_workload/srcs/proxygen_binding/pyproject.toml
+++ b/packages/django_workload/srcs/proxygen_binding/pyproject.toml
@@ -1,0 +1,20 @@
+[build-system]
+requires = ["setuptools>=42", "wheel", "pybind11>=2.6.0"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "proxygen_binding"
+version = "0.1.0"
+description = "Python bindings for Proxygen HTTP server"
+readme = "README.md"
+requires-python = ">=3.8"
+license = {text = "MIT"}
+authors = [
+    {name = "Meta Platforms, Inc."}
+]
+dependencies = [
+    "pybind11>=2.6.0",
+]
+
+[project.optional-dependencies]
+django = ["django>=3.0"]

--- a/packages/django_workload/srcs/proxygen_binding/setup.py
+++ b/packages/django_workload/srcs/proxygen_binding/setup.py
@@ -235,6 +235,7 @@ setup(
         "django_asgi_adapter",
         "example_server",
         "django_server",
+        "event_loop_manager",
     ],
     cmdclass={"build_ext": build_ext},
     zip_safe=False,


### PR DESCRIPTION
Summary:


Upgrade DjangoBench V2 to use Python 3.14 and Cinder 3.14 to take advantage of newer language features and performance improvements. This also adds CinderX for JIT compilation support in the Cinder runtime environment.

Key changes:
- CPython upgraded from 3.10 to 3.14 (built from source on all platforms)
- Cinder upgraded from cinder/3.10 branch to meta/3.14 at pinned commit
- CinderX installed for JIT functionality with validation
- Removed numpy dependency in favor of Python's built-in statistics module
- cassandra-driver now builds from PyPI source for Python 3.14 compatibility
- Fixed run-wrk P50-P99 regex to capture correct latency values
- Fixed django_workload parser to exclude post-benchmark cleanup messages from metrics

Reviewed By: ahmadelyoussef

Differential Revision: D91604990
