### PR TITLE
Catch backend transport errors in ProxyHandler (#584)

### DIFF
--- a/packages/cdn_bench/run.sh
+++ b/packages/cdn_bench/run.sh
@@ -162,7 +162,7 @@ cleanup() {
     fi
   done
   # Give processes time to flush metrics and exit gracefully
-  sleep 2
+  sleep 5
   for pid in "${BG_PIDS[@]}"; do
     if [ -n "$pid" ] && kill -0 "$pid" 2>/dev/null; then
       # Force kill if still running
@@ -518,7 +518,7 @@ run_proxy() {
         kill -INT "$pid" 2>/dev/null || true
       fi
     done
-    sleep 2
+    sleep 5
     for pid in "${BG_PIDS[@]}"; do
     if [ -n "$pid" ] && kill -0 "$pid" 2>/dev/null; then
       # Force kill if still running

--- a/packages/cdn_bench/src/ti/foss_revproxy/proxy/ProxyHandler.cpp
+++ b/packages/cdn_bench/src/ti/foss_revproxy/proxy/ProxyHandler.cpp
@@ -178,9 +178,25 @@ folly::coro::Task<HTTPSourceHolder> ProxyHandler::forwardToBackend(
         new HTTPHybridSource(std::move(headers), std::move(requestSource)),
         std::move(res->reservation));
 
+    // Read the response header event to catch transport errors early.
+    // Without this, TRANSPORT_READ_ERROR leaks to the downstream session
+    // and triggers noisy "Application supplied internal error code" warnings.
+    auto respHeaderTry = co_await co_awaitTry(response.readHeaderEvent());
+    if (respHeaderTry.hasException()) {
+      XLOG(DBG2) << "Backend " << backendIndex
+                 << " response error (likely connection warmup): "
+                 << respHeaderTry.exception().what();
+      recordFailure(requestStart);
+      co_return getDirectResponse(502, "Backend response error\n");
+    }
+
     recordSuccess(requestStart, backendStart);
 
-    co_return std::move(response);
+    // Re-wrap the already-consumed headers + remaining body source into a
+    // new HTTPHybridSource for the downstream session
+    co_return HTTPSourceHolder(new HTTPHybridSource(
+        std::move(respHeaderTry->headers),
+        respHeaderTry->eom ? HTTPSourceHolder() : std::move(response)));
 
   } catch (const std::exception& ex) {
     XLOG(ERR) << "Exception while getting connection: " << ex.what();


### PR DESCRIPTION
Summary:

Intercept TRANSPORT_READ_ERROR from the backend response source before it leaks to the downstream session. Without this, connection pool warmup causes noisy 'Application supplied internal error code ec=4103' warnings on every initial request batch.

Now the proxy reads the response headers itself — if the backend connection errors, it returns a clean 502 instead of propagating the raw transport error downstream.

Also modified BUCK to actually build the dcperf version of the foss_revproxy repo rather then the original internal version

Reviewed By: YifanYuan3

Differential Revision: D101553391
