### PR TITLE
Add two-run pattern for video_transcode_bench timed mini to reduce    runtime

### DIFF
--- a/benchpress/config/jobs.yml
+++ b/benchpress/config/jobs.yml
@@ -1496,7 +1496,7 @@
     - '--sampling-seed {sampling_seed}'
     - '--max-time {max_time}'
     - '--score-mode {score_mode}'
-    - '--fast-jobs-first'
+    - '--fast-jobs-first {fast_jobs_first}'
   vars:
     - 'encoder=svt'
     - 'levels=0:0'
@@ -1508,12 +1508,102 @@
     - 'sampling_seed=1000'
     - 'max_time=600'
     - 'score_mode=megapixel'
+    - 'fast_jobs_first=1'
   hooks:
     - hook: cpu-mpstat
       options:
         args:
           - '-u'   # utilization
           - '1'    # second interval
+    - hook: copymove
+      options:
+        is_move: true
+        after:
+          - 'benchmarks/video_transcode_bench/video_transcode_bench_results.txt'
+          - 'benchmarks/video_transcode_bench/perf.data'
+          - 'benchmarks/video_transcode_bench/breakdown.csv'
+
+- name: video_transcode_bench_svt_timed_prep
+  benchmark: video_transcode_bench
+  description: >
+    Prep run for time-based SVT-AV1 video encoding workload. Downscales all
+    clips and caches them in resized_clips/ for subsequent runs with
+    video_transcode_bench_svt_timed_reuse. After this run, the datasets/cuts/
+    directory (~42GB) can be deleted to save space.
+  args:
+    - '--encoder {encoder}'
+    - '--levels {levels}'
+    - '--output {output}'
+    - '--runtime {runtime}'
+    - '--parallelism {parallelism}'
+    - '--procs {procs}'
+    - '--sample-rate {sample_rate}'
+    - '--sampling-seed {sampling_seed}'
+    - '--max-time {max_time}'
+    - '--score-mode {score_mode}'
+    - '--fast-jobs-first {fast_jobs_first}'
+    - '--keep-downscaled'
+  vars:
+    - 'encoder=svt'
+    - 'levels=0:0'
+    - 'output=video_transcode_bench_results.txt'
+    - 'runtime=medium'
+    - 'parallelism=1'
+    - 'procs=-1'
+    - 'sample_rate=1.0'
+    - 'sampling_seed=1000'
+    - 'max_time=600'
+    - 'score_mode=megapixel'
+    - 'fast_jobs_first=0'
+  hooks:
+    - hook: cpu-mpstat
+      options:
+        args:
+          - '-u'
+          - '1'
+    - hook: copymove
+      options:
+        is_move: true
+        after:
+          - 'benchmarks/video_transcode_bench/video_transcode_bench_results.txt'
+          - 'benchmarks/video_transcode_bench/perf.data'
+          - 'benchmarks/video_transcode_bench/breakdown.csv'
+
+- name: video_transcode_bench_svt_timed_reuse
+  benchmark: video_transcode_bench
+  description: >
+    Reuse run for time-based SVT-AV1 video encoding workload. Skips
+    downscaling and uses cached resized_clips/ from a prior prep run
+    (video_transcode_bench_svt_timed_prep). Errors if resized_clips/
+    is not found. Keeps cached clips for subsequent runs.
+  args:
+    - '--encoder {encoder}'
+    - '--levels {levels}'
+    - '--output {output}'
+    - '--runtime {runtime}'
+    - '--parallelism {parallelism}'
+    - '--procs {procs}'
+    - '--max-time {max_time}'
+    - '--score-mode {score_mode}'
+    - '--fast-jobs-first {fast_jobs_first}'
+    - '--skip-downscale'
+    - '--keep-downscaled'
+  vars:
+    - 'encoder=svt'
+    - 'levels=0:0'
+    - 'output=video_transcode_bench_results.txt'
+    - 'runtime=medium'
+    - 'parallelism=1'
+    - 'procs=-1'
+    - 'max_time=600'
+    - 'score_mode=megapixel'
+    - 'fast_jobs_first=0'
+  hooks:
+    - hook: cpu-mpstat
+      options:
+        args:
+          - '-u'
+          - '1'
     - hook: copymove
       options:
         is_move: true
@@ -1557,12 +1647,13 @@
           - 'benchmarks/video_transcode_bench/breakdown.csv'
 
 
-- name: video_transcode_bench_svt_timed_mini
+- name: video_transcode_bench_svt_timed_mini_prep
   benchmark: video_transcode_bench
   description: >
-    Time-based mini SVT-AV1 video encoding workload. Uses sampling to reduce
-    the dataset and a time limit to ensure consistent runtime regardless of
-    core count. Suitable for quick validation on high core count machines.
+    Prep run for time-based mini SVT-AV1 video encoding workload. Downscales
+    a sampled subset of clips (20%) and caches them in resized_clips/ for
+    subsequent runs with video_transcode_bench_svt_timed_mini_reuse. After
+    this run, the datasets/cuts/ directory (~42GB) can be deleted to save space.
   execute_cmd_from_file: true
   args:
     - '--encoder {encoder}'
@@ -1576,7 +1667,8 @@
     - '--sleep-before-perf {sleep_before_perf}'
     - '--max-time {max_time}'
     - '--score-mode {score_mode}'
-    - '--fast-jobs-first'
+    - '--fast-jobs-first {fast_jobs_first}'
+    - '--keep-downscaled'
   vars:
     - 'encoder=svt'
     - 'levels=0:0'
@@ -1584,11 +1676,53 @@
     - 'runtime=medium'
     - 'parallelism=1'
     - 'procs=-1'
-    - 'sample_rate=1'
+    - 'sample_rate=0.2'
     - 'sampling_seed=1000'
     - 'sleep_before_perf=0'
-    - 'max_time=15'
+    - 'max_time=600'
     - 'score_mode=megapixel'
+    - 'fast_jobs_first=0'
+  hooks:
+    - hook: copymove
+      options:
+        is_move: true
+        after:
+          - 'benchmarks/video_transcode_bench/video_transcode_bench_results.txt'
+          - 'benchmarks/video_transcode_bench/perf.data'
+          - 'benchmarks/video_transcode_bench/breakdown.csv'
+
+- name: video_transcode_bench_svt_timed_mini_reuse
+  benchmark: video_transcode_bench
+  description: >
+    Reuse run for time-based mini SVT-AV1 video encoding workload. Skips
+    downscaling and uses cached resized_clips/ from a prior prep run
+    (video_transcode_bench_svt_timed_mini_prep). Errors if resized_clips/
+    is not found. Keeps cached clips for subsequent runs.
+  execute_cmd_from_file: true
+  args:
+    - '--encoder {encoder}'
+    - '--levels {levels}'
+    - '--output {output}'
+    - '--runtime {runtime}'
+    - '--parallelism {parallelism}'
+    - '--procs {procs}'
+    - '--sleep-before-perf {sleep_before_perf}'
+    - '--max-time {max_time}'
+    - '--score-mode {score_mode}'
+    - '--fast-jobs-first {fast_jobs_first}'
+    - '--skip-downscale'
+    - '--keep-downscaled'
+  vars:
+    - 'encoder=svt'
+    - 'levels=0:0'
+    - 'output=video_transcode_bench_results.txt'
+    - 'runtime=medium'
+    - 'parallelism=1'
+    - 'procs=-1'
+    - 'sleep_before_perf=0'
+    - 'max_time=8'
+    - 'score_mode=megapixel'
+    - 'fast_jobs_first=0'
   hooks:
     - hook: copymove
       options:

--- a/packages/video_transcode_bench/README.md
+++ b/packages/video_transcode_bench/README.md
@@ -70,6 +70,116 @@ Another example. if you would like to run level 5 to 11, you can run the followi
 ./benchpress_cli.py run video_transcode_bench_svt -i '{"levels": "5:11"}'
 ```
 
+## VideoTranscodeBench Timed Mini (Two-Run Pattern)
+
+The timed mini variant uses a two-run pattern to reduce execution time,
+similar to DjangoBench and SparkBench mini versions.
+
+### Run 1: Prep (on a real machine with the full dataset)
+
+Run the prep variant to downscale a sampled subset of clips and cache them
+for reuse:
+
+```bash
+./benchpress_cli.py run video_transcode_bench_svt_timed_mini_prep
+```
+
+This creates the following cached artifacts inside
+`benchmarks/video_transcode_bench/`:
+- `resized_clips/` — downscaled video clips ready for encoding
+- `run-ffmpeg-svt-1p-m*.txt` — encoding command files
+- `job_durations_m*.txt` — per-job duration stats used by the reuse variant
+  to determine how many jobs to run
+
+Back up these files for use on other machines or emulators.
+
+### (Optional) Delete source dataset to save space
+
+After the prep run, the original dataset (~42GB) in `datasets/cuts/` is no
+longer needed. You can delete it to reduce disk usage:
+
+```bash
+rm -rf ./benchmarks/video_transcode_bench/datasets/cuts/
+```
+
+### Run 2+: Reuse (on emulator or target machine)
+
+Copy the cached artifacts to the target machine, then run the reuse variant:
+
+```bash
+./benchpress_cli.py run video_transcode_bench_svt_timed_mini_reuse
+```
+
+This skips the downscaling phase entirely and runs only the encoding workload.
+The reuse variant uses the per-job durations from the prep run to compute
+exactly how many jobs fit within `max_time` on the target machine's core
+count. All cached files are preserved after each run, so the reuse variant
+can be run repeatedly without re-prepping.
+
+If `resized_clips/` is not found, the reuse variant will exit with an error
+directing you to run the prep variant first.
+
+### Tuning parameters
+
+#### Sample rate (`sample_rate`)
+
+The mini prep variant (`video_transcode_bench_svt_timed_mini_prep`) uses
+`sample_rate=0.2` by default, selecting ~20% of the source clips
+(deterministic with `sampling_seed=1000`). The full prep variant
+(`video_transcode_bench_svt_timed_prep`) uses `sample_rate=1.0` (all clips).
+This parameter controls the trade-off between **score representativeness**
+and **image size**:
+
+- **Higher sample rate** (e.g., 0.5 or 1.0): more clips are downscaled and
+  available for encoding. The reuse variant has a larger pool of jobs to draw
+  from, ensuring all cores stay saturated even on high core-count machines.
+  However, this increases the size of `resized_clips/` and the emulator/OS
+  image. With `sample_rate=1.0`, `resized_clips/` can be several GB.
+- **Lower sample rate** (e.g., 0.1): fewer clips, smaller `resized_clips/`
+  directory, faster prep run. On machines with many cores, the job pool may
+  be too small to keep all cores busy for the full `max_time`, reducing the
+  effective measurement window.
+
+To override the default:
+```bash
+./benchpress_cli.py run video_transcode_bench_svt_timed_mini_prep \
+  -i '{"sample_rate": "0.5"}'
+```
+
+#### Fast jobs first (`--fast-jobs-first`)
+
+The prep variant uses `--fast-jobs-first` to reverse the command file order so
+that small-resolution (fast) encoding jobs run first. This is useful for the
+prep run where all jobs complete regardless of order.
+
+The reuse variant does **not** use `--fast-jobs-first`. This is a deliberate
+choice for score representativeness: the reuse variant truncates the job list
+to fit within `max_time`, and if `--fast-jobs-first` were enabled, the
+truncated subset would contain only the smallest clips. Small clips have
+higher per-pixel encoder overhead (setup, GOP management, and I/O costs are
+amortized over fewer pixels), resulting in **lower throughput and a deflated
+score** that is not representative of the full benchmark.
+
+Without `--fast-jobs-first`, the truncated subset includes a mix of clip sizes
+and resolutions, producing a throughput measurement that better reflects the
+full workload.
+
+### Full timed variant (prep/reuse)
+
+The same two-run pattern is available for the full (non-mini) timed variant:
+
+```bash
+# Prep: downscale all clips, full encoding
+./benchpress_cli.py run video_transcode_bench_svt_timed_prep
+
+# Reuse: skip downscaling, reuse cached clips
+./benchpress_cli.py run video_transcode_bench_svt_timed_reuse
+```
+
+These use `sample_rate=1.0` (all clips) and `max_time=600`. Scores from the
+reuse variant can be compared with the prep variant and the original
+`video_transcode_bench_svt_timed` job to validate representativeness.
+
 ## Note
 
 This benchmark normally takes around tens of minutes to finish, depending on the levels or predefined workload you choose. Note that lower levels (like level 1, 2, and 3) can take hours to complete. **We suggest starting form higher levels (or `short` as runtime) for fast iterations.** The default `runtime` is `medium`.

--- a/packages/video_transcode_bench/run.sh
+++ b/packages/video_transcode_bench/run.sh
@@ -100,6 +100,12 @@ main() {
     local fast_jobs_first
     fast_jobs_first=0
 
+    local skip_downscale
+    skip_downscale=0
+
+    local keep_downscaled
+    keep_downscaled=0
+
     # Create a backup of generate_commands_all.py before making any changes, to restore it later and avoid replicating changes for susequent runs
     cp ${FFMPEG_ROOT}/generate_commands_all.py ${FFMPEG_ROOT}/generate_commands_all.backup.py
 
@@ -139,7 +145,13 @@ main() {
                 score_mode="$2"
                 ;;
             --fast-jobs-first)
-                fast_jobs_first=1
+                fast_jobs_first="$2"
+                ;;
+            --skip-downscale)
+                skip_downscale=1
+                ;;
+            --keep-downscaled)
+                keep_downscaled=1
                 ;;
             -h)
                 show_help >&2
@@ -154,7 +166,7 @@ main() {
         esac
 
         case $1 in
-            --levels|--encoder|--output|--runtime|--parallelism|--procs|--sample-rate|--sampling-seed|--sleep-before-perf|--max-time|--score-mode)
+            --levels|--encoder|--output|--runtime|--parallelism|--procs|--sample-rate|--sampling-seed|--sleep-before-perf|--max-time|--score-mode|--fast-jobs-first)
                 if [ -z "$2" ]; then
                     echo "Invalid option: $1 requires an argument" 1>&2
                     exit 1
@@ -220,7 +232,9 @@ main() {
     benchreps_tell_state "working on config"
     pushd "${FFMPEG_ROOT}"
 
-    delete_replicas
+    if [ "$skip_downscale" = "0" ]; then
+        delete_replicas
+    fi
 
     # Prepare the configuration parameters
     low=$(echo "${levels}" | cut -d':' -f1)
@@ -238,11 +252,17 @@ main() {
     range+="]"
 
     # Calculate num_pool
-    num_files=$(find ./datasets/cuts/ | wc -l)
-    num_files=$(echo "$num_files * 8" | bc -l | awk '{print int($0)}')
+    if [ -d "./datasets/cuts/" ]; then
+        num_files=$(find ./datasets/cuts/ | wc -l)
+        num_files=$(echo "$num_files * 8" | bc -l | awk '{print int($0)}')
+    else
+        num_files=0
+    fi
     num_proc=$(nproc)
     if [ -z "$procs" ] || [ $procs -eq -1 ]; then
-        if [ "$num_files" -lt "$num_proc" ]; then
+        if [ "$skip_downscale" = "1" ]; then
+            num_pool_val=$num_proc
+        elif [ "$num_files" -lt "$num_proc" ]; then
             num_pool_val=$num_files
         else
             num_pool_val=$num_proc
@@ -268,48 +288,110 @@ main() {
         exit 1
     fi
 
-    # Use the Python script to modify generate_commands_all.py
-    python3 ./modify_generate_commands_all.py --sample-rate ${sample_rate} --sampling-seed ${sampling_seed} --lp-number "${lp_number}" --num-pool "${num_pool}" --range "${range}" --encoder $encoder
-    # create a copy of generate_commands_all.py to generate_commands_all.debug.py for debugging purposes
-    cp ${FFMPEG_ROOT}/generate_commands_all.py ${FFMPEG_ROOT}/generate_commands_all.debug.py
-    #generate commands
-    python3 ./generate_commands_all.py
-
-    head -n -6 "./${run_sh}" > temp.sh && mv temp.sh "./${run_sh}" && chmod +x ./${run_sh}
-
     # Derive the run-paral-cpu script name from run_sh
     run_paral_cpu="${run_sh/-run-all-paral.sh/-run-paral-cpu.sh}"
     # Determine the encoder test identifier for command file names
     enc_test_id="${run_paral_cpu%-run-paral-cpu.sh}"
 
-    # Reverse command file order so fast (small resolution) jobs run first
-    if [ "$fast_jobs_first" = "1" ]; then
-        for num in $(seq "${low}" "${high}"); do
-            cmd_file="run-${enc_test_id}-m${num}.txt"
-            if [ -f "$cmd_file" ]; then
-                tac "$cmd_file" > "${cmd_file}.tmp" && mv "${cmd_file}.tmp" "$cmd_file"
-            fi
-        done
+    if [ "$skip_downscale" = "1" ] && [ -f "./${run_sh}" ]; then
+        # Reuse command files and scripts from a prior prep run.
+        # Command files are always stored in original order on disk.
+        # fast_jobs_first reversal is applied at runtime in run-paral-cpu.sh.
+        true
+    else
+        # Use the Python script to modify generate_commands_all.py
+        python3 ./modify_generate_commands_all.py --sample-rate ${sample_rate} --sampling-seed ${sampling_seed} --lp-number "${lp_number}" --num-pool "${num_pool}" --range "${range}" --encoder $encoder
+        # create a copy of generate_commands_all.py to generate_commands_all.debug.py for debugging purposes
+        cp ${FFMPEG_ROOT}/generate_commands_all.py ${FFMPEG_ROOT}/generate_commands_all.debug.py
+        #generate commands
+        python3 ./generate_commands_all.py
     fi
 
-    # Overwrite run-paral-cpu to use the timed parallel feeder
-    cat > "./${run_paral_cpu}" <<FEEDER_EOF
+    # Overwrite run-paral-cpu to use the timed parallel feeder.
+    # Command files are always in original order on disk. When fast_jobs_first
+    # is active, tac reverses at runtime so small/fast jobs run first.
+    # Durations file is passed for reuse runs (from a prior prep run).
+    local cmd_input="run-${enc_test_id}-m\$1.txt"
+    local dur_arg=""
+    if [ "$skip_downscale" = "1" ]; then
+        dur_arg=" job_durations_m\$1.txt"
+    fi
+    if [ "$fast_jobs_first" = "1" ]; then
+        cat > "./${run_paral_cpu}" <<FEEDER_EOF
 #!/bin/bash
-./timed_parallel_feeder.sh run-${enc_test_id}-m\$1.txt ${num_pool_val} ${max_time} joblog_m\$1.txt
+tac run-${enc_test_id}-m\$1.txt > .run-${enc_test_id}-m\$1.reversed.txt
+[ -f job_durations_m\$1.txt ] && tac job_durations_m\$1.txt > .job_durations_m\$1.reversed.txt
+CMD_FILE=.run-${enc_test_id}-m\$1.reversed.txt
+DUR_FILE=\$([ -f .job_durations_m\$1.reversed.txt ] && echo .job_durations_m\$1.reversed.txt || echo "")
+./timed_parallel_feeder.sh \$CMD_FILE ${num_pool_val} ${max_time} joblog_m\$1.txt \$DUR_FILE
+rm -f .run-${enc_test_id}-m\$1.reversed.txt .job_durations_m\$1.reversed.txt
 FEEDER_EOF
+    else
+        cat > "./${run_paral_cpu}" <<FEEDER_EOF
+#!/bin/bash
+./timed_parallel_feeder.sh run-${enc_test_id}-m\$1.txt ${num_pool_val} ${max_time} joblog_m\$1.txt${dur_arg}
+FEEDER_EOF
+    fi
     chmod +x "./${run_paral_cpu}"
 
     export LD_LIBRARY_PATH="${FFMPEG_ROOT}/ffmpeg_build/lib64/"
     ldconfig
 
-    #run
+    # Split the generated run script into downscaling and encoding phases.
+    # The generated script prints "Downscaling Finished" between the two
+    # phases. We split on the ORIGINAL script (before any trimming) so that
+    # encoding lines are never lost, regardless of script length.
+    downscale_sh="${run_sh%.sh}-downscale.sh"
+    encode_sh="${run_sh%.sh}-encode.sh"
+    split_line=$(grep -n "Downscaling Finished" "./${run_sh}" | tail -1 | cut -d: -f1)
+    if [ -n "$split_line" ]; then
+        head -n "$split_line" "./${run_sh}" > "./${downscale_sh}"
+        # Extract encoding section: copy variable definitions from the script
+        # header (lines before the first command), then the encoding for-loop
+        # up to its closing "done". Exclude trailing aom-testing boilerplate.
+        # Variable lines are those starting with a variable assignment or array
+        # declaration (e.g., encoder_type=, enc_mode_array=, debug_date=, debug_filename=).
+        last_done_line=$(tail -n +"$((split_line + 1))" "./${run_sh}" | grep -n '^done' | head -1 | cut -d: -f1)
+        if [ -n "$last_done_line" ]; then
+            last_done_line=$((split_line + last_done_line))
+        else
+            last_done_line=$(wc -l < "./${run_sh}")
+        fi
+        {
+            echo '#!/bin/bash'
+            # Copy variable definitions from the script header so the
+            # encoding loop has access to enc_mode_array, encoder_type, etc.
+            head -n "$split_line" "./${run_sh}" | grep '^[a-zA-Z_][a-zA-Z_0-9]*='
+            sed -n "$((split_line + 1)),${last_done_line}p" "./${run_sh}"
+        } > "./${encode_sh}"
+        chmod +x "./${downscale_sh}" "./${encode_sh}"
+    else
+        echo '#!/bin/bash' > "./${downscale_sh}"
+        cp "./${run_sh}" "./${encode_sh}"
+        chmod +x "./${downscale_sh}" "./${encode_sh}"
+    fi
+
+    if [ "$skip_downscale" = "1" ]; then
+        # Reuse cached resized_clips from a prior prep run
+        if [ ! -d "${FFMPEG_ROOT}/resized_clips" ] || [ -z "$(ls -A "${FFMPEG_ROOT}/resized_clips" 2>/dev/null)" ]; then
+            echo "Error: resized_clips/ not found or empty. Run video_transcode_bench_svt_timed_mini_prep first." >&2
+            exit 1
+        fi
+        log_start "$BREAKDOWN_FOLDER" "$preprocessing_operation_name" "$$" "downscaling_cached"
+        log_end "$BREAKDOWN_FOLDER" "$preprocessing_operation_name" "$$" "downscaling_cached"
+    else
+        log_start "$BREAKDOWN_FOLDER" "$preprocessing_operation_name" "$$" "downscaling"
+        ./"${downscale_sh}"
+        log_end "$BREAKDOWN_FOLDER" "$preprocessing_operation_name" "$$" "downscaling"
+    fi
+
     log_preprocessing_end "$BREAKDOWN_FOLDER" "$$"
     log_main_benchmark_start "$BREAKDOWN_FOLDER" "$$"
     benchreps_tell_state "start"
     if [ "${DCPERF_PERF_RECORD}" = 1 ] && ! [ -f "perf.data" ]; then
         collect_perf_record &
     fi
-    ./"${run_sh}"
+    ./"${encode_sh}"
     benchreps_tell_state "done"
     log_main_benchmark_end "$BREAKDOWN_FOLDER" "$$"
     log_postprocessing_start "$BREAKDOWN_FOLDER" "$$"
@@ -416,7 +498,22 @@ FEEDER_EOF
         fi
     done
 
-    delete_replicas
+    # Save per-job durations for reuse runs. The durations file preserves
+    # the command file order (fast-first) so the reuse feeder can compute
+    # exactly how many jobs fit within max_time on any target core count.
+    if [ "$keep_downscaled" = "1" ]; then
+        for num in $(seq "${low}" "${high}"); do
+            joblog="joblog_m${num}.txt"
+            if [ -f "${joblog}" ]; then
+                awk 'NR>1 && $7==0 { print $1, $4 }' "${joblog}" | \
+                    sort -n -k1,1 | awk '{ print $2 }' > "job_durations_m${num}.txt"
+            fi
+        done
+    fi
+
+    if [ "$keep_downscaled" = "0" ]; then
+        delete_replicas
+    fi
 
     # Restore the original generate_commands_all.py from backup
     mv ${FFMPEG_ROOT}/generate_commands_all.backup.py ${FFMPEG_ROOT}/generate_commands_all.py

--- a/packages/video_transcode_bench/timed_parallel_feeder.sh
+++ b/packages/video_transcode_bench/timed_parallel_feeder.sh
@@ -5,12 +5,16 @@
 # LICENSE file in the root directory of this source tree.
 #
 # Timed parallel feeder for VideoTranscodeBench.
-# Feeds jobs from a command file to GNU parallel, stopping when the time
-# limit is reached. In-flight jobs are allowed to finish gracefully.
+# Feeds a bounded number of jobs from a command file to GNU parallel.
+# When a max_time is set, the number of jobs is chosen so that total
+# wall-clock time approximates max_time on the target machine.
 # A joblog is written so callers can determine which jobs succeeded.
 #
-# Usage: timed_parallel_feeder.sh <jobs_file> <num_jobs> <max_time_secs> <joblog_file>
+# Usage: timed_parallel_feeder.sh <jobs_file> <num_jobs> <max_time_secs> <joblog_file> [durations_file]
 #   max_time_secs=0 means no time limit (original behavior).
+#   durations_file (optional): per-job durations from a prior prep run,
+#     one value per line in the same order as jobs_file. Used to compute
+#     how many jobs fit within max_time on this machine's core count.
 
 set -Eeo pipefail
 
@@ -18,9 +22,10 @@ JOBS_FILE="$1"
 NUM_JOBS="$2"
 MAX_TIME="$3"
 JOBLOG_FILE="$4"
+DURATIONS_FILE="${5:-}"
 
 if [ -z "$JOBS_FILE" ] || [ -z "$NUM_JOBS" ] || [ -z "$MAX_TIME" ] || [ -z "$JOBLOG_FILE" ]; then
-    echo "Usage: $0 <jobs_file> <num_jobs> <max_time_secs> <joblog_file>" >&2
+    echo "Usage: $0 <jobs_file> <num_jobs> <max_time_secs> <joblog_file> [durations_file]" >&2
     exit 1
 fi
 
@@ -33,20 +38,24 @@ if [ "$MAX_TIME" -le 0 ]; then
     # No time limit: run all jobs (original behavior)
     parallel --joblog "$JOBLOG_FILE" -j "$NUM_JOBS" < "$JOBS_FILE"
 else
-    # Run parallel in the background with all jobs available.
-    # After the time limit, send SIGTERM to parallel which makes it stop
-    # spawning new jobs while letting in-flight jobs finish gracefully.
-    parallel --joblog "$JOBLOG_FILE" -j "$NUM_JOBS" < "$JOBS_FILE" &
-    PARALLEL_PID=$!
+    TOTAL_JOBS=$(wc -l < "$JOBS_FILE")
+    TARGET_CORE_SECS=$(( MAX_TIME * NUM_JOBS ))
 
-    # Background timer: sends SIGTERM after MAX_TIME seconds
-    ( sleep "$MAX_TIME" && kill -TERM "$PARALLEL_PID" 2>/dev/null ) &
-    TIMER_PID=$!
+    if [ -n "$DURATIONS_FILE" ] && [ -f "$DURATIONS_FILE" ]; then
+        # Compute MAX_JOBS from actual per-job durations: accumulate
+        # durations until sum >= max_time * num_cores (target core-seconds).
+        MAX_JOBS=$(awk -v target="$TARGET_CORE_SECS" '
+            { sum += $1; if (sum >= target) { print NR; exit } }
+            END { if (sum < target) print NR }
+        ' "$DURATIONS_FILE")
+    else
+        # Fallback: estimate 2x jobs as a buffer (no duration data)
+        MAX_JOBS=$(( MAX_TIME * NUM_JOBS * 2 ))
+    fi
 
-    # Wait for parallel to finish (either naturally or after SIGTERM)
-    wait "$PARALLEL_PID" 2>/dev/null || true
-
-    # Clean up the timer if parallel finished before the time limit
-    kill "$TIMER_PID" 2>/dev/null || true
-    wait "$TIMER_PID" 2>/dev/null || true
+    if [ "$MAX_JOBS" -lt "$TOTAL_JOBS" ]; then
+        head -n "$MAX_JOBS" "$JOBS_FILE" | parallel --joblog "$JOBLOG_FILE" -j "$NUM_JOBS" || true
+    else
+        parallel --joblog "$JOBLOG_FILE" -j "$NUM_JOBS" < "$JOBS_FILE" || true
+    fi
 fi


### PR DESCRIPTION
Summary:
The video_transcode_bench_svt_timed_mini benchmark takes ~36 seconds
wall-clock, but only ~15 seconds is actual encoding. The remaining ~19
  seconds is spent downscaling all 42 source clips to target resolutions — a
   data preparation step, not representative of production workloads.

  This diff introduces a two-run pattern (similar to DjangoBench and
  SparkBench mini) that separates preparation from measurement:

  - video_transcode_bench_svt_timed_mini_prep: Downscales a sampled subset
  of clips (20%, ~8 clips) and caches them in resized_clips/ for reuse.
  After this run, the ~42GB source dataset can be deleted to reduce OS image
   size.
  - video_transcode_bench_svt_timed_mini_reuse: Skips downscaling entirely,
  reuses cached resized_clips/, and runs only the encoding workload. Errors
  if the cache doesn't exist. Can be run repeatedly.

  Additional changes:
  - Split the generated run script so downscaling runs during preprocessing
  (tracked as a downscaling sub-operation in breakdown.csv), and only
  encoding runs during main_benchmark
  - Replaced the sleep+SIGTERM time-limiting mechanism in
  timed_parallel_feeder.sh with a deadline-based feeding loop that stops
  dispatching jobs after max_time
  - Reduced max_time from 15 to 10 seconds for both new variants
  - Added --skip-downscale and --keep-downscaled flags to run.sh
  - Updated README with two-run pattern instructions

Differential Revision: D102686096


