### PR TITLE
Always recreate Hive metastore_db to fix TABLE_NOT_FOUND on repeated runs

### DIFF
--- a/packages/spark_standalone/templates/runner.py
+++ b/packages/spark_standalone/templates/runner.py
@@ -10,6 +10,7 @@ import os
 import pathlib
 import re
 import shlex
+import shutil
 import subprocess
 import sys
 import threading
@@ -57,9 +58,12 @@ def download_dataset(args):
 def install_database(args):
     metadata_dir = os.path.join(SPARK_DIR, "spark-4.0.2-bin-hadoop3", "metastore_db")
     database_dir = os.path.join(args.warehouse_dir, f"{args.dataset_name.lower()}.db")
-    if os.path.exists(metadata_dir) and os.path.exists(database_dir):
-        print("Database already created; directly run test")
-        return
+    if os.path.exists(metadata_dir):
+        print("Removing stale metastore_db to ensure tables are recreated")
+        shutil.rmtree(metadata_dir)
+    if os.path.exists(database_dir):
+        print(f"Removing stale warehouse data at {database_dir}")
+        shutil.rmtree(database_dir)
     os.chdir(WORK_DIR)
     cmd_list = [
         "../scripts/run_perf_common.py",


### PR DESCRIPTION
Summary:
Symptom: SparkBench via automark reported "No known db metrics found for
spark_standalone_remote" — the benchmark produced architectural metrics
(mpstat, perf-stat, etc.) but no execution-time results.

Error: Spark query log showed:
  [TABLE_OR_VIEW_NOT_FOUND] The table or view `table_SPdBtF_Y9di_...`
  cannot be found.

Analysis (traced through three layers):

1. perfpub couldn't find metrics — the metrics JSON only contained
   worker_cores/worker_memory, no execution_time_test_93586-stage-* keys.

2. Spark SQL queries failed with TABLE_OR_VIEW_NOT_FOUND because the Hive
   tables were never registered in the metastore.

3. create_tables.sql was silently failing — install_database() in runner.py
   used os.popen() which doesn't check return codes, so the error was
   swallowed. The actual error in create_tables.log was:
     [LOCATION_ALREADY_EXISTS] Cannot name the managed table as `...`,
     as its associated location
     'file:/flash23/warehouse/bpc_t93586_s2_synthetic.db/...'
     already exists. SQLSTATE: 42710
   Spark 4.0 is stricter than 2.x — it refuses CREATE TABLE when the
   warehouse directory already has data from a prior run, even after
   DROP TABLE IF EXISTS clears the metastore entry.

Root cause: install_database() skipped table re-creation when metastore_db/
and the warehouse .db/ directory existed from a prior run. When it didn't
skip (e.g. after manual cleanup of metastore_db), it still failed because
Spark 4.0 rejects CREATE TABLE on a pre-existing warehouse directory.

Fix: Always remove both metastore_db/ and the warehouse .db/ directory
before running install. The source-dataset download is independently
guarded, so this only adds ~30s of CREATE TABLE DDL overhead per run.

Differential Revision: D102699392


