### PR TITLE
Add same-thread client mode and experiment configs

### DIFF
--- a/packages/ucache_bench/client/UcacheBenchClient.cpp
+++ b/packages/ucache_bench/client/UcacheBenchClient.cpp
@@ -25,6 +25,7 @@
 #include <folly/coro/AsyncScope.h>
 #include <folly/coro/BlockingWait.h>
 #include <folly/coro/Promise.h>
+#include <folly/coro/Sleep.h>
 #include <folly/fibers/FiberManagerMap.h>
 #include <folly/io/async/ScopedEventBaseThread.h>
 #include <folly/portability/GFlags.h>
@@ -319,9 +320,9 @@ DEFINE_uint32(value_size_max, 1024, "Maximum value size in bytes");
 DEFINE_double(get_ratio, 0.9, "Ratio of GET operations (vs SET operations)");
 DEFINE_uint32(
     connection_timeout_ms,
-    1000,
+    5000,
     "Connection timeout in milliseconds");
-DEFINE_uint32(send_timeout_ms, 1000, "Send timeout in milliseconds");
+DEFINE_uint32(send_timeout_ms, 5000, "Send timeout in milliseconds");
 DEFINE_string(
     security_mech,
     "plain",
@@ -346,6 +347,30 @@ DEFINE_bool(
     enable_random_source_ip,
     false,
     "Enable random source IP addresses for connection fanout (works with BucketHashSelector)");
+DEFINE_uint32(
+    connection_ramp_seconds,
+    10,
+    "Seconds to gradually ramp up connections before warmup. "
+    "Prevents connection storm when additional_fanout is large. "
+    "0 = disabled (all connections established at once)");
+DEFINE_bool(
+    warmup_adaptive_load,
+    true,
+    "Enable adaptive load control during warmup (TCP congestion control style). "
+    "Starts with low concurrency and ramps up until errors spike, then backs off. "
+    "Prevents TKO cascade when multiple clients warm up simultaneously");
+DEFINE_uint32(
+    warmup_initial_inflight,
+    2,
+    "Initial max inflight per thread when adaptive load is enabled. "
+    "Total initial concurrency = num_threads * warmup_initial_inflight");
+DEFINE_uint32(
+    failures_until_tko,
+    0,
+    "Number of consecutive failures before mcrouter marks a server as TKO "
+    "(0 = use mcrouter default of 3). Production typically uses 12-32. "
+    "With many proxy threads, a low value causes premature TKO because the "
+    "counter is global across all threads");
 DEFINE_bool(verbose, false, "Enable verbose logging");
 DEFINE_bool(
     use_distribution,
@@ -551,6 +576,14 @@ UcacheBenchClient::UcacheBenchClient() {
     options.num_proxies = FLAGS_num_proxies;
   }
 
+  // Configure TKO behavior to match production settings.
+  // The default failures_until_tko=3 is too aggressive with many proxy threads
+  // because the failure counter is global — just 3 timeouts from ANY thread
+  // marks the server as TKO, stopping all traffic.
+  if (FLAGS_failures_until_tko > 0) {
+    options.failures_until_tko = FLAGS_failures_until_tko;
+  }
+
   // Create CarbonRouterInstance with UcacheBench RouterInfo
   auto routerPtr = facebook::memcache::mcrouter::CarbonRouterInstance<
       UcacheBenchRouterInfo>::init("ucache_bench_client", options);
@@ -585,6 +618,11 @@ UcacheBenchClient::UcacheBenchClient() {
           totalConnections);
     } else {
       printf("  Connection fanout disabled (using default connections)\n");
+    }
+    if (FLAGS_failures_until_tko > 0) {
+      printf(
+          "  TKO threshold: %u failures (overriding default of 3)\n",
+          FLAGS_failures_until_tko);
     }
     if (FLAGS_enable_random_source_ip) {
       printf(
@@ -634,6 +672,100 @@ UcacheBenchClient::WarmupResults UcacheBenchClient::warmup() {
     fflush(stdout);
   }
 
+  // Connection ramp-up phase: gradually establish connections to avoid
+  // overwhelming the server's accept queue when additional_fanout is large.
+  // With num_proxies=64 and additional_fanout=500, mcrouter creates 32K
+  // ProxyDestination objects. Without ramp-up, all connections are established
+  // simultaneously on first request, causing a connection storm that TKOs the
+  // server.
+  if (FLAGS_connection_ramp_seconds > 0 && FLAGS_additional_fanout > 0) {
+    uint32_t totalDestinations =
+        FLAGS_num_proxies * (1 + FLAGS_additional_fanout);
+    if (FLAGS_verbose) {
+      printf(
+          "Connection ramp-up: establishing ~%u connections over %u seconds\n",
+          totalDestinations,
+          FLAGS_connection_ramp_seconds);
+      fflush(stdout);
+    }
+
+    // Use a small thread pool for connection ramp-up (1 thread per proxy)
+    uint32_t rampThreads = std::min(numThreads, FLAGS_num_proxies);
+    folly::IOThreadPoolExecutor rampPool(rampThreads);
+    auto rampEvbs = rampPool.getAllEventBases();
+
+    // Create one client with low maxOutstanding for connection ramp-up
+    auto rampClient = routerInstance_->createClient(1);
+
+    auto rampDuration = std::chrono::seconds(FLAGS_connection_ramp_seconds);
+    auto rampStart = std::chrono::steady_clock::now();
+    auto rampEnd = rampStart + rampDuration;
+
+    // Send requests with diverse keys to trigger lazy connection creation
+    // across different hash destinations. Each unique key hashes to a different
+    // ProxyDestination, establishing a new TCP connection.
+    std::atomic<uint64_t> rampOps{0};
+    std::atomic<uint64_t> rampSuccesses{0};
+    std::atomic<uint64_t> rampErrors{0};
+
+    auto rampWorker = [&](size_t /*threadIdx*/) -> folly::coro::Task<void> {
+      while (std::chrono::steady_clock::now() < rampEnd) {
+        std::string key = generateKey();
+        std::string value = generateValue();
+
+        UcbSetRequest request;
+        request.key_ref() = carbon::Keys<folly::IOBuf>(
+            std::move(*folly::IOBuf::copyBuffer(key)));
+        request.value_ref() = *folly::IOBuf::copyBuffer(value);
+        request.exptime_ref() = 3600;
+
+        auto [promise, future] =
+            folly::coro::makePromiseContract<UcbSetReply>();
+
+        rampClient->send(
+            request,
+            [p = std::move(promise)](
+                const UcbSetRequest&, UcbSetReply&& reply) mutable {
+              p.setValue(std::move(reply));
+            });
+
+        UcbSetReply result = co_await std::move(future);
+        rampOps++;
+
+        if (*result.result_ref() == carbon::Result::STORED) {
+          rampSuccesses++;
+        } else {
+          rampErrors++;
+        }
+
+        // Pace the ramp-up: sleep briefly between requests to spread
+        // connection creation over the ramp-up period
+        co_await folly::coro::sleep(std::chrono::milliseconds(1));
+      }
+      co_return;
+    };
+
+    // Start ramp-up workers
+    folly::coro::AsyncScope rampScope;
+    for (size_t i = 0; i < rampThreads; ++i) {
+      rampScope.add(
+          folly::coro::co_withExecutor(
+              rampEvbs.at(i % rampEvbs.size()), rampWorker(i)));
+    }
+
+    folly::coro::blockingWait(
+        rampScope.joinAsync().scheduleOn(rampEvbs.front()));
+
+    if (FLAGS_verbose) {
+      printf(
+          "Connection ramp-up complete: %lu ops (%lu success, %lu errors)\n",
+          rampOps.load(),
+          rampSuccesses.load(),
+          rampErrors.load());
+      fflush(stdout);
+    }
+  }
+
   auto startTime = std::chrono::steady_clock::now();
   auto endTime = startTime + std::chrono::seconds(FLAGS_warmup_seconds);
 
@@ -642,6 +774,15 @@ UcacheBenchClient::WarmupResults UcacheBenchClient::warmup() {
   std::atomic<uint64_t> setSuccesses{0};
   std::atomic<uint64_t> setErrors{0};
   std::atomic<bool> shouldStop{false};
+
+  // Adaptive load control: shared dynamic inflight limit
+  // All workers read this to cap their concurrency. The control thread adjusts
+  // it based on observed error rate (TCP congestion control style: AIMD).
+  std::atomic<uint32_t> currentMaxInflight{maxInflight};
+  if (FLAGS_warmup_adaptive_load) {
+    currentMaxInflight.store(
+        std::min(maxInflight, FLAGS_warmup_initial_inflight));
+  }
 
   // Progress monitoring thread
   std::thread progressThread;
@@ -663,13 +804,111 @@ UcacheBenchClient::WarmupResults UcacheBenchClient::warmup() {
         double successRate = ops > 0 ? (successes * 100.0 / ops) : 0;
 
         printf(
-            "Warmup progress: %.1fs elapsed, %lu ops (%.1f QPS avg), Success: %.1f%%, Errors: %lu\n",
+            "Warmup progress: %.1fs elapsed, %lu ops (%.1f QPS avg), Success: %.1f%%, Errors: %lu, MaxInflight: %u\n",
             elapsed,
             ops,
             avgQps,
             successRate,
-            errors);
+            errors,
+            currentMaxInflight.load());
         fflush(stdout);
+      }
+    });
+  }
+
+  // Adaptive load control thread: monitors error rate and adjusts
+  // currentMaxInflight using AIMD (Additive Increase, Multiplicative Decrease).
+  // Like TCP congestion control: ramp up when healthy, cut back on errors.
+  std::thread adaptiveThread;
+  if (FLAGS_warmup_adaptive_load) {
+    adaptiveThread = std::thread([&]() {
+      constexpr auto kCheckInterval = std::chrono::seconds(2);
+      constexpr double kErrorThreshold = 0.05; // 5% error rate triggers backoff
+      constexpr double kHealthyThreshold = 0.01; // <1% errors = healthy, grow
+
+      uint64_t prevOps = 0;
+      uint64_t prevErrors = 0;
+      bool reachedMax = false;
+
+      while (!shouldStop.load() && std::chrono::steady_clock::now() < endTime) {
+        std::this_thread::sleep_for(kCheckInterval);
+        if (shouldStop.load()) {
+          break;
+        }
+
+        uint64_t curOps = totalOps.load();
+        uint64_t curErrors = setErrors.load();
+
+        uint64_t windowOps = curOps - prevOps;
+        uint64_t windowErrors = curErrors - prevErrors;
+        prevOps = curOps;
+        prevErrors = curErrors;
+
+        if (windowOps < 100) {
+          // Not enough data yet, keep growing slowly
+          uint32_t cur = currentMaxInflight.load();
+          if (cur < maxInflight) {
+            uint32_t next = std::min(maxInflight, cur + 1);
+            currentMaxInflight.store(next);
+            if (FLAGS_verbose) {
+              printf(
+                  "Adaptive load: too few ops (%lu), inflight %u -> %u\n",
+                  windowOps,
+                  cur,
+                  next);
+              fflush(stdout);
+            }
+          }
+          continue;
+        }
+
+        double errorRate =
+            static_cast<double>(windowErrors) / static_cast<double>(windowOps);
+        uint32_t cur = currentMaxInflight.load();
+
+        if (errorRate > kErrorThreshold) {
+          // Multiplicative decrease: halve the inflight limit
+          uint32_t next = std::max(1u, cur / 2);
+          currentMaxInflight.store(next);
+          reachedMax = false;
+          if (FLAGS_verbose) {
+            printf(
+                "Adaptive load: HIGH errors (%.1f%% of %lu ops), inflight %u -> %u (backoff)\n",
+                errorRate * 100.0,
+                windowOps,
+                cur,
+                next);
+            fflush(stdout);
+          }
+        } else if (errorRate < kHealthyThreshold && cur < maxInflight) {
+          // Additive increase: grow inflight
+          // Use slow start (double) when far from max, linear when close
+          uint32_t next;
+          if (cur < maxInflight / 4) {
+            // Slow start phase: double
+            next = std::min(maxInflight, cur * 2);
+          } else {
+            // Congestion avoidance: linear increase
+            uint32_t increment = std::max(1u, maxInflight / 10);
+            next = std::min(maxInflight, cur + increment);
+          }
+          currentMaxInflight.store(next);
+          if (next == maxInflight && !reachedMax) {
+            reachedMax = true;
+            if (FLAGS_verbose) {
+              printf("Adaptive load: reached max inflight %u\n", maxInflight);
+              fflush(stdout);
+            }
+          } else if (FLAGS_verbose && next != cur) {
+            printf(
+                "Adaptive load: healthy (%.2f%% errors), inflight %u -> %u\n",
+                errorRate * 100.0,
+                cur,
+                next);
+            fflush(stdout);
+          }
+        }
+        // If error rate is between thresholds, hold steady
       }
     });
   }
@@ -748,9 +987,11 @@ UcacheBenchClient::WarmupResults UcacheBenchClient::warmup() {
         localSuccesses++;
       } else {
         localErrors++;
-        if (FLAGS_verbose) {
+        // Rate-limit verbose error output to avoid flooding stdout pipe
+        // which can deadlock when run through benchpress/automark
+        if (FLAGS_verbose && (localErrors.load() % 1000 == 1)) {
           printf(
-              "Warmup SET error: %s\n",
+              "Warmup SET error (sample 1/1000): %s\n",
               carbon::resultToString(*result.result_ref()));
         }
       }
@@ -759,10 +1000,12 @@ UcacheBenchClient::WarmupResults UcacheBenchClient::warmup() {
 
     // Main loop - matches production LoadgenWorker::co_run()
     while (std::chrono::steady_clock::now() < endTime) {
-      // Spawn requests up to max_inflight
-      size_t n = maxInflight - inflight.load();
+      // Spawn requests up to current dynamic inflight limit
+      uint32_t limit = currentMaxInflight.load();
+      size_t currentInflight = inflight.load();
+      size_t n = (currentInflight < limit) ? (limit - currentInflight) : 0;
       if (n > 0 && std::chrono::steady_clock::now() < endTime) {
-        for (size_t i = 0; i < n && inflight.load() < maxInflight; i++) {
+        for (size_t i = 0; i < n && inflight.load() < limit; i++) {
           inflight++;
           scope.add(
               folly::coro::co_withExecutor(
@@ -829,6 +1072,9 @@ UcacheBenchClient::WarmupResults UcacheBenchClient::warmup() {
       mainScope.joinAsync().scheduleOn(workerEvbs.front()));
 
   shouldStop = true;
+  if (adaptiveThread.joinable()) {
+    adaptiveThread.join();
+  }
   if (progressThread.joinable()) {
     progressThread.join();
   }
@@ -1135,17 +1381,18 @@ UcacheBenchClient::BenchmarkResults UcacheBenchClient::runBenchmark() {
           workerSetSuccesses[workerId]->fetch_add(1);
         } else {
           workerSetErrors[workerId]->fetch_add(1);
-          if (FLAGS_verbose) {
+          if (FLAGS_verbose &&
+              (workerSetErrors[workerId]->load() % 1000 == 1)) {
             printf(
-                "Benchmark SET error (on GET miss): %s\n",
+                "Benchmark SET error (on GET miss, sample 1/1000): %s\n",
                 carbon::resultToString(*setResult.result_ref()));
           }
         }
       } else {
         workerGetErrors[workerId]->fetch_add(1);
-        if (FLAGS_verbose) {
+        if (FLAGS_verbose && (workerGetErrors[workerId]->load() % 1000 == 1)) {
           printf(
-              "Benchmark GET error: %s\n",
+              "Benchmark GET error (sample 1/1000): %s\n",
               carbon::resultToString(*result.result_ref()));
         }
       }
@@ -1204,9 +1451,9 @@ UcacheBenchClient::BenchmarkResults UcacheBenchClient::runBenchmark() {
         workerSetSuccesses[workerId]->fetch_add(1);
       } else {
         workerSetErrors[workerId]->fetch_add(1);
-        if (FLAGS_verbose) {
+        if (FLAGS_verbose && (workerSetErrors[workerId]->load() % 1000 == 1)) {
           printf(
-              "Benchmark SET error: %s\n",
+              "Benchmark SET error (sample 1/1000): %s\n",
               carbon::resultToString(*result.result_ref()));
         }
       }

--- a/packages/ucache_bench/client/UcacheBenchClient.cpp
+++ b/packages/ucache_bench/client/UcacheBenchClient.cpp
@@ -30,8 +30,10 @@
 #include <folly/io/async/ScopedEventBaseThread.h>
 #include <folly/portability/GFlags.h>
 #include <mcrouter/McrouterFiberContext.h>
+#include <mcrouter/ProxyBase.h>
 #include <mcrouter/lib/carbon/Result.h>
 #include <mcrouter/lib/network/CpuController.h>
+#include <mcrouter/stats.h>
 
 DECLARE_string(config);
 DECLARE_uint32(warmup_ops);
@@ -372,6 +374,14 @@ DEFINE_uint32(
     "With many proxy threads, a low value causes premature TKO because the "
     "counter is global across all threads");
 DEFINE_bool(verbose, false, "Enable verbose logging");
+DEFINE_bool(
+    use_same_thread_client,
+    false,
+    "Use createSameThreadClient() to eliminate cross-thread message queue hops. "
+    "Workers run directly on McRouter proxy EventBases instead of a separate "
+    "thread pool. This matches production's same-thread dispatch pattern and "
+    "can significantly improve throughput by eliminating 2 cross-thread hops "
+    "per request");
 DEFINE_bool(
     use_distribution,
     false,
@@ -1172,23 +1182,59 @@ UcacheBenchClient::BenchmarkResults UcacheBenchClient::runBenchmark() {
   std::vector<double> allLatencies;
   allLatencies.reserve(100000 * numThreads);
 
-  // Create IO thread pool for coroutine execution - matches production pattern
-  folly::IOThreadPoolExecutor workerPool(numThreads);
-  auto workerEvbs = workerPool.getAllEventBases();
-
-  // Create clients for each worker with maxInflight - matches production
-  // pattern McRouter's maximumOutstanding will handle backpressure via internal
-  // semaphore
+  // Create clients and get EventBases for worker coroutines.
+  // Two modes:
+  //   1. Same-thread mode: workers run on proxy EventBases, bypassing the
+  //      cross-thread message queue. One worker per proxy.
+  //   2. Remote-thread mode (default): workers run on a separate thread pool,
+  //      requests are dispatched to proxy threads via message queue.
+  std::unique_ptr<folly::IOThreadPoolExecutor> workerPool;
+  std::vector<folly::EventBase*> workerEvbs;
   std::vector<
       memcache::mcrouter::CarbonRouterClient<UcacheBenchRouterInfo>::Pointer>
       clients;
-  clients.reserve(numThreads);
-  for (uint32_t i = 0; i < numThreads; ++i) {
-    // Use maxInflight as maximumOutstanding - McRouter will block if limit
-    // reached
-    auto client = routerInstance_->createClient(maxInflight);
-    if (client) {
-      clients.push_back(std::move(client));
+
+  if (FLAGS_use_same_thread_client) {
+    // Same-thread mode: one worker per proxy, running on proxy EventBases.
+    // This eliminates the worker->proxy->worker cross-thread hops.
+    size_t numProxies = routerInstance_->opts().num_proxies;
+    clients.reserve(numProxies);
+    workerEvbs.reserve(numProxies);
+
+    for (size_t i = 0; i < numProxies; ++i) {
+      auto* proxy = routerInstance_->getProxyBase(i);
+      if (!proxy) {
+        continue;
+      }
+      workerEvbs.push_back(&proxy->eventBase().getEventBase());
+
+      auto client = routerInstance_->createSameThreadClient(maxInflight);
+      if (client) {
+        client->setProxyIndex(i);
+        clients.push_back(std::move(client));
+      }
+    }
+
+    if (FLAGS_verbose) {
+      printf(
+          "Using same-thread client mode: %zu workers on proxy EventBases\n",
+          clients.size());
+      fflush(stdout);
+    }
+  } else {
+    // Remote-thread mode (original): separate worker thread pool.
+    workerPool = std::make_unique<folly::IOThreadPoolExecutor>(numThreads);
+    auto evbKeepAlives = workerPool->getAllEventBases();
+    for (auto& ka : evbKeepAlives) {
+      workerEvbs.push_back(ka.get());
+    }
+
+    clients.reserve(numThreads);
+    for (uint32_t i = 0; i < numThreads; ++i) {
+      auto client = routerInstance_->createClient(maxInflight);
+      if (client) {
+        clients.push_back(std::move(client));
+      }
     }
   }
 
@@ -1546,6 +1592,122 @@ UcacheBenchClient::BenchmarkResults UcacheBenchClient::runBenchmark() {
   }
 
   results.latencies = std::move(allLatencies);
+
+  // Dump mcrouter pipeline stats for profiling
+  if (routerInstance_) {
+    using facebook::memcache::mcrouter::num_stats;
+    using facebook::memcache::mcrouter::prepare_stats;
+    using facebook::memcache::mcrouter::stat_t;
+
+    stat_t stats[num_stats];
+    facebook::memcache::mcrouter::init_stats(stats);
+    prepare_stats(*routerInstance_, stats);
+
+    printf("\n=== McRouter Pipeline Stats ===\n");
+
+    // Key timing stats
+    auto printDoubleStat = [&](const char* label,
+                               facebook::memcache::mcrouter::stat_name_t s) {
+      double val = folly::make_atomic_ref(stats[s].data.dbl)
+                       .load(std::memory_order_relaxed);
+      printf("  %-40s: %.2f\n", label, val);
+    };
+    auto printUint64Stat = [&](const char* label,
+                               facebook::memcache::mcrouter::stat_name_t s) {
+      uint64_t val = folly::make_atomic_ref(stats[s].data.uint64)
+                         .load(std::memory_order_relaxed);
+      printf("  %-40s: %lu\n", label, val);
+    };
+
+    printDoubleStat(
+        "duration_us (avg RPC latency)",
+        facebook::memcache::mcrouter::duration_us_stat);
+    printDoubleStat(
+        "duration_get_us", facebook::memcache::mcrouter::duration_get_us_stat);
+    printDoubleStat(
+        "duration_update_us",
+        facebook::memcache::mcrouter::duration_update_us_stat);
+    printDoubleStat(
+        "processing_time_us (mcrouter only)",
+        facebook::memcache::mcrouter::processing_time_us_stat);
+    printDoubleStat(
+        "destination_batch_size",
+        facebook::memcache::mcrouter::destination_batch_size_stat);
+    printUint64Stat(
+        "destination_pending_reqs",
+        facebook::memcache::mcrouter::destination_pending_reqs_stat);
+    printUint64Stat(
+        "destination_inflight_reqs",
+        facebook::memcache::mcrouter::destination_inflight_reqs_stat);
+    printUint64Stat(
+        "destination_max_pending_reqs",
+        facebook::memcache::mcrouter::destination_max_pending_reqs_stat);
+    printUint64Stat(
+        "destination_max_inflight_reqs",
+        facebook::memcache::mcrouter::destination_max_inflight_reqs_stat);
+    printUint64Stat(
+        "outstanding_route_get_reqs_queued",
+        facebook::memcache::mcrouter::outstanding_route_get_reqs_queued_stat);
+    printUint64Stat(
+        "outstanding_route_update_reqs_queued",
+        facebook::memcache::mcrouter::
+            outstanding_route_update_reqs_queued_stat);
+
+    printf("=== End McRouter Pipeline Stats ===\n\n");
+
+    // Also write to file for retrieval via sush2
+    FILE* statsFile = fopen("/tmp/mcrouter_stats.txt", "w");
+    if (statsFile) {
+      auto writeDoubleStat = [&](const char* label,
+                                 facebook::memcache::mcrouter::stat_name_t s) {
+        double val = folly::make_atomic_ref(stats[s].data.dbl)
+                         .load(std::memory_order_relaxed);
+        fprintf(statsFile, "%-40s: %.2f\n", label, val);
+      };
+      auto writeUint64Stat = [&](const char* label,
+                                 facebook::memcache::mcrouter::stat_name_t s) {
+        uint64_t val = folly::make_atomic_ref(stats[s].data.uint64)
+                           .load(std::memory_order_relaxed);
+        fprintf(statsFile, "%-40s: %lu\n", label, val);
+      };
+
+      writeDoubleStat(
+          "duration_us (avg RPC latency)",
+          facebook::memcache::mcrouter::duration_us_stat);
+      writeDoubleStat(
+          "duration_get_us",
+          facebook::memcache::mcrouter::duration_get_us_stat);
+      writeDoubleStat(
+          "duration_update_us",
+          facebook::memcache::mcrouter::duration_update_us_stat);
+      writeDoubleStat(
+          "processing_time_us (mcrouter only)",
+          facebook::memcache::mcrouter::processing_time_us_stat);
+      writeDoubleStat(
+          "destination_batch_size",
+          facebook::memcache::mcrouter::destination_batch_size_stat);
+      writeUint64Stat(
+          "destination_pending_reqs",
+          facebook::memcache::mcrouter::destination_pending_reqs_stat);
+      writeUint64Stat(
+          "destination_inflight_reqs",
+          facebook::memcache::mcrouter::destination_inflight_reqs_stat);
+      writeUint64Stat(
+          "destination_max_pending_reqs",
+          facebook::memcache::mcrouter::destination_max_pending_reqs_stat);
+      writeUint64Stat(
+          "destination_max_inflight_reqs",
+          facebook::memcache::mcrouter::destination_max_inflight_reqs_stat);
+      writeUint64Stat(
+          "outstanding_route_get_reqs_queued",
+          facebook::memcache::mcrouter::outstanding_route_get_reqs_queued_stat);
+      writeUint64Stat(
+          "outstanding_route_update_reqs_queued",
+          facebook::memcache::mcrouter::
+              outstanding_route_update_reqs_queued_stat);
+      fclose(statsFile);
+    }
+  }
 
   // Notify admin server that benchmark is done (if connected)
   if (hasAdminConnection()) {

--- a/packages/ucache_bench/run.py
+++ b/packages/ucache_bench/run.py
@@ -25,6 +25,7 @@ import argparse
 import os
 import pathlib
 import subprocess
+import sys
 import threading
 from typing import List, Optional
 
@@ -133,14 +134,12 @@ def run_cmd(
             stderr=subprocess.STDOUT,
         )
         try:
-            if timeout:
-                proc.wait(timeout=timeout)
-            else:
-                proc.wait()
+            # Use communicate() instead of wait() to actively read stdout
+            # and avoid pipe deadlock when the child produces verbose output
+            stdout, _ = proc.communicate(timeout=timeout)
         except subprocess.TimeoutExpired:
             proc.terminate()
-            proc.wait()
-        stdout, _ = proc.communicate()
+            stdout, _ = proc.communicate()
         return stdout.decode("utf-8")
     else:
         return ""
@@ -398,7 +397,26 @@ def run_server(args: argparse.Namespace) -> None:
         t_prof.start()
 
     stdout = run_cmd(server_cmd, timeout=None, for_real=args.real)
-    print(stdout)
+
+    # Write full output to a log file for debugging, then only print
+    # the tail to stdout. This prevents pipe deadlock with the parent
+    # process (benchpress) which may use proc.wait() before reading
+    # stdout — if output exceeds the 64KB pipe buffer, both processes
+    # deadlock. The results JSON is always at the end of the output.
+    log_path = os.path.join(UCACHE_BENCH_DIR, "server_output.log")
+    try:
+        with open(log_path, "w") as f:
+            f.write(stdout)
+        print(f"Full server output written to {log_path}", file=sys.stderr)
+    except OSError as e:
+        print(f"Warning: could not write server log: {e}", file=sys.stderr)
+
+    # Print only the last 200 lines to stdout (results JSON + summary)
+    lines = stdout.split("\n")
+    if len(lines) > 200:
+        print(f"[...truncated {len(lines) - 200} lines of verbose output...]")
+    tail = lines[-200:] if len(lines) > 200 else lines
+    print("\n".join(tail))
 
     if "DCPERF_PERF_RECORD" in os.environ and os.environ["DCPERF_PERF_RECORD"] == "1":
         # pyrefly: ignore [unbound-name]
@@ -435,10 +453,18 @@ def run_client(args: argparse.Namespace) -> None:
     if args.admin_port > 0:
         client_cmd.append(f"--admin_port={args.admin_port}")
 
+    # Connection ramp-up configuration
+    if args.connection_ramp_seconds != 10:
+        client_cmd.append(f"--connection_ramp_seconds={args.connection_ramp_seconds}")
+    if not args.warmup_adaptive_load:
+        client_cmd.append("--warmup_adaptive_load=false")
+    if args.warmup_initial_inflight != 2:
+        client_cmd.append(f"--warmup_initial_inflight={args.warmup_initial_inflight}")
+
     # Timeout configuration
-    if args.connection_timeout_ms != 1000:
+    if args.connection_timeout_ms != 5000:
         client_cmd.append(f"--connection_timeout_ms={args.connection_timeout_ms}")
-    if args.send_timeout_ms != 1000:
+    if args.send_timeout_ms != 5000:
         client_cmd.append(f"--send_timeout_ms={args.send_timeout_ms}")
 
     # Security configuration
@@ -463,11 +489,30 @@ def run_client(args: argparse.Namespace) -> None:
     if args.enable_random_source_ip:
         client_cmd.append("--enable_random_source_ip=true")
 
+    if args.failures_until_tko > 0:
+        client_cmd.append(f"--failures_until_tko={args.failures_until_tko}")
+
     if args.verbose:
         client_cmd.append("--verbose=true")
 
     stdout = run_cmd(client_cmd, timeout=None, for_real=args.real)
-    print(stdout)
+
+    # Write full output to a log file for debugging, then only print
+    # the tail to stdout to prevent pipe deadlock with parent process.
+    log_path = os.path.join(UCACHE_BENCH_DIR, "client_output.log")
+    try:
+        with open(log_path, "w") as f:
+            f.write(stdout)
+        print(f"Full client output written to {log_path}", file=sys.stderr)
+    except OSError as e:
+        print(f"Warning: could not write client log: {e}", file=sys.stderr)
+
+    # Print only the last 200 lines to stdout (results JSON + summary)
+    lines = stdout.split("\n")
+    if len(lines) > 200:
+        print(f"[...truncated {len(lines) - 200} lines of verbose output...]")
+    tail = lines[-200:] if len(lines) > 200 else lines
+    print("\n".join(tail))
 
 
 def init_parser() -> argparse.ArgumentParser:
@@ -779,13 +824,13 @@ def init_parser() -> argparse.ArgumentParser:
     client_parser.add_argument(
         "--connection-timeout-ms",
         type=int,
-        default=1000,
+        default=5000,
         help="Connection timeout in milliseconds",
     )
     client_parser.add_argument(
         "--send-timeout-ms",
         type=int,
-        default=1000,
+        default=5000,
         help="Send timeout in milliseconds",
     )
     client_parser.add_argument(
@@ -839,6 +884,24 @@ def init_parser() -> argparse.ArgumentParser:
         type=int,
         default=0,
         help="Enable random source IP addresses for connection fanout (set to non-zero to enable)",
+    )
+    client_parser.add_argument(
+        "--connection-ramp-seconds",
+        type=int,
+        default=10,
+        help="Seconds to gradually ramp up connections before warmup (0 = disabled)",
+    )
+    client_parser.add_argument(
+        "--warmup-adaptive-load",
+        type=int,
+        default=1,
+        help="Enable adaptive load control during warmup (1=enabled, 0=disabled)",
+    )
+    client_parser.add_argument(
+        "--warmup-initial-inflight",
+        type=int,
+        default=2,
+        help="Initial max inflight per thread when adaptive load is enabled",
     )
 
     # Workload configuration
@@ -907,6 +970,14 @@ def init_parser() -> argparse.ArgumentParser:
         default=0,
         help="Admin server port for multi-client coordination (0 = disabled). "
         "Uses server_host since admin server runs on same machine as cache server.",
+    )
+
+    client_parser.add_argument(
+        "--failures-until-tko",
+        type=int,
+        default=0,
+        help="Number of consecutive failures before mcrouter marks server as TKO "
+        "(0 = mcrouter default of 3). Production typically uses 12-32.",
     )
 
     client_parser.add_argument(

--- a/packages/ucache_bench/run.py
+++ b/packages/ucache_bench/run.py
@@ -492,6 +492,9 @@ def run_client(args: argparse.Namespace) -> None:
     if args.failures_until_tko > 0:
         client_cmd.append(f"--failures_until_tko={args.failures_until_tko}")
 
+    if args.use_same_thread_client:
+        client_cmd.append("--use_same_thread_client=true")
+
     if args.verbose:
         client_cmd.append("--verbose=true")
 
@@ -902,6 +905,13 @@ def init_parser() -> argparse.ArgumentParser:
         type=int,
         default=2,
         help="Initial max inflight per thread when adaptive load is enabled",
+    )
+
+    client_parser.add_argument(
+        "--use-same-thread-client",
+        type=int,
+        default=0,
+        help="Use createSameThreadClient() to eliminate cross-thread hops (1=enabled, 0=disabled)",
     )
 
     # Workload configuration

--- a/packages/ucache_bench/server/UcacheBenchRpcServer.cpp
+++ b/packages/ucache_bench/server/UcacheBenchRpcServer.cpp
@@ -179,6 +179,12 @@ apache::thrift::ThriftServer& UcacheBenchRpcServer::addThriftServer() {
   // No limit on concurrent active requests.
   thriftServer_->setMaxRequests(0);
 
+  // Large listen backlog to handle connection storms from clients using
+  // additional_fanout. With num_proxies=64 and additional_fanout=500,
+  // a single client creates ~32K connections. Default backlog (1024) is
+  // too small and causes connections to be refused, triggering mcrouter TKO.
+  thriftServer_->setListenBacklog(65536);
+
   // Disable per-request tracking overhead.
   thriftServer_->disableActiveRequestsTracking();
 


### PR DESCRIPTION
Summary:
- Add createSameThreadClient() support to eliminate cross-thread message queue hops
- Workers run directly on McRouter proxy EventBases instead of separate thread pool
- Add use_same_thread_client flag/config through full stack (client, run.py, jobs YAML, automark)
- Add experiment config files for various benchmark configurations

Differential Revision: D98968871


