### PR TITLE
Expose duration flag for cdn_bench server and proxy roles

### DIFF
--- a/benchpress/config/jobs_ehw.yml
+++ b/benchpress/config/jobs_ehw.yml
@@ -9,9 +9,11 @@
         - '-m server'
         - '-P {ports}'
         - '-p {protocol}'
+        - '-d {duration}'
       vars:
         - 'ports=8082'
         - 'protocol=h2'
+        - 'duration=120'
     proxy:
       args:
         - '-m proxy'
@@ -19,11 +21,13 @@
         - '-b {backend_ports}'
         - '-P {ports}'
         - '-p {protocol}'
+        - '-d {duration}'
       vars:
         - 'backend_hosts='
         - 'backend_ports='
         - 'ports=8081'
         - 'protocol=h2'
+        - 'duration=120'
     client:
       args:
         - '-m client'

--- a/packages/cdn_bench/run.sh
+++ b/packages/cdn_bench/run.sh
@@ -222,7 +222,9 @@ verify_content_server() {
   local port="$2"
   echo -n "  Probing content_server at ${host}:${port} ... "
   local http_code
-  http_code=$(curl -sf --connect-timeout 5 -o /dev/null -w "%{http_code}" "http://[${host}]:${port}/" 2>/dev/null || echo "000")
+  http_code=$(curl -sf --connect-timeout 5 -o /dev/null -w "%{http_code}" "http://[${host}]:${port}/" 2>/dev/null \
+    || curl -sf --connect-timeout 5 -o /dev/null -w "%{http_code}" --http2-prior-knowledge "http://[${host}]:${port}/" 2>/dev/null \
+    || echo "000")
   if [ "$http_code" = "000" ]; then
     echo "-x> no response (connection refused or timeout)"
     return 1
@@ -452,6 +454,8 @@ run_proxy() {
     echo -n "  Checking backend ${bhost}:${bport} ... "
     if curl -sf --connect-timeout 5 -o /dev/null "http://[${bhost}]:${bport}/" 2>/dev/null; then
       echo "-> reachable"
+    elif curl -sf --connect-timeout 5 -o /dev/null --http2-prior-knowledge "http://[${bhost}]:${bport}/" 2>/dev/null; then
+      echo "-> reachable (h2)"
     else
       echo "-x-> UNREACHABLE"
       all_backends_ok=false


### PR DESCRIPTION
Summary:
Two fixes for cdn_bench:

1. Expose duration as a role_input for server and proxy roles. Previously only the client had it, so the server auto-terminated after 80s (hardcoded 60s + 20s grace) making multi-host runs flaky.

2. Fix h2 backend health check — the proxy's backend reachability check and the server's self-probe used plain curl (h1), which fails when the content_server runs in h2 plaintext mode. Now falls back to --http2-prior-knowledge.

Differential Revision: D101552694


