### PR TITLE
Add Neoverse V3  perf counter collection to benchpress and   perfpub (#566)

### DIFF
--- a/benchpress/plugins/hooks/perf_monitors/topdown.py
+++ b/benchpress/plugins/hooks/perf_monitors/topdown.py
@@ -624,6 +624,20 @@ class NVPerfUtil(BasePerfUtil):
         super(NVPerfUtil, self).run()
 
 
+class NeoVerseV3PerfUtil(BasePerfUtil):
+    def __init__(self, interval, job_uuid, **kwargs):
+        super(NeoVerseV3PerfUtil, self).__init__(
+            interval,
+            job_uuid,
+            "nv3-perf-collector",
+            perf_collect_script_name="collect_neoversev3_perf_counters.sh",
+            perf_postproc_script_name="generate_arm_neoversev3_perf_report.py",
+        )
+
+    def run(self):
+        super(NeoVerseV3PerfUtil, self).run()
+
+
 class DummyPerfUtil:
     def __init__(self, interval, job_uuid, **kwargs):
         pass
@@ -662,6 +676,24 @@ def choose_perfspect():
         return DummyPerfUtil
 
 
+def is_neoversev3():
+    """Detect ARM Neoverse V3 platforms via DMI system-family or system-version."""
+    for dmi_field in ("system-family", "system-version"):
+        try:
+            p = subprocess.Popen(
+                ["dmidecode", "-s", dmi_field],
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                encoding="utf-8",
+            )
+            out, _ = p.communicate()
+            if "neoverse-v3" in out.lower() or "neoverse_v3" in out.lower():
+                return True
+        except Exception:
+            pass
+    return False
+
+
 cpuinfo = get_cpuinfo()
 cpu_vendor = get_cpu_vendor(cpuinfo)
 if cpu_vendor == "intel":
@@ -672,6 +704,8 @@ elif cpu_vendor == "arm":
     vendor2 = get_cpu_vendor_from_dmi()
     if vendor2 == "nvidia":
         TopDown = NVPerfUtil
+    elif is_neoversev3():
+        TopDown = NeoVerseV3PerfUtil
     else:
         TopDown = ARMPerfUtil
 else:

--- a/perfpub/utils.py
+++ b/perfpub/utils.py
@@ -29,6 +29,7 @@ TIMESTAMP_COLUMN_MAP = {
     "amd-zen4-perf-collector-timeseries.csv": ("Timestamp_Secs", "relative_secs"),
     "amd-zen5-perf-collector-timeseries.csv": ("Timestamp_Secs", "relative_secs"),
     "nv-perf-collector-timeseries.csv": ("Timestamp_Secs", "relative_secs"),
+    "nv3-perf-collector-timeseries.csv": ("Timestamp_Secs", "relative_secs"),
     "arm-perf-collector-transposed.csv": ("time", "relative_secs"),
     "topdown-intel.sys.csv": ("TS", "epoch_secs"),
 }
@@ -575,6 +576,21 @@ def read_arm_perf_collector(
     )
 
 
+def read_neoversev3_perf_collector(
+    interval, last_secs, skip_last_secs, start_time=None, end_time=None, bm_epoch=None
+):
+    return sample_avg_from_csv(
+        "nv3-perf-collector-timeseries.csv",
+        interval,
+        last_secs,
+        skip_last_secs,
+        exclude_columns=("index", "Timestamp_Secs"),
+        start_time=start_time,
+        end_time=end_time,
+        bm_epoch=bm_epoch,
+    )
+
+
 def read_intel_perfspect(
     interval, last_secs, skip_last_secs, start_time=None, end_time=None, bm_epoch=None
 ):
@@ -817,6 +833,10 @@ def process_metrics(
         "metric_TMA_Retiring(%)": "retiring",
         "Topdown Level 1/Bad Speculation": "bad_speculation",
         "metric_TMA_Bad_Speculation(%)": "bad_speculation",
+        "TopDown bad Speculation %": "bad_speculation",
+        "TopDown Bad Speculation %": "bad_speculation",
+        "L1 iCache MPKI": "L1_icache_mpki",
+        "L1 dCache MPKI": "L1_dcache_mpki",
         "L2 Code MPKI": "L2_code_mpki",
         "metric_L2 demand code MPI": "L2_code_mpki",
         "L2 Data MPKI": "L2_data_mpki",
@@ -890,6 +910,19 @@ def process_metrics(
         if key in Map:
             db_fields[f"{Map[key]}"] = value
     res += arm_perf_collector
+    nv3_perf_collector = read_neoversev3_perf_collector(
+        args.interval,
+        args.last_secs,
+        args.skip_last_secs,
+        start_time,
+        end_time,
+        bm_epoch,
+    )
+    for line in nv3_perf_collector.splitlines():
+        key, value = line.split(",")
+        if key in Map:
+            db_fields[f"{Map[key]}"] = value
+    res += nv3_perf_collector
     intel_perfspect = read_intel_perfspect(
         args.interval,
         args.last_secs,


### PR DESCRIPTION
Summary:

ARM Neoverse V3 currently falls through to ARMPerfUtil which relies on ARM's topdown-tool — this fails silently on some ARM Neoverse V3 machnes , producing no TopDown or microarchitectural metrics (FrontendBound, BackendBound, MPKI, instruction mix, etc.). The V3 collection and report scripts (collect_neoversev3_perf_counters.sh, generate_arm_neoversev3_perf_report.py) already exist but were not wired into the perf hook or perfpub pipeline. This diff:
  - Adds NeoVerseV3PerfUtil class to topdown.py that uses the existing V3 scripts
  - Adds is_neoversev3() detection (via DMI system-product-name and kernel version fallback) so V3 is automatically routed to the V3 collector instead of the failing topdown-tool
  - Adds read_neoversev3_perf_collector() to both utils.py and utils_internal.py and calls it in process_metrics() so V3 metrics flow into overall-metrics.csv
  - Adds V3 metric name variants (TopDown Bad Speculation %, L1 iCache MPKI, L1 dCache MPKI) to the perfpub Map for DB storage

Reviewed By: charles-typ

Differential Revision: D99724547


