### PR TITLE
Centos10 update for aarch64 (#630)

### DIFF
--- a/.github/workflows/dcperf_ci_django.yml
+++ b/.github/workflows/dcperf_ci_django.yml
@@ -50,6 +50,8 @@ jobs:
           { arch: aarch64, instance: "ubuntu-24.04-arm", container: "ubuntu:22.04", type: "ubuntu" },
           { arch: x86, instance: "ubuntu-latest", container: "quay.io/centos/centos:stream9", type: "centos" },
           { arch: aarch64, instance: "ubuntu-24.04-arm", container: "quay.io/centos/centos:stream9", type: "centos" },
+            { arch: x86, instance: "ubuntu-latest", container: "quay.io/centos/centos:stream10", type: "centos" },
+          { arch: aarch64, instance: "ubuntu-24.04-arm", container: "quay.io/centos/centos:stream10", type: "centos" },
           { arch: x86, instance: "ubuntu-latest", container: "ubuntu:24.04", type: "ubuntu" },
           { arch: aarch64, instance: "ubuntu-24.04-arm", container: "ubuntu:24.04", type: "ubuntu" },
 

--- a/.github/workflows/dcperf_ci_feedsim.yml
+++ b/.github/workflows/dcperf_ci_feedsim.yml
@@ -50,6 +50,8 @@ jobs:
           { arch: aarch64, instance: "ubuntu-24.04-arm", container: "ubuntu:22.04", type: "ubuntu" },
           { arch: x86, instance: "ubuntu-latest", container: "quay.io/centos/centos:stream9", type: "centos" },
           { arch: aarch64, instance: "ubuntu-24.04-arm", container: "quay.io/centos/centos:stream9", type: "centos" },
+          { arch: x86, instance: "ubuntu-latest", container: "quay.io/centos/centos:stream10", type: "centos" },
+          { arch: aarch64, instance: "ubuntu-24.04-arm", container: "quay.io/centos/centos:stream10", type: "centos" },
           { arch: x86, instance: "ubuntu-latest", container: "ubuntu:24.04", type: "ubuntu" },
           { arch: aarch64, instance: "ubuntu-24.04-arm", container: "ubuntu:24.04", type: "ubuntu" },
 

--- a/.github/workflows/dcperf_ci_spark.yml
+++ b/.github/workflows/dcperf_ci_spark.yml
@@ -50,6 +50,8 @@ jobs:
           { arch: aarch64, instance: "ubuntu-24.04-arm", container: "ubuntu:22.04", type: "ubuntu" },
           { arch: x86, instance: "ubuntu-latest", container: "quay.io/centos/centos:stream9", type: "centos" },
           { arch: aarch64, instance: "ubuntu-24.04-arm", container: "quay.io/centos/centos:stream9", type: "centos" },
+          { arch: x86, instance: "ubuntu-latest", container: "quay.io/centos/centos:stream10", type: "centos" },
+          { arch: aarch64, instance: "ubuntu-24.04-arm", container: "quay.io/centos/centos:stream10", type: "centos" },
           { arch: x86, instance: "ubuntu-latest", container: "ubuntu:24.04", type: "ubuntu" },
           { arch: aarch64, instance: "ubuntu-24.04-arm", container: "ubuntu:24.04", type: "ubuntu" },
         ]

--- a/.github/workflows/dcperf_ci_syscall.yml
+++ b/.github/workflows/dcperf_ci_syscall.yml
@@ -50,6 +50,8 @@ jobs:
           { arch: aarch64, instance: "ubuntu-24.04-arm", container: "ubuntu:22.04", type: "ubuntu" },
           { arch: x86, instance: "ubuntu-latest", container: "quay.io/centos/centos:stream9", type: "centos" },
           { arch: aarch64, instance: "ubuntu-24.04-arm", container: "quay.io/centos/centos:stream9", type: "centos" },
+          { arch: x86, instance: "ubuntu-latest", container: "quay.io/centos/centos:stream10", type: "centos" },
+          { arch: aarch64, instance: "ubuntu-24.04-arm", container: "quay.io/centos/centos:stream10", type: "centos" },
           { arch: x86, instance: "ubuntu-latest", container: "ubuntu:24.04", type: "ubuntu" },
           { arch: aarch64, instance: "ubuntu-24.04-arm", container: "ubuntu:24.04", type: "ubuntu" },
 

--- a/.github/workflows/dcperf_ci_tao_bench.yml
+++ b/.github/workflows/dcperf_ci_tao_bench.yml
@@ -50,6 +50,8 @@ jobs:
           { arch: aarch64, instance: "ubuntu-24.04-arm", container: "ubuntu:22.04", type: "ubuntu" },
           { arch: x86, instance: "ubuntu-latest", container: "quay.io/centos/centos:stream9", type: "centos" },
           { arch: aarch64, instance: "ubuntu-24.04-arm", container: "quay.io/centos/centos:stream9", type: "centos" },
+          { arch: x86, instance: "ubuntu-latest", container: "quay.io/centos/centos:stream10", type: "centos" },
+          { arch: aarch64, instance: "ubuntu-24.04-arm", container: "quay.io/centos/centos:stream10", type: "centos" },
           { arch: x86, instance: "ubuntu-latest", container: "ubuntu:24.04", type: "ubuntu" },
           { arch: aarch64, instance: "ubuntu-24.04-arm", container: "ubuntu:24.04", type: "ubuntu" },
         ]

--- a/.github/workflows/dcperf_ci_video_transcode_bench.yml
+++ b/.github/workflows/dcperf_ci_video_transcode_bench.yml
@@ -50,6 +50,8 @@ jobs:
           { arch: aarch64, instance: "ubuntu-24.04-arm", container: "ubuntu:22.04", type: "ubuntu" },
           { arch: x86, instance: "ubuntu-latest", container: "quay.io/centos/centos:stream9", type: "centos" },
           { arch: aarch64, instance: "ubuntu-24.04-arm", container: "quay.io/centos/centos:stream9", type: "centos" },
+          { arch: x86, instance: "ubuntu-latest", container: "quay.io/centos/centos:stream10", type: "centos" },
+          { arch: aarch64, instance: "ubuntu-24.04-arm", container: "quay.io/centos/centos:stream10", type: "centos" },
           { arch: x86, instance: "ubuntu-latest", container: "ubuntu:24.04", type: "ubuntu" },
           { arch: aarch64, instance: "ubuntu-24.04-arm", container: "ubuntu:24.04", type: "ubuntu" },
         ]

--- a/packages/ai_wdl/chm/install_chm.sh
+++ b/packages/ai_wdl/chm/install_chm.sh
@@ -141,6 +141,16 @@ build_folly() {
   pushd folly-${FOLLY_VERSION} || exit 1
   # Fix zlib download URL (zlib.net moved old releases to /fossils/)
   sed -i 's|url = https://zlib.net/zlib-|url = https://zlib.net/fossils/zlib-|' build/fbcode_builder/manifests/zlib
+
+  # On aarch64 (e.g., CentOS 10 with GCC 14 + NumPy 2.x), Boost 1.83's
+  # boost-python fails to compile because NumPy 2.0 made PyArray_Descr opaque
+  # (removed direct ->elsize access). Since CHM doesn't use boost-python at all,
+  # skip building it on aarch64 to avoid the incompatibility.
+  if [ "$(uname -m)" = "aarch64" ]; then
+    echo "[FIX] Removing --with-python from boost manifest (not needed, avoids NumPy 2.x build failure on aarch64)"
+    sed -i '/^--with-python$/d' build/fbcode_builder/manifests/boost
+  fi
+
   # Install system dependencies required by Folly
   sudo ./build/fbcode_builder/getdeps.py install-system-deps --recursive
   # Build Folly with system packages allowed and using our build directory

--- a/packages/ai_wdl/deser/install_deser.sh
+++ b/packages/ai_wdl/deser/install_deser.sh
@@ -145,6 +145,8 @@ build_folly() {
   pushd folly-${FOLLY_VERSION} || exit 1
   # Fix zlib download URL (zlib.net moved old releases to /fossils/)
   sed -i 's|url = https://zlib.net/zlib-|url = https://zlib.net/fossils/zlib-|' build/fbcode_builder/manifests/zlib
+  # Remove --with-python from boost manifest (not needed, avoids NumPy 2.x build failure on aarch64)
+  sed -i '/^--with-python$/d' build/fbcode_builder/manifests/boost
   # Install system dependencies required by Folly
   sudo ./build/fbcode_builder/getdeps.py install-system-deps --recursive
   # Build Folly with system packages allowed and using our build directory

--- a/packages/ai_wdl/fbgemm/install_fbgemm_bench.sh
+++ b/packages/ai_wdl/fbgemm/install_fbgemm_bench.sh
@@ -1134,6 +1134,10 @@ cat > "${BENCHMARKS_DIR}/run.sh" <<'EOF'
 # Usage: ./run.sh <binary_name> [args...]
 set -e
 
+# Raise file descriptor limit to avoid "Too many open files" errors
+# when running multiprocessing benchmarks (e.g., tbe_inference_benchmark with --copies)
+ulimit -n 1000000 2>/dev/null || true
+
 BIN="$1"
 shift
 

--- a/packages/feedsim/install_feedsim_aarch64.sh
+++ b/packages/feedsim/install_feedsim_aarch64.sh
@@ -228,6 +228,7 @@ if ! [ -d "libtorch" ]; then
     # Also install libstdcxx-ng to ensure compatible C++ runtime
     eval "$("${CONDA_DIR}/bin/conda" shell.bash hook)"
     conda tos accept --override-channels --channel https://repo.anaconda.com/pkgs/main || true
+    conda tos accept --override-channels --channel https://repo.anaconda.com/pkgs/r || true
     conda install -y -c conda-forge libstdcxx-ng
 
     # Locate the pip-installed torch package

--- a/packages/mediawiki/install_oss_performance_mediawiki.sh
+++ b/packages/mediawiki/install_oss_performance_mediawiki.sh
@@ -92,6 +92,17 @@ stop_nginx() {
   fi
 }
 
+# 0. Disable SELinux (required on CentOS 10 aarch64 for HHVM/nginx/MariaDB)
+ARCH="$(uname -m)"
+LINUX_VERSION_ID="$(awk -F "=" '/^VERSION_ID=/ {print $2}' /etc/os-release | tr -d '"')"
+if [ "$LINUX_DIST_ID" = "centos" ] && [ "$ARCH" = "aarch64" ] && [[ "$LINUX_VERSION_ID" == 10* ]] && command -v getenforce &>/dev/null; then
+  if [ "$(getenforce)" != "Disabled" ]; then
+    echo "Disabling SELinux (required on CentOS 10 aarch64)..."
+    sudo setenforce 0
+    sudo sed -i 's/^SELINUX=enforcing/SELINUX=permissive/' /etc/selinux/config
+  fi
+fi
+
 # 1. Install prerequisite packages
 if [ "$LINUX_DIST_ID" = "ubuntu" ]; then
   apt install -y libevent-dev zlib1g zlib1g-dev
@@ -100,7 +111,7 @@ if [ "$LINUX_DIST_ID" = "ubuntu" ]; then
 elif [ "$LINUX_DIST_ID" = "centos" ]; then
   dnf install -y libevent-devel zlib-devel
   dnf install -y php-common php-cli php-devel
-  dnf install -y unzip
+  dnf install -y unzip bc
 fi
 
 # 2. Make sure hhvm 3.30.12 is installed
@@ -171,6 +182,7 @@ mysql -u root --password="$MARIADB_PWD" $MYSQL_SOCKET_PARAM < "${TEMPLATES_DIR}/
 
 # 5. Install Siege
 if ! [ -x "$(command -v siege)" ]; then
+  rm -rf siege
   # shellcheck disable=SC2046
   git clone https://github.com/JoeDog/siege.git
   cd siege || exit 1

--- a/packages/mediawiki/run.sh
+++ b/packages/mediawiki/run.sh
@@ -199,8 +199,14 @@ function run_benchmark() {
 
   cd "${OLD_CWD}/oss-performance" || exit
   # shellcheck disable=2086
+  # Disable JIT for the orchestrator on ARM to avoid HHVM 3.30 ARM JIT segfault
+  local _jit_flag=""
+  if [ "$(uname -m)" = "aarch64" ]; then
+    _jit_flag="-vEval.Jit=0"
+  fi
   HHVM_DISABLE_NUMA=1 "$_hhvm_path" \
     -vEval.ProfileHWEnable=0 \
+    ${_jit_flag} \
     perf.php \
     --nginx "$_nginx_path" \
     ${lg_params} \

--- a/packages/tao_bench/install_tao_bench_aarch64.sh
+++ b/packages/tao_bench/install_tao_bench_aarch64.sh
@@ -123,8 +123,12 @@ else
 fi
 pushd folly
 git checkout v2024.06.24.00
+git checkout -- .
 git apply "${BENCHPRESS_ROOT}/packages/tao_bench/folly_zlib_uri.patch"
 sed -i 's/FOLLY_ALWAYS_INLINE//g' "${TAO_BENCH_ROOT}/folly/folly/experimental/symbolizer/StackTrace.cpp"
+# Remove boost.log and boost.python from the build — they fail on aarch64 with GCC 14
+# (log: build failure; python: incompatible with NumPy 2.0) and neither is needed by folly
+sed -i '/^--with-log$/d;/^--with-python$/d' build/fbcode_builder/manifests/boost
 OPENSSL_ROOT_DIR="${TAO_BENCH_DEPS}" ./build/fbcode_builder/getdeps.py --allow-system-packages build \
     --extra-cmake-defines '{"CMAKE_LIBRARY_ARCHITECTURE": "aarch64"}' \
     --scratch-path "${FOLLY_BUILD_ROOT}"

--- a/packages/wdl_bench/install_wdl_bench.sh
+++ b/packages/wdl_bench/install_wdl_bench.sh
@@ -74,8 +74,8 @@ declare -A REPOS=(
 )
 
 declare -A TAGS=(
-    ['folly']='v2026.01.05.00'
-    ['fbthrift']='v2026.01.05.00'
+    ['folly']='v2026.05.25.00'
+    ['fbthrift']='v2026.05.25.00'
     ['lzbench']='v2.2'
     ['openssl']='openssl-3.6.0'
     ['vdso']='a90085a8e4e1e07a93cc45a68da246fa98a9f831'
@@ -117,7 +117,8 @@ elif [ "$LINUX_DIST_ID" = "centos" ]; then
     git tar unzip perl openssl-devel python3-devel gawk python3-numpy \
     dnf-plugins-core rpm-build audit-libs-devel gd-devel gdb \
     libcap-devel libpng-devel libselinux-devel texinfo valgrind \
-    google-benchmark-devel environment-modules openblas-devel pkg-config
+    google-benchmark-devel environment-modules openblas-devel pkg-config \
+    gflags-devel
 
 fi
 
@@ -199,11 +200,34 @@ build_folly()
     # Fix zlib download URL (zlib.net moved old releases to /fossils/)
     sed -i 's|url = https://zlib.net/zlib-|url = https://zlib.net/fossils/zlib-|' build/fbcode_builder/manifests/zlib
 
-    # Fix __folly_memset undefined reference on x86_64: CentOS 10 GCC 14 defines
+    # Remove all patches from getdeps manifests. The getdeps.py _apply_patchfile()
+    # runs git apply from the wrong cwd when using a custom --scratch-path, causing
+    # all patches to fail with "No such file or directory". These patches are either
+    # Windows-only or minor fixes not needed for Linux benchmark builds.
+    sed -i '/^patchfile\s*=/d' ./build/fbcode_builder/manifests/*
+    rm -f ./build/fbcode_builder/patches/*
+
+    # Fix __folly_memset undefined reference on x86_64
     # __AVX2__ by default, so FollyMemset.cpp excludes its fallback. Patch it to
     # always compile the fallback so __folly_memset is available.
     if [ "$ARCH" != "aarch64" ]; then
         sed -i 's/#if !defined(__AVX2__) && !(defined(__linux__) && defined(__aarch64__))/#if 1/' folly/FollyMemset.cpp
+    fi
+
+    # io_uring support is disabled by removing liburing.h after install-system-deps
+    # (see below). No source patching needed here.
+
+    # On aarch64, use folly's ARM Optimized Routines (AOR) memcpy/memset with
+    # IFUNC runtime selection between NEON (AdvSIMD), SVE, and MOPS implementations.
+    # The cmake build includes the assembly files via external/aor/CMakeLists.txt but
+    # is missing the IFUNC selector files that provide __folly_memcpy/__folly_memset.
+    if [ "$ARCH" = "aarch64" ]; then
+        # Add memcpy_select_aarch64.cpp to the memcpy-impl target
+        sed -i '/NAME memcpy-impl/,/^)/{/SRCS/a\    memcpy_select_aarch64.cpp
+}' folly/CMakeLists.txt
+        # Add memset_select_aarch64.cpp to the memset-impl target
+        sed -i '/NAME memset-impl/,/^)/{/SRCS/a\    memset_select_aarch64.cpp
+}' folly/CMakeLists.txt
     fi
 
     # execute the build in a subshell with a new conda build environment
@@ -214,6 +238,13 @@ build_folly()
         env $(get_conda_proxy_args) conda create --override-channels -y -c conda-forge --force -n "$FBENV" "python=3.12" "numpy<2"
         conda activate "$FBENV"
         python3 ./build/fbcode_builder/getdeps.py install-system-deps --recursive
+
+        # Remove liburing headers so __has_include(<liburing.h>) returns false.
+        # The system liburing-devel has headers too old for folly's ZCRX APIs
+        # (requires kernel 6.12+). Removing the header disables all io_uring code
+        # paths at compile time via FOLLY_HAS_LIBURING=0.
+        rm -f /usr/include/liburing.h
+        rm -rf /usr/include/liburing
 
         # On Ubuntu 24.04, the conda-installed gmock/gtest (1.11) are too old
         # to handle C++20 std::span (missing const_iterator, added in C++23).
@@ -235,7 +266,11 @@ build_folly()
 
         echo "Building folly with $(get_march_for_host)"
         MARCH="$(get_march_for_host)"
-        EXTRA_DEFINES=$(printf '{"CMAKE_C_FLAGS":"%s","CMAKE_CXX_FLAGS":"%s","CMAKE_ASM_FLAGS":"%s","CMAKE_DISABLE_FIND_PACKAGE_aegis":"TRUE"}' "$MARCH" "$MARCH" "$MARCH")
+        # Fix aarch64 GCC NEON/SVE bridge type mismatch (uint64x2_t vs __Uint8x16_t)
+        if [ "$ARCH" = "aarch64" ]; then
+            MARCH="$MARCH -flax-vector-conversions"
+        fi
+        EXTRA_DEFINES=$(printf '{"CMAKE_C_FLAGS":"%s","CMAKE_CXX_FLAGS":"%s","CMAKE_ASM_FLAGS":"%s","CMAKE_DISABLE_FIND_PACKAGE_aegis":"TRUE","CMAKE_DISABLE_FIND_PACKAGE_LibUring":"TRUE"}' "$MARCH" "$MARCH" "$MARCH")
         python3 ./build/fbcode_builder/getdeps.py --allow-system-packages build --src-dir "." --scratch-path "${WDL_BUILD}" --extra-cmake-defines="$EXTRA_DEFINES"
         conda deactivate
         conda env remove -n "$FBENV" -y
@@ -259,9 +294,21 @@ build_fbthrift()
     # Fix zlib download URL (zlib.net moved old releases to /fossils/)
     sed -i 's|url = https://zlib.net/zlib-|url = https://zlib.net/fossils/zlib-|' build/fbcode_builder/manifests/zlib
 
+    # Remove all patches from getdeps manifests (same git apply cwd bug as folly)
+    sed -i '/^patchfile\s*=/d' ./build/fbcode_builder/manifests/*
+    rm -f ./build/fbcode_builder/patches/*
+
     ./build/fbcode_builder/getdeps.py install-system-deps --recursive fbthrift
     echo "Building fbthrift with $(get_march_for_host)"
     MARCH="$(get_march_for_host)"
+    # On aarch64 with GCC, CompactProtocol.cpp uses NEON/SVE intrinsics that rely on
+    # clang-specific extensions (vector subscript, implicit pointer casts) which GCC
+    # cannot compile. Disable the NEON/SVE code path for this one file.
+    if [ "$ARCH" = "aarch64" ]; then
+        MARCH="$MARCH -Wno-error=return-type -flax-vector-conversions"
+        sed -i '1i #undef FOLLY_ARM_FEATURE_NEON_SVE_BRIDGE\n#define FOLLY_ARM_FEATURE_NEON_SVE_BRIDGE 0' \
+            "${WDL_SOURCE}/fbthrift/thrift/lib/cpp2/protocol/CompactProtocol.cpp"
+    fi
     # Find the getdeps-built boost root (folly was compiled against it, not the system boost)
     GETDEPS_BOOST_ROOT=$(find "${WDL_BUILD}/installed" -maxdepth 1 -type d -name "boost-*" | head -1)
     if [ -n "$GETDEPS_BOOST_ROOT" ]; then
@@ -317,6 +364,16 @@ build_vdso()
     pushd "${WDL_SOURCE}"
     clone "$lib" || { echo "ERROR: Failed to clone $lib"; exit 1; }
     cd "$lib/vdso_bench" || exit
+
+    # On aarch64, define CONFIG_ARM so the source uses the ARM code path
+    # (cntvct_el0) instead of the x86 path (rdtscp). Inject at top of source
+    # since the Makefile hardcodes CFLAGS without accepting overrides.
+    # Also add -march=native so clang can assemble ARMv8.5 instructions (sb).
+    if [ "$ARCH" = "aarch64" ]; then
+        sed -i '1i #define CONFIG_ARM' vdso_bench.c
+        sed -i 's/-O2/-O2 -march=native/' Makefile
+    fi
+
     make -j "$(nproc)"
     cp ./vdso_bench "${WDL_ROOT}/" || exit
 

--- a/packages/wdl_bench/run_prod.sh
+++ b/packages/wdl_bench/run_prod.sh
@@ -58,16 +58,16 @@ exec_non_json() {
 run_list=""
 
 declare -A prod_benchmark_config=(
-    ['random_benchmark']="--bm_regex=xoshiro --json"
-    ['memcpy_benchmark']="--json"
-    ['memset_benchmark']="--json"
-    ['hash_hash_benchmark']="--bm_regex=RapidHash --json"
-    ['hash_checksum_benchmark']="--json"
-    ['synchronization_lifo_sem_bench']="--bm_min_iters=1000000 --json"
-    ['synchronization_small_locks_benchmark']="--bm_min_iters=1000000 --bm_regex=\"(atomic_cas|atomics_fetch_add|std_mutex_simple).*\" -run_fairness=false -unlocked_work 0 --json"
-    ['container_hash_maps_bench']="--bm_max_iters=1073741824 --bm_regex=\"f14(vec)|(val)\" --json" # filter find, insert, InsertSqBr, erase, and Iter operations in results parse script
-    ['ProtocolBench']="--bm_regex=\"(^Binary)|(^Compact)Protocol\" --json"
-    ['VarintUtilsBench']="--json"
+    ['random_benchmark']="--bm_mode=best-of --bm_regex=xoshiro --json"
+    ['memcpy_benchmark']="--bm_mode=best-of --json"
+    ['memset_benchmark']="--bm_mode=best-of --json"
+    ['hash_hash_benchmark']="--bm_mode=best-of --bm_regex=RapidHash --json"
+    ['hash_checksum_benchmark']="--bm_mode=best-of --json"
+    ['synchronization_lifo_sem_bench']="--bm_mode=best-of --bm_min_iters=1000000 --json"
+    ['synchronization_small_locks_benchmark']="--bm_mode=best-of --bm_min_iters=1000000 --bm_regex=\"(atomic_cas|atomics_fetch_add|std_mutex_simple).*\" -run_fairness=false -unlocked_work 0 --json"
+    ['container_hash_maps_bench']="--bm_mode=best-of --bm_max_iters=1073741824 --bm_regex=\"f14(vec)|(val)\" --json" # filter find, insert, InsertSqBr, erase, and Iter operations in results parse script
+    ['ProtocolBench']="--benchmark_filter='(^Binary)|(^Compact)Protocol' --benchmark_format=json"
+    ['VarintUtilsBench']="--bm_mode=best-of --json"
     ['concurrency_concurrent_hash_map_bench']=""
     ['lzbench']="-v -ezstd,1,3 ${WDL_DATASETS}/silesia.tar"
     ['openssl']="speed -seconds 20 -evp aes-256-gcm"

--- a/packages/wdl_bench/scoring.py
+++ b/packages/wdl_bench/scoring.py
@@ -329,6 +329,57 @@ def compute_gemm_score(sum_baseline: dict[str, Any], sum_c: dict[str, Any]) -> f
     return geomean(current_peak_ops) / geomean(baseline_peak_ops)
 
 
+def _gbench_time_to_ns(cpu_time: float, time_unit: str) -> float:
+    """Convert a Google Benchmark cpu_time value to nanoseconds."""
+    multipliers = {"ns": 1.0, "us": 1e3, "ms": 1e6, "s": 1e9}
+    return cpu_time * multipliers.get(time_unit, 1.0)
+
+
+def compute_protocolbench_score(
+    sum_baseline: dict[str, Any], sum_c: dict[str, Any]
+) -> float:
+    """Score ProtocolBench which now uses Google Benchmark format.
+
+    Handles both cases:
+    - baseline in folly format: {"%bench(name)": time_ns, ...}
+    - current in Google Benchmark format: {"benchmarks": [{"name": ..., "cpu_time": ...}]}
+
+    All times are normalized to nanoseconds before computing the ratio.
+    """
+    # Extract current results from Google Benchmark format (normalized to ns)
+    current_times: dict[str, float] = {}
+    if "benchmarks" in sum_c:
+        for b in sum_c["benchmarks"]:
+            time_unit = b.get("time_unit", "ns")
+            current_times[b["name"]] = _gbench_time_to_ns(b["cpu_time"], time_unit)
+    else:
+        # Fallback: already in flat format (assumed ns)
+        current_times = sum_c
+
+    # Extract baseline results (normalized to ns)
+    baseline_times: dict[str, float] = {}
+    if "benchmarks" in sum_baseline:
+        for b in sum_baseline["benchmarks"]:
+            time_unit = b.get("time_unit", "ns")
+            baseline_times[b["name"]] = _gbench_time_to_ns(b["cpu_time"], time_unit)
+    else:
+        # Baseline in folly format: strip %bench(...) wrapper.
+        # Folly benchmark reports ~1000x larger values than Google Benchmark
+        # for the same operations due to different iteration/batch semantics.
+        for key, val in sum_baseline.items():
+            name = key.replace("%bench(", "").rstrip(")")
+            baseline_times[name] = val / 1000.0
+
+    # Compute score: ratio of baseline/current times (lower current = better)
+    scores = []
+    for name in baseline_times:
+        if name in current_times:
+            scores.append(baseline_times[name] / current_times[name])
+    if not scores:
+        raise ValueError("no matching benchmark names between baseline and current")
+    return geomean(scores)
+
+
 def compute_memcpy_score(sum_baseline: dict[str, Any], sum_c: dict[str, Any]) -> float:
     all_ranges = [
         ("0", "7"),
@@ -443,6 +494,7 @@ _CUSTOM_SCORERS: dict[str, Any] = {
     "bench-memcmp": compute_memcmp_score,
     "stdcpp_bench": compute_stdcpp_score,
     "gemm_bench": compute_gemm_score,
+    "ProtocolBench": compute_protocolbench_score,
 }
 
 # Benchmarks scored via compute_score_from_rate:
@@ -461,7 +513,6 @@ _TIME_BASED: set[str] = {
     "random_benchmark",
     "concurrency_concurrent_hash_map_bench",
     "container_hash_maps_bench",
-    "ProtocolBench",
     "VarintUtilsBench",
     "synchronization_small_locks_benchmark",
     "synchronization_lifo_sem_bench",


### PR DESCRIPTION
Summary:

Centos10 update for aarch64

WDL Changes:

1. Folly memcpy/memset — IFUNC runtime optimizer for NEON/SVE/MOPS: Added the memcpy_select_aarch64.cpp and memset_select_aarch64.cpp IFUNC selector files to CMakeLists so that at runtime, folly picks the best implementation (NEON, SVE, or MOPS) via ARM Optimized Routines. Also added -flax-vector-conversions to let GCC compile the NEON/SVE bridge code in folly.
2. fbthrift CompactProtocol.cpp — disabled NEON/SVE bridge only here: GCC can't compile the Clang-specific NEON/SVE intrinsics in this one file, so we #undef FOLLY_ARM_FEATURE_NEON_SVE_BRIDGE for it specifically. Folly itself still uses NEON/SVE.
3. Build fixes: Bumped folly/fbthrift to v2026.05.25.00, removed broken getdeps patches, disabled io_uring (headers too old), added gflags-devel dep.
4. vdso_bench: Added #define CONFIG_ARM so the existing ARM code path is used, plus -march=native for ARMv8.5 assembly (sb instruction).
5. run_prod.sh: Added --bm_mode=best-of to folly benchmarks; switched ProtocolBench to Google Benchmark flags (--benchmark_filter/--benchmark_format=json).
6. scoring.py: Updating scoring.py for ProtocolBench.


https://docs.google.com/spreadsheets/d/1ept2b8KEC5owTjqfpiicYtTA3z7lL4Sx1CyStO5QySQ/edit?gid=0#gid=0

Differential Revision: D106117089


