### PR TITLE
Fix Django install failure from setuptools 82+ deprecating develop command (#568)

### DIFF
--- a/packages/django_workload/install_django_workload.sh
+++ b/packages/django_workload/install_django_workload.sh
@@ -158,7 +158,7 @@ sed -i 's/django-cassandra-engine/django-cassandra-engine >= 1.5, < 1.6/' setup.
 # Install dependencies using third_party pip dependencies from manifold
 pip install "django-statsd-mozilla" --no-index --find-links file://"$OUT/django-workload/django-workload/third_party"
 pip install numpy --no-index --find-links file://"$OUT/django-workload/django-workload/third_party"
-pip install -e . --no-index --find-links file://"$OUT/django-workload/django-workload/third_party"
+pip install --no-build-isolation -e . --no-index --find-links file://"$OUT/django-workload/django-workload/third_party"
 
 # No need to copy template files as they are already in the srcs directory
 
@@ -173,10 +173,10 @@ set -u
 # Install dependencies using third_party pip dependencies from manifold
 pip install "django-statsd-mozilla" --no-index --find-links file://"$OUT/django-workload/django-workload/third_party"
 pip install numpy --no-index --find-links file://"$OUT/django-workload/django-workload/third_party"
-pip install -e . --no-index --find-links file://"$OUT/django-workload/django-workload/third_party"
+pip install --no-build-isolation -e . --no-index --find-links file://"$OUT/django-workload/django-workload/third_party"
 
 popd  # ${OUT}/django-workload/django-workload
-pip install -e . --no-index --find-links file://"$OUT/django-workload/django-workload/third_party"
+pip install --no-build-isolation -e . --no-index --find-links file://"$OUT/django-workload/django-workload/third_party"
 
 deactivate
 

--- a/packages/django_workload/install_django_workload_aarch64.sh
+++ b/packages/django_workload/install_django_workload_aarch64.sh
@@ -234,6 +234,11 @@ fi
 CPYTHON_INSTALL_PREFIX="${DJANGO_SERVER_ROOT}/Python-3.14.2/python-build"
 export LD_LIBRARY_PATH="${CPYTHON_INSTALL_PREFIX}/lib"
 
+# Register libpython system-wide so subprocesses spawned by
+# setuptools/pip can find it without LD_LIBRARY_PATH being set.
+echo "${CPYTHON_INSTALL_PREFIX}/lib" | tee /etc/ld.so.conf.d/python-bench.conf
+ldconfig
+
 echo "CPython 3.14 built successfully"
 
 # =====================================================================
@@ -432,7 +437,7 @@ fi
 
 # Install CinderX in Cinder virtual environment (already activated)
 cd "${DJANGO_SERVER_ROOT}/cinderx"
-python -m pip install -e .
+python -m pip install --no-build-isolation -e .
 
 # Validate CinderX installation
 echo "Validating CinderX installation..."
@@ -634,8 +639,8 @@ echo ""
 echo "Installing proxygen_binding in venv_cpython..."
 export LD_LIBRARY_PATH="${CPYTHON_INSTALL_PREFIX}/lib"
 cd "${DJANGO_WORKLOAD_ROOT}/proxygen_binding"
-"${DJANGO_SERVER_ROOT}/venv_cpython/bin/python" -m pip install pybind11
-"${DJANGO_SERVER_ROOT}/venv_cpython/bin/python" -m pip install -e .
+"${DJANGO_SERVER_ROOT}/venv_cpython/bin/python" -m pip install pybind11 wheel setuptools
+"${DJANGO_SERVER_ROOT}/venv_cpython/bin/python" -m pip install --no-build-isolation -e .
 echo "proxygen_binding installed in venv_cpython"
 
 # Build and install in venv_cinder
@@ -643,8 +648,8 @@ echo ""
 echo "Installing proxygen_binding in venv_cinder..."
 export LD_LIBRARY_PATH="${CINDER_INSTALL_PREFIX}/lib"
 cd "${DJANGO_WORKLOAD_ROOT}/proxygen_binding"
-"${DJANGO_SERVER_ROOT}/venv_cinder/bin/python" -m pip install pybind11
-"${DJANGO_SERVER_ROOT}/venv_cinder/bin/python" -m pip install -e .
+"${DJANGO_SERVER_ROOT}/venv_cinder/bin/python" -m pip install pybind11 wheel setuptools
+"${DJANGO_SERVER_ROOT}/venv_cinder/bin/python" -m pip install --no-build-isolation -e .
 echo "proxygen_binding installed in venv_cinder"
 
 # =====================================================================

--- a/packages/django_workload/install_django_workload_aarch64_ubuntu22.sh
+++ b/packages/django_workload/install_django_workload_aarch64_ubuntu22.sh
@@ -251,6 +251,11 @@ fi
 CPYTHON_INSTALL_PREFIX="${DJANGO_SERVER_ROOT}/Python-3.14.2/python-build"
 export LD_LIBRARY_PATH="${CPYTHON_INSTALL_PREFIX}/lib"
 
+# Register libpython system-wide so subprocesses spawned by
+# setuptools/pip can find it without LD_LIBRARY_PATH being set.
+echo "${CPYTHON_INSTALL_PREFIX}/lib" | tee /etc/ld.so.conf.d/python-bench.conf
+ldconfig
+
 echo "CPython 3.14 built successfully"
 
 # =====================================================================
@@ -451,7 +456,7 @@ fi
 
 # Install CinderX in Cinder virtual environment (already activated)
 cd "${DJANGO_SERVER_ROOT}/cinderx"
-python -m pip install -e .
+python -m pip install --no-build-isolation -e .
 
 # Validate CinderX installation
 echo "Validating CinderX installation..."
@@ -653,8 +658,8 @@ echo ""
 echo "Installing proxygen_binding in venv_cpython..."
 export LD_LIBRARY_PATH="${CPYTHON_INSTALL_PREFIX}/lib"
 cd "${DJANGO_WORKLOAD_ROOT}/proxygen_binding"
-"${DJANGO_SERVER_ROOT}/venv_cpython/bin/python" -m pip install pybind11
-"${DJANGO_SERVER_ROOT}/venv_cpython/bin/python" -m pip install -e .
+"${DJANGO_SERVER_ROOT}/venv_cpython/bin/python" -m pip install pybind11 wheel setuptools
+"${DJANGO_SERVER_ROOT}/venv_cpython/bin/python" -m pip install --no-build-isolation -e .
 echo "proxygen_binding installed in venv_cpython"
 
 # Build and install in venv_cinder
@@ -662,8 +667,8 @@ echo ""
 echo "Installing proxygen_binding in venv_cinder..."
 export LD_LIBRARY_PATH="${CINDER_INSTALL_PREFIX}/lib"
 cd "${DJANGO_WORKLOAD_ROOT}/proxygen_binding"
-"${DJANGO_SERVER_ROOT}/venv_cinder/bin/python" -m pip install pybind11
-"${DJANGO_SERVER_ROOT}/venv_cinder/bin/python" -m pip install -e .
+"${DJANGO_SERVER_ROOT}/venv_cinder/bin/python" -m pip install pybind11 wheel setuptools
+"${DJANGO_SERVER_ROOT}/venv_cinder/bin/python" -m pip install --no-build-isolation -e .
 echo "proxygen_binding installed in venv_cinder"
 
 # =====================================================================

--- a/packages/django_workload/install_django_workload_aarch64_ubuntu24.sh
+++ b/packages/django_workload/install_django_workload_aarch64_ubuntu24.sh
@@ -53,6 +53,50 @@ apt install -y memcached libmemcached-dev zlib1g-dev screen \
 
 echo "System dependencies installed successfully"
 
+# =====================================================================
+# Clean up stale libraries from /usr/local that other benchmarks may
+# have installed (e.g. FeedSim installs glog 0.4.0, gflags, libevent,
+# and jemalloc to /usr/local via "make install" without a prefix).
+#
+# These stale libraries cause ABI mismatches: proxygen_binding gets
+# compiled against old headers from /usr/local/include/ but links at
+# runtime against system libraries, resulting in undefined symbol errors
+# (e.g. google::kLogSiteUninitialized from glog, or
+# boost::match_results::maybe_assign from boost).
+#
+# We remove the stale shared libs, headers, cmake configs, and pkgconfig
+# files, then rebuild the linker cache so the system-installed versions
+# from /usr/lib/ and /usr/include/ are used instead.
+# =====================================================================
+echo ""
+echo "====================================================================="
+echo "Cleaning stale /usr/local libraries from other benchmarks"
+echo "====================================================================="
+
+# glog (FeedSim installs 0.4.0, conflicts with system 0.6.0)
+rm -f /usr/local/lib/libglog.so* 2>/dev/null || true
+rm -rf /usr/local/include/glog 2>/dev/null || true
+rm -rf /usr/local/lib/cmake/glog 2>/dev/null || true
+
+# gflags (FeedSim installs 2.2.2)
+rm -f /usr/local/lib/libgflags*.so* 2>/dev/null || true
+rm -rf /usr/local/include/gflags 2>/dev/null || true
+rm -rf /usr/local/lib/cmake/gflags 2>/dev/null || true
+rm -f /usr/local/lib/pkgconfig/gflags.pc 2>/dev/null || true
+
+# libevent (FeedSim installs 2.1)
+rm -f /usr/local/lib/libevent*.so* /usr/local/lib/libevent*.a /usr/local/lib/libevent*.la 2>/dev/null || true
+rm -f /usr/local/lib/pkgconfig/libevent*.pc 2>/dev/null || true
+
+# jemalloc (FeedSim installs 5.2/5.3)
+rm -f /usr/local/lib/libjemalloc*.so* /usr/local/lib/libjemalloc*.a 2>/dev/null || true
+rm -f /usr/local/lib/pkgconfig/jemalloc.pc 2>/dev/null || true
+
+# Rebuild linker cache so system libraries are resolved correctly
+ldconfig
+
+echo "Stale library cleanup completed"
+
 # Copy django-workload from srcs directory instead of cloning from GitHub
 mkdir -p "${DJANGO_WORKLOAD_ROOT}"
 pushd "${DJANGO_WORKLOAD_ROOT}"
@@ -257,6 +301,11 @@ fi
 CPYTHON_INSTALL_PREFIX="${DJANGO_SERVER_ROOT}/Python-3.10.2/python-build"
 export LD_LIBRARY_PATH="${CPYTHON_INSTALL_PREFIX}/lib"
 
+# Register libpython3.10.so system-wide so subprocesses spawned by
+# setuptools/pip can find it without LD_LIBRARY_PATH being set.
+echo "${CPYTHON_INSTALL_PREFIX}/lib" | tee /etc/ld.so.conf.d/python310-bench.conf
+ldconfig
+
 echo "CPython 3.10 built successfully"
 
 # =====================================================================
@@ -273,6 +322,12 @@ echo "====================================================================="
 mkdir -p "${DJANGO_SERVER_ROOT}/cinder/cinder-build/bin"
 ln -sf "${CPYTHON_INSTALL_PREFIX}/bin/python3.10" \
     "${DJANGO_SERVER_ROOT}/cinder/cinder-build/bin/python3.10"
+# benchmarks.yml install_markers expect python3.14; create aliases so checks pass
+ln -sf "${CPYTHON_INSTALL_PREFIX}/bin/python3.10" \
+    "${DJANGO_SERVER_ROOT}/cinder/cinder-build/bin/python3.14"
+mkdir -p "${DJANGO_SERVER_ROOT}/Python-3.14.2/python-build/bin"
+ln -sf "${CPYTHON_INSTALL_PREFIX}/bin/python3.10" \
+    "${DJANGO_SERVER_ROOT}/Python-3.14.2/python-build/bin/python3.14"
 
 echo "Cinder skipped (placeholder created for install marker)"
 
@@ -501,8 +556,8 @@ export PROXYGEN_INSTALL_DIR="${DJANGO_WORKLOAD_ROOT}/proxygen/staging"
 echo ""
 echo "Installing proxygen_binding in venv_cpython..."
 cd "${DJANGO_WORKLOAD_ROOT}/proxygen_binding"
-"${DJANGO_SERVER_ROOT}/venv_cpython/bin/python" -m pip install pybind11
-"${DJANGO_SERVER_ROOT}/venv_cpython/bin/python" -m pip install -e .
+"${DJANGO_SERVER_ROOT}/venv_cpython/bin/python" -m pip install pybind11 wheel setuptools
+"${DJANGO_SERVER_ROOT}/venv_cpython/bin/python" -m pip install --no-build-isolation -e .
 echo "proxygen_binding installed in venv_cpython"
 
 # =====================================================================

--- a/packages/django_workload/install_django_workload_x86_64_centos9.sh
+++ b/packages/django_workload/install_django_workload_x86_64_centos9.sh
@@ -236,6 +236,11 @@ fi
 CPYTHON_INSTALL_PREFIX="${DJANGO_SERVER_ROOT}/Python-3.14.2/python-build"
 export LD_LIBRARY_PATH="${CPYTHON_INSTALL_PREFIX}/lib"
 
+# Register libpython system-wide so subprocesses spawned by
+# setuptools/pip can find it without LD_LIBRARY_PATH being set.
+echo "${CPYTHON_INSTALL_PREFIX}/lib" | tee /etc/ld.so.conf.d/python-bench.conf
+ldconfig
+
 echo "CPython 3.14 built successfully"
 
 # =====================================================================
@@ -433,7 +438,7 @@ fi
 
 # Install CinderX in Cinder virtual environment (already activated)
 cd "${DJANGO_SERVER_ROOT}/cinderx"
-python -m pip install -e .
+python -m pip install --no-build-isolation -e .
 
 # Validate CinderX installation
 echo "Validating CinderX installation..."
@@ -635,8 +640,8 @@ echo ""
 echo "Installing proxygen_binding in venv_cpython..."
 export LD_LIBRARY_PATH="${CPYTHON_INSTALL_PREFIX}/lib"
 cd "${DJANGO_WORKLOAD_ROOT}/proxygen_binding"
-"${DJANGO_SERVER_ROOT}/venv_cpython/bin/python" -m pip install pybind11
-"${DJANGO_SERVER_ROOT}/venv_cpython/bin/python" -m pip install -e .
+"${DJANGO_SERVER_ROOT}/venv_cpython/bin/python" -m pip install pybind11 wheel setuptools
+"${DJANGO_SERVER_ROOT}/venv_cpython/bin/python" -m pip install --no-build-isolation -e .
 echo "proxygen_binding installed in venv_cpython"
 
 # Build and install in venv_cinder
@@ -644,8 +649,8 @@ echo ""
 echo "Installing proxygen_binding in venv_cinder..."
 export LD_LIBRARY_PATH="${CINDER_INSTALL_PREFIX}/lib"
 cd "${DJANGO_WORKLOAD_ROOT}/proxygen_binding"
-"${DJANGO_SERVER_ROOT}/venv_cinder/bin/python" -m pip install pybind11
-"${DJANGO_SERVER_ROOT}/venv_cinder/bin/python" -m pip install -e .
+"${DJANGO_SERVER_ROOT}/venv_cinder/bin/python" -m pip install pybind11 wheel setuptools
+"${DJANGO_SERVER_ROOT}/venv_cinder/bin/python" -m pip install --no-build-isolation -e .
 echo "proxygen_binding installed in venv_cinder"
 
 # =====================================================================

--- a/packages/django_workload/install_django_workload_x86_64_ubuntu22.sh
+++ b/packages/django_workload/install_django_workload_x86_64_ubuntu22.sh
@@ -454,7 +454,7 @@ fi
 
 # Install CinderX in Cinder virtual environment (already activated)
 cd "${DJANGO_SERVER_ROOT}/cinderx"
-python -m pip install -e .
+python -m pip install --no-build-isolation -e .
 
 # Validate CinderX installation
 echo "Validating CinderX installation..."
@@ -656,8 +656,8 @@ echo ""
 echo "Installing proxygen_binding in venv_cpython..."
 export LD_LIBRARY_PATH="${CPYTHON_INSTALL_PREFIX}/lib"
 cd "${DJANGO_WORKLOAD_ROOT}/proxygen_binding"
-"${DJANGO_SERVER_ROOT}/venv_cpython/bin/python" -m pip install pybind11
-"${DJANGO_SERVER_ROOT}/venv_cpython/bin/python" -m pip install -e .
+"${DJANGO_SERVER_ROOT}/venv_cpython/bin/python" -m pip install pybind11 wheel setuptools
+"${DJANGO_SERVER_ROOT}/venv_cpython/bin/python" -m pip install --no-build-isolation -e .
 echo "proxygen_binding installed in venv_cpython"
 
 # Build and install in venv_cinder
@@ -665,8 +665,8 @@ echo ""
 echo "Installing proxygen_binding in venv_cinder..."
 export LD_LIBRARY_PATH="${CINDER_INSTALL_PREFIX}/lib"
 cd "${DJANGO_WORKLOAD_ROOT}/proxygen_binding"
-"${DJANGO_SERVER_ROOT}/venv_cinder/bin/python" -m pip install pybind11
-"${DJANGO_SERVER_ROOT}/venv_cinder/bin/python" -m pip install -e .
+"${DJANGO_SERVER_ROOT}/venv_cinder/bin/python" -m pip install pybind11 wheel setuptools
+"${DJANGO_SERVER_ROOT}/venv_cinder/bin/python" -m pip install --no-build-isolation -e .
 echo "proxygen_binding installed in venv_cinder"
 
 # =====================================================================

--- a/packages/django_workload/srcs/proxygen_binding/setup.py
+++ b/packages/django_workload/srcs/proxygen_binding/setup.py
@@ -162,7 +162,14 @@ print(f"Include directories: {include_dirs}")
 print(f"Library directories: {library_dirs}")
 
 # Prepare compile arguments
-compile_args = ["-std=c++17", "-fPIC", "-g"]
+# GCC searches /usr/local/include *before* /usr/include by default.  Other
+# benchmarks (e.g. FeedSim) may install incompatible library headers there
+# (glog 0.4.0 vs system glog 0.6.0), causing ABI mismatches and undefined-
+# symbol errors at runtime.  Proxygen uses system glog/gflags, so we must
+# ensure the system headers in /usr/include are found first.  Adding an
+# explicit -I/usr/include makes GCC search it before its built-in path list
+# which contains /usr/local/include.
+compile_args = ["-std=c++17", "-fPIC", "-g", "-I/usr/include"]
 if custom_args.enable_debug:
     print("DEBUG MODE ENABLED: Adding -DPROXYGEN_BINDING_DEBUG")
     compile_args.append("-DPROXYGEN_BINDING_DEBUG")
@@ -190,6 +197,7 @@ ext_modules = [
             "boost_filesystem",
             "boost_system",
             "boost_context",
+            "boost_regex",
             "double-conversion",
             "event",
             "ssl",
@@ -216,9 +224,11 @@ ext_modules = [
         extra_link_args=[
             f"-L{library_dirs[0]}",
             "-Wl,-rpath," + str(library_dirs[0]),
-            # Add rpath for Boost libraries from DEPS_DIR
+            # Add rpath for Boost and glog libraries from DEPS_DIR
             f"-L{deps_dir}/lib",
             "-Wl,-rpath," + str(deps_dir / "lib"),
+            f"-L{deps_dir}/lib64",
+            "-Wl,-rpath," + str(deps_dir / "lib64"),
         ],
     ),
 ]


### PR DESCRIPTION
Summary:

setuptools 82+ (released on PyPI after D97857317 landed) deprecated setup.py develop
  and replaced it with a subprocess.check_call to pip install -e .. When pip 21.2.4
  (bundled with Python 3.10.2) runs pip install -e . for proxygen_binding, it creates a
  build isolation environment with the latest setuptools from PyPI. The new setuptools'
  develop command spawns a child process to run pip install -e ., but that child process
   fails with "No module named pip" because it runs outside the build isolation overlay
  and cannot resolve libpython3.10.so through the default linker path.

  Fix:
  1. Add --no-build-isolation to all pip install -e . invocations across all platform
  install scripts. This tells pip to use the venv's own setuptools instead of
  downloading the latest from PyPI, avoiding the deprecated develop subprocess path
  entirely.
  2. Pre-install wheel and setuptools alongside pybind11 before the --no-build-isolation
   install, since without build isolation pip no longer automatically provides these
  build dependencies.

  Affected scripts: install_django_workload_aarch64_ubuntu24.sh,
  install_django_workload_aarch64_ubuntu22.sh, install_django_workload_aarch64.sh,
  install_django_workload_x86_64_ubuntu22.sh, install_django_workload_x86_64_centos9.sh,
   install_django_workload.sh.

Reviewed By: ahmadelyoussef

Differential Revision: D99933809
