### PR TITLE
Fix CinderX install failure on Python 3.12+ venvs

### DIFF
--- a/packages/django_workload/install_django_workload_aarch64.sh
+++ b/packages/django_workload/install_django_workload_aarch64.sh
@@ -437,6 +437,10 @@ fi
 
 # Install CinderX in Cinder virtual environment (already activated)
 cd "${DJANGO_SERVER_ROOT}/cinderx"
+# Python 3.12+ venvs no longer include setuptools by default.
+# CinderX uses setuptools.build_meta as its build backend, so we must
+# install it explicitly before --no-build-isolation.
+python -m pip install setuptools wheel
 python -m pip install --no-build-isolation -e .
 
 # Validate CinderX installation

--- a/packages/django_workload/install_django_workload_aarch64_ubuntu22.sh
+++ b/packages/django_workload/install_django_workload_aarch64_ubuntu22.sh
@@ -456,6 +456,10 @@ fi
 
 # Install CinderX in Cinder virtual environment (already activated)
 cd "${DJANGO_SERVER_ROOT}/cinderx"
+# Python 3.12+ venvs no longer include setuptools by default.
+# CinderX uses setuptools.build_meta as its build backend, so we must
+# install it explicitly before --no-build-isolation.
+python -m pip install setuptools wheel
 python -m pip install --no-build-isolation -e .
 
 # Validate CinderX installation

--- a/packages/django_workload/install_django_workload_x86_64_centos9.sh
+++ b/packages/django_workload/install_django_workload_x86_64_centos9.sh
@@ -438,6 +438,10 @@ fi
 
 # Install CinderX in Cinder virtual environment (already activated)
 cd "${DJANGO_SERVER_ROOT}/cinderx"
+# Python 3.12+ venvs no longer include setuptools by default.
+# CinderX uses setuptools.build_meta as its build backend, so we must
+# install it explicitly before --no-build-isolation.
+python -m pip install setuptools wheel
 python -m pip install --no-build-isolation -e .
 
 # Validate CinderX installation

--- a/packages/django_workload/install_django_workload_x86_64_ubuntu22.sh
+++ b/packages/django_workload/install_django_workload_x86_64_ubuntu22.sh
@@ -454,6 +454,10 @@ fi
 
 # Install CinderX in Cinder virtual environment (already activated)
 cd "${DJANGO_SERVER_ROOT}/cinderx"
+# Python 3.12+ venvs no longer include setuptools by default.
+# CinderX uses setuptools.build_meta as its build backend, so we must
+# install it explicitly before --no-build-isolation.
+python -m pip install setuptools wheel
 python -m pip install --no-build-isolation -e .
 
 # Validate CinderX installation


### PR DESCRIPTION
Summary: Python 3.12+ venvs no longer include setuptools by default. CinderX uses setuptools.build_meta as its build backend, so `pip install --no-build-isolation` fails with `BackendUnavailable: Cannot import 'setuptools.build_meta'`. Fix by explicitly installing setuptools and wheel before the CinderX editable install, matching what the proxygen_binding install already does later in the same scripts.

Differential Revision: D100868144


