### PR TITLE
cdn_bench: multi-instance parser and scientific notation fix

### DIFF
--- a/benchpress/plugins/parsers/cdn_bench.py
+++ b/benchpress/plugins/parsers/cdn_bench.py
@@ -840,12 +840,24 @@ class CDNBenchParser(Parser):
 
         Expects structured key-value output from the cdn_bench run.sh script
         with sections: Configuration, Client Results, Proxy Results.
+        Accumulates metrics across multiple instances.
 
         Args:
             stdout: stdout lines from benchmark execution
             metrics: dictionary to store metrics
         """
         current_section: str = ""
+        client_instance: int = 0
+        proxy_instance: int = 0
+
+        # Accumulators for cross-instance totals
+        total_client_sent: int = 0
+        total_client_received: int = 0
+        total_client_errors: int = 0
+        total_client_resets: int = 0
+        total_proxy_received: int = 0
+        total_proxy_succeeded: int = 0
+        total_proxy_failed: int = 0
 
         for line in stdout:
             line = line.strip()
@@ -853,10 +865,12 @@ class CDNBenchParser(Parser):
             # Track sections
             if line == "Configuration":
                 current_section = "config"
-            elif line == "Client Results":
+            elif line.startswith("Client Results"):
                 current_section = "client"
-            elif line == "Proxy Results":
+                client_instance += 1
+            elif line.startswith("Proxy Results"):
                 current_section = "proxy"
+                proxy_instance += 1
             elif line.startswith("Benchmark Execution Complete"):
                 current_section = ""
 
@@ -891,39 +905,50 @@ class CDNBenchParser(Parser):
             elif current_section == "client":
                 if line.startswith("Requests Sent:"):
                     try:
-                        metrics["client_requests_sent"] = int(
-                            line.split(":", 1)[-1].strip()
-                        )
+                        val = int(line.split(":", 1)[-1].strip())
+                        metrics[f"client_{client_instance}_requests_sent"] = val
+                        total_client_sent += val
+                        metrics["client_requests_sent"] = total_client_sent
                     except ValueError:
                         pass
                 elif line.startswith("Responses Received:"):
                     try:
-                        metrics["client_responses_received"] = int(
-                            line.split(":", 1)[-1].strip()
-                        )
+                        val = int(line.split(":", 1)[-1].strip())
+                        metrics[f"client_{client_instance}_responses_received"] = val
+                        total_client_received += val
+                        metrics["client_responses_received"] = total_client_received
                     except ValueError:
                         pass
                 elif line.startswith("Errors:"):
                     try:
-                        metrics["client_errors"] = int(line.split(":", 1)[-1].strip())
+                        val = int(line.split(":", 1)[-1].strip())
+                        metrics[f"client_{client_instance}_errors"] = val
+                        total_client_errors += val
+                        metrics["client_errors"] = total_client_errors
                     except ValueError:
                         pass
                 elif line.startswith("Resets:"):
                     try:
-                        metrics["client_resets"] = int(line.split(":", 1)[-1].strip())
+                        val = int(line.split(":", 1)[-1].strip())
+                        metrics[f"client_{client_instance}_resets"] = val
+                        total_client_resets += val
+                        metrics["client_resets"] = total_client_resets
                     except ValueError:
                         pass
                 elif line.startswith("Elapsed Time ms:"):
                     try:
-                        metrics["client_elapsed_ms"] = int(
+                        metrics[f"client_{client_instance}_elapsed_ms"] = int(
                             line.split(":", 1)[-1].strip()
                         )
                     except ValueError:
                         pass
                 elif line.startswith("Actual RPS:"):
                     try:
-                        metrics["client_actual_rps"] = float(
-                            line.split(":", 1)[-1].strip()
+                        val = float(line.split(":", 1)[-1].strip())
+                        metrics[f"client_{client_instance}_actual_rps"] = val
+                        # Accumulate total RPS across instances
+                        metrics["client_actual_rps"] = (
+                            metrics.get("client_actual_rps", 0) + val
                         )
                     except ValueError:
                         pass
@@ -932,61 +957,82 @@ class CDNBenchParser(Parser):
             elif current_section == "proxy":
                 if line.startswith("Requests Received:"):
                     try:
-                        metrics["proxy_requests_received"] = int(
-                            line.split(":", 1)[-1].strip()
-                        )
+                        val = int(line.split(":", 1)[-1].strip())
+                        metrics[f"proxy_{proxy_instance}_requests_received"] = val
+                        total_proxy_received += val
+                        metrics["proxy_requests_received"] = total_proxy_received
                     except ValueError:
                         pass
                 elif line.startswith("Requests Succeeded:"):
                     try:
-                        metrics["proxy_requests_succeeded"] = int(
-                            line.split(":", 1)[-1].strip()
-                        )
+                        val = int(line.split(":", 1)[-1].strip())
+                        metrics[f"proxy_{proxy_instance}_requests_succeeded"] = val
+                        total_proxy_succeeded += val
+                        metrics["proxy_requests_succeeded"] = total_proxy_succeeded
                     except ValueError:
                         pass
                 elif line.startswith("Requests Failed:"):
                     try:
-                        metrics["proxy_requests_failed"] = int(
-                            line.split(":", 1)[-1].strip()
-                        )
+                        val = int(line.split(":", 1)[-1].strip())
+                        metrics[f"proxy_{proxy_instance}_requests_failed"] = val
+                        total_proxy_failed += val
+                        metrics["proxy_requests_failed"] = total_proxy_failed
                     except ValueError:
                         pass
                 elif line.startswith("Success Rate:"):
                     match = re.search(r"([\d.]+)", line.split(":", 1)[-1])
                     if match:
-                        metrics["proxy_success_rate_pct"] = float(match.group(1))
+                        metrics[f"proxy_{proxy_instance}_success_rate_pct"] = float(
+                            match.group(1)
+                        )
                 elif line.startswith("Actual RPS:"):
                     try:
-                        metrics["proxy_actual_rps"] = float(
-                            line.split(":", 1)[-1].strip()
+                        val = float(line.split(":", 1)[-1].strip())
+                        metrics[f"proxy_{proxy_instance}_actual_rps"] = val
+                        metrics["proxy_actual_rps"] = (
+                            metrics.get("proxy_actual_rps", 0) + val
                         )
                     except ValueError:
                         pass
                 elif line.startswith("Avg Total Latency ms:"):
                     try:
-                        metrics["proxy_avg_latency_ms"] = float(
+                        metrics[f"proxy_{proxy_instance}_avg_latency_ms"] = float(
                             line.split(":", 1)[-1].strip()
                         )
                     except ValueError:
                         pass
                 elif line.startswith("Avg Backend Latency ms:"):
                     try:
-                        metrics["proxy_avg_backend_latency_ms"] = float(
-                            line.split(":", 1)[-1].strip()
+                        metrics[f"proxy_{proxy_instance}_avg_backend_latency_ms"] = (
+                            float(line.split(":", 1)[-1].strip())
                         )
                     except ValueError:
                         pass
                 elif line.startswith("Retries Attempted:"):
                     try:
-                        metrics["proxy_retries_attempted"] = int(
+                        metrics[f"proxy_{proxy_instance}_retries_attempted"] = int(
                             line.split(":", 1)[-1].strip()
                         )
                     except ValueError:
                         pass
                 elif line.startswith("Retries Succeeded:"):
                     try:
-                        metrics["proxy_retries_succeeded"] = int(
+                        metrics[f"proxy_{proxy_instance}_retries_succeeded"] = int(
                             line.split(":", 1)[-1].strip()
                         )
                     except ValueError:
                         pass
+
+        # Store instance counts
+        metrics["client_instances"] = client_instance
+        metrics["proxy_instances"] = proxy_instance
+
+        # Compute aggregate success rate
+        if total_proxy_received > 0:
+            metrics["proxy_success_rate_pct"] = (
+                total_proxy_succeeded / total_proxy_received * 100
+            )
+        if total_client_sent > 0:
+            metrics["client_error_rate_pct"] = (
+                total_client_errors / total_client_sent * 100
+            )

--- a/packages/cdn_bench/run.sh
+++ b/packages/cdn_bench/run.sh
@@ -291,7 +291,7 @@ parse_client_stderr() {
     errors=$(grep -oP 'Errors: \K[0-9]+' "$stderr_file" | tail -1 || echo "0")
     resets=$(grep -oP 'Resets: \K[0-9]+' "$stderr_file" | tail -1 || echo "0")
     elapsed_ms=$(grep -oP 'Elapsed time: \K[0-9]+' "$stderr_file" | tail -1 || echo "0")
-    actual_rps=$(grep -oP 'Actual RPS: \K[0-9.]+' "$stderr_file" | tail -1 || echo "0")
+    actual_rps=$(grep -oP 'Actual RPS: \K[0-9.eE+\-]+' "$stderr_file" | tail -1 || echo "0")
     echo "  ${prefix}Requests Sent: ${requests_sent}"
     echo "  ${prefix}Responses Received: ${responses_received}"
     echo "  ${prefix}Errors: ${errors}"
@@ -312,17 +312,17 @@ parse_proxy_stderr() {
     req_recv=$(grep -oP 'Requests Received: \K[0-9]+' "$stderr_file" | tail -1 || echo "0")
     req_succ=$(grep -oP 'Requests Succeeded: \K[0-9]+' "$stderr_file" | tail -1 || echo "0")
     req_fail=$(grep -oP 'Requests Failed: \K[0-9]+' "$stderr_file" | tail -1 || echo "0")
-    success_rate=$(grep -oP 'Success Rate: \K[0-9.]+' "$stderr_file" | tail -1 || echo "0")
-    actual_rps=$(grep -oP 'Actual RPS: \K[0-9.]+' "$stderr_file" | tail -1 || echo "0")
-    avg_latency=$(grep -oP 'Avg Total Latency: \K[0-9.]+' "$stderr_file" | tail -1 || echo "0")
-    backend_latency=$(grep -oP 'Avg Backend Latency: \K[0-9.]+' "$stderr_file" | tail -1 || echo "0")
+    success_rate=$(grep -oP 'Success Rate: \K[0-9.eE+\-]+' "$stderr_file" | tail -1 || echo "0")
+    actual_rps=$(grep -oP 'Actual RPS: \K[0-9.eE+\-]+' "$stderr_file" | tail -1 || echo "0")
+    avg_latency=$(grep -oP 'Avg Total Latency: \K[0-9.eE+\-]+' "$stderr_file" | tail -1 || echo "0")
+    backend_latency=$(grep -oP 'Avg Backend Latency: \K[0-9.eE+\-]+' "$stderr_file" | tail -1 || echo "0")
     retries_attempted=$(grep -oP 'Retries Attempted: \K[0-9]+' "$stderr_file" | tail -1 || echo "0")
     retries_succeeded=$(grep -oP 'Retries Succeeded: \K[0-9]+' "$stderr_file" | tail -1 || echo "0")
     echo "  ${prefix}Requests Received: ${req_recv}"
     echo "  ${prefix}Requests Succeeded: ${req_succ}"
     echo "  ${prefix}Requests Failed: ${req_fail}"
-    echo "  ${prefix}Success Rate: ${success_rate}%"
-    echo "  ${prefix}Actual RPS: ${actual_rps}"
+    echo "  ${prefix}Success Rate: $(printf '%.2f' "$success_rate")%"
+    echo "  ${prefix}Actual RPS: $(printf '%.1f' "$actual_rps")"
     echo "  ${prefix}Avg Total Latency ms: ${avg_latency}"
     echo "  ${prefix}Avg Backend Latency ms: ${backend_latency}"
     echo "  ${prefix}Retries Attempted: ${retries_attempted}"

--- a/packages/cdn_bench/run.sh
+++ b/packages/cdn_bench/run.sh
@@ -157,9 +157,20 @@ cleanup() {
   echo "Cleaning up processes..."
   for pid in "${BG_PIDS[@]}"; do
     if [ -n "$pid" ] && kill -0 "$pid" 2>/dev/null; then
-      kill "$pid" 2>/dev/null || true
-      wait "$pid" 2>/dev/null || true
+      # Send SIGINT first (graceful shutdown — lets proxy flush metrics)
+      kill -INT "$pid" 2>/dev/null || true
     fi
+  done
+  # Give processes time to flush metrics and exit gracefully
+  sleep 2
+  for pid in "${BG_PIDS[@]}"; do
+    if [ -n "$pid" ] && kill -0 "$pid" 2>/dev/null; then
+      # Force kill if still running
+      kill -9 "$pid" 2>/dev/null || true
+    fi
+  done
+  for pid in "${BG_PIDS[@]}"; do
+    wait "$pid" 2>/dev/null || true
   done
   # Remove temp files matching our pattern
   rm -f "${SCRIPT_DIR}"/.content_stderr* "${SCRIPT_DIR}"/.proxy_stderr* "${SCRIPT_DIR}"/.client_stderr*
@@ -237,12 +248,12 @@ start_proxy_server() {
     --backend_servers="${backend_servers}"
     --backend_ports="${backend_ports}"
     --metrics_summary
-    --metrics_interval=0
+    --metrics_interval=5
   )
   if [ -n "$PLAINTEXT_PROTO" ]; then
     args+=(--backend_h2)
   fi
-  "${BIN_DIR}/proxy_server" "${args[@]}" 2>"${stderr_file}" &
+  "${BIN_DIR}/proxy_server" "${args[@]}" 2> >(tee -a "${stderr_file}" >&2) &
   local pid=$!
   BG_PIDS+=("$pid")
   echo "  proxy_server PID: ${pid} (port ${port})"
@@ -367,10 +378,19 @@ run_server() {
 
   echo ""
   echo "All content_server instances running. Waiting for termination signal..."
-  echo "Send SIGTERM or SIGINT to stop."
 
-  # Wait for any background process to exit (or signal)
-  wait
+  if [ -n "$DURATION" ] && [ "$DURATION" -gt 0 ] 2>/dev/null; then
+    local grace=20
+    local total=$((DURATION + grace))
+    echo "Auto-terminate in ${total}s (client duration ${DURATION}s + ${grace}s grace)."
+    sleep "$total"
+    echo ""
+    echo "Duration elapsed — terminating backend instances..."
+  else
+    echo "Send SIGTERM or SIGINT to stop."
+    # Wait for any background process to exit (or signal)
+    wait
+  fi
 }
 
 ###############################################################################
@@ -480,10 +500,36 @@ run_proxy() {
 
   echo ""
   echo "All proxy_server instances running. Waiting for termination signal..."
-  echo "Send SIGTERM or SIGINT to stop."
 
-  # Wait for any background process to exit (or signal)
-  wait || true
+  if [ -n "$DURATION" ] && [ "$DURATION" -gt 0 ] 2>/dev/null; then
+    local grace=10
+    local total=$((DURATION + grace))
+    echo "Auto-terminate in ${total}s (client duration ${DURATION}s + ${grace}s grace)."
+    sleep "$total"
+    echo ""
+    echo "Duration elapsed — stopping proxy instances gracefully..."
+    # Send SIGINT to proxy processes so they flush metrics summary
+    for pid in "${BG_PIDS[@]}"; do
+      if [ -n "$pid" ] && kill -0 "$pid" 2>/dev/null; then
+        kill -INT "$pid" 2>/dev/null || true
+      fi
+    done
+    sleep 2
+    for pid in "${BG_PIDS[@]}"; do
+    if [ -n "$pid" ] && kill -0 "$pid" 2>/dev/null; then
+      # Force kill if still running
+      kill -9 "$pid" 2>/dev/null || true
+    fi
+  done
+    # Wait for them to exit
+    for pid in "${BG_PIDS[@]}"; do
+      wait "$pid" 2>/dev/null || true
+    done
+  else
+    echo "Send SIGTERM or SIGINT to stop."
+    # Wait for any background process to exit (or signal)
+    wait || true
+  fi
 
   # Output proxy metrics for all instances
   echo ""
@@ -524,13 +570,58 @@ run_client() {
   IFS=',' read -ra TARGET_ARRAY <<< "$PROXY_TARGETS"
   local num_targets=${#TARGET_ARRAY[@]}
 
+  # =========================================================================
+  # Sanity check: verify all proxy targets are reachable before sending traffic
+  # =========================================================================
+  echo "====================================================================="
+  echo "Proxy Reachability Check"
+  echo "====================================================================="
+  local all_proxies_ok=true
+  for entry in "${TARGET_ARRAY[@]}"; do
+    entry="$(echo "$entry" | tr -d ' ')"
+    local port="${entry##*:}"
+    local host="${entry%:"$port"}"
+    echo -n "  Checking proxy ${host}:${port} ... "
+    if curl -sf --connect-timeout 5 -o /dev/null "http://[${host}]:${port}/" 2>/dev/null; then
+      echo "-> reachable"
+    elif curl -sf --connect-timeout 5 -o /dev/null --http2-prior-knowledge "http://[${host}]:${port}/" 2>/dev/null; then
+      echo "-> reachable (h2)"
+    else
+      echo "-x-> UNREACHABLE"
+      all_proxies_ok=false
+    fi
+  done
+  echo ""
+
+  if [ "$all_proxies_ok" = false ]; then
+    echo "====================================================================="
+    echo "ERROR: One or more proxy targets are not reachable!"
+    echo "====================================================================="
+    echo ""
+    echo "  Ensure proxy_server is running on the proxy host:"
+    echo "    ./run.sh -m proxy -B <backend_hosts> -b <backend_ports> -P <ports> -p ${PROTOCOL}"
+    echo ""
+    echo "  Then verify from this host:"
+    for entry in "${TARGET_ARRAY[@]}"; do
+      entry="$(echo "$entry" | tr -d ' ')"
+      local port="${entry##*:}"
+      local host="${entry%:"$port"}"
+      echo "    curl -sf http://[${host}]:${port}/"
+    done
+    echo ""
+    echo "Aborting client startup."
+    exit 1
+  fi
+  echo "All proxy targets reachable"
+  echo ""
+
   if [ "$num_targets" -eq 1 ]; then
     # Single target: run in foreground
     local entry="${TARGET_ARRAY[0]}"
     entry="$(echo "$entry" | tr -d ' ')"
     # IPv6-safe host:port parsing — port is the last colon-separated field if numeric
     local port="${entry##*:}"
-    local host="${entry%:$port}"
+    local host="${entry%:"$port"}"
 
     echo "Starting traffic_client..."
     echo "  Target: ${host}:${port}"
@@ -551,7 +642,7 @@ run_client() {
       entry="$(echo "$entry" | tr -d ' ')"
       # IPv6-safe host:port parsing
       local port="${entry##*:}"
-      local host="${entry%:$port}"
+      local host="${entry%:"$port"}"
 
       echo "Starting traffic_client instance ${idx} targeting ${host}:${port}..."
       run_traffic_client "${host}" "${port}" "${SCRIPT_DIR}/.client_stderr_${idx}" &

--- a/packages/cdn_bench/run.sh
+++ b/packages/cdn_bench/run.sh
@@ -204,6 +204,27 @@ start_content_server() {
 }
 
 ###############################################################################
+# Helper: verify content_server is serving requests (not just listening)
+###############################################################################
+verify_content_server() {
+  local host="$1"
+  local port="$2"
+  echo -n "  Probing content_server at ${host}:${port} ... "
+  local http_code
+  http_code=$(curl -sf --connect-timeout 5 -o /dev/null -w "%{http_code}" "http://[${host}]:${port}/" 2>/dev/null || echo "000")
+  if [ "$http_code" = "000" ]; then
+    echo "-x> no response (connection refused or timeout)"
+    return 1
+  elif [ "$http_code" -ge 200 ] && [ "$http_code" -lt 400 ]; then
+    echo "-> HTTP ${http_code}"
+    return 0
+  else
+    echo "-x>  HTTP ${http_code} (server responded but with error)"
+    return 0
+  fi
+}
+
+###############################################################################
 # Helper: start proxy_server instance
 ###############################################################################
 start_proxy_server() {
@@ -331,6 +352,19 @@ run_server() {
     wait_for_port "${port}"
   done
 
+  # Verify content_servers are actually serving responses
+  echo ""
+  echo "====================================================================="
+  echo "Content Server Health Check"
+  echo "====================================================================="
+  local hostname_ip
+  hostname_ip=$(hostname -I | awk '{print $1}')
+  for port in "${PORT_ARRAY[@]}"; do
+    port="$(echo "$port" | tr -d ' ')"
+    verify_content_server "::1" "${port}" || verify_content_server "${hostname_ip}" "${port}" || true
+  done
+  echo ""
+
   echo ""
   echo "All content_server instances running. Waiting for termination signal..."
   echo "Send SIGTERM or SIGINT to stop."
@@ -367,6 +401,64 @@ run_proxy() {
   echo "  Listen Ports: ${ports}"
   echo "  Backend Servers: ${backend_servers}"
   echo "  Backend Ports: ${backend_ports}"
+  echo ""
+
+  # =========================================================================
+  # Sanity check: verify all backends are reachable before starting proxies
+  # =========================================================================
+  echo "====================================================================="
+  echo "Backend Reachability Check"
+  echo "====================================================================="
+  IFS=',' read -ra BHOST_ARRAY <<< "$backend_servers"
+  IFS=',' read -ra BPORT_ARRAY <<< "$backend_ports"
+  local all_backends_ok=true
+  local checked=()
+
+  for i in "${!BHOST_ARRAY[@]}"; do
+    local bhost="${BHOST_ARRAY[$i]}"
+    local bport="${BPORT_ARRAY[$i]:-${BPORT_ARRAY[0]}}"
+    bhost="$(echo "$bhost" | tr -d ' ')"
+    bport="$(echo "$bport" | tr -d ' ')"
+    local key="${bhost}:${bport}"
+
+    # Skip duplicates (same host:port may appear multiple times for load balancing)
+    local already_checked=false
+    for c in "${checked[@]:-}"; do
+      [ "$c" = "$key" ] && already_checked=true && break
+    done
+    "$already_checked" && continue
+    checked+=("$key")
+
+    echo -n "  Checking backend ${bhost}:${bport} ... "
+    if curl -sf --connect-timeout 5 -o /dev/null "http://[${bhost}]:${bport}/" 2>/dev/null; then
+      echo "-> reachable"
+    else
+      echo "-x-> UNREACHABLE"
+      all_backends_ok=false
+    fi
+  done
+
+  echo ""
+  if [ "$all_backends_ok" = false ]; then
+    echo "====================================================================="
+    echo "ERROR: One or more backends are not reachable!"
+    echo "====================================================================="
+    echo ""
+    echo "  Ensure content_server is running on the backend host(s):"
+    echo "    ./benchpress -b ehw run cdn_bench --role server -i 1 \\"
+    echo "      --role_input='{\"ports\":\"${backend_ports}\",\"protocol\":\"${PROTOCOL}\"}'"
+    echo ""
+    echo "  Then verify from this host:"
+    for c in "${checked[@]}"; do
+      local h="${c%:*}"
+      local p="${c##*:}"
+      echo "    curl -sf http://[${h}]:${p}/"
+    done
+    echo ""
+    echo "Aborting proxy startup."
+    exit 1
+  fi
+  echo "All backends reachable"
   echo ""
 
   IFS=',' read -ra PORT_ARRAY <<< "$ports"
@@ -436,8 +528,9 @@ run_client() {
     # Single target: run in foreground
     local entry="${TARGET_ARRAY[0]}"
     entry="$(echo "$entry" | tr -d ' ')"
-    local host="${entry%:*}"
+    # IPv6-safe host:port parsing — port is the last colon-separated field if numeric
     local port="${entry##*:}"
+    local host="${entry%:$port}"
 
     echo "Starting traffic_client..."
     echo "  Target: ${host}:${port}"
@@ -456,8 +549,9 @@ run_client() {
     declare -a CLIENT_PIDS=()
     for entry in "${TARGET_ARRAY[@]}"; do
       entry="$(echo "$entry" | tr -d ' ')"
-      local host="${entry%:*}"
+      # IPv6-safe host:port parsing
       local port="${entry##*:}"
+      local host="${entry%:$port}"
 
       echo "Starting traffic_client instance ${idx} targeting ${host}:${port}..."
       run_traffic_client "${host}" "${port}" "${SCRIPT_DIR}/.client_stderr_${idx}" &


### PR DESCRIPTION
Summary:
Two fixes found while running multi-proxy CDN benchmarks on Gen10+/Gen11 edge hosts:

**cdn_bench.py parser — multi-instance support:**
- Section headers now match with startswith() instead of exact ==, so 'Client Results (instance 0, target ...)' is correctly detected
- Per-instance metrics stored as client_1_requests_sent, proxy_2_actual_rps etc
- Aggregate totals accumulated across instances (client_requests_sent = sum of all instances)
- Computed aggregate success/error rates and instance counts
```
  "metrics": {
    "client_instances": 0,
    "exit_code": 0,
    "protocol": "h1",
    "proxy_1_actual_rps": 4000.0,
    "proxy_1_avg_backend_latency_ms": 176.534,
    "proxy_1_avg_latency_ms": 177.0,
    "proxy_1_requests_failed": 0,
    "proxy_1_requests_received": 280356,
    "proxy_1_requests_succeeded": 280356,
    "proxy_1_retries_attempted": 0,
    "proxy_1_retries_succeeded": 0,
    "proxy_1_success_rate_pct": 100.0,
    "proxy_2_actual_rps": 4000.0,
    "proxy_2_avg_backend_latency_ms": 175.723,
    "proxy_2_avg_latency_ms": 176.0,
    "proxy_2_requests_failed": 0,
    "proxy_2_requests_received": 285273,
    "proxy_2_requests_succeeded": 285273,
    "proxy_2_retries_attempted": 0,
    "proxy_2_retries_succeeded": 0,
    "proxy_2_success_rate_pct": 100.0,
    "proxy_actual_rps": 8000.0,
    "proxy_instances": 2,
    "proxy_requests_failed": 0,
    "proxy_requests_received": 565629,
    "proxy_requests_succeeded": 565629,
    "proxy_success_rate_pct": 100.0
  },
```
**run.sh — scientific notation handling:**
- Proxy metrics regex updated to match scientific notation (e.g. 5e+03 was parsed as just 5)
- printf formatting for Success Rate (%.2f) and Actual RPS (%.1f) so 1e+02 displays as 100.00%
```
        Proxy Results (instance 0, port 8081)
          Requests Received: 276720
          Requests Succeeded: 276719
          Requests Failed: 1
          Success Rate: 100.00%
          Actual RPS: 4000.0
          Avg Total Latency ms: 180
          Avg Backend Latency ms: 180.095
          Retries Attempted: 0
          Retries Succeeded: 0

        Proxy Role Complete

        Cleaning up processes...
stderr:

Results Report:
{
  "benchmark_args": [
    "-m proxy",
    "-B 2401:db00:f01b:301d:face:0:18f:0",
    "-b 8080",
    "-P 8081",
    "-p h1"
  ],
  "benchmark_desc": "Distributed CDN benchmark. Run server, proxy, and client roles on separate hosts. Supports multiple instances of each role for scaling.\n",
  "benchmark_hooks": [
    "perf: {'perfstat': {'interval': 1}, 'mpstat': {'interval': 1}, 'netstat': {'interval': 1}}",
    "copymove: {'is_move': True, 'after': ['packages/cdn_bench/cdn_bench_run.log']}"
  ],
  "benchmark_name": "cdn_bench",
  "machines": [
    {
      "cpu_architecture": "x86_64",
      "cpu_model": "INTEL(R) XEON(R) PLATINUM 8558P",
      "hostname": "fnedge932.01.ams2.facebook.com",
      "kernel_version": "6.4.3-0_fbk15_hardened_2630_gf27365f948db",
      "mem_total_kib": "525701232 KiB",
      "num_cpus_usable": 96,
      "num_logical_cpus": "96",
      "os_distro": "centos",
      "os_release_name": "CentOS Stream 9",
      "threads_per_core": "2"
    }
  ],
  "metadata": {
    "L1d cache": "2.3 MiB (48 instances)",
    "L1i cache": "1.5 MiB (48 instances)",
    "L2 cache": "96 MiB (48 instances)",
    "L3 cache": "260 MiB (1 instance)"
  },
  "metrics": {
    "client_instances": 0,
    "exit_code": 0,
    "protocol": "h1",
    "proxy_1_actual_rps": 4000.0,
    "proxy_1_avg_backend_latency_ms": 180.095,
    "proxy_1_avg_latency_ms": 180.0,
    "proxy_1_requests_failed": 1,
    "proxy_1_requests_received": 276720,
    "proxy_1_requests_succeeded": 276719,
    "proxy_1_retries_attempted": 0,
    "proxy_1_retries_succeeded": 0,
    "proxy_1_success_rate_pct": 100.0,
    "proxy_actual_rps": 4000.0,
    "proxy_instances": 1,
    "proxy_requests_failed": 1,
    "proxy_requests_received": 276720,
    "proxy_requests_succeeded": 276719,
    "proxy_success_rate_pct": 99.99963862387973
  },
```

Reviewed By: YifanYuan3

Differential Revision: D100658456


