### PR TITLE
Use git-core instead of git in install scripts

### DIFF
--- a/packages/django_workload/install_django_workload_aarch64.sh
+++ b/packages/django_workload/install_django_workload_aarch64.sh
@@ -41,7 +41,7 @@ dnf groupinstall "Development Tools" -y --exclude="texlive*"
 dnf install -y memcached libmemcached-awesome-devel zlib-devel screen \
     openssl-devel bzip2-devel libffi-devel wget make xz-devel haproxy \
     xxhash-devel perl-FindBin perl-JSON perl-core liburing-devel \
-    ninja-build clang libev libev-devel cmake
+    ninja-build clang libev libev-devel cmake git-core
 
 echo "System dependencies installed successfully"
 

--- a/packages/django_workload/install_django_workload_aarch64_ubuntu22_24.sh
+++ b/packages/django_workload/install_django_workload_aarch64_ubuntu22_24.sh
@@ -41,7 +41,7 @@ apt install -y memcached libmemcached-dev zlib1g-dev screen \
     libssl-dev libcrypt-dev haproxy libxxhash-dev \
     perl liburing-dev ninja-build libev4 libev-dev cmake \
     software-properties-common build-essential libbz2-dev libreadline-dev \
-    libsqlite3-dev libncurses-dev liblzma-dev wget unzip netcat-openbsd
+    libsqlite3-dev libncurses-dev liblzma-dev wget unzip netcat-openbsd git
 
 # Detect Ubuntu version for version-specific logic
 UBUNTU_VERSION="$(. /etc/os-release && echo "${VERSION_ID}")"

--- a/packages/django_workload/install_django_workload_x86_64_centos.sh
+++ b/packages/django_workload/install_django_workload_x86_64_centos.sh
@@ -41,7 +41,7 @@ dnf groupinstall "Development Tools" -y --exclude="texlive*"
 dnf install -y memcached libmemcached-awesome-devel zlib-devel screen \
     openssl-devel bzip2-devel libffi-devel wget make xz-devel haproxy \
     xxhash-devel perl-FindBin perl-JSON perl-core liburing-devel \
-    ninja-build clang libev libev-devel cmake
+    ninja-build clang libev libev-devel cmake git-core
 
 # Verify critical headers are present (zlib.h is needed by pylibmc)
 if [ ! -f /usr/include/zlib.h ]; then

--- a/packages/django_workload/install_django_workload_x86_64_ubuntu22_24.sh
+++ b/packages/django_workload/install_django_workload_x86_64_ubuntu22_24.sh
@@ -41,7 +41,7 @@ apt install -y memcached libmemcached-dev zlib1g-dev screen \
     libssl-dev libcrypt-dev haproxy libxxhash-dev \
     perl liburing-dev ninja-build libev4 libev-dev cmake \
     software-properties-common build-essential libbz2-dev libreadline-dev \
-    libsqlite3-dev libncurses-dev liblzma-dev wget unzip netcat-openbsd
+    libsqlite3-dev libncurses-dev liblzma-dev wget unzip netcat-openbsd git
 
 # Detect Ubuntu version for version-specific logic
 UBUNTU_VERSION="$(. /etc/os-release && echo "${VERSION_ID}")"


### PR DESCRIPTION
Summary:
On TWshared CentOS Stream 9 hosts, `dnf install -y git` reports the package as
installed but `/usr/bin/git` does not exist, causing django benchmark installs to
fail at Step 5 (Building Cinder) with "git: command not found".

**Root cause:** Meta's Source Control team recently rolled out `fb-git-core` (a Meta-built
git client RPM) to the fleet. The `fb-git-core-debuginfo` subpackage in the `fb-runtime`
repo incorrectly declares `Provides: git-core = 2.53.0`. When `dnf install -y git` runs,
DNF sees this as satisfying the `git` package's dependency on `git-core` and installs
only the debuginfo package — which contains no actual git binary. The real `git-core`
package (with `/usr/bin/git`) is never pulled in.

**Fix:** Use `git-core` explicitly instead of `git` in all dnf-based install commands.
This forces DNF to install the real binary package regardless of the broken provides
declaration. Ubuntu/apt scripts are unaffected (they use `git` which is correct for apt).

**Files changed:**
- benchpress install scripts (x86_64_centos, aarch64): `git` → `git-core` in dnf install
- automark client `_install_dependencies()`: `git` → `git-core`

Reported upstream: https://fb.workplace.com/groups/rde.oncall/permalink/26213599821673616/

Reviewed By: YifanYuan3

Differential Revision: D104732655


