### PR TITLE
Move GAPBS to mem suite, expand to 6 benchmarks, fix install (#635)

### DIFF
--- a/benchpress/config/__init__.py
+++ b/benchpress/config/__init__.py
@@ -76,6 +76,7 @@ register_benchmark_suite("system")
 register_benchmark_suite("ai")
 register_benchmark_suite("ehw")
 register_benchmark_suite("dpu_perf")
+register_benchmark_suite("mem")
 
 
 class BenchpressConfig:

--- a/benchpress/config/benchmarks_mem.yml
+++ b/benchpress/config/benchmarks_mem.yml
@@ -11,3 +11,111 @@ xsbench:
       - Threads
       - Est. Memory Usage (MB)
       - Total XS Lookups
+
+gapbs_bc:
+  parser: gapbs
+  install_script: ./packages/gapbs/install_gapbs.sh
+  cleanup_script: ./packages/gapbs/cleanup_gapbs.sh
+  install_markers:
+    - ./benchmarks/gapbs/bc
+  path: ./benchmarks/gapbs/bc
+  tags:
+    scope:
+      - kernel
+    component:
+      - cpu
+  metrics:
+    - generate_time
+    - build_time
+    - trial_time
+    - average_time
+
+gapbs_bfs:
+  parser: gapbs
+  install_script: ./packages/gapbs/install_gapbs.sh
+  cleanup_script: ./packages/gapbs/cleanup_gapbs.sh
+  install_markers:
+    - ./benchmarks/gapbs/bfs
+  path: ./benchmarks/gapbs/bfs
+  tags:
+    scope:
+      - kernel
+    component:
+      - cpu
+  metrics:
+    - generate_time
+    - build_time
+    - trial_time
+    - average_time
+
+gapbs_cc:
+  parser: gapbs
+  install_script: ./packages/gapbs/install_gapbs.sh
+  cleanup_script: ./packages/gapbs/cleanup_gapbs.sh
+  install_markers:
+    - ./benchmarks/gapbs/cc
+  path: ./benchmarks/gapbs/cc
+  tags:
+    scope:
+      - kernel
+    component:
+      - cpu
+  metrics:
+    - generate_time
+    - build_time
+    - trial_time
+    - average_time
+
+gapbs_pr:
+  parser: gapbs
+  install_script: ./packages/gapbs/install_gapbs.sh
+  cleanup_script: ./packages/gapbs/cleanup_gapbs.sh
+  install_markers:
+    - ./benchmarks/gapbs/pr
+  path: ./benchmarks/gapbs/pr
+  tags:
+    scope:
+      - kernel
+    component:
+      - cpu
+  metrics:
+    - generate_time
+    - build_time
+    - trial_time
+    - average_time
+
+gapbs_sssp:
+  parser: gapbs
+  install_script: ./packages/gapbs/install_gapbs.sh
+  cleanup_script: ./packages/gapbs/cleanup_gapbs.sh
+  install_markers:
+    - ./benchmarks/gapbs/sssp
+  path: ./benchmarks/gapbs/sssp
+  tags:
+    scope:
+      - kernel
+    component:
+      - cpu
+  metrics:
+    - generate_time
+    - build_time
+    - trial_time
+    - average_time
+
+gapbs_tc:
+  parser: gapbs
+  install_script: ./packages/gapbs/install_gapbs.sh
+  cleanup_script: ./packages/gapbs/cleanup_gapbs.sh
+  install_markers:
+    - ./benchmarks/gapbs/tc
+  path: ./benchmarks/gapbs/tc
+  tags:
+    scope:
+      - kernel
+    component:
+      - cpu
+  metrics:
+    - generate_time
+    - build_time
+    - trial_time
+    - average_time

--- a/benchpress/config/jobs_mem.yml
+++ b/benchpress/config/jobs_mem.yml
@@ -11,3 +11,76 @@
     - "history=500000"
     #- "size=Large" # XL 120GB, XXL 225GB
     #- "gridpoints=11303"
+
+# GAPBS jobs - default to a synthetic Kronecker graph (-g {scale}, 2^scale
+# vertices, ~16 avg degree) so the job is self-contained and avoids the
+# multi-GB twitter download. The graph and trials are exposed as `vars` so
+# they can be tuned per run by editing the values below.
+#
+# Default scale=25 -> 2^25 ≈ 33M vertices, ~530M edges, ~4-8 GB CSR
+# footprint (more for sssp/pr which keep additional per-vertex state).
+# Bump scale to 27-28 for >32 GB working sets; each +1 in scale roughly
+# doubles memory. To run against a pre-built real-world graph instead,
+# replace the args block with e.g.:
+#   args:
+#     - -f ./benchmarks/graphs/twitter.sg
+#     - -n {trials}
+- benchmark: gapbs_bc
+  name: gapbs_bc
+  description: GAP bc benchmark (betweenness centrality) on a synthetic Kronecker graph
+  args:
+    - -g {scale}
+    - -n {trials}
+  vars:
+    - "scale=25"
+    - "trials=3"
+
+- benchmark: gapbs_bfs
+  name: gapbs_bfs
+  description: GAP bfs benchmark on a synthetic Kronecker graph
+  args:
+    - -g {scale}
+    - -n {trials}
+  vars:
+    - "scale=25"
+    - "trials=3"
+
+- benchmark: gapbs_cc
+  name: gapbs_cc
+  description: GAP cc benchmark (connected components) on a synthetic Kronecker graph
+  args:
+    - -g {scale}
+    - -n {trials}
+  vars:
+    - "scale=25"
+    - "trials=3"
+
+- benchmark: gapbs_tc
+  name: gapbs_tc
+  description: GAP tc benchmark (triangle count, requires undirected graph; -g auto-undirects)
+  args:
+    - -g {scale}
+    - -n {trials}
+  vars:
+    - "scale=25"
+    - "trials=3"
+
+- benchmark: gapbs_pr
+  name: gapbs_pr
+  description: GAP pr benchmark (PageRank) on a synthetic Kronecker graph
+  args:
+    - -g {scale}
+    - -n {trials}
+  vars:
+    - "scale=25"
+    - "trials=3"
+
+- benchmark: gapbs_sssp
+  name: gapbs_sssp
+  description: GAP sssp benchmark on a synthetic Kronecker graph
+  args:
+    - -g {scale}
+    - -n {trials}
+  vars:
+    - "scale=25"
+    - "trials=3"

--- a/packages/gapbs/cleanup_gapbs.sh
+++ b/packages/gapbs/cleanup_gapbs.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+set -Eeuo pipefail
+
+SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)
+BENCHPRESS_ROOT="$(readlink -f "${SCRIPT_DIR}/../..")"
+
+"${BENCHPRESS_ROOT}"/install_remove_git.sh remove
+
+GAPBS_INSTALLATION_PREFIX="$(pwd)/benchmarks/gapbs"
+rm -rf "${GAPBS_INSTALLATION_PREFIX}"

--- a/packages/gapbs/install_gapbs.sh
+++ b/packages/gapbs/install_gapbs.sh
@@ -1,0 +1,54 @@
+#!/bin/bash
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+#
+# Installs the GAP Benchmark Suite (gapbs) from upstream
+# https://github.com/sbeamer/gapbs (tag v1.1).
+#
+# Produces six benchmark binaries (bc, bfs, cc, pr, sssp, tc) plus the
+# `converter` utility in ${BENCHPRESS_ROOT}/benchmarks/gapbs/. Jobs can
+# either point at the synthetic Kronecker generator (`-g <SCALE>`) or at a
+# pre-built `.sg` / `.wsg` / `.sgU` graph file via `-f`. Building large
+# real-world graphs (e.g. twitter_rv) is intentionally NOT done here -
+# do it in a separate one-off step to keep this script idempotent and
+# cheap to re-run.
+
+set -Eeuo pipefail
+
+SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)
+BENCHPRESS_ROOT="$(readlink -f "${SCRIPT_DIR}/../..")"
+
+GAPBS_GIT_REPO_URL="https://github.com/sbeamer/gapbs.git"
+GAPBS_GIT_COMMIT_TAG="v1.1"
+
+# Install system deps. fb-fwdproxy-config gives `git clone` access to public
+# github via fwdproxy on Meta dev servers / sandboxes.
+dnf install -y fb-fwdproxy-config gcc gcc-c++ libstdc++
+
+BENCHMARKS_DIR="$(pwd)/benchmarks"
+mkdir -p "${BENCHMARKS_DIR}"
+
+GAPBS_INSTALLATION_PREFIX="${BENCHMARKS_DIR}/gapbs"
+
+rm -rf build
+mkdir -p build
+cd build/ || exit 1
+
+"${BENCHPRESS_ROOT}"/install_remove_git.sh install
+
+# shellcheck disable=SC2046
+git $(fwdproxy-config --git-command git) clone "${GAPBS_GIT_REPO_URL}"
+cd gapbs/ || exit 1
+git checkout -b benchpress "tags/${GAPBS_GIT_COMMIT_TAG}"
+
+make -j"$(nproc)"
+
+mkdir -p "${GAPBS_INSTALLATION_PREFIX}"
+mv bc bfs cc pr sssp tc converter "${GAPBS_INSTALLATION_PREFIX}"
+cd ../../ || exit 1
+
+rm -rf build/
+
+echo "GAP benchmark suite (${GAPBS_GIT_COMMIT_TAG}) installed into ${GAPBS_INSTALLATION_PREFIX}"


### PR DESCRIPTION
Summary:

Supersedes the WIP D95906223. Rebases the GAPBS migration on top of
the graph500 v3 promotion (D106560426) and addresses the bugs that
made the WIP unrunnable on Meta dev servers.

Changes:

1. Move the GAPBS benchmark definitions out of `benchmarks_internal.yml`
   (where only `gapbs_bc`, `gapbs_bfs`, `gapbs_tc` existed) and into
   `benchmarks_mem.yml`. Add the three missing kernels — `gapbs_cc`,
   `gapbs_pr`, `gapbs_sssp` — so all six GAP kernels are covered.

2. Register the `mem` suite in `benchpress/config/__init__.py`. Without
   this, `benchmarks_mem.yml` and `jobs_mem.yml` were dead config files
   — `--benchmarks mem` was not a valid option and `xsbench` (added in
   D92435088) was also unreachable. Now all 7 entries (xsbench + 6
   gapbs) are listed by `./benchpress --benchmarks mem list`.

3. Rewrite `install_gapbs.sh` to match the `packages/graph500/`
   pattern: `set -Eeuo pipefail`, install deps via `dnf`
   (`fb-fwdproxy-config`, `gcc`, `gcc-c++`, `libstdc++`), wire git
   through fwdproxy via `install_remove_git.sh install` + `git
   \$(fwdproxy-config --git-command git) clone`, pin to upstream tag
   `v1.1`, build with `make -j\$(nproc)`, then move the six binaries
   plus `converter` into `\$BENCHPRESS_ROOT/benchmarks/gapbs/`.

   Dropped the `build_twitter()` helper from the WIP — it `wget`'d
   ~25 GB of Twitter graph data from public GitHub (no fwdproxy) and
   built ~50 GB of `.sg/.wsg/.sgU` files, which is what tripped the
   EdenFS issue the prior test plan flagged. The Twitter graph is now
   an out-of-band setup the user performs once; the default jobs use
   the synthetic Kronecker generator (`-g SCALE`) which needs no input
   graph file at all.

4. Rewrite `cleanup_gapbs.sh` with `BENCHPRESS_ROOT` + the matching
   `install_remove_git.sh remove` proxy teardown (the WIP dropped this).

5. Move both scripts from the repo root to `packages/gapbs/` and
   update all `install_script`/`cleanup_script` paths in
   `benchmarks_mem.yml` to use the new relative paths. Add
   `install_markers` like graph500 does so `./benchpress list_status`
   can detect a built install.

6. `jobs_mem.yml` defaults to `-g 20 -n 3` for all six jobs (no graph
   file required). The job descriptions explain that overriding
   `args=` to `-f ./benchmark/graphs/twitter.sg -n 3` works for users
   who have a prebuilt Twitter graph in the working directory.

7. Add `test_cc_sample_output`, `test_pr_sample_output`,
   `test_sssp_sample_output` to `tests/test_gapbs_parser.py` covering
   the three new kernels. All six tests pass.

Reviewed By: excelle08

Differential Revision: D95906223


