### PR TITLE
Add dr_trace library to DCPerf and hook CHM benchmark (#578)

### DIFF
--- a/packages/ai_wdl/chm/CMakeLists.txt
+++ b/packages/ai_wdl/chm/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.10)
-project(ChmBench LANGUAGES CXX)
+project(ChmBench LANGUAGES C CXX)
 set(CMAKE_CXX_COMPILER "g++")
 
 
@@ -15,3 +15,14 @@ add_executable(chm_bench ChmBenchmark.cpp)
 
 
 target_link_libraries(chm_bench PRIVATE Folly::folly)
+
+# Optional DynamoRIO tracing support
+option(ENABLE_DR_TRACE "Enable DynamoRIO tracing hooks" OFF)
+if(ENABLE_DR_TRACE)
+  add_subdirectory(${CMAKE_SOURCE_DIR}/dr_trace ${CMAKE_BINARY_DIR}/dr_trace)
+  target_link_libraries(chm_bench PRIVATE dr_trace)
+  # drsyms stubs must be compiled directly into the binary (not inside
+  # libdr_trace.a) so they resolve references from --whole-archive
+  # drmemtrace_drstatic before the linker finishes.
+  target_sources(chm_bench PRIVATE ${CMAKE_SOURCE_DIR}/dr_trace/drsyms_stubs.c)
+endif()

--- a/packages/ai_wdl/chm/ChmBenchmark.cpp
+++ b/packages/ai_wdl/chm/ChmBenchmark.cpp
@@ -33,6 +33,10 @@
 
 #include "./ConcurrentHashMap.h"
 
+#ifdef DR_TRACE_INCLUDED
+#include "dr_trace.h"
+#endif
+
 // Command line flags
 DEFINE_string(distribution_file, "", "Path to the distribution CSV file");
 DEFINE_int32(num_threads, 4, "Number of worker threads per batch");
@@ -689,7 +693,16 @@ int main(int argc, char* argv[]) {
 
   // Execute benchmark and display results
   chm_benchmark::ChmBenchmark benchmark(*distributionOpt, config);
+
+#ifdef DR_TRACE_INCLUDED
+  trace_configure_env();
+  trace_start();
+#endif
   auto results = benchmark.run();
+#ifdef DR_TRACE_INCLUDED
+  trace_stop();
+#endif
+
   chm_benchmark::ChmBenchmark::printResults(results);
 
   return 0;

--- a/packages/ai_wdl/chm/README.md
+++ b/packages/ai_wdl/chm/README.md
@@ -64,3 +64,15 @@ After the benchmark finished, benchpress will report the results in JSON format 
 ```
 
 The key metrics is the throughput which is measure as `Mops/sec`.
+
+
+## Run `chm` with tracing
+
+To enable DynamoRIO tracing with chm, set ENABLE_DR_TRACE=1 when installing. This builds DynamoRIO from source (~5 min) and statically links it into the benchmark binary. DynamoRIO will be built under chm's build directory. After doing this, the binary will be instrumented with DynamoRIO and will write traces to /tmp/drmemtrace_out/ by default. Tracing starts and stops automatically around the benchmark workload:
+
+```
+ENABLE_DR_TRACE=1 ./benchpress_cli.py -b ai install chm_a -f
+./benchpress_cli.py -b ai run chm_a
+```
+
+Note that multi-threaded workloads produce large traces (100+ GB/min), so you may want to run trace_configure() to limit the size and duration of the trace. See dr_trace's README for more details.

--- a/packages/ai_wdl/chm/install_chm.sh
+++ b/packages/ai_wdl/chm/install_chm.sh
@@ -66,13 +66,11 @@ install_system_dependencies() {
     # Ubuntu
     echo "Detected Ubuntu system, installing Ubuntu dependencies"
     sudo apt-get update
-    sudo apt-get install -y libssl-dev
-    sudo apt-get install -y clang
+    sudo apt-get install -y libssl-dev clang
   elif command -v dnf >/dev/null 2>&1; then
     # CentOS
     echo "Detected CentOS system, installing CentOS dependencies"
-    sudo dnf install -y openssl-devel
-    sudo dnf install -y clang
+    sudo dnf install -y openssl-devel clang
   else
     echo "ERROR: This script only supports Ubuntu (apt-get) and CentOS (dnf)"
     exit 1
@@ -161,8 +159,20 @@ build_benchmark() {
   cp "${BPKGS_CHM_ROOT}/model_a.dist" "${BENCHMARKS_DIR}"
   cp "${BPKGS_CHM_ROOT}/model_b.dist" "${BENCHMARKS_DIR}"
 
+  # Optionally set up DynamoRIO tracing support
+  DR_TRACE_FLAGS=""
+  if [ "${ENABLE_DR_TRACE:-0}" = "1" ]; then
+    echo "[DR_TRACE] Setting up DynamoRIO tracing support..."
+    cp -r "${BPKGS_CHM_ROOT}/../../common/dr_trace" "${BUILD_DIR}/dr_trace"
+    # shellcheck disable=SC1091
+    source "${BUILD_DIR}/dr_trace/install_dynamorio.sh"
+    # shellcheck disable=SC2154
+    DR_TRACE_FLAGS="-DENABLE_DR_TRACE=ON -DDR_INSTALL=${DR_INSTALL}"
+  fi
+
   # Configure CMake for optimized release build
-  cmake -DCMAKE_CXX_FLAGS="-O3 -g1" .
+  # shellcheck disable=SC2086
+  cmake -DCMAKE_CXX_FLAGS="-O3 -g1" ${DR_TRACE_FLAGS} .
 
   # Build using all available cores
   make -j

--- a/packages/common/dr_trace/CMakeLists.txt
+++ b/packages/common/dr_trace/CMakeLists.txt
@@ -1,0 +1,84 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+cmake_minimum_required(VERSION 3.10)
+
+# DR_INSTALL must point to the DynamoRIO install prefix (contains
+# include/, lib64/, ext/, tools/ directories).  Set by the parent
+# project or via -DDR_INSTALL=... on the cmake command line.
+if(NOT DR_INSTALL)
+  message(FATAL_ERROR
+    "DR_INSTALL must be set to the DynamoRIO install directory. "
+    "Run install_dynamorio.sh first, then pass -DDR_INSTALL=<path>.")
+endif()
+
+find_package(glog REQUIRED)
+
+# --- dr_trace library ---------------------------------------------------
+add_library(dr_trace STATIC dr_trace.cpp dr_trace.h)
+target_include_directories(dr_trace PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
+target_compile_definitions(dr_trace PUBLIC DR_TRACE_INCLUDED=1)
+target_include_directories(dr_trace PUBLIC
+  ${DR_INSTALL}/include
+  ${DR_INSTALL}/ext/include
+  ${DR_INSTALL}/tools/include/drmemtrace)
+
+# --- Import DynamoRIO static libraries -----------------------------------
+# We use the _drstatic variants of all extension libraries and
+# drmemtrace_drstatic.  This avoids pulling in drsyms (and its bundled
+# elfutils which has missing arch-backend objects in DynamoRIO's pre-built
+# releases and source-built installs alike).  The consumer binary must
+# compile drsyms_stubs.c to satisfy the residual drsym_* references.
+
+add_library(dynamorio_static STATIC IMPORTED)
+set_target_properties(dynamorio_static PROPERTIES
+  IMPORTED_LOCATION ${DR_INSTALL}/lib64/release/libdynamorio_static.a)
+
+add_library(drlibc STATIC IMPORTED)
+set_target_properties(drlibc PROPERTIES
+  IMPORTED_LOCATION ${DR_INSTALL}/lib64/libdrlibc.a)
+
+add_library(drmemtrace_drstatic STATIC IMPORTED)
+set_target_properties(drmemtrace_drstatic PROPERTIES
+  IMPORTED_LOCATION ${DR_INSTALL}/tools/lib64/release/libdrmemtrace_drstatic.a)
+
+add_library(drcontainers_drstatic STATIC IMPORTED)
+set_target_properties(drcontainers_drstatic PROPERTIES
+  IMPORTED_LOCATION ${DR_INSTALL}/ext/lib64/release/libdrcontainers_drstatic.a)
+
+# Extension libraries (all _drstatic variants, excluding drsyms).
+# drpttracer is x86-only (Intel Processor Trace).
+set(DR_EXT_LIBS
+  drutil drmgr drreg drsyscall drcovlib drwrap
+  drstatecmp drx drbbdup drsyscall_record_lib)
+if(CMAKE_SYSTEM_PROCESSOR STREQUAL "x86_64")
+  list(APPEND DR_EXT_LIBS drpttracer)
+endif()
+
+foreach(lib ${DR_EXT_LIBS})
+  add_library(${lib}_drstatic STATIC IMPORTED)
+  set_target_properties(${lib}_drstatic PROPERTIES
+    IMPORTED_LOCATION ${DR_INSTALL}/ext/lib64/release/lib${lib}_drstatic.a)
+endforeach()
+
+# --- Link order ----------------------------------------------------------
+# drmemtrace_drstatic and dynamorio_static must be linked with
+# --whole-archive so that DR's client init (dr_client_main) and
+# the tracing callbacks are not stripped by the linker.
+
+target_link_libraries(dr_trace
+  -Wl,--whole-archive drmemtrace_drstatic -Wl,--no-whole-archive
+  drcontainers_drstatic)
+foreach(lib ${DR_EXT_LIBS})
+  target_link_libraries(dr_trace ${lib}_drstatic)
+endforeach()
+target_link_libraries(dr_trace
+  -Wl,--whole-archive dynamorio_static drlibc -Wl,--no-whole-archive
+  -Wl,--allow-multiple-definition
+  -Wl,--as-needed
+  -rdynamic
+  -Wl,--defsym,dynamorio_so_start=__executable_start
+  -Wl,--defsym,dynamorio_so_end=end
+  glog::glog z lz4 snappy dl pthread)

--- a/packages/common/dr_trace/README.md
+++ b/packages/common/dr_trace/README.md
@@ -1,0 +1,112 @@
+# dr_trace — DynamoRIO Tracing Library
+
+Lightweight C++ library that provides programmatic start/stop control over
+[DynamoRIO](https://dynamorio.org/) memory tracing (`drmemtrace`). Designed
+for embedding into benchmarks so that traces can be collected on demand without
+modifying the benchmark's normal execution path.
+
+DynamoRIO must be statically linked into the final binary (Dynamic linking has
+limitations resolving if code belongs to the app or DynamoRIO). Output traces
+can be analyzed with DynamoRIO tools like `drraw2trace` and `drcachesim`.
+
+## Quick start
+
+Adding is simple. Include `dr_trace.h`, then use one of the provided hooks to start/stop
+tracing. By using `#ifdef DR_TRACE_INCLUDED` guards around tracing calls, the application
+can run without any overhead when built without DynamoRIO.
+
+Optionally, use `trace_configure()` before initialization to set trace length limits, the
+output directory, the verbosity of output, and other options. See `dr_trace.h` for details.
+
+```cpp
+#ifdef DR_TRACE_INCLUDED
+#include "dr_trace.h"
+#endif
+
+// ... setup, warmup, etc ...
+
+#ifdef DR_TRACE_INCLUDED
+DrTraceConfig cfg;
+cfg.outdir = "/data/traces/my_workload";
+cfg.max_trace_seconds = 60;  // watchdog: auto-stop after 60s
+trace_configure(cfg);
+
+trace_start();
+#endif
+
+run_workload();
+
+#ifdef DR_TRACE_INCLUDED
+trace_stop();
+#endif
+```
+
+## Profiling modes
+
+| Function | Trigger | Use case |
+|---|---|---|
+| `trace_start()` / `trace_stop()` | Direct | Bracket a known code region |
+| `trace_execution_pipe()` | `echo 30 > <outdir>/dr_trace_trigger` | Profile a running service on demand |
+| `trace_execution_delay<S,D>()` | Timer | Skip S sec startup, then profile D sec |
+| `trace_execution_roi<N,D>()` | ROI counter | Skip N kernel calls, then profile D sec |
+
+### Direct start/stop
+
+`trace_start()` and `trace_stop()` are convenience wrappers around
+`trace_init()` + `trace_begin()` and `trace_end()`. Use these to bracket
+a known code region inline.
+
+### Pipe-triggered
+
+`trace_execution_pipe()` creates a named pipe at `<outdir>/dr_trace_trigger`
+and blocks until a trigger is written. Run it in a background thread:
+
+```cpp
+std::thread bg(trace_execution_pipe);
+// ... application runs ...
+// In another terminal:
+//   echo 30 > /tmp/drmemtrace_out/dr_trace_trigger   # trace for 30 seconds
+//   echo go > /tmp/drmemtrace_out/dr_trace_trigger   # trace for 10s (default)
+bg.join();
+```
+
+### Delay-based
+
+`trace_execution_delay<S, D>()` sleeps for `S` seconds (letting the
+application warm up), then traces for `D` seconds. Template parameters are
+compile-time constants to ensure reproducible methodology across runs.
+
+```cpp
+std::thread bg(trace_execution_delay<30, 10>);
+bg.join();
+```
+
+### ROI-based
+
+`trace_execution_roi<N, D>()` waits for `N` calls to `trace_roi_hit()`,
+then traces for `D` seconds. Insert `trace_roi_hit()` at the start of the
+kernel you want to trace:
+
+```cpp
+std::thread bg(trace_execution_roi<100, 10>);
+while (running) { trace_roi_hit(); run_kernel(); }
+bg.join();
+```
+
+## Building with CMake
+
+```bash
+# Set DynamoRIO_DIR to the cmake/ directory inside a DynamoRIO install
+cmake -DENABLE_DR_TRACE=ON -DDynamoRIO_DIR=/path/to/dynamorio/cmake ..
+make
+```
+
+The benchmark's `CMakeLists.txt` should conditionally include dr_trace:
+
+```cmake
+option(ENABLE_DR_TRACE "Enable DynamoRIO tracing hooks" OFF)
+if(ENABLE_DR_TRACE)
+  add_subdirectory(${CMAKE_SOURCE_DIR}/dr_trace ${CMAKE_BINARY_DIR}/dr_trace)
+  target_link_libraries(my_benchmark PRIVATE dr_trace)
+endif()
+```

--- a/packages/common/dr_trace/dr_trace.cpp
+++ b/packages/common/dr_trace/dr_trace.cpp
@@ -1,0 +1,244 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * dr_trace.cpp - DynamoRIO Trace Instrumentation
+ *
+ * Implementation of dr_trace.h, see header for more details.
+ */
+
+#include "dr_trace.h"
+
+#include <cerrno>
+#include <chrono>
+#include <cstdio>
+#include <cstring>
+#include <ctime>
+#include <string>
+
+/* ---- Global configuration ---- */
+
+// NOLINTNEXTLINE(facebook-avoid-non-const-global-variables)
+static DrTraceConfig g_config;
+// NOLINTNEXTLINE(facebook-avoid-non-const-global-variables)
+static std::atomic<bool> g_tracing_active{false};
+// NOLINTNEXTLINE(facebook-avoid-non-const-global-variables)
+std::atomic<bool> dr_trace_roi_log{true};
+// NOLINTNEXTLINE(facebook-avoid-non-const-global-variables)
+std::atomic<uint32_t> dr_trace_roi_count{0};
+
+void trace_configure(const DrTraceConfig& config) {
+  g_config = config;
+}
+
+void trace_configure_env(void) {
+  DrTraceConfig cfg;
+
+  const char* val = getenv("DR_TRACE_OUTDIR");
+  if (val != nullptr) {
+    cfg.outdir = val;
+  }
+
+  val = getenv("DR_TRACE_VERBOSE");
+  if (val != nullptr) {
+    cfg.verbose = atoi(val);
+  }
+
+  val = getenv("DR_TRACE_IGNORE_ASSERTS");
+  if (val != nullptr) {
+    cfg.ignore_asserts = (atoi(val) != 0);
+  }
+
+  val = getenv("DR_TRACE_MAX_TRACE_SECONDS");
+  if (val != nullptr) {
+    cfg.max_trace_seconds = static_cast<uint32_t>(atoi(val));
+  }
+
+  g_config = cfg;
+}
+
+/* ---- Forward Declarations ---- */
+
+void trace_init(void);
+void trace_begin(void);
+void trace_end(void);
+void trace_start_watchdog(void);
+
+/* ---- Direct start/stop hooks ---- */
+
+void trace_start(void) {
+  trace_init();
+  trace_begin();
+}
+
+void trace_stop(void) {
+  trace_end();
+}
+
+/* ---- Pipe-triggered hooks ---- */
+
+static void write_trace_info(const char* outdir, uint32_t duration_secs) {
+  std::string path = std::string(outdir) + "/trace_info.txt";
+  FILE* f = fopen(path.c_str(), "w");
+  if (!f) {
+    return;
+  }
+
+  time_t now = time(nullptr);
+  struct tm tm_buf{};
+  localtime_r(&now, &tm_buf);
+  char timebuf[64];
+  strftime(timebuf, sizeof(timebuf), "%Y-%m-%d %H:%M:%S", &tm_buf);
+
+  fprintf(f, "trace_start_time: %s\n", timebuf);
+  fprintf(f, "trace_duration_secs: %u\n", duration_secs);
+  fprintf(f, "outdir: %s\n", outdir);
+  fclose(f);
+}
+
+void trace_execution_pipe(void) {
+  trace_init();
+
+  std::string pipe_path = std::string(g_config.outdir) + "/dr_trace_trigger";
+  unlink(pipe_path.c_str());
+  if (mkfifo(pipe_path.c_str(), 0644) != 0 && errno != EEXIST) {
+    LOG(ERROR) << "Failed to create trigger pipe " << pipe_path
+               << " (errno=" << errno << ")";
+    return;
+  }
+  LOG(INFO) << "Waiting for trace trigger: echo [duration_secs] > "
+            << pipe_path;
+
+  uint32_t duration = 10;
+  {
+    int fd = open(pipe_path.c_str(), O_RDONLY);
+    if (fd < 0) {
+      LOG(ERROR) << "Failed to open trigger pipe " << pipe_path
+                 << " (errno=" << errno << ")";
+      unlink(pipe_path.c_str());
+      return;
+    }
+    char buf[64] = {};
+    read(fd, buf, sizeof(buf) - 1);
+    close(fd);
+    unlink(pipe_path.c_str());
+
+    int parsed = atoi(buf);
+    if (parsed > 0) {
+      duration = static_cast<uint32_t>(parsed);
+    }
+  }
+  LOG(INFO) << "Trace trigger received! Duration: " << duration << " seconds";
+
+  write_trace_info(g_config.outdir, duration);
+
+  trace_begin();
+  // NOLINTNEXTLINE(facebook-hte-BadCall-sleep)
+  sleep(duration);
+  trace_end();
+}
+
+/* ---- Support for ROI hooks ---- */
+
+void trace_roi_hit(void) {
+  if (dr_trace_roi_log.load(std::memory_order_relaxed)) {
+    dr_trace_roi_count.fetch_add(1, std::memory_order_relaxed);
+  }
+}
+
+/* ---- Core functions ---- */
+
+// Create output directory and set DYNAMORIO_OPTIONS env var from
+// DrTraceConfig. If DYNAMORIO_OPTIONS is already set, it is left
+// unchanged. Safe to call multiple times.
+void trace_init(void) {
+  mkdir(g_config.outdir, 0755);
+
+  if (getenv("DYNAMORIO_OPTIONS") != nullptr) {
+    return;
+  }
+
+  std::string opts =
+      "-rstats_to_stderr -no_hook_vsyscall"
+      " -disable_traces -no_enable_reset";
+
+  if (g_config.ignore_asserts) {
+    opts +=
+        " -ignore_assert_list"
+        " '/mnt/srcs/dynamorio/core/unix/os.c:10307"
+        ";/mnt/srcs/dynamorio/core/unix/os.c:557'";
+  }
+
+  opts +=
+      " -client_lib ';;-offline"
+      " -verbose " +
+      std::to_string(g_config.verbose) + " -outdir " + g_config.outdir + "'";
+
+  int result = setenv("DYNAMORIO_OPTIONS", opts.c_str(), 1);
+  CHECK_EQ(result, 0) << "Failed to set DYNAMORIO_OPTIONS";
+}
+
+// Start DynamoRIO instrumentation. Idempotent: no-op if already tracing.
+// Spawns a watchdog thread (before DR) if max_trace_seconds > 0.
+void trace_begin(void) {
+  bool expected = false;
+  if (!g_tracing_active.compare_exchange_strong(expected, true)) {
+    LOG(WARNING) << "trace_begin() called while already tracing — ignoring";
+    return;
+  }
+
+  // Spawn watchdog BEFORE dr_app_setup_and_start() — creating threads while
+  // DR is active causes "Failed to take over all threads" errors.
+  if (g_config.max_trace_seconds > 0) {
+    trace_start_watchdog();
+  }
+
+  LOG(INFO) << "Starting tracing...";
+  dr_app_setup_and_start();
+  CHECK(dr_app_running_under_dynamorio())
+      << "Failed to start DynamoRIO instrumentation";
+  LOG(INFO) << "Running under DR " << std::boolalpha
+            << dr_app_running_under_dynamorio();
+}
+
+// Stop DynamoRIO instrumentation. Idempotent: no-op if not tracing.
+// Safe against concurrent calls (watchdog + explicit stop).
+void trace_end(void) {
+  bool expected = true;
+  if (!g_tracing_active.compare_exchange_strong(expected, false)) {
+    LOG(WARNING) << "trace_end() called while not tracing — ignoring";
+    return;
+  }
+
+  LOG(INFO) << "Stopping tracing...";
+  dr_app_stop_and_cleanup();
+  LOG(INFO) << "Stopped tracing.";
+}
+
+/* ---- Watchdog ---- */
+
+// Start watchdog thread to stop tracing when time limit is reached.
+void trace_start_watchdog(void) {
+  uint32_t timeout = g_config.max_trace_seconds;
+  if (timeout == 0) {
+    return;
+  }
+
+  std::thread watchdog([timeout] {
+    // NOLINTNEXTLINE(facebook-hte-BadCall-sleep_for)
+    std::this_thread::sleep_for(std::chrono::seconds(timeout));
+    bool exp = true;
+    if (g_tracing_active.compare_exchange_strong(exp, false)) {
+      LOG(WARNING) << "Trace auto-stopped after " << timeout
+                   << "s (watchdog timeout)";
+      dr_app_stop_and_cleanup();
+      LOG(INFO) << "Stopped tracing.";
+    }
+  });
+  // NOLINTNEXTLINE(facebook-hte-BadCall-detach)
+  watchdog.detach();
+}

--- a/packages/common/dr_trace/dr_trace.h
+++ b/packages/common/dr_trace/dr_trace.h
@@ -1,0 +1,204 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * dr_trace.h - DynamoRIO Trace Instrumentation
+ *
+ * Provides several tracing methods for use with drmemtrace_static.
+ * All methods produce offline traces in an output directory.
+ *
+ * Methods:
+ *   trace_start() / trace_stop()       - Direct start/stop at code locations
+ *   trace_execution_pipe()             - Wait for pipe trigger, parse duration
+ *   trace_execution_delay<S,D>()       - Wait S seconds, trace for D seconds
+ *   trace_execution_roi<N,D>()         - Wait for N ROI hits, trace D seconds
+ *
+ * Configuration:
+ *   If DYNAMORIO_OPTIONS is already set in the environment, it takes
+ *   precedence over all configuration. Call trace_configure() before
+ *   any tracing function to customize the output directory, verbosity,
+ *   or assertion handling. If not called, defaults are used.
+ *
+ * Safety:
+ *   trace_begin() and trace_end() are safe by default:
+ *   - trace_begin() is idempotent: calling it while already tracing is a
+ *     no-op (logs a warning).
+ *   - trace_end() is idempotent: calling it without a matching
+ *     trace_begin(), or calling it twice, is a no-op (logs a warning).
+ *   - If max_trace_seconds > 0, trace_begin() spawns a watchdog thread
+ *     that auto-stops tracing after the timeout. This prevents runaway
+ *     traces from filling disk (traces are 100+ GB for multi-threaded
+ *     workloads). The watchdog and trace_end() use an atomic CAS to
+ *     ensure only one of them actually stops tracing.
+ */
+
+#pragma once
+
+// DynamoRIO requires target OS and architecture macros before inclusion.
+#define LINUX 1
+#if defined(__x86_64__)
+#define X86_64 1
+#elif defined(__aarch64__)
+#define ARM_64 1
+#endif
+
+#include <dr_api.h>
+#include <fcntl.h>
+#include <glog/logging.h>
+#include <sys/stat.h>
+#include <unistd.h>
+#include <atomic>
+#include <chrono>
+#include <csignal>
+#include <cstdint>
+#include <cstdlib>
+#include <thread>
+
+/* ---- Configuration ---- */
+
+struct DrTraceConfig {
+  const char* outdir = "/tmp/drmemtrace_out";
+  int verbose = 3;
+  bool ignore_asserts = true;
+  uint32_t max_trace_seconds =
+      0; // watchdog timeout in seconds (0 = no timeout)
+};
+
+/**
+ * Overrides default tracing configuration.
+ * Call before any tracing function.
+ */
+void trace_configure(const DrTraceConfig& config);
+
+/**
+ * Configure tracing from environment variables.
+ * Reads DR_TRACE_OUTDIR, DR_TRACE_VERBOSE, DR_TRACE_IGNORE_ASSERTS,
+ * and DR_TRACE_MAX_TRACE_SECONDS. Unset variables keep their defaults.
+ */
+void trace_configure_env(void);
+
+/**
+ * Create output directory and set DYNAMORIO_OPTIONS from DrTraceConfig.
+ * Safe to call multiple times. Call before trace_begin().
+ */
+void trace_init(void);
+
+/**
+ * Start DynamoRIO instrumentation.
+ * Idempotent: no-op if already tracing.
+ * Spawns a watchdog thread if max_trace_seconds > 0.
+ * The watchdog is spawned BEFORE DR starts (creating threads while DR is
+ * active causes "Failed to take over all threads" errors).
+ */
+void trace_begin(void);
+
+/**
+ * Stop DynamoRIO instrumentation.
+ * Idempotent: no-op if not currently tracing. Safe against concurrent
+ * calls (e.g. watchdog + explicit stop).
+ */
+void trace_end(void);
+
+/* ---- Direct start/stop ---- */
+
+/**
+ * Convenience wrapper: trace_init() + trace_begin().
+ */
+void trace_start(void);
+
+/**
+ * Convenience wrapper: trace_end().
+ */
+void trace_stop(void);
+
+/* ---- Pipe-triggered (background thread) ---- */
+
+/**
+ * Wait for an external trigger via named pipe, then trace.
+ *
+ * Usage:
+ *   std::thread bg(trace_execution_pipe);
+ *   // ... application runs ...
+ *   // In another terminal:
+ *   //   echo 30 > <outdir>/dr_trace_trigger   # trace for 30 seconds
+ *   //   echo go > <outdir>/dr_trace_trigger   # trace for 10 seconds (default)
+ *   bg.join();
+ *
+ * The pipe input is parsed as a duration in seconds. Non-numeric input
+ * (e.g. "go") defaults to 10 seconds. The actual duration is recorded
+ * in <outdir>/trace_info.txt.
+ */
+void trace_execution_pipe(void);
+
+/* ---- Delay-based (background thread) ---- */
+
+/**
+ * Wait StartDelaySeconds, then trace for TraceDurationSeconds.
+ *
+ * Template parameters are compile-time constants to ensure any two
+ * traces from the same binary use the exact same methodology.
+ *
+ * Usage:
+ *   std::thread bg(trace_execution_delay<30, 10>);
+ *   bg.join();
+ */
+template <uint32_t StartDelaySeconds, uint32_t TraceDurationSeconds>
+void trace_execution_delay(void) {
+  trace_init();
+
+  LOG(INFO) << "Sleeping for " << StartDelaySeconds
+            << " seconds before starting tracing...";
+  // NOLINTNEXTLINE(facebook-hte-BadCall-sleep_for)
+  std::this_thread::sleep_for(std::chrono::seconds(StartDelaySeconds));
+
+  trace_begin();
+  // NOLINTNEXTLINE(facebook-hte-BadCall-sleep_for)
+  std::this_thread::sleep_for(std::chrono::seconds(TraceDurationSeconds));
+  trace_end();
+}
+
+/* ---- ROI-based (background thread) ---- */
+
+// NOLINTNEXTLINE(facebook-avoid-non-const-global-variables)
+extern std::atomic<uint32_t> dr_trace_roi_count;
+// NOLINTNEXTLINE(facebook-avoid-non-const-global-variables)
+extern std::atomic<bool> dr_trace_roi_log;
+
+/**
+ * Increment the ROI counter. Call at the start of kernels to trace.
+ */
+void trace_roi_hit(void);
+
+/**
+ * Wait for StartROICount ROI hits, then trace for TraceDurationSeconds.
+ *
+ * Template parameters are compile-time constants to ensure any two
+ * traces from the same binary use the exact same methodology.
+ *
+ * Usage:
+ *   std::thread bg(trace_execution_roi<100, 10>);
+ *   while (running) { trace_roi_hit(); run_kernel(); }
+ *   bg.join();
+ */
+template <uint32_t StartROICount, uint32_t TraceDurationSeconds>
+void trace_execution_roi(void) {
+  trace_init();
+
+  LOG(INFO) << "Waiting for " << StartROICount
+            << " ROI hits before starting tracing...";
+
+  while (dr_trace_roi_count.load(std::memory_order_relaxed) < StartROICount) {
+    // NOLINTNEXTLINE(facebook-hte-BadCall-sleep_for)
+    std::this_thread::sleep_for(std::chrono::milliseconds(10));
+  }
+  dr_trace_roi_log.store(false, std::memory_order_relaxed);
+
+  trace_begin();
+  // NOLINTNEXTLINE(facebook-hte-BadCall-sleep_for)
+  std::this_thread::sleep_for(std::chrono::seconds(TraceDurationSeconds));
+  trace_end();
+}

--- a/packages/common/dr_trace/drsyms_stubs.c
+++ b/packages/common/dr_trace/drsyms_stubs.c
@@ -1,0 +1,86 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * drsyms_stubs.c - Stub drsyms functions for OSS/CMake builds
+ *
+ * When using drmemtrace_drstatic (the no-elfutils variant of drmemtrace),
+ * drsyms symbols are still referenced but never called for offline tracing.
+ * These stubs satisfy the linker without pulling in elfutils, which has
+ * missing arch backend objects in DynamoRIO's bundled build.
+ *
+ * Not needed for internal Buck builds — the tp2 dynamorio package provides
+ * drmemtrace_drstatic_nosyms which excludes drsyms entirely.
+ */
+
+#include <stddef.h>
+
+/* All functions return DRSYM_ERROR (1) to indicate failure. This is safe
+ * because drmemtrace's offline tracer never calls drsyms for symbol
+ * resolution — it only records raw addresses. */
+int drsym_init(int shmid) {
+  return 1;
+}
+int drsym_exit(void) {
+  return 1;
+}
+int drsym_lookup_symbol(
+    void* mod,
+    const char* sym,
+    size_t* off,
+    unsigned int flags) {
+  return 1;
+}
+int drsym_lookup_address(
+    void* mod,
+    size_t off,
+    void* info,
+    unsigned int flags) {
+  return 1;
+}
+int drsym_enumerate_symbols(
+    void* mod,
+    void* cb,
+    void* data,
+    unsigned int flags) {
+  return 1;
+}
+int drsym_get_type(
+    void* mod,
+    size_t off,
+    unsigned int levels,
+    void* buf,
+    size_t sz) {
+  return 1;
+}
+int drsym_get_func_type(void* mod, size_t off, void* buf, size_t sz) {
+  return 1;
+}
+int drsym_expand_type(
+    void* mod,
+    unsigned int idx,
+    unsigned int levels,
+    void* buf,
+    size_t sz) {
+  return 1;
+}
+int drsym_demangle_symbol(
+    char* dst,
+    size_t dstsz,
+    const char* mangled,
+    unsigned int flags) {
+  return 1;
+}
+int drsym_get_module_debug_kind(void* mod, void* kind) {
+  return 1;
+}
+int drsym_module_has_symbols(void* mod) {
+  return 1;
+}
+int drsym_free_resources(void* mod) {
+  return 1;
+}

--- a/packages/common/dr_trace/install_dynamorio.sh
+++ b/packages/common/dr_trace/install_dynamorio.sh
@@ -1,0 +1,104 @@
+#!/bin/bash
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+# install_dynamorio.sh: Build DynamoRIO from source
+#
+# This script is meant to be sourced by benchmark install scripts.
+# It clones DynamoRIO at a pinned version, builds it, and installs
+# it to $BUILD_DIR/dynamorio.
+#
+# Prerequisites:
+#   - BUILD_DIR must be set to the benchmark's build directory
+#   - cmake, git, and a C/C++ compiler must be available
+#   - sudo access (to install system dependencies)
+#
+# After sourcing:
+#   - DR_INSTALL is exported, pointing to the DynamoRIO install prefix
+#   - DynamoRIO binaries (drraw2trace, drrun, etc.) are at $DR_INSTALL/tools/bin64/
+
+# ---- Prerequisite checks ----
+
+fail() {
+  echo "[DR_TRACE] ERROR: $1" >&2
+  return 1 2>/dev/null || exit 1
+}
+
+if [ -z "${BUILD_DIR}" ]; then
+  fail "BUILD_DIR is not set. Set it to the benchmark's build directory."
+fi
+
+if [ ! -d "${BUILD_DIR}" ]; then
+  fail "BUILD_DIR='${BUILD_DIR}' does not exist."
+fi
+
+for cmd in cmake git; do
+  if ! command -v "${cmd}" >/dev/null 2>&1; then
+    fail "'${cmd}' is not installed or not in PATH."
+  fi
+done
+
+# Check for a working C++ compiler (cmake will fail late with a cryptic error)
+if ! command -v c++ >/dev/null 2>&1 && ! command -v g++ >/dev/null 2>&1 && ! command -v clang++ >/dev/null 2>&1; then
+  fail "No C++ compiler found (need c++, g++, or clang++ in PATH)."
+fi
+
+# ---- Build configuration ----
+
+# Pinned DynamoRIO version (cronbuild tag from GitHub)
+DR_VERSION="11.90.20482"
+DR_TAG="cronbuild-${DR_VERSION}"
+
+DR_SRC="${BUILD_DIR}/dynamorio_src"
+DR_INSTALL="${BUILD_DIR}/dynamorio"
+
+# Skip if already built
+if [ -f "${DR_INSTALL}/cmake/DynamoRIOConfig.cmake" ]; then
+  echo "[DR_TRACE] DynamoRIO already installed at: ${DR_INSTALL}"
+  export DR_INSTALL
+  export DynamoRIO_DIR="${DR_INSTALL}/cmake"
+  # shellcheck disable=SC2317  # exit 0 is reachable when script is executed (not sourced)
+  return 0 2>/dev/null || exit 0
+fi
+
+echo "[DR_TRACE] Building DynamoRIO ${DR_VERSION} from source..."
+
+# Install system dependencies for DynamoRIO and dr_trace
+echo "[DR_TRACE] Installing system dependencies..."
+if command -v apt-get >/dev/null 2>&1; then
+  sudo apt-get install -y -qq libelf-dev zlib1g-dev liblz4-dev libsnappy-dev
+elif command -v dnf >/dev/null 2>&1; then
+  sudo dnf install -y -q elfutils-libelf-devel zlib-devel lz4-devel snappy-devel
+fi
+
+# Clone with submodules (elfutils is a submodule required by drsyms)
+if [ ! -d "${DR_SRC}" ]; then
+  echo "[DR_TRACE] Cloning DynamoRIO..."
+  git clone --depth 1 --recursive --branch "${DR_TAG}" \
+    https://github.com/DynamoRIO/dynamorio.git "${DR_SRC}"
+fi
+
+# Build
+echo "[DR_TRACE] Configuring DynamoRIO..."
+mkdir -p "${DR_SRC}/build"
+cmake -S "${DR_SRC}" -B "${DR_SRC}/build" \
+  -DCMAKE_BUILD_TYPE=Release \
+  -DCMAKE_INSTALL_PREFIX="${DR_INSTALL}" \
+  -DBUILD_SAMPLES=OFF \
+  -DBUILD_TESTS=OFF \
+  -DBUILD_DOCS=OFF
+
+echo "[DR_TRACE] Compiling DynamoRIO (this may take several minutes)..."
+cmake --build "${DR_SRC}/build" --parallel "$(nproc)"
+
+echo "[DR_TRACE] Installing DynamoRIO..."
+cmake --install "${DR_SRC}/build"
+
+# Export for CMake
+export DR_INSTALL
+export DynamoRIO_DIR="${DR_INSTALL}/cmake"
+
+echo "[DR_TRACE] DynamoRIO installed at: ${DR_INSTALL}"
+echo "[DR_TRACE] DR_INSTALL=${DR_INSTALL}"


### PR DESCRIPTION
Summary:

New files in packages/common/dr_trace/:

dr_trace.h/cpp: Tracing API with MIT license and watchdog timeout safety (auto-stops after max_trace_seconds to prevent runaway traces filling disk)
CMakeLists.txt: Static library using upstream find_package(DynamoRIO) with --defsym linker flags
install_dynamorio.sh: Downloads pre-built DynamoRIO release for x86_64/aarch64
README.md: Usage docs with ifdef pattern, configuration, and post-processing instructions
CHM benchmark hooks (off by default):

ChmBenchmark.cpp: 7 lines of ifdef-guarded trace_start()/trace_stop() around benchmark.run()
CMakeLists.txt: ENABLE_DR_TRACE option with conditional add_subdirectory
install_chm.sh: Optionally copies dr_trace sources and downloads DynamoRIO when ENABLE_DR_TRACE=1

Reviewed By: excelle08

Differential Revision: D100660787


