### PR TITLE
Propagate `PrivacyLibAgenticContext` through Carbon requests and Thrift transport headers (#621)

### DIFF
--- a/packages/ucache_bench/protocol/gen/UcacheBenchThriftTransport.h
+++ b/packages/ucache_bench/protocol/gen/UcacheBenchThriftTransport.h
@@ -54,6 +54,10 @@ folly::Try<apache::thrift::RpcResponseComplete<ucachebench::UcbDeleteReply>> sen
     rpcOptions.setWriteHeader(
         std::string{carbon::MessageCommon::kClientIdentifierHeader}, request.getClientIdentifier().value());
   }
+  if (FOLLY_UNLIKELY(request.getPrivacyLibAgenticContext().has_value())) {
+    rpcOptions.setWriteHeader(
+        std::string{carbon::MessageCommon::kPrivacyLibAgenticContextHeader}, request.getPrivacyLibAgenticContext().value());
+  }
   rpcOptions.setContextPropMask(0);
 
 #ifndef LIBMC_FBTRACE_DISABLE
@@ -93,6 +97,10 @@ folly::Try<apache::thrift::RpcResponseComplete<ucachebench::UcbGetReply>> sendSy
   if (FOLLY_UNLIKELY(request.getClientIdentifier().has_value())) {
     rpcOptions.setWriteHeader(
         std::string{carbon::MessageCommon::kClientIdentifierHeader}, request.getClientIdentifier().value());
+  }
+  if (FOLLY_UNLIKELY(request.getPrivacyLibAgenticContext().has_value())) {
+    rpcOptions.setWriteHeader(
+        std::string{carbon::MessageCommon::kPrivacyLibAgenticContextHeader}, request.getPrivacyLibAgenticContext().value());
   }
   rpcOptions.setContextPropMask(0);
 
@@ -134,6 +142,10 @@ folly::Try<apache::thrift::RpcResponseComplete<ucachebench::UcbSetReply>> sendSy
     rpcOptions.setWriteHeader(
         std::string{carbon::MessageCommon::kClientIdentifierHeader}, request.getClientIdentifier().value());
   }
+  if (FOLLY_UNLIKELY(request.getPrivacyLibAgenticContext().has_value())) {
+    rpcOptions.setWriteHeader(
+        std::string{carbon::MessageCommon::kPrivacyLibAgenticContextHeader}, request.getPrivacyLibAgenticContext().value());
+  }
   rpcOptions.setContextPropMask(0);
 
 #ifndef LIBMC_FBTRACE_DISABLE
@@ -173,6 +185,10 @@ folly::Try<apache::thrift::RpcResponseComplete<McVersionReply>> sendSyncHelper(
   if (FOLLY_UNLIKELY(request.getClientIdentifier().has_value())) {
     rpcOptions.setWriteHeader(
         std::string{carbon::MessageCommon::kClientIdentifierHeader}, request.getClientIdentifier().value());
+  }
+  if (FOLLY_UNLIKELY(request.getPrivacyLibAgenticContext().has_value())) {
+    rpcOptions.setWriteHeader(
+        std::string{carbon::MessageCommon::kPrivacyLibAgenticContextHeader}, request.getPrivacyLibAgenticContext().value());
   }
   rpcOptions.setContextPropMask(0);
 


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebook/mcrouter/pull/479

X-link: https://github.com/facebook/hhvm/pull/9778


Propagate the `PrivacyLibAgenticContext` as a `privacylib-propagation` Thrift header from clients through mcrouter to DevProxy.

We capture the context before enqueuing the request in the mcrouter message queue. And then we set the header in the mcrouter Thrift transport layer.

Diagram:

```
Caller thread (RequestContext available)
    │
    ├── CacheClientImplBase::buildSingleRequest()  ← captures context here
    │   └── carbonReq.setPrivacyLibAgenticContext(serialized)
    │
    ├── RequestBuilderHelper::updateTaoRequestCommonPart()  ← also captures here (TAO-specific)
    │   └── carbonReq.setPrivacyLibAgenticContext(serialized)
    │
    ╧ ── MessageQueue ──────────────────── (RequestContext lost, but field survives)
    │
    └── ThriftTransport::sendSyncHelper()
        └── request.getPrivacyLibAgenticContext().has_value()
            └── rpcOptions.setWriteHeader("privacylib-propagation", value)
```

We are focusing on Thrift transport exclusively as we are trying to close gaps in DevProxy layer.

Reviewed By: ghostonhuang

Differential Revision: D105269091


