### PR TITLE
Fix FeedSim aarch64 install: prevent cmake from finding stale conda   CUDA cmake configs (#600)

### DIFF
--- a/packages/feedsim/install_feedsim_aarch64.sh
+++ b/packages/feedsim/install_feedsim_aarch64.sh
@@ -214,10 +214,8 @@ if ! [ -d "libtorch" ]; then
     ln -sf "${TORCH_DIR}/lib" "${FEEDSIM_THIRD_PARTY_SRC}/libtorch/lib"
     ln -sf "${TORCH_DIR}/share" "${FEEDSIM_THIRD_PARTY_SRC}/libtorch/share"
 
-    # Also symlink cmake files into conda share dir (some cmake scripts look there)
-    mkdir -p "${CONDA_DIR}/share/cmake"
-    ln -sf "${TORCH_DIR}/share/cmake/Caffe2" "${CONDA_DIR}/share/cmake/Caffe2"
-    ln -sf "${TORCH_DIR}/share/cmake/Torch" "${CONDA_DIR}/share/cmake/Torch"
+    # Remove any leftover conda cmake files that could confuse find_package
+    rm -rf "${CONDA_DIR}/share/cmake/Caffe2" "${CONDA_DIR}/share/cmake/Torch"
 
     msg "LibTorch (CPU-only) installed via pip: ${FEEDSIM_THIRD_PARTY_SRC}/libtorch"
 else
@@ -288,7 +286,7 @@ BP_CXX="${BP_CXX:-g++}"
 
 cmake -G Ninja \
     -DCMAKE_BUILD_TYPE=Release \
-    -DCMAKE_PREFIX_PATH="${FEEDSIM_THIRD_PARTY_SRC}/build-deps;${FEEDSIM_THIRD_PARTY_SRC}/miniconda3" \
+    -DCMAKE_PREFIX_PATH="${FEEDSIM_THIRD_PARTY_SRC}/build-deps" \
     -DCMAKE_C_COMPILER="$BP_CC" \
     -DCMAKE_CXX_COMPILER="$BP_CXX" \
     -DCMAKE_C_FLAGS_RELEASE="$FS_CFLAGS" \


### PR DESCRIPTION
Summary:

D102920058 switched FeedSim's aarch64 libtorch installation from conda to pip to get a CPU-only build (the conda package ships CUDA-enabled cmake
  configs                                                                   
  that fail on CPU-only ARM servers ).                
                                                                            
  However, two issues remained:                                             
                                                                            
  1. The script created symlinks from `miniconda3/share/cmake/` to the pip  
  torch                                                         
     `miniconda3/` path, it computed `_IMPORT_PREFIX` as `miniconda3/` and  
  looked                                                                    
     for `libc10.so` there — but the actual libraries live in the pip torch 
     directory. Fix: replace the symlinks with `rm -rf` to clean up any     
  leftover                                                                  
     conda cmake files.                                                     
                                                                            
  2. `CMAKE_PREFIX_PATH` included `miniconda3`, causing cmake to search that
     prefix for packages. This could find stale conda cmake files from      
  previous                                                                  
     installs. Fix: remove `miniconda3` from `CMAKE_PREFIX_PATH`.           
                                                                 
  With these fixes, cmake only finds Caffe2/Torch through the               
  `libtorch/share/cmake/`                                                   
  symlinks, where `_IMPORT_PREFIX` correctly resolves to `libtorch/` and the
  library symlinks point to the actual pip torch `.so` files.

Reviewed By: YifanYuan3, excelle08

Differential Revision: D102990925


