### PR TITLE
moving the breakdown.csv for feedsim

### DIFF
--- a/benchpress/config/jobs.yml
+++ b/benchpress/config/jobs.yml
@@ -692,6 +692,7 @@
           - 'benchmarks/feedsim/feedsim_results*.txt'
           - 'benchmarks/feedsim/feedsim-multi-inst-*.log'
           - 'benchmarks/feedsim/src/perf.data'
+          - 'benchmarks/feedsim/breakdown.csv'
           - '/tmp/feedsim_log.txt'
 
 - name: feedsim_autoscale_dlrm
@@ -825,6 +826,7 @@
           - 'benchmarks/feedsim/feedsim_results*.txt'
           - 'benchmarks/feedsim/feedsim-multi-inst-*.log'
           - 'benchmarks/feedsim/src/perf.data'
+          - 'benchmarks/feedsim/breakdown.csv'
           - '/tmp/feedsim_log.txt'
 
 - name: feedsim_autoscale_arm_mini


### PR DESCRIPTION
Summary: moving breakdown.csv to the metric folder

Differential Revision: D100246085


