### PR TITLE
Fix server crash on GCC 15 with _GLIBCXX_ASSERTIONS

### DIFF
--- a/packages/tao_bench/0009-tao_bench_rand_bounds_check.diff
+++ b/packages/tao_bench/0009-tao_bench_rand_bounds_check.diff
@@ -1,0 +1,35 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+#
+# Fix tao_bench_server crash on GCC 15+ where _GLIBCXX_ASSERTIONS is
+# enabled by default. std::uniform_int_distribution asserts min <= max,
+# and folly::Random::rand32(min, max) calls distribution(min, max-1),
+# which crashes when min >= max. This can happen in the item generator
+# as the cache fills during warmup.
+#
+# Backward compatible: on older GCC, the check is simply redundant.
+diff --git a/db_items.cpp b/db_items.cpp
+--- a/db_items.cpp
++++ b/db_items.cpp
+@@ -84,6 +84,9 @@
+ }
+ 
+ uint64_t db_items::getUint64(uint64_t n_min, uint64_t n_max) {
++    // Guard against inverted ranges that trigger _GLIBCXX_ASSERTIONS
++    // in std::uniform_int_distribution on GCC 15+
++    if (n_min >= n_max) return n_min;
+     uint64_t result = 0;
+     pthread_mutex_lock(&rngLock);
+     result = folly::Random::rand64(n_min, n_max, _rng);
+@@ -92,6 +95,9 @@
+ }
+ 
+ uint32_t db_items::getUint32(uint32_t n_min, uint32_t n_max) {
++    // Guard against inverted ranges that trigger _GLIBCXX_ASSERTIONS
++    // in std::uniform_int_distribution on GCC 15+
++    if (n_min >= n_max) return n_min;
+     uint32_t result = 0;
+     pthread_mutex_lock(&rngLock);
+     result = folly::Random::rand32(n_min, n_max, _rng);

--- a/packages/tao_bench/install_tao_bench_aarch64.sh
+++ b/packages/tao_bench/install_tao_bench_aarch64.sh
@@ -141,6 +141,7 @@ patch -p1 -i "${BPKGS_TAO_BENCH_ROOT}/0003-tao_bench_thread_pool_naming.diff"
 patch -p1 -i "${BPKGS_TAO_BENCH_ROOT}/0006-tao_bench_slow_thread_use_semaphore.diff"
 patch -p1 -i "${BPKGS_TAO_BENCH_ROOT}/0007-tao_bench_smart_nanosleep.diff"
 patch -p1 -i "${BPKGS_TAO_BENCH_ROOT}/0008-tao_bench_count_nanosleeps.diff"
+patch -p1 -i "${BPKGS_TAO_BENCH_ROOT}/0009-tao_bench_rand_bounds_check.diff"
 
 # Find the path to folly and fmt
 FOLLY_INSTALLED_PATH="${FOLLY_BUILD_ROOT}/installed/folly"

--- a/packages/tao_bench/install_tao_bench_x86_64.sh
+++ b/packages/tao_bench/install_tao_bench_x86_64.sh
@@ -136,6 +136,7 @@ patch -p1 -i "${BPKGS_TAO_BENCH_ROOT}/0003-tao_bench_thread_pool_naming.diff"
 patch -p1 -i "${BPKGS_TAO_BENCH_ROOT}/0006-tao_bench_slow_thread_use_semaphore.diff"
 patch -p1 -i "${BPKGS_TAO_BENCH_ROOT}/0007-tao_bench_smart_nanosleep.diff"
 patch -p1 -i "${BPKGS_TAO_BENCH_ROOT}/0008-tao_bench_count_nanosleeps.diff"
+patch -p1 -i "${BPKGS_TAO_BENCH_ROOT}/0009-tao_bench_rand_bounds_check.diff"
 
 # Find the path to folly and fmt
 FOLLY_INSTALLED_PATH="${FOLLY_BUILD_ROOT}/installed/folly"


### PR DESCRIPTION
Summary:
tao_bench_server crashes during warmup on systems where GCC 15+ is the
default compiler (e.g. Ubuntu 25.10). The crash manifests as:

  uniform_int_dist.h:108: Assertion '_M_a <= _M_b' failed.

GCC 15 defines _GLIBCXX_ASSERTIONS by default, enabling runtime checks in
libstdc++ headers. std::uniform_int_distribution asserts min <= max in its
constructor. folly::Random::rand32(min, max) calls
uniform_int_distribution(min, max-1), which triggers the assertion when
min >= max.

The item generator's getUint32/getUint64 can receive inverted ranges as
the cache fills during warmup. On older GCC this silently produced a
garbage value; on GCC 15+ it aborts the server with SIGABRT.

The fix adds bounds checking in db_items.cpp before the folly::Random
calls. When min >= max, return min (consistent with folly::Random's own
min==max handling). Backward compatible with all GCC versions.

___

overriding_review_checks_triggers_an_audit_and_retroactive_review
Oncall Short Name: feed_ranking_infra

Differential Revision: D102233079


