### PR TITLE
Skip git install when fb-git-core is already present

### DIFF
--- a/packages/django_workload/install_django_workload.sh
+++ b/packages/django_workload/install_django_workload.sh
@@ -40,7 +40,8 @@ fi
 cd "$BP_TMP" || exit 1
 
 # Install system dependencies
-dnf install -y git memcached libmemcached-devel zlib-devel screen python36 \
+which git &>/dev/null || dnf install -y git-core
+dnf install -y memcached libmemcached-devel zlib-devel screen python36 \
     python36-devel python3-numpy haproxy
 
 # Copy django-workload from srcs directory instead of cloning from GitHub

--- a/packages/django_workload/install_django_workload_aarch64.sh
+++ b/packages/django_workload/install_django_workload_aarch64.sh
@@ -41,7 +41,8 @@ dnf groupinstall "Development Tools" -y --exclude="texlive*"
 dnf install -y memcached libmemcached-awesome-devel zlib-devel screen \
     openssl-devel bzip2-devel libffi-devel wget make xz-devel haproxy \
     xxhash-devel perl-FindBin perl-JSON perl-core liburing-devel \
-    ninja-build clang libev libev-devel cmake git-core
+    ninja-build clang libev libev-devel cmake
+which git &>/dev/null || dnf install -y git-core
 
 echo "System dependencies installed successfully"
 

--- a/packages/django_workload/install_django_workload_x86_64_centos.sh
+++ b/packages/django_workload/install_django_workload_x86_64_centos.sh
@@ -41,7 +41,8 @@ dnf groupinstall "Development Tools" -y --exclude="texlive*"
 dnf install -y memcached libmemcached-awesome-devel zlib-devel screen \
     openssl-devel bzip2-devel libffi-devel wget make xz-devel haproxy \
     xxhash-devel perl-FindBin perl-JSON perl-core liburing-devel \
-    ninja-build clang libev libev-devel cmake git-core
+    ninja-build clang libev libev-devel cmake
+which git &>/dev/null || dnf install -y git-core
 
 # Verify critical headers are present (zlib.h is needed by pylibmc)
 if [ ! -f /usr/include/zlib.h ]; then


### PR DESCRIPTION
Summary:
On hosts where Meta's `fb-git-core` RPM is already installed, `dnf install -y
git-core` fails with an RPM conflict (Transaction test error: file conflicts with
package fb-git-core). This causes django benchmark installs to fail on the db host
during automark --init.

D104732655 fixed the case where `dnf install -y git` silently installs only the
debuginfo package (no actual binary). But it did not handle this second failure mode
where `fb-git-core` provides a working git and dnf refuses to install the conflicting
upstream `git-core` package.

Fix: Check if git is already available before attempting to install it. This handles
both scenarios:
1. fb-git-core present with working git → skip install
2. No git available → install git-core as before

Differential Revision: D105245152


