### PR TITLE
Add configurable cpu_work_us and bucket_lock_power for CPU tuning (#644)

### DIFF
--- a/packages/ucache_bench/client/UcacheBenchClient.cpp
+++ b/packages/ucache_bench/client/UcacheBenchClient.cpp
@@ -25,6 +25,7 @@
 #include <folly/coro/AsyncScope.h>
 #include <folly/coro/BlockingWait.h>
 #include <folly/coro/Promise.h>
+#include <folly/coro/Sleep.h>
 #include <folly/fibers/FiberManagerMap.h>
 #include <folly/io/async/ScopedEventBaseThread.h>
 #include <folly/portability/GFlags.h>
@@ -319,9 +320,9 @@ DEFINE_uint32(value_size_max, 1024, "Maximum value size in bytes");
 DEFINE_double(get_ratio, 0.9, "Ratio of GET operations (vs SET operations)");
 DEFINE_uint32(
     connection_timeout_ms,
-    1000,
+    5000,
     "Connection timeout in milliseconds");
-DEFINE_uint32(send_timeout_ms, 1000, "Send timeout in milliseconds");
+DEFINE_uint32(send_timeout_ms, 5000, "Send timeout in milliseconds");
 DEFINE_string(
     security_mech,
     "plain",
@@ -346,6 +347,30 @@ DEFINE_bool(
     enable_random_source_ip,
     false,
     "Enable random source IP addresses for connection fanout (works with BucketHashSelector)");
+DEFINE_uint32(
+    connection_ramp_seconds,
+    10,
+    "Seconds to gradually ramp up connections before warmup. "
+    "Prevents connection storm when additional_fanout is large. "
+    "0 = disabled (all connections established at once)");
+DEFINE_bool(
+    warmup_adaptive_load,
+    true,
+    "Enable adaptive load control during warmup (TCP congestion control style). "
+    "Starts with low concurrency and ramps up until errors spike, then backs off. "
+    "Prevents TKO cascade when multiple clients warm up simultaneously");
+DEFINE_uint32(
+    warmup_initial_inflight,
+    2,
+    "Initial max inflight per thread when adaptive load is enabled. "
+    "Total initial concurrency = num_threads * warmup_initial_inflight");
+DEFINE_uint32(
+    failures_until_tko,
+    0,
+    "Number of consecutive failures before mcrouter marks a server as TKO "
+    "(0 = use mcrouter default of 3). Production typically uses 12-32. "
+    "With many proxy threads, a low value causes premature TKO because the "
+    "counter is global across all threads");
 DEFINE_bool(verbose, false, "Enable verbose logging");
 DEFINE_bool(
     use_distribution,
@@ -551,6 +576,14 @@ UcacheBenchClient::UcacheBenchClient() {
     options.num_proxies = FLAGS_num_proxies;
   }
 
+  // Configure TKO behavior to match production settings.
+  // The default failures_until_tko=3 is too aggressive with many proxy threads
+  // because the failure counter is global — just 3 timeouts from ANY thread
+  // marks the server as TKO, stopping all traffic.
+  if (FLAGS_failures_until_tko > 0) {
+    options.failures_until_tko = FLAGS_failures_until_tko;
+  }
+
   // Create CarbonRouterInstance with UcacheBench RouterInfo
   auto routerPtr = facebook::memcache::mcrouter::CarbonRouterInstance<
       UcacheBenchRouterInfo>::init("ucache_bench_client", options);
@@ -585,6 +618,11 @@ UcacheBenchClient::UcacheBenchClient() {
           totalConnections);
     } else {
       printf("  Connection fanout disabled (using default connections)\n");
+    }
+    if (FLAGS_failures_until_tko > 0) {
+      printf(
+          "  TKO threshold: %u failures (overriding default of 3)\n",
+          FLAGS_failures_until_tko);
     }
     if (FLAGS_enable_random_source_ip) {
       printf(
@@ -634,6 +672,100 @@ UcacheBenchClient::WarmupResults UcacheBenchClient::warmup() {
     fflush(stdout);
   }
 
+  // Connection ramp-up phase: gradually establish connections to avoid
+  // overwhelming the server's accept queue when additional_fanout is large.
+  // With num_proxies=64 and additional_fanout=500, mcrouter creates 32K
+  // ProxyDestination objects. Without ramp-up, all connections are established
+  // simultaneously on first request, causing a connection storm that TKOs the
+  // server.
+  if (FLAGS_connection_ramp_seconds > 0 && FLAGS_additional_fanout > 0) {
+    uint32_t totalDestinations =
+        FLAGS_num_proxies * (1 + FLAGS_additional_fanout);
+    if (FLAGS_verbose) {
+      printf(
+          "Connection ramp-up: establishing ~%u connections over %u seconds\n",
+          totalDestinations,
+          FLAGS_connection_ramp_seconds);
+      fflush(stdout);
+    }
+
+    // Use a small thread pool for connection ramp-up (1 thread per proxy)
+    uint32_t rampThreads = std::min(numThreads, FLAGS_num_proxies);
+    folly::IOThreadPoolExecutor rampPool(rampThreads);
+    auto rampEvbs = rampPool.getAllEventBases();
+
+    // Create one client with low maxOutstanding for connection ramp-up
+    auto rampClient = routerInstance_->createClient(1);
+
+    auto rampDuration = std::chrono::seconds(FLAGS_connection_ramp_seconds);
+    auto rampStart = std::chrono::steady_clock::now();
+    auto rampEnd = rampStart + rampDuration;
+
+    // Send requests with diverse keys to trigger lazy connection creation
+    // across different hash destinations. Each unique key hashes to a different
+    // ProxyDestination, establishing a new TCP connection.
+    std::atomic<uint64_t> rampOps{0};
+    std::atomic<uint64_t> rampSuccesses{0};
+    std::atomic<uint64_t> rampErrors{0};
+
+    auto rampWorker = [&](size_t /*threadIdx*/) -> folly::coro::Task<void> {
+      while (std::chrono::steady_clock::now() < rampEnd) {
+        std::string key = generateKey();
+        std::string value = generateValue();
+
+        UcbSetRequest request;
+        request.key_ref() = carbon::Keys<folly::IOBuf>(
+            std::move(*folly::IOBuf::copyBuffer(key)));
+        request.value_ref() = *folly::IOBuf::copyBuffer(value);
+        request.exptime_ref() = 3600;
+
+        auto [promise, future] =
+            folly::coro::makePromiseContract<UcbSetReply>();
+
+        rampClient->send(
+            request,
+            [p = std::move(promise)](
+                const UcbSetRequest&, UcbSetReply&& reply) mutable {
+              p.setValue(std::move(reply));
+            });
+
+        UcbSetReply result = co_await std::move(future);
+        rampOps++;
+
+        if (*result.result_ref() == carbon::Result::STORED) {
+          rampSuccesses++;
+        } else {
+          rampErrors++;
+        }
+
+        // Pace the ramp-up: sleep briefly between requests to spread
+        // connection creation over the ramp-up period
+        co_await folly::coro::sleep(std::chrono::milliseconds(1));
+      }
+      co_return;
+    };
+
+    // Start ramp-up workers
+    folly::coro::AsyncScope rampScope;
+    for (size_t i = 0; i < rampThreads; ++i) {
+      rampScope.add(
+          folly::coro::co_withExecutor(
+              rampEvbs.at(i % rampEvbs.size()), rampWorker(i)));
+    }
+
+    folly::coro::blockingWait(
+        rampScope.joinAsync().scheduleOn(rampEvbs.front()));
+
+    if (FLAGS_verbose) {
+      printf(
+          "Connection ramp-up complete: %lu ops (%lu success, %lu errors)\n",
+          rampOps.load(),
+          rampSuccesses.load(),
+          rampErrors.load());
+      fflush(stdout);
+    }
+  }
+
   auto startTime = std::chrono::steady_clock::now();
   auto endTime = startTime + std::chrono::seconds(FLAGS_warmup_seconds);
 
@@ -642,6 +774,15 @@ UcacheBenchClient::WarmupResults UcacheBenchClient::warmup() {
   std::atomic<uint64_t> setSuccesses{0};
   std::atomic<uint64_t> setErrors{0};
   std::atomic<bool> shouldStop{false};
+
+  // Adaptive load control: shared dynamic inflight limit
+  // All workers read this to cap their concurrency. The control thread adjusts
+  // it based on observed error rate (TCP congestion control style: AIMD).
+  std::atomic<uint32_t> currentMaxInflight{maxInflight};
+  if (FLAGS_warmup_adaptive_load) {
+    currentMaxInflight.store(
+        std::min(maxInflight, FLAGS_warmup_initial_inflight));
+  }
 
   // Progress monitoring thread
   std::thread progressThread;
@@ -663,13 +804,111 @@ UcacheBenchClient::WarmupResults UcacheBenchClient::warmup() {
         double successRate = ops > 0 ? (successes * 100.0 / ops) : 0;
 
         printf(
-            "Warmup progress: %.1fs elapsed, %lu ops (%.1f QPS avg), Success: %.1f%%, Errors: %lu\n",
+            "Warmup progress: %.1fs elapsed, %lu ops (%.1f QPS avg), Success: %.1f%%, Errors: %lu, MaxInflight: %u\n",
             elapsed,
             ops,
             avgQps,
             successRate,
-            errors);
+            errors,
+            currentMaxInflight.load());
         fflush(stdout);
+      }
+    });
+  }
+
+  // Adaptive load control thread: monitors error rate and adjusts
+  // currentMaxInflight using AIMD (Additive Increase, Multiplicative Decrease).
+  // Like TCP congestion control: ramp up when healthy, cut back on errors.
+  std::thread adaptiveThread;
+  if (FLAGS_warmup_adaptive_load) {
+    adaptiveThread = std::thread([&]() {
+      constexpr auto kCheckInterval = std::chrono::seconds(2);
+      constexpr double kErrorThreshold = 0.05; // 5% error rate triggers backoff
+      constexpr double kHealthyThreshold = 0.01; // <1% errors = healthy, grow
+
+      uint64_t prevOps = 0;
+      uint64_t prevErrors = 0;
+      bool reachedMax = false;
+
+      while (!shouldStop.load() && std::chrono::steady_clock::now() < endTime) {
+        std::this_thread::sleep_for(kCheckInterval);
+        if (shouldStop.load()) {
+          break;
+        }
+
+        uint64_t curOps = totalOps.load();
+        uint64_t curErrors = setErrors.load();
+
+        uint64_t windowOps = curOps - prevOps;
+        uint64_t windowErrors = curErrors - prevErrors;
+        prevOps = curOps;
+        prevErrors = curErrors;
+
+        if (windowOps < 100) {
+          // Not enough data yet, keep growing slowly
+          uint32_t cur = currentMaxInflight.load();
+          if (cur < maxInflight) {
+            uint32_t next = std::min(maxInflight, cur + 1);
+            currentMaxInflight.store(next);
+            if (FLAGS_verbose) {
+              printf(
+                  "Adaptive load: too few ops (%lu), inflight %u -> %u\n",
+                  windowOps,
+                  cur,
+                  next);
+              fflush(stdout);
+            }
+          }
+          continue;
+        }
+
+        double errorRate =
+            static_cast<double>(windowErrors) / static_cast<double>(windowOps);
+        uint32_t cur = currentMaxInflight.load();
+
+        if (errorRate > kErrorThreshold) {
+          // Multiplicative decrease: halve the inflight limit
+          uint32_t next = std::max(1u, cur / 2);
+          currentMaxInflight.store(next);
+          reachedMax = false;
+          if (FLAGS_verbose) {
+            printf(
+                "Adaptive load: HIGH errors (%.1f%% of %lu ops), inflight %u -> %u (backoff)\n",
+                errorRate * 100.0,
+                windowOps,
+                cur,
+                next);
+            fflush(stdout);
+          }
+        } else if (errorRate < kHealthyThreshold && cur < maxInflight) {
+          // Additive increase: grow inflight
+          // Use slow start (double) when far from max, linear when close
+          uint32_t next;
+          if (cur < maxInflight / 4) {
+            // Slow start phase: double
+            next = std::min(maxInflight, cur * 2);
+          } else {
+            // Congestion avoidance: linear increase
+            uint32_t increment = std::max(1u, maxInflight / 10);
+            next = std::min(maxInflight, cur + increment);
+          }
+          currentMaxInflight.store(next);
+          if (next == maxInflight && !reachedMax) {
+            reachedMax = true;
+            if (FLAGS_verbose) {
+              printf("Adaptive load: reached max inflight %u\n", maxInflight);
+              fflush(stdout);
+            }
+          } else if (FLAGS_verbose && next != cur) {
+            printf(
+                "Adaptive load: healthy (%.2f%% errors), inflight %u -> %u\n",
+                errorRate * 100.0,
+                cur,
+                next);
+            fflush(stdout);
+          }
+        }
+        // If error rate is between thresholds, hold steady
       }
     });
   }
@@ -748,9 +987,11 @@ UcacheBenchClient::WarmupResults UcacheBenchClient::warmup() {
         localSuccesses++;
       } else {
         localErrors++;
-        if (FLAGS_verbose) {
+        // Rate-limit verbose error output to avoid flooding stdout pipe
+        // which can deadlock when run through benchpress/automark
+        if (FLAGS_verbose && (localErrors.load() % 1000 == 1)) {
           printf(
-              "Warmup SET error: %s\n",
+              "Warmup SET error (sample 1/1000): %s\n",
               carbon::resultToString(*result.result_ref()));
         }
       }
@@ -759,10 +1000,12 @@ UcacheBenchClient::WarmupResults UcacheBenchClient::warmup() {
 
     // Main loop - matches production LoadgenWorker::co_run()
     while (std::chrono::steady_clock::now() < endTime) {
-      // Spawn requests up to max_inflight
-      size_t n = maxInflight - inflight.load();
+      // Spawn requests up to current dynamic inflight limit
+      uint32_t limit = currentMaxInflight.load();
+      size_t currentInflight = inflight.load();
+      size_t n = (currentInflight < limit) ? (limit - currentInflight) : 0;
       if (n > 0 && std::chrono::steady_clock::now() < endTime) {
-        for (size_t i = 0; i < n && inflight.load() < maxInflight; i++) {
+        for (size_t i = 0; i < n && inflight.load() < limit; i++) {
           inflight++;
           scope.add(
               folly::coro::co_withExecutor(
@@ -829,6 +1072,9 @@ UcacheBenchClient::WarmupResults UcacheBenchClient::warmup() {
       mainScope.joinAsync().scheduleOn(workerEvbs.front()));
 
   shouldStop = true;
+  if (adaptiveThread.joinable()) {
+    adaptiveThread.join();
+  }
   if (progressThread.joinable()) {
     progressThread.join();
   }
@@ -1135,17 +1381,18 @@ UcacheBenchClient::BenchmarkResults UcacheBenchClient::runBenchmark() {
           workerSetSuccesses[workerId]->fetch_add(1);
         } else {
           workerSetErrors[workerId]->fetch_add(1);
-          if (FLAGS_verbose) {
+          if (FLAGS_verbose &&
+              (workerSetErrors[workerId]->load() % 1000 == 1)) {
             printf(
-                "Benchmark SET error (on GET miss): %s\n",
+                "Benchmark SET error (on GET miss, sample 1/1000): %s\n",
                 carbon::resultToString(*setResult.result_ref()));
           }
         }
       } else {
         workerGetErrors[workerId]->fetch_add(1);
-        if (FLAGS_verbose) {
+        if (FLAGS_verbose && (workerGetErrors[workerId]->load() % 1000 == 1)) {
           printf(
-              "Benchmark GET error: %s\n",
+              "Benchmark GET error (sample 1/1000): %s\n",
               carbon::resultToString(*result.result_ref()));
         }
       }
@@ -1204,9 +1451,9 @@ UcacheBenchClient::BenchmarkResults UcacheBenchClient::runBenchmark() {
         workerSetSuccesses[workerId]->fetch_add(1);
       } else {
         workerSetErrors[workerId]->fetch_add(1);
-        if (FLAGS_verbose) {
+        if (FLAGS_verbose && (workerSetErrors[workerId]->load() % 1000 == 1)) {
           printf(
-              "Benchmark SET error: %s\n",
+              "Benchmark SET error (sample 1/1000): %s\n",
               carbon::resultToString(*result.result_ref()));
         }
       }

--- a/packages/ucache_bench/client/UcacheBenchClient.cpp
+++ b/packages/ucache_bench/client/UcacheBenchClient.cpp
@@ -30,8 +30,10 @@
 #include <folly/io/async/ScopedEventBaseThread.h>
 #include <folly/portability/GFlags.h>
 #include <mcrouter/McrouterFiberContext.h>
+#include <mcrouter/ProxyBase.h>
 #include <mcrouter/lib/carbon/Result.h>
 #include <mcrouter/lib/network/CpuController.h>
+#include <mcrouter/stats.h>
 
 DECLARE_string(config);
 DECLARE_uint32(warmup_ops);
@@ -372,6 +374,14 @@ DEFINE_uint32(
     "With many proxy threads, a low value causes premature TKO because the "
     "counter is global across all threads");
 DEFINE_bool(verbose, false, "Enable verbose logging");
+DEFINE_bool(
+    use_same_thread_client,
+    false,
+    "Use createSameThreadClient() to eliminate cross-thread message queue hops. "
+    "Workers run directly on McRouter proxy EventBases instead of a separate "
+    "thread pool. This matches production's same-thread dispatch pattern and "
+    "can significantly improve throughput by eliminating 2 cross-thread hops "
+    "per request");
 DEFINE_bool(
     use_distribution,
     false,
@@ -1172,23 +1182,59 @@ UcacheBenchClient::BenchmarkResults UcacheBenchClient::runBenchmark() {
   std::vector<double> allLatencies;
   allLatencies.reserve(100000 * numThreads);
 
-  // Create IO thread pool for coroutine execution - matches production pattern
-  folly::IOThreadPoolExecutor workerPool(numThreads);
-  auto workerEvbs = workerPool.getAllEventBases();
-
-  // Create clients for each worker with maxInflight - matches production
-  // pattern McRouter's maximumOutstanding will handle backpressure via internal
-  // semaphore
+  // Create clients and get EventBases for worker coroutines.
+  // Two modes:
+  //   1. Same-thread mode: workers run on proxy EventBases, bypassing the
+  //      cross-thread message queue. One worker per proxy.
+  //   2. Remote-thread mode (default): workers run on a separate thread pool,
+  //      requests are dispatched to proxy threads via message queue.
+  std::unique_ptr<folly::IOThreadPoolExecutor> workerPool;
+  std::vector<folly::EventBase*> workerEvbs;
   std::vector<
       memcache::mcrouter::CarbonRouterClient<UcacheBenchRouterInfo>::Pointer>
       clients;
-  clients.reserve(numThreads);
-  for (uint32_t i = 0; i < numThreads; ++i) {
-    // Use maxInflight as maximumOutstanding - McRouter will block if limit
-    // reached
-    auto client = routerInstance_->createClient(maxInflight);
-    if (client) {
-      clients.push_back(std::move(client));
+
+  if (FLAGS_use_same_thread_client) {
+    // Same-thread mode: one worker per proxy, running on proxy EventBases.
+    // This eliminates the worker->proxy->worker cross-thread hops.
+    size_t numProxies = routerInstance_->opts().num_proxies;
+    clients.reserve(numProxies);
+    workerEvbs.reserve(numProxies);
+
+    for (size_t i = 0; i < numProxies; ++i) {
+      auto* proxy = routerInstance_->getProxyBase(i);
+      if (!proxy) {
+        continue;
+      }
+      workerEvbs.push_back(&proxy->eventBase().getEventBase());
+
+      auto client = routerInstance_->createSameThreadClient(maxInflight);
+      if (client) {
+        client->setProxyIndex(i);
+        clients.push_back(std::move(client));
+      }
+    }
+
+    if (FLAGS_verbose) {
+      printf(
+          "Using same-thread client mode: %zu workers on proxy EventBases\n",
+          clients.size());
+      fflush(stdout);
+    }
+  } else {
+    // Remote-thread mode (original): separate worker thread pool.
+    workerPool = std::make_unique<folly::IOThreadPoolExecutor>(numThreads);
+    auto evbKeepAlives = workerPool->getAllEventBases();
+    for (auto& ka : evbKeepAlives) {
+      workerEvbs.push_back(ka.get());
+    }
+
+    clients.reserve(numThreads);
+    for (uint32_t i = 0; i < numThreads; ++i) {
+      auto client = routerInstance_->createClient(maxInflight);
+      if (client) {
+        clients.push_back(std::move(client));
+      }
     }
   }
 
@@ -1546,6 +1592,122 @@ UcacheBenchClient::BenchmarkResults UcacheBenchClient::runBenchmark() {
   }
 
   results.latencies = std::move(allLatencies);
+
+  // Dump mcrouter pipeline stats for profiling
+  if (routerInstance_) {
+    using facebook::memcache::mcrouter::num_stats;
+    using facebook::memcache::mcrouter::prepare_stats;
+    using facebook::memcache::mcrouter::stat_t;
+
+    stat_t stats[num_stats];
+    facebook::memcache::mcrouter::init_stats(stats);
+    prepare_stats(*routerInstance_, stats);
+
+    printf("\n=== McRouter Pipeline Stats ===\n");
+
+    // Key timing stats
+    auto printDoubleStat = [&](const char* label,
+                               facebook::memcache::mcrouter::stat_name_t s) {
+      double val = folly::make_atomic_ref(stats[s].data.dbl)
+                       .load(std::memory_order_relaxed);
+      printf("  %-40s: %.2f\n", label, val);
+    };
+    auto printUint64Stat = [&](const char* label,
+                               facebook::memcache::mcrouter::stat_name_t s) {
+      uint64_t val = folly::make_atomic_ref(stats[s].data.uint64)
+                         .load(std::memory_order_relaxed);
+      printf("  %-40s: %lu\n", label, val);
+    };
+
+    printDoubleStat(
+        "duration_us (avg RPC latency)",
+        facebook::memcache::mcrouter::duration_us_stat);
+    printDoubleStat(
+        "duration_get_us", facebook::memcache::mcrouter::duration_get_us_stat);
+    printDoubleStat(
+        "duration_update_us",
+        facebook::memcache::mcrouter::duration_update_us_stat);
+    printDoubleStat(
+        "processing_time_us (mcrouter only)",
+        facebook::memcache::mcrouter::processing_time_us_stat);
+    printDoubleStat(
+        "destination_batch_size",
+        facebook::memcache::mcrouter::destination_batch_size_stat);
+    printUint64Stat(
+        "destination_pending_reqs",
+        facebook::memcache::mcrouter::destination_pending_reqs_stat);
+    printUint64Stat(
+        "destination_inflight_reqs",
+        facebook::memcache::mcrouter::destination_inflight_reqs_stat);
+    printUint64Stat(
+        "destination_max_pending_reqs",
+        facebook::memcache::mcrouter::destination_max_pending_reqs_stat);
+    printUint64Stat(
+        "destination_max_inflight_reqs",
+        facebook::memcache::mcrouter::destination_max_inflight_reqs_stat);
+    printUint64Stat(
+        "outstanding_route_get_reqs_queued",
+        facebook::memcache::mcrouter::outstanding_route_get_reqs_queued_stat);
+    printUint64Stat(
+        "outstanding_route_update_reqs_queued",
+        facebook::memcache::mcrouter::
+            outstanding_route_update_reqs_queued_stat);
+
+    printf("=== End McRouter Pipeline Stats ===\n\n");
+
+    // Also write to file for retrieval via sush2
+    FILE* statsFile = fopen("/tmp/mcrouter_stats.txt", "w");
+    if (statsFile) {
+      auto writeDoubleStat = [&](const char* label,
+                                 facebook::memcache::mcrouter::stat_name_t s) {
+        double val = folly::make_atomic_ref(stats[s].data.dbl)
+                         .load(std::memory_order_relaxed);
+        fprintf(statsFile, "%-40s: %.2f\n", label, val);
+      };
+      auto writeUint64Stat = [&](const char* label,
+                                 facebook::memcache::mcrouter::stat_name_t s) {
+        uint64_t val = folly::make_atomic_ref(stats[s].data.uint64)
+                           .load(std::memory_order_relaxed);
+        fprintf(statsFile, "%-40s: %lu\n", label, val);
+      };
+
+      writeDoubleStat(
+          "duration_us (avg RPC latency)",
+          facebook::memcache::mcrouter::duration_us_stat);
+      writeDoubleStat(
+          "duration_get_us",
+          facebook::memcache::mcrouter::duration_get_us_stat);
+      writeDoubleStat(
+          "duration_update_us",
+          facebook::memcache::mcrouter::duration_update_us_stat);
+      writeDoubleStat(
+          "processing_time_us (mcrouter only)",
+          facebook::memcache::mcrouter::processing_time_us_stat);
+      writeDoubleStat(
+          "destination_batch_size",
+          facebook::memcache::mcrouter::destination_batch_size_stat);
+      writeUint64Stat(
+          "destination_pending_reqs",
+          facebook::memcache::mcrouter::destination_pending_reqs_stat);
+      writeUint64Stat(
+          "destination_inflight_reqs",
+          facebook::memcache::mcrouter::destination_inflight_reqs_stat);
+      writeUint64Stat(
+          "destination_max_pending_reqs",
+          facebook::memcache::mcrouter::destination_max_pending_reqs_stat);
+      writeUint64Stat(
+          "destination_max_inflight_reqs",
+          facebook::memcache::mcrouter::destination_max_inflight_reqs_stat);
+      writeUint64Stat(
+          "outstanding_route_get_reqs_queued",
+          facebook::memcache::mcrouter::outstanding_route_get_reqs_queued_stat);
+      writeUint64Stat(
+          "outstanding_route_update_reqs_queued",
+          facebook::memcache::mcrouter::
+              outstanding_route_update_reqs_queued_stat);
+      fclose(statsFile);
+    }
+  }
 
   // Notify admin server that benchmark is done (if connected)
   if (hasAdminConnection()) {

--- a/packages/ucache_bench/run.py
+++ b/packages/ucache_bench/run.py
@@ -25,6 +25,7 @@ import argparse
 import os
 import pathlib
 import subprocess
+import sys
 import threading
 from typing import List, Optional
 
@@ -133,14 +134,12 @@ def run_cmd(
             stderr=subprocess.STDOUT,
         )
         try:
-            if timeout:
-                proc.wait(timeout=timeout)
-            else:
-                proc.wait()
+            # Use communicate() instead of wait() to actively read stdout
+            # and avoid pipe deadlock when the child produces verbose output
+            stdout, _ = proc.communicate(timeout=timeout)
         except subprocess.TimeoutExpired:
             proc.terminate()
-            proc.wait()
-        stdout, _ = proc.communicate()
+            stdout, _ = proc.communicate()
         return stdout.decode("utf-8")
     else:
         return ""
@@ -398,7 +397,26 @@ def run_server(args: argparse.Namespace) -> None:
         t_prof.start()
 
     stdout = run_cmd(server_cmd, timeout=None, for_real=args.real)
-    print(stdout)
+
+    # Write full output to a log file for debugging, then only print
+    # the tail to stdout. This prevents pipe deadlock with the parent
+    # process (benchpress) which may use proc.wait() before reading
+    # stdout — if output exceeds the 64KB pipe buffer, both processes
+    # deadlock. The results JSON is always at the end of the output.
+    log_path = os.path.join(UCACHE_BENCH_DIR, "server_output.log")
+    try:
+        with open(log_path, "w") as f:
+            f.write(stdout)
+        print(f"Full server output written to {log_path}", file=sys.stderr)
+    except OSError as e:
+        print(f"Warning: could not write server log: {e}", file=sys.stderr)
+
+    # Print only the last 200 lines to stdout (results JSON + summary)
+    lines = stdout.split("\n")
+    if len(lines) > 200:
+        print(f"[...truncated {len(lines) - 200} lines of verbose output...]")
+    tail = lines[-200:] if len(lines) > 200 else lines
+    print("\n".join(tail))
 
     if "DCPERF_PERF_RECORD" in os.environ and os.environ["DCPERF_PERF_RECORD"] == "1":
         # pyrefly: ignore [unbound-name]
@@ -435,10 +453,18 @@ def run_client(args: argparse.Namespace) -> None:
     if args.admin_port > 0:
         client_cmd.append(f"--admin_port={args.admin_port}")
 
+    # Connection ramp-up configuration
+    if args.connection_ramp_seconds != 10:
+        client_cmd.append(f"--connection_ramp_seconds={args.connection_ramp_seconds}")
+    if not args.warmup_adaptive_load:
+        client_cmd.append("--warmup_adaptive_load=false")
+    if args.warmup_initial_inflight != 2:
+        client_cmd.append(f"--warmup_initial_inflight={args.warmup_initial_inflight}")
+
     # Timeout configuration
-    if args.connection_timeout_ms != 1000:
+    if args.connection_timeout_ms != 5000:
         client_cmd.append(f"--connection_timeout_ms={args.connection_timeout_ms}")
-    if args.send_timeout_ms != 1000:
+    if args.send_timeout_ms != 5000:
         client_cmd.append(f"--send_timeout_ms={args.send_timeout_ms}")
 
     # Security configuration
@@ -463,11 +489,30 @@ def run_client(args: argparse.Namespace) -> None:
     if args.enable_random_source_ip:
         client_cmd.append("--enable_random_source_ip=true")
 
+    if args.failures_until_tko > 0:
+        client_cmd.append(f"--failures_until_tko={args.failures_until_tko}")
+
     if args.verbose:
         client_cmd.append("--verbose=true")
 
     stdout = run_cmd(client_cmd, timeout=None, for_real=args.real)
-    print(stdout)
+
+    # Write full output to a log file for debugging, then only print
+    # the tail to stdout to prevent pipe deadlock with parent process.
+    log_path = os.path.join(UCACHE_BENCH_DIR, "client_output.log")
+    try:
+        with open(log_path, "w") as f:
+            f.write(stdout)
+        print(f"Full client output written to {log_path}", file=sys.stderr)
+    except OSError as e:
+        print(f"Warning: could not write client log: {e}", file=sys.stderr)
+
+    # Print only the last 200 lines to stdout (results JSON + summary)
+    lines = stdout.split("\n")
+    if len(lines) > 200:
+        print(f"[...truncated {len(lines) - 200} lines of verbose output...]")
+    tail = lines[-200:] if len(lines) > 200 else lines
+    print("\n".join(tail))
 
 
 def init_parser() -> argparse.ArgumentParser:
@@ -779,13 +824,13 @@ def init_parser() -> argparse.ArgumentParser:
     client_parser.add_argument(
         "--connection-timeout-ms",
         type=int,
-        default=1000,
+        default=5000,
         help="Connection timeout in milliseconds",
     )
     client_parser.add_argument(
         "--send-timeout-ms",
         type=int,
-        default=1000,
+        default=5000,
         help="Send timeout in milliseconds",
     )
     client_parser.add_argument(
@@ -839,6 +884,24 @@ def init_parser() -> argparse.ArgumentParser:
         type=int,
         default=0,
         help="Enable random source IP addresses for connection fanout (set to non-zero to enable)",
+    )
+    client_parser.add_argument(
+        "--connection-ramp-seconds",
+        type=int,
+        default=10,
+        help="Seconds to gradually ramp up connections before warmup (0 = disabled)",
+    )
+    client_parser.add_argument(
+        "--warmup-adaptive-load",
+        type=int,
+        default=1,
+        help="Enable adaptive load control during warmup (1=enabled, 0=disabled)",
+    )
+    client_parser.add_argument(
+        "--warmup-initial-inflight",
+        type=int,
+        default=2,
+        help="Initial max inflight per thread when adaptive load is enabled",
     )
 
     # Workload configuration
@@ -907,6 +970,14 @@ def init_parser() -> argparse.ArgumentParser:
         default=0,
         help="Admin server port for multi-client coordination (0 = disabled). "
         "Uses server_host since admin server runs on same machine as cache server.",
+    )
+
+    client_parser.add_argument(
+        "--failures-until-tko",
+        type=int,
+        default=0,
+        help="Number of consecutive failures before mcrouter marks server as TKO "
+        "(0 = mcrouter default of 3). Production typically uses 12-32.",
     )
 
     client_parser.add_argument(

--- a/packages/ucache_bench/run.py
+++ b/packages/ucache_bench/run.py
@@ -398,6 +398,10 @@ def run_server(args: argparse.Namespace) -> None:
     if args.bucket_lock_power > 0:
         server_cmd.append(f"--bucket_lock_power={args.bucket_lock_power}")
 
+    # Configurable per-request CPU work
+    if args.cpu_work_us > 0:
+        server_cmd.append(f"--cpu_work_us={args.cpu_work_us}")
+
     # Production-like per-request features
     if args.production_features:
         server_cmd.append("--production_features=true")
@@ -806,6 +810,14 @@ def init_parser() -> argparse.ArgumentParser:
         type=int,
         default=0,
         help="Per-request CPU overhead simulation level (0=disabled, 1=light ~3%%, 2=medium ~5%%, 3=heavy ~8%%)",
+    )
+
+    # Configurable per-request CPU work
+    server_parser.add_argument(
+        "--cpu-work-us",
+        type=int,
+        default=0,
+        help="Microseconds of CPU busy-work per request. 0=disabled.",
     )
 
     # CacheTable-style bucket locking

--- a/packages/ucache_bench/run.py
+++ b/packages/ucache_bench/run.py
@@ -390,6 +390,10 @@ def run_server(args: argparse.Namespace) -> None:
             f"--fiber_pool_resize_period_ms={args.fiber_pool_resize_period_ms}"
         )
 
+    # Per-request CPU overhead simulation
+    if args.cpu_overhead_level > 0:
+        server_cmd.append(f"--cpu_overhead_level={args.cpu_overhead_level}")
+
     if "DCPERF_PERF_RECORD" in os.environ and os.environ["DCPERF_PERF_RECORD"] == "1":
         delay = args.perf_record_delay
         print(f"DCPERF_PERF_RECORD=1, will start perf record after {delay}s delay")
@@ -786,6 +790,14 @@ def init_parser() -> argparse.ArgumentParser:
         type=int,
         default=1000,
         help="Period in ms for resizing the fiber pool (0 = disabled)",
+    )
+
+    # Per-request CPU overhead simulation
+    server_parser.add_argument(
+        "--cpu-overhead-level",
+        type=int,
+        default=0,
+        help="Per-request CPU overhead simulation level (0=disabled, 1=light ~3%%, 2=medium ~5%%, 3=heavy ~8%%)",
     )
 
     # Profiling configuration

--- a/packages/ucache_bench/run.py
+++ b/packages/ucache_bench/run.py
@@ -492,6 +492,9 @@ def run_client(args: argparse.Namespace) -> None:
     if args.failures_until_tko > 0:
         client_cmd.append(f"--failures_until_tko={args.failures_until_tko}")
 
+    if args.use_same_thread_client:
+        client_cmd.append("--use_same_thread_client=true")
+
     if args.verbose:
         client_cmd.append("--verbose=true")
 
@@ -902,6 +905,13 @@ def init_parser() -> argparse.ArgumentParser:
         type=int,
         default=2,
         help="Initial max inflight per thread when adaptive load is enabled",
+    )
+
+    client_parser.add_argument(
+        "--use-same-thread-client",
+        type=int,
+        default=0,
+        help="Use createSameThreadClient() to eliminate cross-thread hops (1=enabled, 0=disabled)",
     )
 
     # Workload configuration

--- a/packages/ucache_bench/run.py
+++ b/packages/ucache_bench/run.py
@@ -394,6 +394,14 @@ def run_server(args: argparse.Namespace) -> None:
     if args.cpu_overhead_level > 0:
         server_cmd.append(f"--cpu_overhead_level={args.cpu_overhead_level}")
 
+    # CacheTable-style bucket locking
+    if args.bucket_lock_power > 0:
+        server_cmd.append(f"--bucket_lock_power={args.bucket_lock_power}")
+
+    # Production-like per-request features
+    if args.production_features:
+        server_cmd.append("--production_features=true")
+
     if "DCPERF_PERF_RECORD" in os.environ and os.environ["DCPERF_PERF_RECORD"] == "1":
         delay = args.perf_record_delay
         print(f"DCPERF_PERF_RECORD=1, will start perf record after {delay}s delay")
@@ -798,6 +806,22 @@ def init_parser() -> argparse.ArgumentParser:
         type=int,
         default=0,
         help="Per-request CPU overhead simulation level (0=disabled, 1=light ~3%%, 2=medium ~5%%, 3=heavy ~8%%)",
+    )
+
+    # CacheTable-style bucket locking
+    server_parser.add_argument(
+        "--bucket-lock-power",
+        type=int,
+        default=0,
+        help="CacheTable-style fiber-aware RW bucket locks. 2^N locks. Production=20. 0=disabled.",
+    )
+
+    # Production-like per-request features
+    server_parser.add_argument(
+        "--production-features",
+        type=int,
+        default=0,
+        help="Enable production-like per-request overhead (key construction, ACL, stats, timestamps). 0=disabled, 1=enabled.",
     )
 
     # Profiling configuration

--- a/packages/ucache_bench/server/UcacheBenchRpcServer.cpp
+++ b/packages/ucache_bench/server/UcacheBenchRpcServer.cpp
@@ -179,6 +179,12 @@ apache::thrift::ThriftServer& UcacheBenchRpcServer::addThriftServer() {
   // No limit on concurrent active requests.
   thriftServer_->setMaxRequests(0);
 
+  // Large listen backlog to handle connection storms from clients using
+  // additional_fanout. With num_proxies=64 and additional_fanout=500,
+  // a single client creates ~32K connections. Default backlog (1024) is
+  // too small and causes connections to be refused, triggering mcrouter TKO.
+  thriftServer_->setListenBacklog(65536);
+
   // Disable per-request tracking overhead.
   thriftServer_->disableActiveRequestsTracking();
 

--- a/packages/ucache_bench/server/UcacheBenchServer.cpp
+++ b/packages/ucache_bench/server/UcacheBenchServer.cpp
@@ -387,6 +387,21 @@ std::string UcacheBenchServer::serializeIdentityAttributes(
   return serialized;
 }
 
+// Hot key detection matching production TLHotKeyTracker::check().
+// Production calls bumpHash() on two thread-local HotHashDetectors per request
+// (one for QPS hotness, one for egress hotness) and again on the egress
+// detector per response. This drives L1 counter increments, conditional L2
+// probes, and periodic maintenance (counter decay, threshold adjustment).
+void UcacheBenchServer::runHotKeyDetection(uint64_t keyHash) {
+  auto& detectors = *hotKeyDetectors_;
+  // QPS detector bump (matches TLHotKeyTracker::checkHotKeyOnly)
+  auto qpsResult = detectors.qpsDetector.bumpHash(keyHash);
+  folly::doNotOptimizeAway(qpsResult);
+  // Egress detector bump (matches TLHotKeyTracker::check egress path)
+  auto egressResult = detectors.egressDetector.bumpHash(keyHash);
+  folly::doNotOptimizeAway(egressResult);
+}
+
 // Build compound key matching production McStoredKey construction.
 // Production builds: UcacheStoredKey(key, hashAlias, kcbId, ticket)
 // This involves string concatenation, hashing, and memory allocation.
@@ -471,6 +486,10 @@ void UcacheBenchServer::runProductionGetOverhead(
   folly::doNotOptimizeAway(egressHash);
   prodStats_.overloadChecks.fetch_add(1, std::memory_order_relaxed);
 
+  // 9b. Hot key detection (matches TLHotKeyTracker::check per request)
+  // Production bumps two thread-local HotHashDetectors per request
+  runHotKeyDetection(keyHash);
+
   // 10. CRC32C checksum on value data (matches production integrity checks)
   // Production computes CRC32C on item data for integrity verification.
   // Uses hardware-accelerated CRC32C (SSE4.2 on x86).
@@ -532,6 +551,9 @@ void UcacheBenchServer::runProductionSetOverhead(
 
   // Thrift deserialization simulation (production deserializes SET request)
   simulateThriftSerialization(key, valueData, valueLen, /*hit=*/true);
+
+  // Hot key detection (same as GET path)
+  runHotKeyDetection(keyHash);
 
   // Stats
   auto inflight =

--- a/packages/ucache_bench/server/UcacheBenchServer.cpp
+++ b/packages/ucache_bench/server/UcacheBenchServer.cpp
@@ -402,6 +402,88 @@ void UcacheBenchServer::runHotKeyDetection(uint64_t keyHash) {
   folly::doNotOptimizeAway(egressResult);
 }
 
+// Egress rate limiting simulation matching production NetworkOverloadProtector.
+// Production tracks per-key egress via ConcurrentLRUHashMap with
+// SlidingWindowCounter + DynamicTokenBucket per entry. On every response:
+// 1. Hash map lookup by key hash (ConcurrentLRUHashMap::find)
+// 2. Sliding window counter read (getValue across time buckets)
+// 3. Token bucket consume check (DynamicTokenBucket::consume)
+// 4. Sliding window counter write (add response size)
+// We simulate with a thread-local F14 map doing equivalent work.
+void UcacheBenchServer::runEgressRateLimiting(
+    uint64_t keyHash,
+    size_t responseSize) {
+  auto& tracker = *egressTrackers_;
+
+  // Simulate ConcurrentLRUHashMap::find + potential insert
+  auto it = tracker.keyEgress.find(keyHash);
+  if (it == tracker.keyEgress.end()) {
+    // Simulate insert with SlidingWindowCounter + TokenBucket allocation
+    tracker.keyEgress[keyHash] = {responseSize, 1};
+  } else {
+    // Simulate sliding window read (sum across buckets)
+    auto& [totalBytes, count] = it->second;
+    uint64_t windowValue = totalBytes;
+    folly::doNotOptimizeAway(windowValue);
+
+    // Simulate token bucket consume check
+    bool hasTokens = (count < 10000); // simplified rate check
+    folly::doNotOptimizeAway(hasTokens);
+
+    // Simulate sliding window write
+    totalBytes += responseSize;
+    count++;
+  }
+
+  tracker.totalBytes += responseSize;
+
+  // Periodic cleanup matching LRU eviction (every 8192 requests)
+  if (++tracker.cleanupCounter >= 8192) {
+    tracker.cleanupCounter = 0;
+    // Simulate LRU eviction: remove entries exceeding maxKeysToTrack
+    if (tracker.keyEgress.size() > 4096) {
+      auto eraseIt = tracker.keyEgress.begin();
+      for (size_t i = 0; i < 1024 && eraseIt != tracker.keyEgress.end(); i++) {
+        eraseIt = tracker.keyEgress.erase(eraseIt);
+      }
+    }
+  }
+}
+
+// KCB (Key Client Binding) double-lookup simulation.
+// Production does TWO CacheLib lookups when KCB IDs mismatch:
+// first findSlow() for master item, then another findSlow() for derived item.
+// This happens for a significant fraction of requests (~20-30%).
+// We simulate by doing an additional CacheLib find with a modified key.
+void UcacheBenchServer::runKcbDoubleLookup(const std::string& key) {
+  // Build derived key (production appends KCB version suffix)
+  std::string derivedKey = key + ":kcb:v2";
+
+  // Second CacheLib lookup (matches production findSlow for derived item)
+  auto derivedHandle = cache_->find(derivedKey);
+  folly::doNotOptimizeAway(derivedHandle != nullptr);
+}
+
+// Per-thread CPU load measurement matching production shouldLoadShed().
+// Production reads thread-local timing counters to estimate per-thread CPU
+// load, comparing against a threshold to decide if load shedding is needed.
+void UcacheBenchServer::runCpuLoadMeasurement() {
+  auto& counters = *cpuLoadCounters_;
+
+  struct timespec ts;
+  clock_gettime(CLOCK_THREAD_CPUTIME_ID, &ts);
+  uint64_t cpuNs = ts.tv_sec * 1000000000ULL + ts.tv_nsec;
+
+  counters.requestsProcessed.fetch_add(1, std::memory_order_relaxed);
+  counters.totalProcessingNs.store(cpuNs, std::memory_order_relaxed);
+
+  // Simulate the load comparison (read previous + compute ratio)
+  auto reqs = counters.requestsProcessed.load(std::memory_order_relaxed);
+  auto totalNs = counters.totalProcessingNs.load(std::memory_order_relaxed);
+  bool shouldShed = (reqs > 0 && totalNs / reqs > 50000); // 50us threshold
+  folly::doNotOptimizeAway(shouldShed);
+}
+
 // Build compound key matching production McStoredKey construction.
 // Production builds: UcacheStoredKey(key, hashAlias, kcbId, ticket)
 // This involves string concatenation, hashing, and memory allocation.
@@ -490,6 +572,21 @@ void UcacheBenchServer::runProductionGetOverhead(
   // Production bumps two thread-local HotHashDetectors per request
   runHotKeyDetection(keyHash);
 
+  // 9c. Egress rate limiting (matches NetworkOverloadProtector::checkStatus)
+  // Production tracks per-key egress via ConcurrentLRUHashMap + sliding window
+  if (hit && valueLen > 0) {
+    runEgressRateLimiting(keyHash, valueLen);
+  }
+
+  // 9d. KCB double-lookup (matches production Key Client Binding)
+  // Production does a second CacheLib find for ~20-30% of requests
+  if ((keyHash & 0x3) == 0) { // ~25% of requests
+    runKcbDoubleLookup(key);
+  }
+
+  // 9e. Per-thread CPU load measurement (matches shouldLoadShed)
+  runCpuLoadMeasurement();
+
   // 10. CRC32C checksum on value data (matches production integrity checks)
   // Production computes CRC32C on item data for integrity verification.
   // Uses hardware-accelerated CRC32C (SSE4.2 on x86).
@@ -554,6 +651,19 @@ void UcacheBenchServer::runProductionSetOverhead(
 
   // Hot key detection (same as GET path)
   runHotKeyDetection(keyHash);
+
+  // Egress rate limiting (SET responses also tracked in production)
+  if (valueLen > 0) {
+    runEgressRateLimiting(keyHash, valueLen);
+  }
+
+  // KCB double-lookup (~25% of requests)
+  if ((keyHash & 0x3) == 0) {
+    runKcbDoubleLookup(key);
+  }
+
+  // Per-thread CPU load measurement
+  runCpuLoadMeasurement();
 
   // Stats
   auto inflight =

--- a/packages/ucache_bench/server/UcacheBenchServer.cpp
+++ b/packages/ucache_bench/server/UcacheBenchServer.cpp
@@ -7,8 +7,11 @@
 
 #include "UcacheBenchServer.h"
 
+#include <folly/BenchmarkUtil.h>
 #include <folly/Format.h>
+#include <folly/hash/Hash.h>
 #include <folly/portability/GFlags.h>
+#include <time.h>
 #include <chrono>
 
 #include "cachelib/allocator/CacheAllocator.h"
@@ -240,6 +243,72 @@ void UcacheBenchServer::setupCacheLib() {
   }
 }
 
+void UcacheBenchServer::simulatePerRequestOverhead(const std::string& key) {
+  if (config_.cpu_overhead_level == 0) {
+    return;
+  }
+
+  // Level 1+: Simulate ACL/identity hash checks and key construction
+  // Production ucache computes identity hashes for access control, constructs
+  // CacheTable keys with region/pool prefixes, and reads timestamps.
+  uint64_t hash = folly::hash::fnv64(key);
+  hash = folly::hash::twang_mix64(hash);
+  hash = folly::hash::fnv64_buf(key.data(), key.size(), hash);
+
+  struct timespec ts;
+  clock_gettime(CLOCK_MONOTONIC, &ts);
+  clock_gettime(CLOCK_REALTIME, &ts);
+
+  // Level 1+: Simulate per-request memory allocations
+  // Production ucache does string allocations for key construction,
+  // serialization buffers, identity objects, and ACL results. These
+  // allocations create jemalloc mutex contention under high concurrency,
+  // which is a major contributor to production kernel CPU (~7.5% from
+  // queued_spin_lock_slowpath in futex for jemalloc).
+  {
+    // Simulate key construction + identity string allocation
+    auto buf = std::make_unique<char[]>(256);
+    std::memcpy(buf.get(), key.data(), std::min(key.size(), size_t(256)));
+    folly::doNotOptimizeAway(buf.get());
+  }
+
+  if (config_.cpu_overhead_level >= 2) {
+    // Level 2+: More hash computation + larger allocations
+    hash = folly::hash::fnv64_buf(key.data(), key.size(), hash);
+    hash = folly::hash::twang_mix64(hash);
+    clock_gettime(CLOCK_MONOTONIC, &ts);
+    clock_gettime(CLOCK_REALTIME, &ts);
+
+    // Simulate serialization buffer allocation (attribute serialization,
+    // privacy logging buffer, Luna sampling context)
+    {
+      auto buf = std::make_unique<char[]>(512);
+      std::memset(buf.get(), 0, 512);
+      std::memcpy(buf.get(), key.data(), std::min(key.size(), size_t(512)));
+      folly::doNotOptimizeAway(buf.get());
+    }
+  }
+
+  if (config_.cpu_overhead_level >= 3) {
+    // Level 3: Heavy allocation pressure matching production
+    // Production creates multiple temporary objects per request:
+    // identity context, ACL result, privacy log entry, sampling decision,
+    // data access zone policy result, response attributes.
+    for (int i = 0; i < 3; ++i) {
+      hash = folly::hash::fnv64_buf(key.data(), key.size(), hash);
+      hash = folly::hash::twang_mix64(hash);
+      clock_gettime(CLOCK_MONOTONIC, &ts);
+
+      auto buf = std::make_unique<char[]>(1024);
+      std::memset(buf.get(), static_cast<int>(hash & 0xFF), 1024);
+      folly::doNotOptimizeAway(buf.get());
+    }
+  }
+
+  folly::doNotOptimizeAway(hash);
+  folly::doNotOptimizeAway(ts);
+}
+
 folly::SemiFuture<UcbGetReply> UcacheBenchServer::processUcbGet(
     const UcbGetRequest& req) {
   UcbGetReply reply;
@@ -248,6 +317,9 @@ folly::SemiFuture<UcbGetReply> UcacheBenchServer::processUcbGet(
   try {
     // Extract key from Carbon Keys type - convert to string
     std::string keyStr = req.key()->fullKey().str();
+
+    // Simulate production per-request CPU overhead (ACL, hashing, timestamps)
+    simulatePerRequestOverhead(keyStr);
 
     auto item = cache_->find(keyStr);
     if (item) {
@@ -292,6 +364,9 @@ folly::SemiFuture<UcbSetReply> UcacheBenchServer::processUcbSet(
   try {
     // Extract key from Carbon Keys type - convert to string
     std::string keyStr = req.key()->fullKey().str();
+
+    // Simulate production per-request CPU overhead (ACL, hashing, timestamps)
+    simulatePerRequestOverhead(keyStr);
 
     // Extract value from IOBuf (need to work with the const IOBuf)
     const auto& valueIoBuf = req.value();

--- a/packages/ucache_bench/server/UcacheBenchServer.cpp
+++ b/packages/ucache_bench/server/UcacheBenchServer.cpp
@@ -26,6 +26,33 @@ namespace ucachebench {
 UcacheBenchServer::UcacheBenchServer(const UcacheBenchConfig& config)
     : config_(config) {
   setupCacheLib();
+
+  // Initialize CacheTable-style bucket locks if enabled
+  if (config_.bucket_lock_power > 0) {
+    bucketLocks_ = std::make_unique<BucketLocks>(
+        config_.bucket_lock_power,
+        std::make_shared<facebook::cachelib::MurmurHash2>());
+    if (config_.verbose) {
+      printf(
+          "Bucket locking enabled: 2^%u = %u locks (fiber-aware RW mutex)\n",
+          config_.bucket_lock_power,
+          1u << config_.bucket_lock_power);
+    }
+  }
+
+  // Initialize production-like ACL prefix table
+  // Simulates production's granular ACL prefix categories.
+  // Production has ~100-500 ACL categories with prefix matching.
+  if (config_.production_features_enabled) {
+    for (uint64_t i = 0; i < 256; ++i) {
+      aclPrefixTable_[i] = static_cast<uint32_t>(i % 8); // 8 ACL categories
+    }
+    if (config_.verbose) {
+      printf(
+          "Production features enabled: key construction, stats tracking, "
+          "ACL checks, overload protection\n");
+    }
+  }
 }
 
 UcacheBenchServer::~UcacheBenchServer() {
@@ -309,6 +336,120 @@ void UcacheBenchServer::simulatePerRequestOverhead(const std::string& key) {
   folly::doNotOptimizeAway(ts);
 }
 
+// Build compound key matching production McStoredKey construction.
+// Production builds: UcacheStoredKey(key, hashAlias, kcbId, ticket)
+// This involves string concatenation, hashing, and memory allocation.
+std::string UcacheBenchServer::buildCompoundKey(const std::string& key) {
+  // Matches createMcStoredKeyFromRequest: prefix + key + kcbId suffix
+  // Production allocates UcacheStoredKey with region prefix, pool name, etc.
+  std::string compound;
+  compound.reserve(key.size() + 32);
+  compound.append("uc:"); // region prefix (production: "uc:")
+  compound.append(config_.pool_name); // pool name
+  compound.push_back(':');
+  compound.append(key); // actual key
+  compound.append(":v1"); // version suffix
+  return compound;
+}
+
+// Production-like GET overhead: key construction, hashing, ACL, stats,
+// timestamps
+void UcacheBenchServer::runProductionGetOverhead(
+    const std::string& key,
+    bool hit) {
+  // 1. Key construction (matches createMcStoredKey)
+  auto compoundKey = buildCompoundKey(key);
+
+  // 2. Key hashing (matches getHashForKey using MurmurHash2)
+  uint64_t keyHash =
+      facebook::cachelib::MurmurHash2()(compoundKey.data(), compoundKey.size());
+  folly::doNotOptimizeAway(keyHash);
+
+  // 3. Timestamp reads (matches ucache::gettime() called at request start)
+  struct timespec ts;
+  clock_gettime(CLOCK_MONOTONIC, &ts);
+
+  // 4. ACL prefix check (matches prefixAclsHandler_->checkAcl)
+  // Production: extracts key prefix, looks up ACL category, checks identity
+  uint64_t prefixHash =
+      folly::hash::fnv64_buf(key.data(), std::min(key.size(), size_t(8)));
+  auto aclIt = aclPrefixTable_.find(prefixHash & 0xFF);
+  prodStats_.aclChecks.fetch_add(1, std::memory_order_relaxed);
+  if (aclIt != aclPrefixTable_.end()) {
+    prodStats_.aclAllowed.fetch_add(1, std::memory_order_relaxed);
+  }
+  folly::doNotOptimizeAway(aclIt);
+
+  // 5. Overload protection check (matches OverloadProtector::onRequest)
+  // Production reads atomic counters to check CPU and network overload
+  auto inflight =
+      prodStats_.inflightRequests.fetch_add(1, std::memory_order_relaxed);
+  folly::doNotOptimizeAway(inflight);
+
+  // 6. Stats tracking (matches many USTAT_INCR / STAT_INCREMENT calls)
+  // Production increments: requests, keyBytesTotal, prefixCounters,
+  // get_hit/get_miss, tickets_checked, inflight_requests
+  prodStats_.totalRequests.fetch_add(1, std::memory_order_relaxed);
+  prodStats_.keyBytesTotal.fetch_add(key.size(), std::memory_order_relaxed);
+  if (hit) {
+    prodStats_.getHits.fetch_add(1, std::memory_order_relaxed);
+    prodStats_.prefixCounterHits.fetch_add(1, std::memory_order_relaxed);
+  } else {
+    prodStats_.getMisses.fetch_add(1, std::memory_order_relaxed);
+  }
+
+  // 7. Ticket staleness check (matches checkTicketStaleness)
+  // Production: reads FOLLY_SETTING, compares HLC tickets
+  prodStats_.ticketChecks.fetch_add(1, std::memory_order_relaxed);
+
+  // 8. Overload check completion + egress hash
+  // Production: computeAndStoreEgressHash, enforceEgressLimit
+  uint64_t egressHash = folly::hash::twang_mix64(keyHash);
+  folly::doNotOptimizeAway(egressHash);
+  prodStats_.overloadChecks.fetch_add(1, std::memory_order_relaxed);
+
+  // 9. Response timestamp (matches ServiceRouterLoggingHandler post-write)
+  clock_gettime(CLOCK_MONOTONIC, &ts);
+  folly::doNotOptimizeAway(ts);
+
+  // Decrement inflight
+  prodStats_.inflightRequests.fetch_sub(1, std::memory_order_relaxed);
+}
+
+// Production-like SET overhead
+void UcacheBenchServer::runProductionSetOverhead(const std::string& key) {
+  auto compoundKey = buildCompoundKey(key);
+  uint64_t keyHash =
+      facebook::cachelib::MurmurHash2()(compoundKey.data(), compoundKey.size());
+  folly::doNotOptimizeAway(keyHash);
+
+  struct timespec ts;
+  clock_gettime(CLOCK_MONOTONIC, &ts);
+
+  // ACL check
+  uint64_t prefixHash =
+      folly::hash::fnv64_buf(key.data(), std::min(key.size(), size_t(8)));
+  auto aclIt = aclPrefixTable_.find(prefixHash & 0xFF);
+  prodStats_.aclChecks.fetch_add(1, std::memory_order_relaxed);
+  if (aclIt != aclPrefixTable_.end()) {
+    prodStats_.aclAllowed.fetch_add(1, std::memory_order_relaxed);
+  }
+
+  // Stats
+  auto inflight =
+      prodStats_.inflightRequests.fetch_add(1, std::memory_order_relaxed);
+  folly::doNotOptimizeAway(inflight);
+  prodStats_.totalRequests.fetch_add(1, std::memory_order_relaxed);
+  prodStats_.keyBytesTotal.fetch_add(key.size(), std::memory_order_relaxed);
+  prodStats_.setStored.fetch_add(1, std::memory_order_relaxed);
+  prodStats_.overloadChecks.fetch_add(1, std::memory_order_relaxed);
+
+  clock_gettime(CLOCK_MONOTONIC, &ts);
+  folly::doNotOptimizeAway(ts);
+
+  prodStats_.inflightRequests.fetch_sub(1, std::memory_order_relaxed);
+}
+
 folly::SemiFuture<UcbGetReply> UcacheBenchServer::processUcbGet(
     const UcbGetRequest& req) {
   UcbGetReply reply;
@@ -318,11 +459,26 @@ folly::SemiFuture<UcbGetReply> UcacheBenchServer::processUcbGet(
     // Extract key from Carbon Keys type - convert to string
     std::string keyStr = req.key()->fullKey().str();
 
-    // Simulate production per-request CPU overhead (ACL, hashing, timestamps)
+    // Legacy CPU overhead simulation
     simulatePerRequestOverhead(keyStr);
 
+    // Acquire shared bucket lock if enabled
+    std::optional<BucketLocks::ReadLockHolder> bucketLock;
+    if (bucketLocks_) {
+      bucketLock.emplace(
+          bucketLocks_->lockShared(keyStr.data(), keyStr.size()));
+    }
+
     auto item = cache_->find(keyStr);
-    if (item) {
+    bool hit = item != nullptr;
+
+    // Production-like per-request overhead (after cache lookup, like
+    // production)
+    if (config_.production_features_enabled) {
+      runProductionGetOverhead(keyStr, hit);
+    }
+
+    if (hit) {
       // Cache hit
       reply.result() = carbon::Result::FOUND;
 
@@ -365,10 +521,22 @@ folly::SemiFuture<UcbSetReply> UcacheBenchServer::processUcbSet(
     // Extract key from Carbon Keys type - convert to string
     std::string keyStr = req.key()->fullKey().str();
 
-    // Simulate production per-request CPU overhead (ACL, hashing, timestamps)
+    // Legacy CPU overhead simulation
     simulatePerRequestOverhead(keyStr);
 
-    // Extract value from IOBuf (need to work with the const IOBuf)
+    // Production-like per-request overhead
+    if (config_.production_features_enabled) {
+      runProductionSetOverhead(keyStr);
+    }
+
+    // Acquire exclusive bucket lock if enabled
+    std::optional<BucketLocks::WriteLockHolder> bucketLock;
+    if (bucketLocks_) {
+      bucketLock.emplace(
+          bucketLocks_->lockExclusive(keyStr.data(), keyStr.size()));
+    }
+
+    // Extract value from IOBuf
     const auto& valueIoBuf = req.value();
     auto valueStr = valueIoBuf->to<std::string>();
 

--- a/packages/ucache_bench/server/UcacheBenchServer.cpp
+++ b/packages/ucache_bench/server/UcacheBenchServer.cpp
@@ -484,6 +484,33 @@ void UcacheBenchServer::runCpuLoadMeasurement() {
   folly::doNotOptimizeAway(shouldShed);
 }
 
+// Configurable CPU busy-work per request.
+// Burns cpu_work_us microseconds of CPU doing real computation (hash chains)
+// to simulate aggregate production overhead that can't be individually
+// replicated.
+void UcacheBenchServer::runCpuBusyWork(const std::string& key) {
+  if (config_.cpu_work_us == 0) {
+    return;
+  }
+  struct timespec start, now;
+  clock_gettime(CLOCK_MONOTONIC, &start);
+  uint64_t hash = folly::hash::fnv64(key);
+  uint64_t targetNs = static_cast<uint64_t>(config_.cpu_work_us) * 1000;
+  for (;;) {
+    // Do real computation to burn CPU
+    for (int i = 0; i < 64; ++i) {
+      hash = folly::hash::twang_mix64(hash);
+    }
+    folly::doNotOptimizeAway(hash);
+    clock_gettime(CLOCK_MONOTONIC, &now);
+    uint64_t elapsedNs = (now.tv_sec - start.tv_sec) * 1000000000ULL +
+        (now.tv_nsec - start.tv_nsec);
+    if (elapsedNs >= targetNs) {
+      break;
+    }
+  }
+}
+
 // Build compound key matching production McStoredKey construction.
 // Production builds: UcacheStoredKey(key, hashAlias, kcbId, ticket)
 // This involves string concatenation, hashing, and memory allocation.
@@ -825,6 +852,9 @@ folly::SemiFuture<UcbGetReply> UcacheBenchServer::processUcbGet(
       runProductionGetOverhead(keyStr, hit, valPtr, valLen);
     }
 
+    // Configurable CPU busy-work
+    runCpuBusyWork(keyStr);
+
     if (hit) {
       // Cache hit
       reply.result() = carbon::Result::FOUND;
@@ -879,6 +909,9 @@ folly::SemiFuture<UcbSetReply> UcacheBenchServer::processUcbSet(
     if (config_.production_features_enabled) {
       runProductionSetOverhead(keyStr, valueStr.data(), valueStr.size());
     }
+
+    // Configurable CPU busy-work
+    runCpuBusyWork(keyStr);
 
     // Acquire exclusive bucket lock if enabled
     std::optional<BucketLocks::WriteLockHolder> bucketLock;

--- a/packages/ucache_bench/server/UcacheBenchServer.cpp
+++ b/packages/ucache_bench/server/UcacheBenchServer.cpp
@@ -9,7 +9,9 @@
 
 #include <folly/BenchmarkUtil.h>
 #include <folly/Format.h>
+#include <folly/hash/Checksum.h>
 #include <folly/hash/Hash.h>
+#include <folly/io/IOBuf.h>
 #include <folly/portability/GFlags.h>
 #include <time.h>
 #include <chrono>
@@ -47,10 +49,11 @@ UcacheBenchServer::UcacheBenchServer(const UcacheBenchConfig& config)
     for (uint64_t i = 0; i < 256; ++i) {
       aclPrefixTable_[i] = static_cast<uint32_t>(i % 8); // 8 ACL categories
     }
+    initMockIdentityAttributes();
     if (config_.verbose) {
       printf(
           "Production features enabled: key construction, stats tracking, "
-          "ACL checks, overload protection\n");
+          "ACL checks, auth serialization, overload protection\n");
     }
   }
 }
@@ -336,6 +339,54 @@ void UcacheBenchServer::simulatePerRequestOverhead(const std::string& key) {
   folly::doNotOptimizeAway(ts);
 }
 
+// Initialize mock identity attributes matching production's authenticated
+// identity context. Production builds these from TLS certificate fields,
+// service identity, and connection metadata.
+void UcacheBenchServer::initMockIdentityAttributes() {
+  mockIdentityAttributes_ = {
+      {"authn.namespace", "service_identity"},
+      {"authn.name", "ucache.regional.prn:prn:facebook:ucache:us-east"},
+      {"authn.cert.subject",
+       "CN=ucache.regional.us-east.facebook.com,O=Facebook Inc,L=Menlo Park,ST=California,C=US"},
+      {"authn.peer.ipaddress", "2401:db00:026c:6419:face:0000:03e3:0000"},
+      {"authn.connection.security_protocol", "TLS_AES_256_GCM_SHA384"},
+  };
+}
+
+// Serialize identity attributes matching production's
+// security::authn::attributes::serializer::serialize().
+// Production URI-escapes each attribute key+value and joins with '&'.
+// This showed up as ~1% CPU per thread in perf profiles.
+std::string UcacheBenchServer::serializeIdentityAttributes(
+    const std::string& requestKey) {
+  std::string serialized;
+  serialized.reserve(512);
+
+  for (size_t i = 0; i < mockIdentityAttributes_.size(); ++i) {
+    if (i > 0) {
+      serialized.push_back('&');
+    }
+    // URI-escape key and value (matches production's folly::uriEscape calls)
+    std::string escapedKey;
+    folly::uriEscape(mockIdentityAttributes_[i].key, escapedKey);
+    std::string escapedValue;
+    folly::uriEscape(mockIdentityAttributes_[i].value, escapedValue);
+
+    serialized.append(escapedKey);
+    serialized.push_back('=');
+    serialized.append(escapedValue);
+  }
+
+  // Production also appends request-specific context
+  std::string escapedReqKey;
+  folly::uriEscape(requestKey, escapedReqKey);
+  serialized.append("&req.key=");
+  serialized.append(escapedReqKey);
+
+  folly::doNotOptimizeAway(serialized.data());
+  return serialized;
+}
+
 // Build compound key matching production McStoredKey construction.
 // Production builds: UcacheStoredKey(key, hashAlias, kcbId, ticket)
 // This involves string concatenation, hashing, and memory allocation.
@@ -353,10 +404,13 @@ std::string UcacheBenchServer::buildCompoundKey(const std::string& key) {
 }
 
 // Production-like GET overhead: key construction, hashing, ACL, stats,
-// timestamps
+// timestamps,
+// checksum, serialization, IOBuf processing
 void UcacheBenchServer::runProductionGetOverhead(
     const std::string& key,
-    bool hit) {
+    bool hit,
+    const void* valueData,
+    size_t valueLen) {
   // 1. Key construction (matches createMcStoredKey)
   auto compoundKey = buildCompoundKey(key);
 
@@ -380,13 +434,22 @@ void UcacheBenchServer::runProductionGetOverhead(
   }
   folly::doNotOptimizeAway(aclIt);
 
-  // 5. Overload protection check (matches OverloadProtector::onRequest)
+  // 5. Auth attribute serialization (matches
+  // ThriftConnectionAttributesHandler::preReadImpl ->
+  // ContextBasedPolicyChecker::isAccessPermitted ->
+  // security::authn::attributes::serializer::serialize)
+  // Production serializes connection identity attributes with URI escaping
+  // for every request. This is ~1% of CPU per thread in production perf.
+  auto serializedAttrs = serializeIdentityAttributes(key);
+  folly::doNotOptimizeAway(serializedAttrs.data());
+
+  // 6. Overload protection check (matches OverloadProtector::onRequest)
   // Production reads atomic counters to check CPU and network overload
   auto inflight =
       prodStats_.inflightRequests.fetch_add(1, std::memory_order_relaxed);
   folly::doNotOptimizeAway(inflight);
 
-  // 6. Stats tracking (matches many USTAT_INCR / STAT_INCREMENT calls)
+  // 7. Stats tracking (matches many USTAT_INCR / STAT_INCREMENT calls)
   // Production increments: requests, keyBytesTotal, prefixCounters,
   // get_hit/get_miss, tickets_checked, inflight_requests
   prodStats_.totalRequests.fetch_add(1, std::memory_order_relaxed);
@@ -398,17 +461,36 @@ void UcacheBenchServer::runProductionGetOverhead(
     prodStats_.getMisses.fetch_add(1, std::memory_order_relaxed);
   }
 
-  // 7. Ticket staleness check (matches checkTicketStaleness)
+  // 8. Ticket staleness check (matches checkTicketStaleness)
   // Production: reads FOLLY_SETTING, compares HLC tickets
   prodStats_.ticketChecks.fetch_add(1, std::memory_order_relaxed);
 
-  // 8. Overload check completion + egress hash
+  // 9. Overload check completion + egress hash
   // Production: computeAndStoreEgressHash, enforceEgressLimit
   uint64_t egressHash = folly::hash::twang_mix64(keyHash);
   folly::doNotOptimizeAway(egressHash);
   prodStats_.overloadChecks.fetch_add(1, std::memory_order_relaxed);
 
-  // 9. Response timestamp (matches ServiceRouterLoggingHandler post-write)
+  // 10. CRC32C checksum on value data (matches production integrity checks)
+  // Production computes CRC32C on item data for integrity verification.
+  // Uses hardware-accelerated CRC32C (SSE4.2 on x86).
+  if (hit && valueData && valueLen > 0) {
+    auto crc = computeValueChecksum(valueData, valueLen);
+    folly::doNotOptimizeAway(crc);
+  }
+
+  // 11. Thrift compact protocol serialization simulation
+  // Production serializes every response through Thrift CompactProtocol.
+  // This involves varint encoding, field headers, and data copies.
+  simulateThriftSerialization(key, valueData, valueLen, hit);
+
+  // 12. IOBuf chain construction and manipulation
+  // Production builds multi-segment IOBuf chains for network responses.
+  if (hit && valueData && valueLen > 0) {
+    simulateIoBufProcessing(valueData, valueLen);
+  }
+
+  // 13. Response timestamp (matches ServiceRouterLoggingHandler post-write)
   clock_gettime(CLOCK_MONOTONIC, &ts);
   folly::doNotOptimizeAway(ts);
 
@@ -417,7 +499,10 @@ void UcacheBenchServer::runProductionGetOverhead(
 }
 
 // Production-like SET overhead
-void UcacheBenchServer::runProductionSetOverhead(const std::string& key) {
+void UcacheBenchServer::runProductionSetOverhead(
+    const std::string& key,
+    const void* valueData,
+    size_t valueLen) {
   auto compoundKey = buildCompoundKey(key);
   uint64_t keyHash =
       facebook::cachelib::MurmurHash2()(compoundKey.data(), compoundKey.size());
@@ -435,6 +520,19 @@ void UcacheBenchServer::runProductionSetOverhead(const std::string& key) {
     prodStats_.aclAllowed.fetch_add(1, std::memory_order_relaxed);
   }
 
+  // Auth attribute serialization (same as GET path)
+  auto serializedAttrs = serializeIdentityAttributes(key);
+  folly::doNotOptimizeAway(serializedAttrs.data());
+
+  // CRC32C checksum on incoming value (production verifies value integrity)
+  if (valueData && valueLen > 0) {
+    auto crc = computeValueChecksum(valueData, valueLen);
+    folly::doNotOptimizeAway(crc);
+  }
+
+  // Thrift deserialization simulation (production deserializes SET request)
+  simulateThriftSerialization(key, valueData, valueLen, /*hit=*/true);
+
   // Stats
   auto inflight =
       prodStats_.inflightRequests.fetch_add(1, std::memory_order_relaxed);
@@ -448,6 +546,121 @@ void UcacheBenchServer::runProductionSetOverhead(const std::string& key) {
   folly::doNotOptimizeAway(ts);
 
   prodStats_.inflightRequests.fetch_sub(1, std::memory_order_relaxed);
+}
+
+// Simulate CRC32C checksum computation on response values.
+// Production ucache computes checksums for data integrity verification
+// (matching CacheLib's item checksum and mcrouter's payload CRC).
+// CRC32C uses hardware acceleration (SSE4.2) on x86, making it fast but
+// still measurably present in perf profiles at high QPS.
+uint32_t UcacheBenchServer::computeValueChecksum(const void* data, size_t len) {
+  return folly::crc32c(
+      reinterpret_cast<const uint8_t*>(data), len, /*startingChecksum=*/0);
+}
+
+// Simulate Thrift compact protocol serialization overhead.
+// Production serializes every response through Thrift compact protocol:
+// field headers (type + id), varint-encoded lengths, and value bytes.
+// This shows up as ~3-5% CPU in production perf profiles for high-QPS pools.
+void UcacheBenchServer::simulateThriftSerialization(
+    const std::string& key,
+    const void* valueData,
+    size_t valueLen,
+    bool hit) {
+  // Simulate compact protocol field encoding:
+  // - Result field (1 byte type + varint field id + varint value)
+  // - Flags field (same pattern)
+  // - Key field (type + id + varint length + key bytes)
+  // - Value field (type + id + varint length + value bytes for hits)
+  //
+  // We build a simulated serialization buffer matching the work done by
+  // apache::thrift::CompactProtocolWriter
+
+  // Pre-size buffer: header overhead + key + value
+  size_t estimatedSize = 64 + key.size() + (hit ? valueLen : 0);
+  std::string serBuf;
+  serBuf.reserve(estimatedSize);
+
+  // Field 1: result (compact protocol: delta field id + type nibble + value)
+  serBuf.push_back(0x15); // field delta=1, type=i32
+  // Varint encode the result
+  uint32_t result = hit ? 1 : 0;
+  while (result >= 0x80) {
+    serBuf.push_back(static_cast<char>(result | 0x80));
+    result >>= 7;
+  }
+  serBuf.push_back(static_cast<char>(result));
+
+  // Field 2: flags
+  serBuf.push_back(0x15); // field delta=1, type=i32
+  serBuf.push_back(0x00);
+
+  // Field 3: key as binary
+  serBuf.push_back(0x18); // field delta=1, type=binary
+  // Varint encode length
+  uint32_t keyLen = static_cast<uint32_t>(key.size());
+  while (keyLen >= 0x80) {
+    serBuf.push_back(static_cast<char>(keyLen | 0x80));
+    keyLen >>= 7;
+  }
+  serBuf.push_back(static_cast<char>(keyLen));
+  serBuf.append(key);
+
+  // Field 4: value as binary (for hits)
+  if (hit && valueData && valueLen > 0) {
+    serBuf.push_back(0x18); // field delta=1, type=binary
+    uint32_t vLen = static_cast<uint32_t>(valueLen);
+    while (vLen >= 0x80) {
+      serBuf.push_back(static_cast<char>(vLen | 0x80));
+      vLen >>= 7;
+    }
+    serBuf.push_back(static_cast<char>(vLen));
+    // Copy value data (simulates the actual serialization copy)
+    serBuf.append(
+        reinterpret_cast<const char*>(valueData),
+        std::min(valueLen, size_t(4096))); // Cap at 4KB to avoid huge copies
+  }
+
+  // Stop field
+  serBuf.push_back(0x00);
+
+  folly::doNotOptimizeAway(serBuf.data());
+  folly::doNotOptimizeAway(serBuf.size());
+}
+
+// Simulate IOBuf chain construction and manipulation.
+// Production builds response IOBuf chains with multiple segments:
+// header IOBuf -> value IOBuf -> trailer IOBuf.
+// The IOBuf allocation, chaining, and eventual coalescing adds overhead.
+void UcacheBenchServer::simulateIoBufProcessing(
+    const void* valueData,
+    size_t valueLen) {
+  if (!valueData || valueLen == 0) {
+    return;
+  }
+
+  // Simulate the work of building a multi-segment IOBuf response:
+  // 1. Allocate header IOBuf (protocol header + flags)
+  auto headerBuf = folly::IOBuf::create(32);
+  headerBuf->append(16); // 16 bytes of protocol header
+  std::memset(headerBuf->writableData(), 0x01, 16);
+
+  // 2. Wrap value data in an IOBuf (zero-copy reference)
+  auto valueBuf = folly::IOBuf::wrapBuffer(valueData, valueLen);
+
+  // 3. Chain them together (header -> value)
+  headerBuf->appendChain(std::move(valueBuf));
+
+  // 4. Compute total chain length (production does this for stats/logging)
+  size_t chainLen = headerBuf->computeChainDataLength();
+  folly::doNotOptimizeAway(chainLen);
+
+  // 5. Coalesce if needed (production coalesces small chains for network send)
+  if (chainLen < 2048) {
+    headerBuf->coalesce();
+  }
+
+  folly::doNotOptimizeAway(headerBuf->data());
 }
 
 folly::SemiFuture<UcbGetReply> UcacheBenchServer::processUcbGet(
@@ -475,7 +688,9 @@ folly::SemiFuture<UcbGetReply> UcacheBenchServer::processUcbGet(
     // Production-like per-request overhead (after cache lookup, like
     // production)
     if (config_.production_features_enabled) {
-      runProductionGetOverhead(keyStr, hit);
+      const void* valPtr = hit ? item->getMemory() : nullptr;
+      size_t valLen = hit ? item->getSize() : 0;
+      runProductionGetOverhead(keyStr, hit, valPtr, valLen);
     }
 
     if (hit) {
@@ -524,9 +739,13 @@ folly::SemiFuture<UcbSetReply> UcacheBenchServer::processUcbSet(
     // Legacy CPU overhead simulation
     simulatePerRequestOverhead(keyStr);
 
+    // Extract value early so we can pass it to production overhead
+    const auto& valueIoBuf = req.value();
+    auto valueStr = valueIoBuf->to<std::string>();
+
     // Production-like per-request overhead
     if (config_.production_features_enabled) {
-      runProductionSetOverhead(keyStr);
+      runProductionSetOverhead(keyStr, valueStr.data(), valueStr.size());
     }
 
     // Acquire exclusive bucket lock if enabled
@@ -535,10 +754,6 @@ folly::SemiFuture<UcbSetReply> UcacheBenchServer::processUcbSet(
       bucketLock.emplace(
           bucketLocks_->lockExclusive(keyStr.data(), keyStr.size()));
     }
-
-    // Extract value from IOBuf
-    const auto& valueIoBuf = req.value();
-    auto valueStr = valueIoBuf->to<std::string>();
 
     // Create item
     auto item = cache_->allocate(poolId_, keyStr, valueStr.size());

--- a/packages/ucache_bench/server/UcacheBenchServer.h
+++ b/packages/ucache_bench/server/UcacheBenchServer.h
@@ -10,6 +10,7 @@
 #include <cachelib/allocator/CacheAllocator.h>
 #include <cachelib/common/Hash.h>
 #include <cachelib/common/Mutex.h>
+#include <folly/String.h>
 #include <folly/container/F14Map.h>
 #include <folly/fibers/TimedMutex.h>
 #include <folly/futures/Future.h>
@@ -202,8 +203,24 @@ class UcacheBenchServer {
   // Production-like per-request processing
   // Returns a compound key string (like McStoredKey in production)
   std::string buildCompoundKey(const std::string& key);
-  void runProductionGetOverhead(const std::string& key, bool hit);
-  void runProductionSetOverhead(const std::string& key);
+  void runProductionGetOverhead(
+      const std::string& key,
+      bool hit,
+      const void* valueData = nullptr,
+      size_t valueLen = 0);
+  void runProductionSetOverhead(
+      const std::string& key,
+      const void* valueData = nullptr,
+      size_t valueLen = 0);
+
+  // Additional production-like CPU work
+  uint32_t computeValueChecksum(const void* data, size_t len);
+  void simulateThriftSerialization(
+      const std::string& key,
+      const void* valueData,
+      size_t valueLen,
+      bool hit);
+  void simulateIoBufProcessing(const void* valueData, size_t valueLen);
 
   // Increment metrics based on current phase
   void recordGet(bool hit);
@@ -246,6 +263,18 @@ class UcacheBenchServer {
 
   // ACL prefix table (simulates production granular ACL categories)
   folly::F14FastMap<uint64_t, uint32_t> aclPrefixTable_;
+
+  // Production auth attribute serialization
+  // Production calls security::authn::attributes::serializer::serialize()
+  // per request, which URI-escapes identity attributes into query strings.
+  // This showed up as ~1% CPU per thread in production perf profiles.
+  struct IdentityAttribute {
+    std::string key;
+    std::string value;
+  };
+  std::vector<IdentityAttribute> mockIdentityAttributes_;
+  void initMockIdentityAttributes();
+  std::string serializeIdentityAttributes(const std::string& requestKey);
 
   // Phase-based metric tracking
   std::atomic<TrackingPhase> currentPhase_{TrackingPhase::NONE};

--- a/packages/ucache_bench/server/UcacheBenchServer.h
+++ b/packages/ucache_bench/server/UcacheBenchServer.h
@@ -11,6 +11,7 @@
 #include <folly/futures/Future.h>
 #include <atomic>
 #include <condition_variable>
+#include <cstdint>
 #include <memory>
 #include <mutex>
 #include <string>
@@ -104,6 +105,12 @@ struct UcacheBenchConfig {
   uint64_t cachelib_num_shards = 0; // 0 = use default
   uint32_t min_alloc_size = 64; // Minimum allocation size in bytes
 
+  // Per-request CPU overhead simulation
+  // Simulates production CPU work (ACL checks, key hashing, timestamps) that
+  // is absent from the minimal ucachebench request path.
+  // 0 = disabled, 1 = light (~3% CPU), 2 = medium (~5%), 3 = heavy (~8%)
+  uint32_t cpu_overhead_level = 0;
+
   // Navy (NVM/SSD cache) config (if navy_cache_size_mb > 0, hybrid mode is
   // enabled)
   std::string navy_cache_path = "/tmp/ucachebench_ssd";
@@ -173,6 +180,9 @@ class UcacheBenchServer {
 
  private:
   void setupCacheLib();
+
+  // Simulate per-request CPU overhead matching production ucache
+  void simulatePerRequestOverhead(const std::string& key);
 
   // Increment metrics based on current phase
   void recordGet(bool hit);

--- a/packages/ucache_bench/server/UcacheBenchServer.h
+++ b/packages/ucache_bench/server/UcacheBenchServer.h
@@ -294,6 +294,30 @@ class UcacheBenchServer {
   folly::ThreadLocal<HotKeyDetectors> hotKeyDetectors_;
   void runHotKeyDetection(uint64_t keyHash);
 
+  // Egress rate limiting simulation (matches NetworkOverloadProtector)
+  // Production tracks per-key egress via ConcurrentLRUHashMap with
+  // SlidingWindowCounter + DynamicTokenBucket per entry.
+  // We simulate with a thread-local F14 map doing hash lookups + counter
+  // updates.
+  struct EgressTracker {
+    folly::F14FastMap<uint64_t, std::pair<uint64_t, uint64_t>> keyEgress;
+    uint64_t totalBytes{0};
+    uint32_t cleanupCounter{0};
+  };
+  folly::ThreadLocal<EgressTracker> egressTrackers_;
+  void runEgressRateLimiting(uint64_t keyHash, size_t responseSize);
+
+  // KCB double-lookup simulation (matches production Key Client Binding)
+  void runKcbDoubleLookup(const std::string& key);
+
+  // Per-thread CPU load measurement (matches shouldLoadShed)
+  struct alignas(64) CpuLoadCounters {
+    std::atomic<uint64_t> requestsProcessed{0};
+    std::atomic<uint64_t> totalProcessingNs{0};
+  };
+  folly::ThreadLocal<CpuLoadCounters> cpuLoadCounters_;
+  void runCpuLoadMeasurement();
+
   // Phase-based metric tracking
   std::atomic<TrackingPhase> currentPhase_{TrackingPhase::NONE};
   PhaseMetrics warmupMetrics_;

--- a/packages/ucache_bench/server/UcacheBenchServer.h
+++ b/packages/ucache_bench/server/UcacheBenchServer.h
@@ -10,7 +10,9 @@
 #include <cachelib/allocator/CacheAllocator.h>
 #include <cachelib/common/Hash.h>
 #include <cachelib/common/Mutex.h>
+#include <cachelib/common/hothash/HotHashDetector.h>
 #include <folly/String.h>
+#include <folly/ThreadLocal.h>
 #include <folly/container/F14Map.h>
 #include <folly/fibers/TimedMutex.h>
 #include <folly/futures/Future.h>
@@ -275,6 +277,22 @@ class UcacheBenchServer {
   std::vector<IdentityAttribute> mockIdentityAttributes_;
   void initMockIdentityAttributes();
   std::string serializeIdentityAttributes(const std::string& requestKey);
+
+  // Hot key detection (matches production TLHotKeyTracker)
+  // Production maintains two thread-local HotHashDetectors per IO thread:
+  // one for QPS hotness, one for egress hotness. Each call to bumpHash()
+  // does L1 counter increment + conditional L2 probe + periodic maintenance.
+  // We store detectors per-thread via folly::ThreadLocal.
+  struct HotKeyDetectors {
+    facebook::cachelib::HotHashDetector qpsDetector;
+    facebook::cachelib::HotHashDetector egressDetector;
+    HotKeyDetectors()
+        : qpsDetector(1024, 8, 30, 128), // production defaults
+          egressDetector(1024, 16, 30, 128) // egress uses 2x warm set
+    {}
+  };
+  folly::ThreadLocal<HotKeyDetectors> hotKeyDetectors_;
+  void runHotKeyDetection(uint64_t keyHash);
 
   // Phase-based metric tracking
   std::atomic<TrackingPhase> currentPhase_{TrackingPhase::NONE};

--- a/packages/ucache_bench/server/UcacheBenchServer.h
+++ b/packages/ucache_bench/server/UcacheBenchServer.h
@@ -8,6 +8,10 @@
 #pragma once
 
 #include <cachelib/allocator/CacheAllocator.h>
+#include <cachelib/common/Hash.h>
+#include <cachelib/common/Mutex.h>
+#include <folly/container/F14Map.h>
+#include <folly/fibers/TimedMutex.h>
 #include <folly/futures/Future.h>
 #include <atomic>
 #include <condition_variable>
@@ -105,11 +109,22 @@ struct UcacheBenchConfig {
   uint64_t cachelib_num_shards = 0; // 0 = use default
   uint32_t min_alloc_size = 64; // Minimum allocation size in bytes
 
-  // Per-request CPU overhead simulation
-  // Simulates production CPU work (ACL checks, key hashing, timestamps) that
-  // is absent from the minimal ucachebench request path.
-  // 0 = disabled, 1 = light (~3% CPU), 2 = medium (~5%), 3 = heavy (~8%)
+  // Per-request CPU overhead simulation (LEGACY - use production_features)
   uint32_t cpu_overhead_level = 0;
+
+  // CacheTable-style bucket locking
+  // 0 = disabled, >0 = 2^bucket_lock_power locks (production default: 20)
+  uint32_t bucket_lock_power = 0;
+
+  // Production-like per-request features
+  // Enables realistic per-request overhead matching production ucache:
+  // - Compound key construction (McStoredKey-like)
+  // - MurmurHash2 key hashing (matching getHashForKey)
+  // - Multiple atomic stat increments per request (matching USTAT_INCR)
+  // - ACL prefix hash lookup
+  // - Timestamp reads (matching ucache::gettime)
+  // - Overload check simulation (atomic reads)
+  bool production_features_enabled = false;
 
   // Navy (NVM/SSD cache) config (if navy_cache_size_mb > 0, hybrid mode is
   // enabled)
@@ -181,8 +196,14 @@ class UcacheBenchServer {
  private:
   void setupCacheLib();
 
-  // Simulate per-request CPU overhead matching production ucache
+  // Simulate per-request CPU overhead (legacy)
   void simulatePerRequestOverhead(const std::string& key);
+
+  // Production-like per-request processing
+  // Returns a compound key string (like McStoredKey in production)
+  std::string buildCompoundKey(const std::string& key);
+  void runProductionGetOverhead(const std::string& key, bool hit);
+  void runProductionSetOverhead(const std::string& key);
 
   // Increment metrics based on current phase
   void recordGet(bool hit);
@@ -192,9 +213,39 @@ class UcacheBenchServer {
   // Periodic stats thread function
   void periodicStatsLoop(uint32_t intervalSec);
 
+  // Bucket lock type matching production CacheTable:
+  // folly::fibers::TimedRWMutexWritePriority yields the fiber on contention,
+  // driving fiber scheduling overhead and jemalloc contention.
+  using BucketMutex =
+      folly::fibers::TimedRWMutexWritePriority<folly::fibers::GenericBaton>;
+  using BucketLocks = facebook::cachelib::RWBucketLocks<BucketMutex>;
+
   UcacheBenchConfig config_;
   std::unique_ptr<CacheAllocator> cache_;
   PoolId poolId_{};
+  std::unique_ptr<BucketLocks> bucketLocks_;
+
+  // Production-like per-request stats counters
+  // Matches the many USTAT_INCR / STAT_INCREMENT calls in production ucache.
+  // Each is a separate cache line to create realistic atomic contention
+  // patterns.
+  struct alignas(64) ProdStats {
+    std::atomic<uint64_t> inflightRequests{0};
+    std::atomic<uint64_t> totalRequests{0};
+    std::atomic<uint64_t> getHits{0};
+    std::atomic<uint64_t> getMisses{0};
+    std::atomic<uint64_t> setStored{0};
+    std::atomic<uint64_t> keyBytesTotal{0};
+    std::atomic<uint64_t> valueBytesTotal{0};
+    std::atomic<uint64_t> aclChecks{0};
+    std::atomic<uint64_t> aclAllowed{0};
+    std::atomic<uint64_t> ticketChecks{0};
+    std::atomic<uint64_t> overloadChecks{0};
+    std::atomic<uint64_t> prefixCounterHits{0};
+  } prodStats_;
+
+  // ACL prefix table (simulates production granular ACL categories)
+  folly::F14FastMap<uint64_t, uint32_t> aclPrefixTable_;
 
   // Phase-based metric tracking
   std::atomic<TrackingPhase> currentPhase_{TrackingPhase::NONE};

--- a/packages/ucache_bench/server/UcacheBenchServer.h
+++ b/packages/ucache_bench/server/UcacheBenchServer.h
@@ -129,6 +129,11 @@ struct UcacheBenchConfig {
   // - Overload check simulation (atomic reads)
   bool production_features_enabled = false;
 
+  // Configurable per-request CPU work (microseconds of busy computation)
+  // Used to simulate aggregate production CPU overhead that can't be
+  // individually replicated (e.g., NVM admission, complex routing, etc.)
+  uint32_t cpu_work_us = 0; // 0 = disabled
+
   // Navy (NVM/SSD cache) config (if navy_cache_size_mb > 0, hybrid mode is
   // enabled)
   std::string navy_cache_path = "/tmp/ucachebench_ssd";
@@ -309,6 +314,9 @@ class UcacheBenchServer {
 
   // KCB double-lookup simulation (matches production Key Client Binding)
   void runKcbDoubleLookup(const std::string& key);
+
+  // Configurable CPU busy-work per request
+  void runCpuBusyWork(const std::string& key);
 
   // Per-thread CPU load measurement (matches shouldLoadShed)
   struct alignas(64) CpuLoadCounters {

--- a/packages/ucache_bench/server/main.cpp
+++ b/packages/ucache_bench/server/main.cpp
@@ -95,6 +95,23 @@ DEFINE_uint32(
     "2=medium (+ CacheTable + serialization ~5%), "
     "3=heavy (+ identity verification + sampling ~8%)");
 
+// CacheTable-style bucket locking
+DEFINE_uint32(
+    bucket_lock_power,
+    0,
+    "Enable CacheTable-style fiber-aware RW bucket locks. "
+    "Number of locks = 2^bucket_lock_power. Production default is 20 (1M locks). "
+    "0 = disabled.");
+
+// Production-like per-request features
+DEFINE_bool(
+    production_features,
+    false,
+    "Enable production-like per-request overhead: compound key construction "
+    "(McStoredKey), MurmurHash2 key hashing, ACL prefix checks, "
+    "stats tracking (12+ atomic increments), timestamp reads, "
+    "and overload protection checks. Matches production ucache request path.");
+
 // Navy (NVM/SSD cache) configuration (if navy_cache_size_mb > 0, hybrid mode
 // is enabled)
 DEFINE_string(
@@ -209,6 +226,12 @@ UcacheBenchConfig createConfigFromFlags() {
 
   // Per-request CPU overhead simulation
   config.cpu_overhead_level = FLAGS_cpu_overhead_level;
+
+  // CacheTable-style bucket locking
+  config.bucket_lock_power = FLAGS_bucket_lock_power;
+
+  // Production-like per-request features
+  config.production_features_enabled = FLAGS_production_features;
 
   // Hash table settings
   config.hashtable_lock_power = FLAGS_hashtable_lock_power;

--- a/packages/ucache_bench/server/main.cpp
+++ b/packages/ucache_bench/server/main.cpp
@@ -103,6 +103,13 @@ DEFINE_uint32(
     "Number of locks = 2^bucket_lock_power. Production default is 20 (1M locks). "
     "0 = disabled.");
 
+// Configurable per-request CPU work
+DEFINE_uint32(
+    cpu_work_us,
+    50,
+    "Microseconds of CPU busy-work per request. Simulates aggregate production "
+    "overhead. 0 = disabled.");
+
 // Production-like per-request features
 DEFINE_bool(
     production_features,
@@ -229,6 +236,9 @@ UcacheBenchConfig createConfigFromFlags() {
 
   // CacheTable-style bucket locking
   config.bucket_lock_power = FLAGS_bucket_lock_power;
+
+  // Configurable per-request CPU work
+  config.cpu_work_us = FLAGS_cpu_work_us;
 
   // Production-like per-request features
   config.production_features_enabled = FLAGS_production_features;

--- a/packages/ucache_bench/server/main.cpp
+++ b/packages/ucache_bench/server/main.cpp
@@ -86,6 +86,15 @@ DEFINE_uint64(
     "Number of CacheLib shards (0 = use default)");
 DEFINE_uint32(min_alloc_size, 64, "Minimum allocation size in bytes");
 
+// Per-request CPU overhead simulation
+DEFINE_uint32(
+    cpu_overhead_level,
+    0,
+    "Per-request CPU overhead simulation level to match production ucache. "
+    "0=disabled, 1=light (ACL hash + timestamps ~3%), "
+    "2=medium (+ CacheTable + serialization ~5%), "
+    "3=heavy (+ identity verification + sampling ~8%)");
+
 // Navy (NVM/SSD cache) configuration (if navy_cache_size_mb > 0, hybrid mode
 // is enabled)
 DEFINE_string(
@@ -197,6 +206,9 @@ UcacheBenchConfig createConfigFromFlags() {
   config.lru_rebalancing_hits_max_age_sec =
       FLAGS_lru_rebalancing_hits_max_age_sec;
   config.lru_hits_victim_by_free_mem = FLAGS_lru_hits_victim_by_free_mem;
+
+  // Per-request CPU overhead simulation
+  config.cpu_overhead_level = FLAGS_cpu_overhead_level;
 
   // Hash table settings
   config.hashtable_lock_power = FLAGS_hashtable_lock_power;


### PR DESCRIPTION
Summary:

- Add cpu_work_us parameter: configurable microseconds of CPU busy-work per
  request using hash computation loops. Allows tuning server CPU utilization
  to match production levels.
- Enable bucket_lock_power=20 in config (production default), adding
  CacheTable-style fiber mutex contention per request.
- Wire cpu_work_us through main.cpp gflags, run.py argparse, and config JSON.

Differential Revision: D99338680


