### PR TITLE
[FeedSim] Keep number of driver threads and thrift threads in balance with SMT

### DIFF
--- a/packages/feedsim/run.sh
+++ b/packages/feedsim/run.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright (c) Meta Platforms, Inc. and affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates & Contributors
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
@@ -42,16 +42,13 @@ SRV_THREADS_DEFAULT=8        # 8 should also suffice for most purposes
 if [[ "$IS_SMT_ON" = 1 ]]; then
   RANKING_THREADS_DEFAULT="$(( $(nproc) * 7/20))"  # 7/20 is 0.35 cpu factor
   SRV_IO_THREADS_DEFAULT="$(echo "${BC_MIN_FN}; min($(nproc) * 7/20, 55)" | bc)" # 0.35 cpu factor, max 55
-  DRIVER_THREADS="$(echo "scale=2; $(nproc) / 5.0 + 0.5 " | bc )"  # Driver threads, rounds nearest.
-  DRIVER_THREADS="${DRIVER_THREADS%.*}"  # Truncate decimal fraction.
-  DRIVER_THREADS="$(echo "${BC_MAX_FN}; max(${DRIVER_THREADS:-0}, 4)" | bc )" # At least 4 threads.
 else
   RANKING_THREADS_DEFAULT="$(( $(nproc) * 15/20))"  # 15/20 is 0.75 cpu factor
   SRV_IO_THREADS_DEFAULT="$(echo "${BC_MIN_FN}; min($(nproc) * 11/20, 55)" | bc)" # 0.55 cpu factor, max 55
-  DRIVER_THREADS="$(echo "scale=2; $(nproc) / 4.0 + 0.5 " | bc )"  # Driver threads, rounds nearest.
-  DRIVER_THREADS="${DRIVER_THREADS%.*}"  # Truncate decimal fraction.
-  DRIVER_THREADS="$(echo "${BC_MAX_FN}; max(${DRIVER_THREADS:-0}, 4)" | bc )" # At least 4 threads.
 fi
+DRIVER_THREADS="$(echo "scale=2; $(nproc) / 4.0 + 0.5 " | bc )"  # Driver threads, rounds nearest.
+DRIVER_THREADS="${DRIVER_THREADS%.*}"  # Truncate decimal fraction.
+DRIVER_THREADS="$(echo "${BC_MAX_FN}; max(${DRIVER_THREADS:-0}, 4)" | bc )" # At least 4 threads.
 
 show_help() {
 cat <<EOF


### PR DESCRIPTION
To achieve optimal performance for FeedSim, the number of driver connections and thrift threads should be always kept in balance. Every driver thread uses 4 connections of the thrift server, so we need to ensure that `#driver_threads * 4 = #thrift_threads`.

- On systems without SMT support, this balance is achieved (`#driver_threads = #thrift_threads/4`). 
- If SMT is enabled (detected via `/sys/devices/system/cpu/smt/active`), `#driver_threads = #thrift_threads/5` is used. So, the number of driver connections is only 80% of the number of thrift threads. Consequently, the driver does not spawn enough threads and only 80% of the thrift threads are busy. 

This PR fixes this discrepancy by using the same formula to compute the number of driver threads on systems with and without SMT. This improves performance by up to 20%. 