### PR TITLE
Promote graph500_omp_csr to default suite and migrate to v3.0.1 reference (#634)

### DIFF
--- a/benchpress/config/benchmarks.yml
+++ b/benchpress/config/benchmarks.yml
@@ -171,6 +171,22 @@ health_check:
   path: ./benchmarks/health_check/run.sh
   metrics: []
 
+graph500_omp_csr:
+  parser: graph500
+  install_script: ./packages/graph500/install_graph500.sh
+  cleanup_script: ./packages/graph500/cleanup_graph500.sh
+  install_markers:
+    - ./benchmarks/graph500/graph500_reference_bfs
+  path: ./packages/graph500/run.sh
+  tags:
+    scope:
+      - kernel
+    component:
+      - cpu
+  metrics:
+    - harmonic_mean_TEPS
+    - harmonic_stddev_TEPS
+
 sleep:
   path: /usr/bin/sleep
   parser: returncode

--- a/benchpress/config/jobs.yml
+++ b/benchpress/config/jobs.yml
@@ -1856,3 +1856,9 @@
     - '{duration}'
   vars:
     - 'duration'
+
+- benchmark: graph500_omp_csr
+  name: graph500_omp_csr
+  description: Graph500 v3 reference BFS (MPI). Single positional arg is SCALE (log2 vertices); run.sh wraps the binary with mpirun -np <largest pow2 <= nproc>.
+  args:
+    - "20"

--- a/benchpress/plugins/parsers/graph500.py
+++ b/benchpress/plugins/parsers/graph500.py
@@ -8,7 +8,15 @@ import re
 
 from benchpress.lib.parser import Parser
 
-TEPS_REGEX = r"(\w+_TEPS):\s+(\d+\.?\d*e?[+-]\d*)"
+# Match `<name>_TEPS:` followed by an optional non-digit token (e.g. the
+# graph500 v3 validation marker `!`), then the metric value.
+#
+# Examples that must parse:
+#   "harmonic_mean_TEPS: 5.66e+07"               (v2)
+#   "bfs  harmonic_mean_TEPS:     !  7.79e+07"   (v3 with validation marker)
+#   "bfs  min_TEPS:                  6.38e+07"   (v3 no marker)
+#   "bfs  harmonic_stddev_TEPS:      604630"     (v3 plain integer)
+TEPS_REGEX = r"(\w+_TEPS):[\s!]+(\d+\.?\d*(?:e[+-]?\d+)?)"
 
 
 class Graph500Parser(Parser):

--- a/packages/graph500/cleanup_graph500.sh
+++ b/packages/graph500/cleanup_graph500.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+BENCHPRESS_ROOT="$(readlink -f "${SCRIPT_DIR}/../..")"
+
+"${BENCHPRESS_ROOT}"/install_remove_git.sh remove
+
+GRAPH500_INSTALLATION_PREFIX="${BENCHMARKS_DIR}/graph500"
+rm -rf "${GRAPH500_INSTALLATION_PREFIX}"

--- a/packages/graph500/install_graph500.sh
+++ b/packages/graph500/install_graph500.sh
@@ -1,0 +1,64 @@
+#!/bin/bash
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+#
+# Installs the Graph500 v3 reference BFS benchmark.
+# Upstream: https://github.com/graph500/graph500 (tag 3.0.1).
+#
+# v3 is MPI-only (no more OpenMP/sequential/XMT kernels) and the build
+# requires `mpicc` + an MPI runtime (we use OpenMPI 4.x).
+# v3 binaries take a positional SCALE arg, e.g. `mpirun -np 4 ./graph500_reference_bfs 20`.
+
+set -Eeuo pipefail
+
+SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)
+BENCHPRESS_ROOT="$(readlink -f "${SCRIPT_DIR}/../..")"
+
+# Install system deps. OpenMPI provides mpicc/mpirun; openmpi-devel ships the
+# headers (mpi.h) and the mpicc wrapper. fb-fwdproxy-config gives the git
+# clone access to public github via fwdproxy.
+dnf install -y fb-fwdproxy-config openmpi openmpi-devel
+
+# Put OpenMPI's mpicc/mpirun on PATH for this script (rpm installs them under
+# /usr/lib64/openmpi/bin, which is not in PATH by default).
+export PATH="/usr/lib64/openmpi/bin:${PATH}"
+export LD_LIBRARY_PATH="/usr/lib64/openmpi/lib:${LD_LIBRARY_PATH:-}"
+
+GRAPH500_GIT_REPO_URL="https://github.com/graph500/graph500.git"
+GRAPH500_GIT_COMMIT_TAG="3.0.1"
+
+BENCHMARKS_DIR="$(pwd)/benchmarks"
+mkdir -p "$BENCHMARKS_DIR"
+
+GRAPH500_INSTALLATION_PREFIX="${BENCHMARKS_DIR}/graph500"
+GRAPH500_BINARY_PATH="${GRAPH500_INSTALLATION_PREFIX}/graph500_reference_bfs"
+GRAPH500_BINARY_SSSP_PATH="${GRAPH500_INSTALLATION_PREFIX}/graph500_reference_bfs_sssp"
+
+rm -rf build
+mkdir -p build
+cd build/ || exit 1
+
+"${BENCHPRESS_ROOT}"/install_remove_git.sh install
+
+# shellcheck disable=SC2046
+git $(fwdproxy-config --git-command git) clone "$GRAPH500_GIT_REPO_URL"
+cd graph500/ || exit 1
+git checkout -b benchpress "tags/${GRAPH500_GIT_COMMIT_TAG}"
+
+# v3 source layout has a single src/Makefile. The default CFLAGS work, but
+# we add -fcommon so the build doesn't fail on GCC >= 10, which defaults to
+# -fno-common and rejects the v3 reference code's unguarded tentative
+# globals (e.g. `int64_t* column;` declared in csr_reference.h).
+make -C src \
+    CFLAGS="-Drestrict=__restrict__ -O3 -DGRAPH_GENERATOR_MPI -DREUSE_CSR_FOR_VALIDATION -I../aml -fcommon"
+
+mkdir -p "${GRAPH500_INSTALLATION_PREFIX}"
+mv src/graph500_reference_bfs "${GRAPH500_BINARY_PATH}"
+mv src/graph500_reference_bfs_sssp "${GRAPH500_BINARY_SSSP_PATH}"
+cd ../../ || exit 1
+
+rm -rf build/
+
+echo "Graph500 (v${GRAPH500_GIT_COMMIT_TAG}) installed into ${GRAPH500_INSTALLATION_PREFIX}"

--- a/packages/graph500/run.sh
+++ b/packages/graph500/run.sh
@@ -1,0 +1,59 @@
+#!/bin/bash
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+#
+# Wrapper that runs Graph500 v3 reference BFS under mpirun.
+#
+# Usage:
+#   ./run.sh <SCALE> [extra mpirun args...]
+#
+# Environment variables:
+#   NP           Number of MPI ranks (must be a power of 2 in v3 unless
+#                you rebuild with -DPROCS_PER_NODE_NOT_POWER_OF_TWO).
+#                Default: largest power of 2 <= $(nproc).
+#   GRAPH500_BIN Path to graph500 binary. Default uses bfs_sssp if it exists
+#                and SKIP_BFS env var to control which kernel runs; otherwise
+#                uses graph500_reference_bfs.
+
+set -Eeuo pipefail
+
+if [[ $# -lt 1 ]]; then
+    echo "Usage: $0 <SCALE> [extra mpirun args...]" >&2
+    exit 1
+fi
+
+SCALE="$1"
+shift
+
+BENCHPRESS_ROOT="$(pwd)"
+GRAPH500_DIR="${BENCHPRESS_ROOT}/benchmarks/graph500"
+GRAPH500_BIN="${GRAPH500_BIN:-${GRAPH500_DIR}/graph500_reference_bfs}"
+
+if [[ ! -x "${GRAPH500_BIN}" ]]; then
+    echo "Graph500 binary not found at ${GRAPH500_BIN}." >&2
+    echo "Run \`./benchpress install graph500_omp_csr\` first." >&2
+    exit 1
+fi
+
+# OpenMPI from rpm lives outside the default PATH.
+export PATH="/usr/lib64/openmpi/bin:${PATH}"
+export LD_LIBRARY_PATH="/usr/lib64/openmpi/lib:${LD_LIBRARY_PATH:-}"
+
+# Pick the largest power of 2 <= nproc unless NP is set.
+nproc_count="$(nproc)"
+if [[ -z "${NP:-}" ]]; then
+    NP=1
+    while (( NP * 2 <= nproc_count )); do
+        NP=$((NP * 2))
+    done
+fi
+
+echo "Running ${GRAPH500_BIN} SCALE=${SCALE} on ${NP} MPI ranks (host has ${nproc_count} CPUs)"
+
+# Optional knobs (defaults are safe on a clean host):
+#   MPIRUN_EXTRA_ARGS  Extra args passed to mpirun (e.g. --allow-run-as-root --oversubscribe)
+MPIRUN_EXTRA_ARGS="${MPIRUN_EXTRA_ARGS:-}"
+# shellcheck disable=SC2086
+exec mpirun ${MPIRUN_EXTRA_ARGS} -np "${NP}" "$@" "${GRAPH500_BIN}" "${SCALE}"


### PR DESCRIPTION
Summary:

Today graph500 only exists in the `internal` benchpress suite (built from
the very old upstream tag `graph500-2.1.4` with an OpenMP-CSR-only build).
This diff:

1. Promotes `graph500_omp_csr` into the default benchmark suite
   (`benchmarks.yml` + `jobs.yml`) so external/OSS DCPerf consumers see
   it via `./benchpress list`.
2. Migrates the install path to the v3 reference (upstream tag `3.0.1`,
   the `newreference` line). v3 dropped the OpenMP/Sequential/XMT
   kernels and only ships the MPI reference (`graph500_reference_bfs`
   and `graph500_reference_bfs_sssp`).
3. Moves install/cleanup scripts from the repo root to
   `packages/graph500/` to match the modern layout used by every
   other benchmark in the default suite (tao_bench, feedsim, ...).
4. Adds a small `packages/graph500/run.sh` mpirun wrapper because v3
   takes a positional SCALE arg (vs v2's `-s SCALE`), and the v3
   binary must be launched under `mpirun -np <power_of_2>`.
5. Fixes the `Graph500Parser` regex to handle v3 output, which prints
   the harmonic mean line as
       `bfs  harmonic_mean_TEPS:     !  7.79e+07`
   with a `!` validation marker between the colon and the value. The
   old regex (`(\\w+_TEPS):\\s+(\\d+\\.?\\d*e?[+-]\\d*)`) couldn't
   match across the `!`, so the headline metric (`harmonic_mean_TEPS`)
   silently dropped from the parsed output. New regex tolerates an
   optional non-digit marker.
6. Adds a `test_graph500_v3_output` parser test pinning the v3 output
   format.

The v2/v1 OpenMP-CSR build is retired (v3 is MPI-only); the job name
`graph500_omp_csr` is kept for backward compatibility with downstream
configs, even though the kernel inside is now MPI.

Differential Revision: D106560426
