### PR TITLE
cdn_bench: graceful shutdown, auto-terminate, and live metrics output (#576)

### DIFF
--- a/packages/cdn_bench/run.sh
+++ b/packages/cdn_bench/run.sh
@@ -157,9 +157,20 @@ cleanup() {
   echo "Cleaning up processes..."
   for pid in "${BG_PIDS[@]}"; do
     if [ -n "$pid" ] && kill -0 "$pid" 2>/dev/null; then
-      kill "$pid" 2>/dev/null || true
-      wait "$pid" 2>/dev/null || true
+      # Send SIGINT first (graceful shutdown — lets proxy flush metrics)
+      kill -INT "$pid" 2>/dev/null || true
     fi
+  done
+  # Give processes time to flush metrics and exit gracefully
+  sleep 2
+  for pid in "${BG_PIDS[@]}"; do
+    if [ -n "$pid" ] && kill -0 "$pid" 2>/dev/null; then
+      # Force kill if still running
+      kill -9 "$pid" 2>/dev/null || true
+    fi
+  done
+  for pid in "${BG_PIDS[@]}"; do
+    wait "$pid" 2>/dev/null || true
   done
   # Remove temp files matching our pattern
   rm -f "${SCRIPT_DIR}"/.content_stderr* "${SCRIPT_DIR}"/.proxy_stderr* "${SCRIPT_DIR}"/.client_stderr*
@@ -237,12 +248,12 @@ start_proxy_server() {
     --backend_servers="${backend_servers}"
     --backend_ports="${backend_ports}"
     --metrics_summary
-    --metrics_interval=0
+    --metrics_interval=5
   )
   if [ -n "$PLAINTEXT_PROTO" ]; then
     args+=(--backend_h2)
   fi
-  "${BIN_DIR}/proxy_server" "${args[@]}" 2>"${stderr_file}" &
+  "${BIN_DIR}/proxy_server" "${args[@]}" 2> >(tee -a "${stderr_file}" >&2) &
   local pid=$!
   BG_PIDS+=("$pid")
   echo "  proxy_server PID: ${pid} (port ${port})"
@@ -367,10 +378,19 @@ run_server() {
 
   echo ""
   echo "All content_server instances running. Waiting for termination signal..."
-  echo "Send SIGTERM or SIGINT to stop."
 
-  # Wait for any background process to exit (or signal)
-  wait
+  if [ -n "$DURATION" ] && [ "$DURATION" -gt 0 ] 2>/dev/null; then
+    local grace=20
+    local total=$((DURATION + grace))
+    echo "Auto-terminate in ${total}s (client duration ${DURATION}s + ${grace}s grace)."
+    sleep "$total"
+    echo ""
+    echo "Duration elapsed — terminating backend instances..."
+  else
+    echo "Send SIGTERM or SIGINT to stop."
+    # Wait for any background process to exit (or signal)
+    wait
+  fi
 }
 
 ###############################################################################
@@ -480,10 +500,36 @@ run_proxy() {
 
   echo ""
   echo "All proxy_server instances running. Waiting for termination signal..."
-  echo "Send SIGTERM or SIGINT to stop."
 
-  # Wait for any background process to exit (or signal)
-  wait || true
+  if [ -n "$DURATION" ] && [ "$DURATION" -gt 0 ] 2>/dev/null; then
+    local grace=10
+    local total=$((DURATION + grace))
+    echo "Auto-terminate in ${total}s (client duration ${DURATION}s + ${grace}s grace)."
+    sleep "$total"
+    echo ""
+    echo "Duration elapsed — stopping proxy instances gracefully..."
+    # Send SIGINT to proxy processes so they flush metrics summary
+    for pid in "${BG_PIDS[@]}"; do
+      if [ -n "$pid" ] && kill -0 "$pid" 2>/dev/null; then
+        kill -INT "$pid" 2>/dev/null || true
+      fi
+    done
+    sleep 2
+    for pid in "${BG_PIDS[@]}"; do
+    if [ -n "$pid" ] && kill -0 "$pid" 2>/dev/null; then
+      # Force kill if still running
+      kill -9 "$pid" 2>/dev/null || true
+    fi
+  done
+    # Wait for them to exit
+    for pid in "${BG_PIDS[@]}"; do
+      wait "$pid" 2>/dev/null || true
+    done
+  else
+    echo "Send SIGTERM or SIGINT to stop."
+    # Wait for any background process to exit (or signal)
+    wait || true
+  fi
 
   # Output proxy metrics for all instances
   echo ""
@@ -524,13 +570,58 @@ run_client() {
   IFS=',' read -ra TARGET_ARRAY <<< "$PROXY_TARGETS"
   local num_targets=${#TARGET_ARRAY[@]}
 
+  # =========================================================================
+  # Sanity check: verify all proxy targets are reachable before sending traffic
+  # =========================================================================
+  echo "====================================================================="
+  echo "Proxy Reachability Check"
+  echo "====================================================================="
+  local all_proxies_ok=true
+  for entry in "${TARGET_ARRAY[@]}"; do
+    entry="$(echo "$entry" | tr -d ' ')"
+    local port="${entry##*:}"
+    local host="${entry%:"$port"}"
+    echo -n "  Checking proxy ${host}:${port} ... "
+    if curl -sf --connect-timeout 5 -o /dev/null "http://[${host}]:${port}/" 2>/dev/null; then
+      echo "-> reachable"
+    elif curl -sf --connect-timeout 5 -o /dev/null --http2-prior-knowledge "http://[${host}]:${port}/" 2>/dev/null; then
+      echo "-> reachable (h2)"
+    else
+      echo "-x-> UNREACHABLE"
+      all_proxies_ok=false
+    fi
+  done
+  echo ""
+
+  if [ "$all_proxies_ok" = false ]; then
+    echo "====================================================================="
+    echo "ERROR: One or more proxy targets are not reachable!"
+    echo "====================================================================="
+    echo ""
+    echo "  Ensure proxy_server is running on the proxy host:"
+    echo "    ./run.sh -m proxy -B <backend_hosts> -b <backend_ports> -P <ports> -p ${PROTOCOL}"
+    echo ""
+    echo "  Then verify from this host:"
+    for entry in "${TARGET_ARRAY[@]}"; do
+      entry="$(echo "$entry" | tr -d ' ')"
+      local port="${entry##*:}"
+      local host="${entry%:"$port"}"
+      echo "    curl -sf http://[${host}]:${port}/"
+    done
+    echo ""
+    echo "Aborting client startup."
+    exit 1
+  fi
+  echo "All proxy targets reachable"
+  echo ""
+
   if [ "$num_targets" -eq 1 ]; then
     # Single target: run in foreground
     local entry="${TARGET_ARRAY[0]}"
     entry="$(echo "$entry" | tr -d ' ')"
     # IPv6-safe host:port parsing — port is the last colon-separated field if numeric
     local port="${entry##*:}"
-    local host="${entry%:$port}"
+    local host="${entry%:"$port"}"
 
     echo "Starting traffic_client..."
     echo "  Target: ${host}:${port}"
@@ -551,7 +642,7 @@ run_client() {
       entry="$(echo "$entry" | tr -d ' ')"
       # IPv6-safe host:port parsing
       local port="${entry##*:}"
-      local host="${entry%:$port}"
+      local host="${entry%:"$port"}"
 
       echo "Starting traffic_client instance ${idx} targeting ${host}:${port}..."
       run_traffic_client "${host}" "${port}" "${SCRIPT_DIR}/.client_stderr_${idx}" &

--- a/packages/cdn_bench/run.sh
+++ b/packages/cdn_bench/run.sh
@@ -204,6 +204,27 @@ start_content_server() {
 }
 
 ###############################################################################
+# Helper: verify content_server is serving requests (not just listening)
+###############################################################################
+verify_content_server() {
+  local host="$1"
+  local port="$2"
+  echo -n "  Probing content_server at ${host}:${port} ... "
+  local http_code
+  http_code=$(curl -sf --connect-timeout 5 -o /dev/null -w "%{http_code}" "http://[${host}]:${port}/" 2>/dev/null || echo "000")
+  if [ "$http_code" = "000" ]; then
+    echo "-x> no response (connection refused or timeout)"
+    return 1
+  elif [ "$http_code" -ge 200 ] && [ "$http_code" -lt 400 ]; then
+    echo "-> HTTP ${http_code}"
+    return 0
+  else
+    echo "-x>  HTTP ${http_code} (server responded but with error)"
+    return 0
+  fi
+}
+
+###############################################################################
 # Helper: start proxy_server instance
 ###############################################################################
 start_proxy_server() {
@@ -331,6 +352,19 @@ run_server() {
     wait_for_port "${port}"
   done
 
+  # Verify content_servers are actually serving responses
+  echo ""
+  echo "====================================================================="
+  echo "Content Server Health Check"
+  echo "====================================================================="
+  local hostname_ip
+  hostname_ip=$(hostname -I | awk '{print $1}')
+  for port in "${PORT_ARRAY[@]}"; do
+    port="$(echo "$port" | tr -d ' ')"
+    verify_content_server "::1" "${port}" || verify_content_server "${hostname_ip}" "${port}" || true
+  done
+  echo ""
+
   echo ""
   echo "All content_server instances running. Waiting for termination signal..."
   echo "Send SIGTERM or SIGINT to stop."
@@ -367,6 +401,64 @@ run_proxy() {
   echo "  Listen Ports: ${ports}"
   echo "  Backend Servers: ${backend_servers}"
   echo "  Backend Ports: ${backend_ports}"
+  echo ""
+
+  # =========================================================================
+  # Sanity check: verify all backends are reachable before starting proxies
+  # =========================================================================
+  echo "====================================================================="
+  echo "Backend Reachability Check"
+  echo "====================================================================="
+  IFS=',' read -ra BHOST_ARRAY <<< "$backend_servers"
+  IFS=',' read -ra BPORT_ARRAY <<< "$backend_ports"
+  local all_backends_ok=true
+  local checked=()
+
+  for i in "${!BHOST_ARRAY[@]}"; do
+    local bhost="${BHOST_ARRAY[$i]}"
+    local bport="${BPORT_ARRAY[$i]:-${BPORT_ARRAY[0]}}"
+    bhost="$(echo "$bhost" | tr -d ' ')"
+    bport="$(echo "$bport" | tr -d ' ')"
+    local key="${bhost}:${bport}"
+
+    # Skip duplicates (same host:port may appear multiple times for load balancing)
+    local already_checked=false
+    for c in "${checked[@]:-}"; do
+      [ "$c" = "$key" ] && already_checked=true && break
+    done
+    "$already_checked" && continue
+    checked+=("$key")
+
+    echo -n "  Checking backend ${bhost}:${bport} ... "
+    if curl -sf --connect-timeout 5 -o /dev/null "http://[${bhost}]:${bport}/" 2>/dev/null; then
+      echo "-> reachable"
+    else
+      echo "-x-> UNREACHABLE"
+      all_backends_ok=false
+    fi
+  done
+
+  echo ""
+  if [ "$all_backends_ok" = false ]; then
+    echo "====================================================================="
+    echo "ERROR: One or more backends are not reachable!"
+    echo "====================================================================="
+    echo ""
+    echo "  Ensure content_server is running on the backend host(s):"
+    echo "    ./benchpress -b ehw run cdn_bench --role server -i 1 \\"
+    echo "      --role_input='{\"ports\":\"${backend_ports}\",\"protocol\":\"${PROTOCOL}\"}'"
+    echo ""
+    echo "  Then verify from this host:"
+    for c in "${checked[@]}"; do
+      local h="${c%:*}"
+      local p="${c##*:}"
+      echo "    curl -sf http://[${h}]:${p}/"
+    done
+    echo ""
+    echo "Aborting proxy startup."
+    exit 1
+  fi
+  echo "All backends reachable"
   echo ""
 
   IFS=',' read -ra PORT_ARRAY <<< "$ports"
@@ -436,8 +528,9 @@ run_client() {
     # Single target: run in foreground
     local entry="${TARGET_ARRAY[0]}"
     entry="$(echo "$entry" | tr -d ' ')"
-    local host="${entry%:*}"
+    # IPv6-safe host:port parsing — port is the last colon-separated field if numeric
     local port="${entry##*:}"
+    local host="${entry%:$port}"
 
     echo "Starting traffic_client..."
     echo "  Target: ${host}:${port}"
@@ -456,8 +549,9 @@ run_client() {
     declare -a CLIENT_PIDS=()
     for entry in "${TARGET_ARRAY[@]}"; do
       entry="$(echo "$entry" | tr -d ' ')"
-      local host="${entry%:*}"
+      # IPv6-safe host:port parsing
       local port="${entry##*:}"
+      local host="${entry%:$port}"
 
       echo "Starting traffic_client instance ${idx} targeting ${host}:${port}..."
       run_traffic_client "${host}" "${port}" "${SCRIPT_DIR}/.client_stderr_${idx}" &


### PR DESCRIPTION
Summary:

Follow-up improvements to cdn_bench run.sh for operational ergonomics.

- Graceful proxy shutdown — sends SIGINT instead of SIGTERM so proxygen flushes its metrics summary before exit, with a 2s grace period before SIGKILL
- Auto-terminate for server and proxy roles when -d (duration) is passed, so long-running roles exit automatically after the client finishes (server: +20s grace, proxy: +10s grace)
- Client-side proxy reachability check — verifies all proxy targets respond (HTTP/1.1 and h2) before sending traffic, aborts with diagnostic info if unreachable
- Proxy stderr tee — proxy_server stderr is now tee'd to both terminal and file so metrics are visible during the run
- Changed metrics_interval from 0 to 5 for periodic metrics output during the run
- Minor quoting fix for IPv6 host:port variable expansion

Differential Revision: D100630922
