### PR TITLE
Fix Neoverse V2 PMU scripts: shortest series alignment and redundant PMC

### DIFF
--- a/perfutils/collect_nvda_neoversev2_perf_counters.sh
+++ b/perfutils/collect_nvda_neoversev2_perf_counters.sh
@@ -26,7 +26,7 @@ INTERVAL_SECS=5
 
 ### Cycles and Instructions
 # r08: ins
-INSTRUCTIONS_RATE='cycles,instructions,duration_time,task-clock,r08'
+INSTRUCTIONS_RATE='cycles,instructions,duration_time,task-clock'
 
 ### Cache Effectiveness Metrics
 # l1d access, l1d miss

--- a/perfutils/generate_arm_perf_report.py
+++ b/perfutils/generate_arm_perf_report.py
@@ -938,7 +938,7 @@ def main(
     ]
 
     filtered_metrics = list(itertools.filterfalse(lambda x: x is None, metrics))
-    shortest_series = max(filtered_metrics, key=lambda m: m["series"].size)
+    shortest_series = min(filtered_metrics, key=lambda m: m["series"].size)
     df_metrics = concat_series(filtered_metrics, shortest_series)
     if series:
         series.write(df_metrics.to_csv(index=False))


### PR DESCRIPTION
Summary:
Fix two bugs in the Neoverse V2 (NVIDIA Grace) perf counter scripts that were also present in the V3 versions (fixed separately in D103485073).

1. DataFrame alignment bug in generate_arm_perf_report.py: `max()` was used to find the "shortest" series for aligning dataframes, which actually selects the longest series, causing NaN values or alignment errors when concatenating shorter series. Changed to `min()`.

2. Redundant r08 event in collect_nvda_neoversev2_perf_counters.sh: the INSTRUCTIONS_RATE group collected both `instructions` (Linux perf hardware generic event) and `r08` (INST_RETIRED). These map to the same underlying PMU counter, wasting one of the 6 available PMC slots and increasing multiplexing pressure. Removed `r08`.

Differential Revision: D103486886


