### PR TITLE
Fixed perf monitor CSV for dissapearing counters

### DIFF
--- a/benchpress/plugins/hooks/perf_monitors/__init__.py
+++ b/benchpress/plugins/hooks/perf_monitors/__init__.py
@@ -120,12 +120,16 @@ class Monitor:
             return ""
 
         csv_text = ""
-        headers = sorted(self.res[0].keys() - {"timestamp"})
+        all_keys = set()
+        for entry in self.res:
+            all_keys.update(entry.keys())
+        all_keys.discard("timestamp")
+        headers = sorted(all_keys)
         csv_text += "index,timestamp," + ",".join(headers) + "\n"
         for i in range(len(self.res)):
-            csv_text += f"{i},{self.res[i]['timestamp']},"
+            csv_text += f"{i},{self.res[i].get('timestamp', '')},"
             for key in headers:
-                csv_text += f"{self.res[i][key]},"
+                csv_text += f"{self.res[i].get(key, '')},"
             csv_text += "\n"
 
         return csv_text


### PR DESCRIPTION
Summary:
gen_csv() in the perf monitor base class built CSV headers from only the first sample's keys, then did hard dict[key] lookups on every subsequent sample. The NetStat monitor can remove counters mid-run (when a
net
 stats file disappears or is unsupported), so later samples end up with fewer keys than the first — boom, KeyError: 'eth0_rx_bytes_per_sec'.

Differential Revision: D100166271


