### PR TITLE
Bootstrap dpu_perf suite with cpu_stream microbenchmark (#633)

### DIFF
--- a/benchpress/config/__init__.py
+++ b/benchpress/config/__init__.py
@@ -75,6 +75,7 @@ register_benchmark_suite("wdl")
 register_benchmark_suite("system")
 register_benchmark_suite("ai")
 register_benchmark_suite("ehw")
+register_benchmark_suite("dpu_perf")
 
 
 class BenchpressConfig:

--- a/benchpress/plugins/parsers/__init__.py
+++ b/benchpress/plugins/parsers/__init__.py
@@ -32,6 +32,7 @@ from .generic import JSONParser
 from .graph500 import Graph500Parser
 from .health_check import HealthCheckParser
 from .iperf import IperfParser
+from .lmbench_lat_mem_rd import LmbenchLatMemRdParser
 from .ltp import LtpParser
 from .mediawiki import MediawikiParser
 from .memcached_bench import MemcachedBenchParser
@@ -100,6 +101,7 @@ def register_parsers(factory):
     factory.register("stream", StreamParser)
     factory.register("mlc", MlcParser)
     factory.register("iperf", IperfParser)
+    factory.register("lmbench_lat_mem_rd", LmbenchLatMemRdParser)
     factory.register("checkmark", CheckmarkParser)
     factory.register("nnpi_net4", NNPINet4Parser)
     factory.register("feedsim", FeedSimParser)

--- a/benchpress/plugins/parsers/lmbench_lat_mem_rd.py
+++ b/benchpress/plugins/parsers/lmbench_lat_mem_rd.py
@@ -1,0 +1,108 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-unsafe
+
+"""Parser for lmbench's `lat_mem_rd` output.
+
+lat_mem_rd prints one header line (`"stride=N`) followed by two-column data
+rows: `<size_MB> <latency_ns>` (whitespace-separated, decimal floats). Sizes
+ramp from sub-KB to the user-supplied max in roughly powers of two with
+intermediate points, so the curve has enough resolution to read off
+cache-boundary inflections.
+
+We emit:
+  - the full curve as a list of [size_MB, latency_ns] pairs,
+  - summary stats (min/max latency, point count),
+  - representative latencies at sizes that approximate L1 / L2 / LLC / DRAM,
+    picked by nearest-neighbour on the curve.
+"""
+
+from benchpress.lib.parser import Parser
+
+
+# Sizes (MB) used to extract characteristic per-cache-level latencies. The
+# parser picks the nearest measured point on the curve to each of these; the
+# names are documentation, not assertions about a specific machine's hierarchy.
+_REPRESENTATIVE_SIZES_MB = [
+    (0.004, "latency_at_4KB_ns"),
+    (0.064, "latency_at_64KB_ns"),
+    (0.256, "latency_at_256KB_ns"),
+    (1.0, "latency_at_1MB_ns"),
+    (8.0, "latency_at_8MB_ns"),
+    (64.0, "latency_at_64MB_ns"),
+    (512.0, "latency_at_512MB_ns"),
+]
+
+
+def _parse_stride(line: str):
+    # Header looks like: "stride=64
+    try:
+        return int(line.split("=", 1)[1].rstrip('"'))
+    except (ValueError, IndexError):
+        return None
+
+
+def _parse_data_row(line: str):
+    parts = line.split()
+    if len(parts) != 2:
+        return None
+    try:
+        return float(parts[0]), float(parts[1])
+    except ValueError:
+        return None
+
+
+def _scan_curve(stdout):
+    curve = []
+    stride = None
+    for raw in stdout:
+        line = raw.strip()
+        if not line:
+            continue
+        if line.startswith('"stride='):
+            stride = _parse_stride(line)
+            continue
+        point = _parse_data_row(line)
+        if point is not None:
+            curve.append([point[0], point[1]])
+    return curve, stride
+
+
+def _representative_points(curve):
+    out = {}
+    sizes_measured = {p[0] for p in curve}
+    for target_mb, name in _REPRESENTATIVE_SIZES_MB:
+        # Only emit a representative point if the curve actually reached
+        # this size — avoids inventing a "DRAM latency" reading from a
+        # small-range run.
+        if target_mb < curve[0][0] - 1e-9 or target_mb > curve[-1][0] + 1e-9:
+            continue
+        nearest = min(sizes_measured, key=lambda s: abs(s - target_mb))
+        for size_mb, latency_ns in curve:
+            if size_mb == nearest:
+                out[name] = latency_ns
+                break
+    return out
+
+
+class LmbenchLatMemRdParser(Parser):
+    def parse(self, stdout, stderr, returncode):
+        curve, stride = _scan_curve(stdout)
+        if not curve:
+            return {}
+
+        metrics = {
+            "stride_bytes": stride,
+            "num_points": len(curve),
+            "size_min_MB": curve[0][0],
+            "size_max_MB": curve[-1][0],
+            "latency_min_ns": min(p[1] for p in curve),
+            "latency_max_ns": max(p[1] for p in curve),
+            "curve": curve,
+        }
+        metrics.update(_representative_points(curve))
+        return metrics


### PR DESCRIPTION
Summary:

**Context:**
We are building a vendor-agnostic DPU / SmartNIC benchmark suite (`dpu_perf`)
to evaluate Meta's custom DPU (Asperta / MDPU) and merchant silicon (BlueField,
Pensando, Mt Evans/Morgan, Octeon, xSight) against a common metric set.
Design context lives in `fbcode/cea/chips/dpu_perf/{PROPOSAL,IMPLEMENTATION,ONEPAGER}.md`.

The implementation plan calls for Tier 1 microbenchmarks to live inside DCPerf /
benchpress as a peer suite of `wdl`/`system`/`ai`/`ehw`, and Tier 2 use-case
scenarios to live in a sibling fbcode package. This diff is the Tier 1 bootstrap.

**Motivation:**
Get the framework wiring in place so subsequent diffs can add microbenchmarks
(cpu/microarch, cpu/atomic-noisy via WDLBench reuse, mem/bw variants, accel
benches, etc.) by following the same pattern without touching infrastructure.

**This diff:**
- Registers a new `dpu_perf` suite via the existing `register_benchmark_suite()`
  one-liner in `benchpress/config/__init__.py`.
- Adds `benchmarks_dpu_perf.yml` + `jobs_dpu_perf.yml` config pair (reuses the
  existing `stream` parser; no new parser needed).
- Adds the `packages/dpu_perf/` package skeleton with `install_stream.sh`,
  `run_stream.sh`, `cleanup_stream.sh`, README. Install clones STREAM from
  upstream github and builds with gcc; auto-detects `fwdproxy-config` on Meta
  corp hosts and falls back to plain `git` for OSS environments.
- Defines two jobs: `cpu_stream_default` (OpenMP default thread count) and
  `cpu_stream_1t` (single thread).
- Wires both YAMLs into the `:config` python_library resources in BUCK.

Works under both `buck2 run fbcode//cea/chips/benchpress:benchpress` and the
plain OSS `./benchpress_cli.py` invocation.

Reviewed By: charles-typ

Differential Revision: D105749203


