### PR TITLE
Add Timestamp_Secs to V3 report + timestamp-based windowing (#581)

### DIFF
--- a/perfpub/utils.py
+++ b/perfpub/utils.py
@@ -304,7 +304,27 @@ def get_start_end_index(
         last_secs = default_last_secs
         skip_last_secs = default_skip_last_secs
 
-    # Calculate indices using last_secs and skip_last_secs
+    # Calculate indices using last_secs and skip_last_secs.
+    # For CSVs with relative_secs/epoch_secs timestamps, use timestamp-based
+    # selection to ensure all CSVs cover the same absolute time window,
+    # regardless of per-CSV collection intervals or start-time offsets.
+    if (
+        ts_format in ("relative_secs", "epoch_secs")
+        and ts_column
+        and ts_column in df.columns
+    ):
+        ts_values = pd.to_numeric(df[ts_column], errors="coerce").dropna()
+        if len(ts_values) >= 2:
+            last_ts = ts_values.iloc[-1]
+            end_ts = last_ts - skip_last_secs
+            start_ts = end_ts - last_secs
+            start_index = int((ts_values - start_ts).abs().idxmin())
+            end_index = int((ts_values - end_ts).abs().idxmin())
+            start_index = max(start_index, 0)
+            end_index = max(end_index, start_index)
+            return start_index, end_index
+
+    # Fallback: row-count arithmetic (for time_of_day CSVs or missing timestamp column)
     if last_secs > 0:
         start_index = (
             len(df)

--- a/perfutils/generate_arm_neoversev3_perf_report.py
+++ b/perfutils/generate_arm_neoversev3_perf_report.py
@@ -820,6 +820,7 @@ def main(
     df = read_csv(perf_csv_file)
     grouped_df = df.groupby("event_name")
     metrics = [
+        timestamp(grouped_df),
         # --- Core throughput ---
         mips(grouped_df),
         muopps(grouped_df),


### PR DESCRIPTION
Summary:

Two related fixes to ensure perfpub selects the correct time window for
perf-collector-timeseries CSVs across all platforms.

**1. V3 report generator: add missing Timestamp_Secs column**

The Neoverse V3 report generator (`generate_arm_neoversev3_perf_report.py`)
defines a `timestamp()` function that emits a `Timestamp_Secs` column, but
never calls it in the metrics list. This column is already emitted by the
V2/Grace and AMD report generators. Without it, perfpub cannot do
timestamp-based row selection for V3 CSVs and must fall back to row-count
arithmetic.

Note: the `index` column in perf-collector-timeseries CSVs is a raw
DataFrame row number (jumps by 67-94 per row due to the multi-event-per-
timestamp structure of perf stat output), NOT a timestamp. Each row is
actually ~5 seconds apart. The `Timestamp_Secs` column provides the real
timestamp.

**2. perfpub: use timestamp-based windowing for --last-secs/--skip-last-secs**

When `--last-secs` and `--skip-last-secs` are specified, `get_start_end_index()`
previously used row-count arithmetic (`len(df) - ceil(last_secs / interval)`),
which depends on all CSVs having the same collection interval. This is fragile:
if different CSVs start collection at different times or have different
intervals, the row-count approach selects different absolute time windows.

Now, for CSVs with `relative_secs` or `epoch_secs` timestamp columns,
perfpub computes the target time window from the last timestamp
(`end = last_ts - skip_last_secs`, `start = end - last_secs`) and finds
the closest matching rows. This reuses the same `idxmin()` pattern already
used for the breakdown.csv path, ensuring all CSVs cover the same absolute
time window.

The row-count arithmetic is preserved as a fallback for `time_of_day`
CSVs (mpstat, memstat, etc.) and for old data lacking timestamp columns.

Differential Revision: D101064874
