### PR TITLE
Strip null bytes from nginx access log to fix UTF-8 errors in metrics

### DIFF
--- a/packages/mediawiki/0008-nginx-strip-null-bytes.diff
+++ b/packages/mediawiki/0008-nginx-strip-null-bytes.diff
@@ -1,0 +1,17 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+diff --git a/base/NginxDaemon.php b/base/NginxDaemon.php
+index aa48307..3e9bb2a 100644
+--- a/base/NginxDaemon.php
++++ b/base/NginxDaemon.php
+@@ -48,6 +48,8 @@ final class NginxDaemon extends Process {
+ 
+     // Custom format: '$status $body_bytes_sent $request_time "$request"'
+     $log = file_get_contents($this->options->tempDir.'/access.log');
++    // Strip null bytes that can appear due to nginx log buffer races on high-throughput ARM systems
++    $log = str_replace("\x00", "", $log);
+     $entries = explode("\n", trim($log));
+     $entries_by_request = array();
+     foreach ($entries as $entry) {

--- a/packages/mediawiki/install_oss_performance_mediawiki.sh
+++ b/packages/mediawiki/install_oss_performance_mediawiki.sh
@@ -231,6 +231,9 @@ git apply --check "${TEMPLATES_DIR}/0001-oss-performance-scalable-hhvm.diff" \
 # templates/oss-performance-mediawiki/0006-oss-performance-reuse-mediawiki-hhvm.diff
 git apply --check "${TEMPLATES_DIR}/0006-oss-performance-reuse-mediawiki-hhvm.diff" \
     && git apply "${TEMPLATES_DIR}/0006-oss-performance-reuse-mediawiki-hhvm.diff"
+# Strip null bytes from nginx access log to fix UTF-8 errors in metrics on ARM
+git apply --check "${TEMPLATES_DIR}/0008-nginx-strip-null-bytes.diff" \
+    && git apply "${TEMPLATES_DIR}/0008-nginx-strip-null-bytes.diff"
 
 # apply options for mediawiki mini patch
 git apply --check "${TEMPLATES_DIR}/0007-oss-performance-more-warmup-options.diff" \


### PR DESCRIPTION
Summary:
On high-throughput ARM systems (Grace/Neoverse-V2 with 72 cores), nginx's
log write buffer occasionally contains null-byte padding prepended to log
lines due to a race condition in buffer reallocation. This causes the
NginxDaemon.php parser to create invalid metric keys like
"Nginx \x00\x00...200" instead of "Nginx 200", which then produces
"String value is not valid UTF8" errors in perfpub's overall_metrics.csv.

Fix: Strip all null bytes from the access log immediately after reading,
before any parsing occurs.

Observed on rtptest4506.cco3 (Grace T11, 72 cores) running mediawiki_mlp
with wrk at ~4.5K RPS — 3,254 out of 2.7M log lines were affected.

Differential Revision: D104310584


