### PR TITLE
Add time-based execution, megapixel scoring, and fast-jobs-first ordering to VideoTranscodeBench (#565)

### DIFF
--- a/benchpress/config/jobs.yml
+++ b/benchpress/config/jobs.yml
@@ -1375,6 +1375,7 @@
     - '--runtime {runtime}'
     - '--parallelism {parallelism}'
     - '--procs {procs}'
+    - '--max-time {max_time}'
   vars:
     - 'encoder=svt'
     - 'levels=0:0'
@@ -1382,6 +1383,50 @@
     - 'runtime=medium'
     - 'parallelism=1'
     - 'procs=-1'
+    - 'max_time=0'
+  hooks:
+    - hook: cpu-mpstat
+      options:
+        args:
+          - '-u'   # utilization
+          - '1'    # second interval
+    - hook: copymove
+      options:
+        is_move: true
+        after:
+          - 'benchmarks/video_transcode_bench/video_transcode_bench_results.txt'
+          - 'benchmarks/video_transcode_bench/perf.data'
+          - 'benchmarks/video_transcode_bench/breakdown.csv'
+
+- name: video_transcode_bench_svt_timed
+  benchmark: video_transcode_bench
+  description: >
+    Time-based SVT-AV1 video encoding workload. Runs encoding for a fixed
+    duration rather than a fixed amount of work, ensuring core saturation
+    regardless of core count.
+  args:
+    - '--encoder {encoder}'
+    - '--levels {levels}'
+    - '--output {output}'
+    - '--runtime {runtime}'
+    - '--parallelism {parallelism}'
+    - '--procs {procs}'
+    - '--sample-rate {sample_rate}'
+    - '--sampling-seed {sampling_seed}'
+    - '--max-time {max_time}'
+    - '--score-mode {score_mode}'
+    - '--fast-jobs-first'
+  vars:
+    - 'encoder=svt'
+    - 'levels=0:0'
+    - 'output=video_transcode_bench_results.txt'
+    - 'runtime=medium'
+    - 'parallelism=1'
+    - 'procs=-1'
+    - 'sample_rate=1.0'
+    - 'sampling_seed=1000'
+    - 'max_time=600'
+    - 'score_mode=megapixel'
   hooks:
     - hook: cpu-mpstat
       options:
@@ -1430,6 +1475,47 @@
           - 'benchmarks/video_transcode_bench/perf.data'
           - 'benchmarks/video_transcode_bench/breakdown.csv'
 
+
+- name: video_transcode_bench_svt_timed_mini
+  benchmark: video_transcode_bench
+  description: >
+    Time-based mini SVT-AV1 video encoding workload. Uses sampling to reduce
+    the dataset and a time limit to ensure consistent runtime regardless of
+    core count. Suitable for quick validation on high core count machines.
+  execute_cmd_from_file: true
+  args:
+    - '--encoder {encoder}'
+    - '--levels {levels}'
+    - '--output {output}'
+    - '--runtime {runtime}'
+    - '--parallelism {parallelism}'
+    - '--procs {procs}'
+    - '--sample-rate {sample_rate}'
+    - '--sampling-seed {sampling_seed}'
+    - '--sleep-before-perf {sleep_before_perf}'
+    - '--max-time {max_time}'
+    - '--score-mode {score_mode}'
+    - '--fast-jobs-first'
+  vars:
+    - 'encoder=svt'
+    - 'levels=0:0'
+    - 'output=video_transcode_bench_results.txt'
+    - 'runtime=medium'
+    - 'parallelism=1'
+    - 'procs=-1'
+    - 'sample_rate=1'
+    - 'sampling_seed=1000'
+    - 'sleep_before_perf=0'
+    - 'max_time=15'
+    - 'score_mode=megapixel'
+  hooks:
+    - hook: copymove
+      options:
+        is_move: true
+        after:
+          - 'benchmarks/video_transcode_bench/video_transcode_bench_results.txt'
+          - 'benchmarks/video_transcode_bench/perf.data'
+          - 'benchmarks/video_transcode_bench/breakdown.csv'
 
 - name: video_transcode_bench_aom
   benchmark: video_transcode_bench

--- a/benchpress/lib/baseline.py
+++ b/benchpress/lib/baseline.py
@@ -11,6 +11,7 @@ BASELINES = {
     "mediawiki": 1280.0,
     "sparkbench": 4.0,
     "video_transcode_svt": 11.2,
+    "video_transcode_svt_mpx": 86.12,
 }
 
 JOB_TO_BM = {
@@ -25,6 +26,8 @@ JOB_TO_BM = {
     "tao_bench_custom": "taobench",
     "tao_bench_autoscale": "taobench",
     "video_transcode_bench_svt": "video_transcode_svt",
+    "video_transcode_bench_svt_timed": "video_transcode_svt_mpx",
+    "video_transcode_bench_svt_timed_mini": "video_transcode_svt_mpx",
 }
 
 
@@ -47,6 +50,8 @@ def get_raw_perf_metric(job_name, metrics):
             return 3600.0 / float(metrics["execution_time_test_93586"])
         elif JOB_TO_BM[job_name] == "video_transcode_svt":
             return float(metrics["throughput_all_levels_hmean_MBps"])
+        elif JOB_TO_BM[job_name] == "video_transcode_svt_mpx":
+            return float(metrics["throughput_all_levels_hmean_MPxps"])
         else:
             return None
     except KeyError:

--- a/benchpress/plugins/parsers/ffmpeg.py
+++ b/benchpress/plugins/parsers/ffmpeg.py
@@ -13,6 +13,7 @@ from benchpress.lib.baseline import BASELINES
 from benchpress.lib.parser import Parser
 
 VIDEO_TRANSCODE_SVT_BASELINE = BASELINES["video_transcode_svt"]
+VIDEO_TRANSCODE_SVT_MPX_BASELINE = BASELINES["video_transcode_svt_mpx"]
 
 
 class FfmpegParser(Parser):
@@ -29,15 +30,21 @@ class FfmpegParser(Parser):
         metrics = {}
         throughputs = []
         encoder = ""
+        score_mode = "throughput"
+        total_data_encoded = 0.0
+        total_megapixels_encoded = 0.0
         for line in stdout:
-            if re.search("total_data_encoded", line):
+            if re.search("^score_mode", line):
+                score_mode = line.split("=")[1].strip()
+            elif re.search("total_megapixels_encoded", line):
+                total_megapixels_encoded = float(line.split()[-1])
+            elif re.search("total_data_encoded", line):
                 total_data_encoded = float(line.split()[-2])
             elif re.search("^encoder", line):
                 encoder = line.split("=")[1]
             elif re.search("res_level", line):
                 level = line.split(":")[0][4:]
                 level_time = level + "_time_secs"
-                level_throughput = level + "_throughput_MBps"
                 time = line.split()[-1]
                 if "." in time:
                     _frac = time.split(".")[1]
@@ -50,13 +57,24 @@ class FfmpegParser(Parser):
                     _hour = time.split(":")[0]
                     time = int(_sec) + int(_min) * 60 + int(_hour) * 3600
                 metrics[level_time] = time
-                metrics[level_throughput] = total_data_encoded * 1024 / float(time)
+                if score_mode == "megapixel":
+                    level_throughput = level + "_throughput_MPxps"
+                    metrics[level_throughput] = total_megapixels_encoded / float(time)
+                else:
+                    level_throughput = level + "_throughput_MBps"
+                    metrics[level_throughput] = total_data_encoded * 1024 / float(time)
                 throughputs.append(metrics[level_throughput])
 
         throughput_hmean = statistics.harmonic_mean(throughputs)
-        metrics["throughput_all_levels_hmean_MBps"] = throughput_hmean
         throughput_gmean = statistics.geometric_mean(throughputs)
-        metrics["throughput_all_levels_geomean_MBps"] = throughput_gmean
-        if encoder == "svt":
-            metrics["score"] = throughput_hmean / VIDEO_TRANSCODE_SVT_BASELINE
+        if score_mode == "megapixel":
+            metrics["throughput_all_levels_hmean_MPxps"] = throughput_hmean
+            metrics["throughput_all_levels_geomean_MPxps"] = throughput_gmean
+            if encoder == "svt":
+                metrics["score"] = throughput_hmean / VIDEO_TRANSCODE_SVT_MPX_BASELINE
+        else:
+            metrics["throughput_all_levels_hmean_MBps"] = throughput_hmean
+            metrics["throughput_all_levels_geomean_MBps"] = throughput_gmean
+            if encoder == "svt":
+                metrics["score"] = throughput_hmean / VIDEO_TRANSCODE_SVT_BASELINE
         return metrics

--- a/packages/video_transcode_bench/install_video_transcode_bench.sh
+++ b/packages/video_transcode_bench/install_video_transcode_bench.sh
@@ -219,6 +219,8 @@ download_testing_scripts
 cp "${BPKGS_FFMPEG_ROOT}/run.sh" ./
 cp ./aom-testing/scripts/content-adaptive-streaming-pipeline-scripts/generate_commands_all.py ./
 cp "${BPKGS_FFMPEG_ROOT}/modify_generate_commands_all.py" ./
+cp "${BPKGS_FFMPEG_ROOT}/timed_parallel_feeder.sh" ./
+chmod +x timed_parallel_feeder.sh
 chmod +x modify_generate_commands_all.py
 mkdir -p tools
 ln -s "${FFMPEG_BUILD}/bin/ffmpeg" ./tools/ffmpeg

--- a/packages/video_transcode_bench/run.sh
+++ b/packages/video_transcode_bench/run.sh
@@ -29,7 +29,7 @@ source "${BENCHPRESS_ROOT}/packages/common/runtime_breakdown_utils.sh"
 
 show_help() {
 cat <<EOF
-Usage: ${0##*/} [-h] [--encoder svt|aom|x264] [--levels low:high]|[--runtime long|medium|short]|[--parallelism 0-6]|[--procs {number of jobs}]|[--sample-rate 0.0-1.0]|[--sampling-seed {seed}] [--sleep-before-perf {seconds}] [--output {output file name}]
+Usage: ${0##*/} [-h] [--encoder svt|aom|x264] [--levels low:high]|[--runtime long|medium|short]|[--parallelism 0-6]|[--procs {number of jobs}]|[--sample-rate 0.0-1.0]|[--sampling-seed {seed}] [--sleep-before-perf {seconds}] [--max-time {seconds}] [--score-mode throughput|megapixel] [--output {output file name}]
 
     -h Display this help and exit
     --encoder encoder name. Default: svt
@@ -38,6 +38,9 @@ Usage: ${0##*/} [-h] [--encoder svt|aom|x264] [--levels low:high]|[--runtime lon
     --sample-rate fraction of clips to process (0.0-1.0). Default: 1.0
     --sampling-seed seed for random sampling. Default: 1000
     --sleep-before-perf sleep time before perf record. Default: 60
+    --max-time max encoding time in seconds. 0 means no limit. Default: 0
+    --score-mode scoring method: throughput (GB/s) or megapixel (MPx/s). Default: throughput
+    --fast-jobs-first reverse command order so fast (small resolution) jobs run first
     -output Result output file name. Default: "ffmpeg_video_workload_results.txt"
 EOF
 }
@@ -88,6 +91,15 @@ main() {
 
     sleep_before_perf=60
 
+    local max_time
+    max_time=0
+
+    local score_mode
+    score_mode="throughput"
+
+    local fast_jobs_first
+    fast_jobs_first=0
+
     # Create a backup of generate_commands_all.py before making any changes, to restore it later and avoid replicating changes for susequent runs
     cp ${FFMPEG_ROOT}/generate_commands_all.py ${FFMPEG_ROOT}/generate_commands_all.backup.py
 
@@ -120,6 +132,15 @@ main() {
             --sleep-before-perf)
                 sleep_before_perf="$2"
                 ;;
+            --max-time)
+                max_time="$2"
+                ;;
+            --score-mode)
+                score_mode="$2"
+                ;;
+            --fast-jobs-first)
+                fast_jobs_first=1
+                ;;
             -h)
                 show_help >&2
                 exit 1
@@ -133,7 +154,7 @@ main() {
         esac
 
         case $1 in
-            --levels|--encoder|--output|--runtime|--parallelism|--procs|--sample-rate|--sampling-seed|--sleep-before-perf)
+            --levels|--encoder|--output|--runtime|--parallelism|--procs|--sample-rate|--sampling-seed|--sleep-before-perf|--max-time|--score-mode)
                 if [ -z "$2" ]; then
                     echo "Invalid option: $1 requires an argument" 1>&2
                     exit 1
@@ -222,13 +243,14 @@ main() {
     num_proc=$(nproc)
     if [ -z "$procs" ] || [ $procs -eq -1 ]; then
         if [ "$num_files" -lt "$num_proc" ]; then
-            num_pool="num_pool = $num_files"
+            num_pool_val=$num_files
         else
-            num_pool="num_pool = $num_proc"
+            num_pool_val=$num_proc
         fi
     else
-        num_pool="num_pool = $procs"
+        num_pool_val=$procs
     fi
+    num_pool="num_pool = $num_pool_val"
 
     # Set lp_number
     lp_number="lp_number = 1"
@@ -255,6 +277,28 @@ main() {
 
     head -n -6 "./${run_sh}" > temp.sh && mv temp.sh "./${run_sh}" && chmod +x ./${run_sh}
 
+    # Derive the run-paral-cpu script name from run_sh
+    run_paral_cpu="${run_sh/-run-all-paral.sh/-run-paral-cpu.sh}"
+    # Determine the encoder test identifier for command file names
+    enc_test_id="${run_paral_cpu%-run-paral-cpu.sh}"
+
+    # Reverse command file order so fast (small resolution) jobs run first
+    if [ "$fast_jobs_first" = "1" ]; then
+        for num in $(seq "${low}" "${high}"); do
+            cmd_file="run-${enc_test_id}-m${num}.txt"
+            if [ -f "$cmd_file" ]; then
+                tac "$cmd_file" > "${cmd_file}.tmp" && mv "${cmd_file}.tmp" "$cmd_file"
+            fi
+        done
+    fi
+
+    # Overwrite run-paral-cpu to use the timed parallel feeder
+    cat > "./${run_paral_cpu}" <<FEEDER_EOF
+#!/bin/bash
+./timed_parallel_feeder.sh run-${enc_test_id}-m\$1.txt ${num_pool_val} ${max_time} joblog_m\$1.txt
+FEEDER_EOF
+    chmod +x "./${run_paral_cpu}"
+
     export LD_LIBRARY_PATH="${FFMPEG_ROOT}/ffmpeg_build/lib64/"
     ldconfig
 
@@ -278,22 +322,97 @@ main() {
         rm "${result_filename}"
     fi
 
+    # Calculate total_data_encoded from successfully completed encode jobs.
+    # Each joblog (produced by timed_parallel_feeder.sh / GNU parallel) has
+    # columns: Seq Host Starttime JobRuntime Send Receive Exitval Signal Command
+    # We extract unique input files (-i <path>) from jobs with Exitval==0.
+    # Each input clip is counted once per level (not once per CRF value).
     total_size=0
-    for file in "${FFMPEG_ROOT}/resized_clips"/*; do
-        size=$(stat -c %s "$file")
-        total_size=$((total_size + size))
+    for num in $(seq "${low}" "${high}"); do
+        joblog="joblog_m${num}.txt"
+        if [ -f "${joblog}" ]; then
+            # Extract unique input clip paths from successful jobs
+            while IFS= read -r input_file; do
+                if [ -n "$input_file" ] && [ -f "$input_file" ]; then
+                    size=$(stat -c %s "$input_file")
+                    total_size=$((total_size + size))
+                fi
+            done < <(awk 'NR>1 && $7==0' "${joblog}" | grep -oP '(?<=-i )\S+\.y4m' | sort -u)
+        fi
     done
 
     total_size_GB=$(echo "$total_size / 1024 / 1024 / 1024" | bc -l | awk '{printf "%.2f", $0}')
 
+    # Calculate total megapixels encoded from all successful jobs (every job counts,
+    # not deduplicated, since each CRF encode is real work).
+    # Resolution and frame count are extracted from the input filename:
+    #   resized: ...to<W>x<H>_lanc_..._<start>_<end>.y4m
+    #   native:  ..._<W>x<H>_..._<start>_<end>.y4m
+    total_megapixels=0
+    if [ "$score_mode" = "megapixel" ]; then
+        for num in $(seq "${low}" "${high}"); do
+            joblog="joblog_m${num}.txt"
+            if [ -f "${joblog}" ]; then
+                level_mpx=$(awk 'NR>1 && $7==0 {
+                    cmd = $0
+                    # Extract input filename from -i flag
+                    match(cmd, /-i ([^ ]+\.y4m)/, arr)
+                    if (arr[1] != "") {
+                        fname = arr[1]
+                        # Extract resolution: prefer "to<W>x<H>" (downscaled), else first "<W>x<H>" (native)
+                        w = 0; h = 0
+                        if (match(fname, /to([0-9]+)x([0-9]+)/, res)) {
+                            w = res[1]; h = res[2]
+                        } else if (match(fname, /([0-9]+)x([0-9]+)/, res)) {
+                            w = res[1]; h = res[2]
+                        }
+                        # Extract frame range: last two _<number> before .y4m
+                        n = split(fname, parts, /[_.]/)
+                        start_f = 0; end_f = 0
+                        for (i = n; i >= 1; i--) {
+                            if (parts[i] == "y4m") continue
+                            if (end_f == 0 && parts[i] ~ /^[0-9]+$/) { end_f = parts[i]+0; continue }
+                            if (start_f == 0 && parts[i] ~ /^[0-9]+$/) { start_f = parts[i]+0; break }
+                        }
+                        frames = end_f - start_f + 1
+                        if (w > 0 && h > 0 && frames > 0) {
+                            pixels += w * h * frames
+                        }
+                    }
+                } END { printf "%.2f", pixels / 1000000 }' "${joblog}")
+                total_megapixels=$(echo "$total_megapixels + $level_mpx" | bc -l)
+            fi
+        done
+    fi
+
     echo "encoder=${encoder}"
+    if [ "$score_mode" = "megapixel" ]; then
+        echo "score_mode=megapixel"
+        total_megapixels_fmt=$(echo "$total_megapixels" | awk '{printf "%.2f", $0}')
+        echo "total_megapixels_encoded: ${total_megapixels_fmt}"
+    fi
     echo "total_data_encoded: ${total_size_GB} GB"
     for num in $(seq "${low}" "${high}"); do
-        filename="time_enc_${num}.log"
-        if [ -f "${filename}" ]; then
-            line=$(grep "Elapsed" "${filename}")
-            last_element=$(echo "${line}" | cut -d' ' -f 8)
-            echo "res_level${num}:" "${last_element}" | tee -a "${result_filename}"
+        if [ "$score_mode" = "megapixel" ]; then
+            joblog="joblog_m${num}.txt"
+            if [ -f "${joblog}" ]; then
+                # Sum JobRuntime (column 4) for successful jobs (Exitval==0, column 7)
+                core_secs=$(awk 'NR>1 && $7==0 { sum += $4 } END { printf "%.2f", sum }' "${joblog}")
+                # Effective time = total core-seconds / number of parallel slots
+                eff_time=$(echo "$core_secs / $num_pool_val" | bc -l)
+                # Format as M:SS.ff to match existing parser expectations
+                eff_min=$(echo "$eff_time / 60" | bc)
+                eff_sec=$(echo "$eff_time - $eff_min * 60" | bc -l | awk '{printf "%05.2f", $0}')
+                echo "res_level${num}: ${eff_min}:${eff_sec}" | tee -a "${result_filename}"
+            fi
+        else
+            # Wall-clock time for throughput mode (preserves existing baseline compatibility)
+            filename="time_enc_${num}.log"
+            if [ -f "${filename}" ]; then
+                line=$(grep "Elapsed" "${filename}")
+                last_element=$(echo "${line}" | cut -d' ' -f 8)
+                echo "res_level${num}:" "${last_element}" | tee -a "${result_filename}"
+            fi
         fi
     done
 

--- a/packages/video_transcode_bench/timed_parallel_feeder.sh
+++ b/packages/video_transcode_bench/timed_parallel_feeder.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+#
+# Timed parallel feeder for VideoTranscodeBench.
+# Feeds jobs from a command file to GNU parallel, stopping when the time
+# limit is reached. In-flight jobs are allowed to finish gracefully.
+# A joblog is written so callers can determine which jobs succeeded.
+#
+# Usage: timed_parallel_feeder.sh <jobs_file> <num_jobs> <max_time_secs> <joblog_file>
+#   max_time_secs=0 means no time limit (original behavior).
+
+set -Eeo pipefail
+
+JOBS_FILE="$1"
+NUM_JOBS="$2"
+MAX_TIME="$3"
+JOBLOG_FILE="$4"
+
+if [ -z "$JOBS_FILE" ] || [ -z "$NUM_JOBS" ] || [ -z "$MAX_TIME" ] || [ -z "$JOBLOG_FILE" ]; then
+    echo "Usage: $0 <jobs_file> <num_jobs> <max_time_secs> <joblog_file>" >&2
+    exit 1
+fi
+
+if [ ! -f "$JOBS_FILE" ]; then
+    echo "Error: jobs file '$JOBS_FILE' not found" >&2
+    exit 1
+fi
+
+if [ "$MAX_TIME" -le 0 ]; then
+    # No time limit: run all jobs (original behavior)
+    parallel --joblog "$JOBLOG_FILE" -j "$NUM_JOBS" < "$JOBS_FILE"
+else
+    # Run parallel in the background with all jobs available.
+    # After the time limit, send SIGTERM to parallel which makes it stop
+    # spawning new jobs while letting in-flight jobs finish gracefully.
+    parallel --joblog "$JOBLOG_FILE" -j "$NUM_JOBS" < "$JOBS_FILE" &
+    PARALLEL_PID=$!
+
+    # Background timer: sends SIGTERM after MAX_TIME seconds
+    ( sleep "$MAX_TIME" && kill -TERM "$PARALLEL_PID" 2>/dev/null ) &
+    TIMER_PID=$!
+
+    # Wait for parallel to finish (either naturally or after SIGTERM)
+    wait "$PARALLEL_PID" 2>/dev/null || true
+
+    # Clean up the timer if parallel finished before the time limit
+    kill "$TIMER_PID" 2>/dev/null || true
+    wait "$TIMER_PID" 2>/dev/null || true
+fi

--- a/perfpub/utils.py
+++ b/perfpub/utils.py
@@ -665,7 +665,14 @@ def process_metrics(
             print("No known db metrics found for spark_standalone_remote")
 
     elif "video_transcode_bench" in bm_name:
-        db_fields["metrics"] = bm_metrics["metrics"]["throughput_all_levels_hmean_MBps"]
+        if "throughput_all_levels_hmean_MPxps" in bm_metrics["metrics"]:
+            db_fields["metrics"] = bm_metrics["metrics"][
+                "throughput_all_levels_hmean_MPxps"
+            ]
+        else:
+            db_fields["metrics"] = bm_metrics["metrics"][
+                "throughput_all_levels_hmean_MBps"
+            ]
     db_fields["others"] = f"'{json.dumps(bm_metrics['metrics'])}'"
 
     # This is assigning value to res variable


### PR DESCRIPTION
Summary:

Motivation
The existing video_transcode_bench_svt_mini job uses --sample-rate 0.01
  to reduce runtime, but this approach has fundamental problems on
  high-core-count machines:
 1. Core underutilization: With only ~1% of clips sampled, the total
  number of encode jobs (clips x resolutions x CRF values) can be fewer
  than available cores. On a 72-core machine, many cores sit idle for the
  entire run — the benchmark measures a fraction of the machine's
  capacity.
  2. Score instability: The throughput-based score (GB/s) varies
  significantly with sample-rate because different subsets of clips have
  different total sizes and encoding characteristics. A 1% sample gives a
  different score than a 10% sample, making cross-run comparisons
  unreliable.
  3. Unrepresentative workload: Sampling removes clips rather than
  shortening the run, so the remaining workload may not reflect the full
  distribution of resolutions and content types.

  A time-based approach solves all three problems: use the full dataset
  (sample-rate=1.0) so all cores stay saturated, and cap runtime with a
  time limit instead. This ensures every machine — regardless of core
  count — runs at full utilization for a consistent, predictable duration.

  Additional challenges required further changes:

  4. Score depends on which jobs complete: With a time limit, only a
  subset of jobs finish. The GB/s throughput metric is biased by
  resolution (1080p jobs contribute more bytes than 144p for similar
  compute). A new megapixel-based metric (MPx/s) normalizes across
  resolutions, making the score stable regardless of which jobs complete.
  5. Slow drain phase: Jobs are ordered large-to-small by default. With a
  short time limit, all slots fill with slow 1080p jobs, few complete
  before the deadline, and in-flight jobs take 30-60s to drain. A new
  --fast-jobs-first option reverses the order, maximizing completions and
  reducing drain to 1-3s.
  6. Inflated total_data_encoded: The previous calculation counted all
  input clips regardless of whether they were actually encoded. Now
  derived from joblog data — only successfully completed, deduplicated
  input files are counted.

  Summary

  Adds a time-bounded execution mode to VideoTranscodeBench that caps
  benchmark runtime via SIGTERM-based parallel job control, along with a
  resolution-normalized megapixel scoring metric and an option to
  prioritize fast jobs.

  Key changes:

  - timed_parallel_feeder.sh (new): Wraps GNU parallel with a time limit.
  When max_time > 0, runs parallel in the background and sends SIGTERM
  after the deadline, allowing in-flight jobs to finish gracefully while
  preventing new jobs from spawning. Produces a joblog for post-hoc
  analysis. When max_time = 0, behaves identically to the original flow.
  - Megapixel score mode (--score-mode megapixel): Computes throughput as
  MPx/s by extracting resolution and frame count from input filenames in
  the joblog. This normalizes across resolutions, making scores stable
  regardless of which job subset completes in timed runs. Baseline derived
   mathematically from existing throughput baseline: 86.12 MPx/s.
  - Effective time from joblogs (megapixel mode only): When
  score_mode=megapixel, uses sum(JobRuntime for successful jobs) /
  num_parallel_slots instead of wall-clock time. The default throughput
  mode continues to use wall-clock time, preserving backward compatibility
   with existing baselines.
  - total_data_encoded fix: Now derives encoded data size from unique
  input files of successful jobs (via joblog), instead of counting all
  clips regardless of completion. Deduplicates across CRF values with sort
   -u.
  - --fast-jobs-first: Reverses command file ordering (via tac) so
  small/fast jobs run first. For short timed runs this maximizes job
  completions and minimizes the drain phase (1-3s vs 30-60s).
  - Two new job definitions in jobs.yml:
    - video_transcode_bench_svt_timed: 600s limit, megapixel scoring,
  fast-jobs-first
    - video_transcode_bench_svt_timed_mini: 15s limit, megapixel scoring,
  fast-jobs-first
  - Backward compatible: Existing jobs are unchanged — max_time=0 means no
   limit, throughput GB/s scoring with wall-clock time, original job
  ordering.

Reviewed By: YifanYuan3

Differential Revision: D98639355
