### PR TITLE
Regenerate carbon protocol files to fix conveyor build

### DIFF
--- a/packages/ucache_bench/protocol/gen/UcacheBenchMessages.cpp
+++ b/packages/ucache_bench/protocol/gen/UcacheBenchMessages.cpp
@@ -12,7 +12,7 @@
  *
  *  @generated
  */
-#include "UcacheBenchMessages.h"
+#include "cea/chips/benchpress/packages/ucache_bench/protocol/gen/UcacheBenchMessages.h"
 
 namespace facebook {
 namespace ucachebench {

--- a/packages/ucache_bench/protocol/gen/UcacheBenchRouterInfo-BuildExtraProvider.cpp
+++ b/packages/ucache_bench/protocol/gen/UcacheBenchRouterInfo-BuildExtraProvider.cpp
@@ -12,7 +12,7 @@
  *
  *  @generated
  */
-#include "UcacheBenchRouterInfo.h"
+#include "cea/chips/benchpress/packages/ucache_bench/protocol/gen/UcacheBenchRouterInfo.h"
 
 #include <mcrouter/routes/McExtraRouteHandleProvider.h>
 

--- a/packages/ucache_bench/protocol/gen/UcacheBenchRouterInfo-ExternTemplate.cpp
+++ b/packages/ucache_bench/protocol/gen/UcacheBenchRouterInfo-ExternTemplate.cpp
@@ -12,7 +12,7 @@
  *
  *  @generated
  */
-#include "UcacheBenchRouterInfo.h"
+#include "cea/chips/benchpress/packages/ucache_bench/protocol/gen/UcacheBenchRouterInfo.h"
 
 #include <folly/dynamic.h>
 

--- a/packages/ucache_bench/protocol/gen/UcacheBenchRouterInfo.cpp
+++ b/packages/ucache_bench/protocol/gen/UcacheBenchRouterInfo.cpp
@@ -12,7 +12,7 @@
  *
  *  @generated
  */
-#include "UcacheBenchRouterInfo.h"
+#include "cea/chips/benchpress/packages/ucache_bench/protocol/gen/UcacheBenchRouterInfo.h"
 
 #include <unordered_map>
 

--- a/packages/ucache_bench/protocol/gen/UcacheBenchRouterInfoFwd.h
+++ b/packages/ucache_bench/protocol/gen/UcacheBenchRouterInfoFwd.h
@@ -41,6 +41,8 @@ class UcbSetRequest;
 namespace facebook {
 namespace ucachebench {
 
+struct UcacheBenchRouterInfo;
+
 namespace detail {
 
 using UcacheBenchRoutableRequests = carbon::List<


### PR DESCRIPTION
Summary:
The carbon compiler (cppgen.py) was recently updated to generate absolute `#include` paths instead of relative ones, and to restructure the thrift BUCK target layout. The checked-in generated files were not regenerated to match, causing the `carbon-UcacheBench-gen` genrule validation to fail in CI. This has been blocking the `cea.chips.benchpress` conveyor build since April 24.

Regenerated by running: `buck2 run fbcode//mcrouter/lib/carbon/facebook/compiler:carbon_compiler -- -i cea/chips/benchpress/packages/ucache_bench/protocol/UcacheBench.idl`

Differential Revision: D103250095


