### PR TITLE
Add multi-source-IP connection scaling (#647)

### DIFF
--- a/packages/ucache_bench/client/UcacheBenchClient.cpp
+++ b/packages/ucache_bench/client/UcacheBenchClient.cpp
@@ -344,7 +344,9 @@ DEFINE_uint32(
 DEFINE_uint32(
     additional_fanout,
     0,
-    "Number of additional connections per server for fanout (0 = disabled, must be <= 32768 - num_proxies)");
+    "Number of additional connections per server for fanout (0 = disabled). "
+    "Limited by ephemeral port range per source IP (~64K). Use LD_PRELOAD=bind_source.so "
+    "with multiple source IPs for higher connection counts.");
 DEFINE_bool(
     enable_random_source_ip,
     false,

--- a/packages/ucache_bench/production_traffic_v2.csv
+++ b/packages/ucache_bench/production_traffic_v2.csv
@@ -1,0 +1,11 @@
+operation,Hits,Samples,request_wire_bytes (avg),request_wire_value_bytes (avg),request_wire_value_bytes (p50),request_wire_value_bytes (p75),request_wire_value_bytes (p95),request_wire_value_bytes (p99),reply_size_before_compression (avg),reply_wire_value_bytes (avg),reply_wire_value_bytes (p50),reply_wire_value_bytes (p75),reply_wire_value_bytes (p95),reply_wire_value_bytes (p99),key_size (avg)
+get,1042120000,104212,0,0,0,0,0,0,0,1567.0159290676697,24,533,7045,17263,63.78330710474801
+lease-get,460320000,46032,0,0,0,0,0,0,0,939.8208637469586,8,78,650,10728,52.91288668752173
+set,142820000,14282,0,2942.158241142697,47,178,4884,37757,0,0,0,0,0,0,66.87634785044112
+lease-set,90820000,9082,0,1460.301035014314,13,86,1891,34042,0,0,0,0,0,0,67.8887910151949
+delete,940000,94,0,0,0,0,0,0,0,0,0,0,0,0,45.255319148936174
+gets,760000,76,0,0,0,0,0,0,0,14.473684210526315,14,14,55,55,69.55263157894737
+add,220000,22,0,17.363636363636363,9,9,55,55,0,0,0,0,0,0,106.63636363636364
+cas,100000,10,0,4,1,9,9,9,0,0,0,0,0,0,89.2
+incr,40000,4,0,0,0,0,0,0,0,0,0,0,0,0,85.5
+metaget,40000,4,0,0,0,0,0,0,0,0,0,0,0,0,27

--- a/packages/ucache_bench/server/UcacheBenchServer.cpp
+++ b/packages/ucache_bench/server/UcacheBenchServer.cpp
@@ -484,6 +484,86 @@ void UcacheBenchServer::runCpuLoadMeasurement() {
   folly::doNotOptimizeAway(shouldShed);
 }
 
+// Static member for FiberToken contention
+std::atomic<uint64_t> UcacheBenchServer::activeFibersTotal_{0};
+
+// Per-request heap allocations matching production ucache patterns.
+// Production does 5-8 heap allocations per request through key construction,
+// fiber task capture, egress tracking, and IOBuf operations.
+// Each allocation goes through jemalloc, which under contention from 300+
+// threads does mmap/munmap syscalls that show up as %sys.
+void UcacheBenchServer::runPerRequestAllocations(
+    const std::string& key,
+    size_t valueLen) {
+  // 1. UcacheStoredKey: std::string cachelibKey_ (key_len + 1 byte for appId)
+  // Production: UcacheKey.h:34-51
+  std::string storedKey(key.size() + 1, '\0');
+  storedKey[0] = static_cast<char>(0x01); // appId byte
+  std::memcpy(storedKey.data() + 1, key.data(), key.size());
+  folly::doNotOptimizeAway(storedKey.data());
+
+  // 2. McStoredKey hashAlias: std::string (matches ct_item.h:135)
+  // Production resolves hash aliases for routing
+  std::string hashAlias = key.substr(0, std::min(key.size(), size_t(16)));
+  folly::doNotOptimizeAway(hashAlias.data());
+
+  // 3. McStoredKey ticket: std::string (matches ct_item.h:137)
+  // Production extracts ticket from request context
+  std::string ticket(32, 'T');
+  folly::doNotOptimizeAway(ticket.data());
+
+  // 4. Fiber task lambda capture allocation
+  // Production: UcacheRequestCommon.h:178 addTaskEager captures
+  // UcacheThriftCallback + Request + FiberToken in a heap-allocated lambda.
+  // Typical size: ~200-500 bytes depending on request type.
+  auto lambdaCapture = std::make_unique<char[]>(256);
+  std::memset(lambdaCapture.get(), 0, 256);
+  folly::doNotOptimizeAway(lambdaCapture.get());
+
+  // 5. KCB derived key construction (matches KcbKeyUtil.cpp:13-19)
+  // Production: fmt::format("{}:kcb:{}", appKey, kcbId)
+  std::string derivedKey = storedKey + ":kcb:12345";
+  folly::doNotOptimizeAway(derivedKey.data());
+
+  // 6. Egress hash computation with vector allocation
+  // Production: UcacheThriftCallback.h:141 allocates vector for multi-get
+  // We simulate a small vector allocation per request
+  std::vector<std::optional<uint64_t>> egressHashes(4);
+  for (size_t i = 0; i < egressHashes.size(); ++i) {
+    egressHashes[i] = folly::hash::twang_mix64(folly::hash::fnv64(key) + i);
+  }
+  folly::doNotOptimizeAway(egressHashes.data());
+
+  // 7. convertToIOBuf std::function allocation
+  // Production: CacheAllocator.h:4567 allocates a type-erased std::function
+  // for the IOBuf converter lambda per cache hit
+  if (valueLen > 0) {
+    std::function<void(void*)> freeFunc = [](void* ptr) {
+      folly::doNotOptimizeAway(ptr);
+    };
+    folly::doNotOptimizeAway(&freeFunc);
+  }
+}
+
+// FiberToken global atomic contention matching production.
+// Production increments a global atomic on fiber entry and decrements on exit.
+// With 300+ IO threads, this creates massive cache-line bouncing as the
+// atomic counter ping-pongs between L1 caches on different cores.
+// This shows up as %sys because cache-line invalidation protocols involve
+// inter-core messaging handled by the kernel's cache coherence mechanisms.
+void UcacheBenchServer::runFiberTokenContention() {
+  // Increment on "fiber entry" (matches FiberToken constructor)
+  auto before = activeFibersTotal_.fetch_add(1, std::memory_order_relaxed);
+  folly::doNotOptimizeAway(before);
+
+  // Per-thread counter increment (matches ++ctx.numActiveFibers_)
+  auto& counters = *cpuLoadCounters_;
+  counters.requestsProcessed.fetch_add(1, std::memory_order_relaxed);
+
+  // Decrement on "fiber exit" (matches FiberToken destructor)
+  activeFibersTotal_.fetch_sub(1, std::memory_order_relaxed);
+}
+
 // Configurable CPU busy-work per request.
 // Burns cpu_work_us microseconds of CPU doing real computation (hash chains)
 // to simulate aggregate production overhead that can't be individually
@@ -528,8 +608,7 @@ std::string UcacheBenchServer::buildCompoundKey(const std::string& key) {
 }
 
 // Production-like GET overhead: key construction, hashing, ACL, stats,
-// timestamps,
-// checksum, serialization, IOBuf processing
+// timestamps, checksum, serialization, IOBuf processing
 void UcacheBenchServer::runProductionGetOverhead(
     const std::string& key,
     bool hit,
@@ -637,6 +716,14 @@ void UcacheBenchServer::runProductionGetOverhead(
   clock_gettime(CLOCK_MONOTONIC, &ts);
   folly::doNotOptimizeAway(ts);
 
+  // 14. Per-request heap allocations (matches production key construction,
+  // fiber task capture, egress hash vector, convertToIOBuf std::function)
+  runPerRequestAllocations(key, hit ? valueLen : 0);
+
+  // 15. FiberToken global atomic contention
+  // (matches UcacheIOThreadContext::FiberToken inc/dec per request)
+  runFiberTokenContention();
+
   // Decrement inflight
   prodStats_.inflightRequests.fetch_sub(1, std::memory_order_relaxed);
 }
@@ -703,6 +790,12 @@ void UcacheBenchServer::runProductionSetOverhead(
 
   clock_gettime(CLOCK_MONOTONIC, &ts);
   folly::doNotOptimizeAway(ts);
+
+  // Per-request heap allocations (same as GET path)
+  runPerRequestAllocations(key, valueLen);
+
+  // FiberToken global atomic contention
+  runFiberTokenContention();
 
   prodStats_.inflightRequests.fetch_sub(1, std::memory_order_relaxed);
 }

--- a/packages/ucache_bench/server/UcacheBenchServer.h
+++ b/packages/ucache_bench/server/UcacheBenchServer.h
@@ -318,6 +318,23 @@ class UcacheBenchServer {
   // Configurable CPU busy-work per request
   void runCpuBusyWork(const std::string& key);
 
+  // Per-request heap allocations matching production ucache.
+  // Production allocates per request:
+  // - UcacheStoredKey: std::string for cachelib key (key_len+1 bytes)
+  // - McStoredKey: 3 std::strings (ukey, hashAlias, ticket)
+  // - Fiber task lambda capture (~200-500 bytes heap via FiberManager)
+  // - Egress hash vector: std::vector<std::optional<uint64_t>> (16*N bytes)
+  // - KCB derived key: fmt::format string allocation
+  // These drive jemalloc pressure → mmap/munmap syscalls → %sys
+  void runPerRequestAllocations(const std::string& key, size_t valueLen);
+
+  // FiberToken global atomic contention matching production.
+  // Production increments/decrements a global atomic<uint64_t> on every
+  // request entry/exit via UcacheIOThreadContext::FiberToken.
+  // This creates cross-thread cache-line bouncing → %sys.
+  static std::atomic<uint64_t> activeFibersTotal_;
+  void runFiberTokenContention();
+
   // Per-thread CPU load measurement (matches shouldLoadShed)
   struct alignas(64) CpuLoadCounters {
     std::atomic<uint64_t> requestsProcessed{0};

--- a/packages/ucache_bench/tools/bind_source.c
+++ b/packages/ucache_bench/tools/bind_source.c
@@ -1,0 +1,140 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/*
+ * LD_PRELOAD library to distribute outgoing TCP connections across multiple
+ * source IPv6 addresses. This allows a single client process to create
+ * far more connections than the ~64K ephemeral port limit per source IP.
+ *
+ * Environment variables:
+ *   BIND_ADDRESSES  Comma-separated list of IPv6 addresses to round-robin.
+ *                   e.g. "2401:db00::1,2401:db00::2,2401:db00::3"
+ *   BIND_ADDRESS    Single IPv6 address (legacy, used if BIND_ADDRESSES unset)
+ *
+ * Usage:
+ *   gcc -shared -fPIC -o bind_source.so bind_source.c -ldl
+ *
+ *   # Single IP (legacy):
+ *   BIND_ADDRESS="2401:db00::1" LD_PRELOAD=./bind_source.so
+ * ./ucachebench_client
+ *
+ *   # Multiple IPs (round-robin):
+ *   BIND_ADDRESSES="2401:db00::1,2401:db00::2,2401:db00::3" \
+ *     LD_PRELOAD=./bind_source.so ./ucachebench_client
+ * --additional_fanout=60000
+ *
+ * With N source IPs and widened port range (1024-65535), each IP supports
+ * ~64K connections. 16 IPs = ~1M connections from a single process.
+ */
+
+#define _GNU_SOURCE
+#include <arpa/inet.h>
+#include <dlfcn.h>
+#include <errno.h>
+#include <netinet/in.h>
+#include <stdatomic.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/socket.h>
+
+#define MAX_BIND_ADDRS 64
+
+static struct sockaddr_in6 g_bind_addrs[MAX_BIND_ADDRS];
+static int g_num_addrs = 0;
+static int g_initialized = 0;
+static atomic_uint g_next_addr = 0;
+static int (*real_connect)(int, const struct sockaddr*, socklen_t) = NULL;
+
+static int parse_addr(const char* str, struct sockaddr_in6* out) {
+  memset(out, 0, sizeof(*out));
+  out->sin6_family = AF_INET6;
+  out->sin6_port = 0;
+  return inet_pton(AF_INET6, str, &out->sin6_addr) == 1 ? 0 : -1;
+}
+
+static void init_once(void) {
+  if (g_initialized)
+    return;
+  g_initialized = 1;
+
+  real_connect = dlsym(RTLD_NEXT, "connect");
+  if (!real_connect) {
+    fprintf(stderr, "bind_source: failed to find real connect()\n");
+    return;
+  }
+
+  /* Try BIND_ADDRESSES first (comma-separated list) */
+  const char* addrs = getenv("BIND_ADDRESSES");
+  if (addrs && addrs[0] != '\0') {
+    char buf[4096];
+    strncpy(buf, addrs, sizeof(buf) - 1);
+    buf[sizeof(buf) - 1] = '\0';
+
+    char* saveptr = NULL;
+    char* tok = strtok_r(buf, ",", &saveptr);
+    while (tok && g_num_addrs < MAX_BIND_ADDRS) {
+      /* Skip leading whitespace */
+      while (*tok == ' ')
+        tok++;
+      if (*tok == '\0') {
+        tok = strtok_r(NULL, ",", &saveptr);
+        continue;
+      }
+
+      if (parse_addr(tok, &g_bind_addrs[g_num_addrs]) == 0) {
+        g_num_addrs++;
+      } else {
+        fprintf(stderr, "bind_source: invalid address '%s', skipping\n", tok);
+      }
+      tok = strtok_r(NULL, ",", &saveptr);
+    }
+
+    if (g_num_addrs > 0) {
+      fprintf(
+          stderr,
+          "bind_source: round-robin across %d source IPs\n",
+          g_num_addrs);
+    }
+    return;
+  }
+
+  /* Fallback to single BIND_ADDRESS */
+  const char* addr = getenv("BIND_ADDRESS");
+  if (addr && addr[0] != '\0') {
+    if (parse_addr(addr, &g_bind_addrs[0]) == 0) {
+      g_num_addrs = 1;
+      fprintf(stderr, "bind_source: will bind to %s\n", addr);
+    } else {
+      fprintf(stderr, "bind_source: invalid BIND_ADDRESS '%s'\n", addr);
+    }
+  }
+}
+
+int connect(int sockfd, const struct sockaddr* addr, socklen_t addrlen) {
+  init_once();
+
+  if (g_num_addrs > 0 && addr->sa_family == AF_INET6) {
+    /* Check if socket is already bound */
+    struct sockaddr_in6 current;
+    socklen_t len = sizeof(current);
+    if (getsockname(sockfd, (struct sockaddr*)&current, &len) == 0) {
+      /* Only bind if not already bound (port == 0 means unbound) */
+      if (current.sin6_port == 0 &&
+          memcmp(&current.sin6_addr, &in6addr_any, sizeof(in6addr_any)) == 0) {
+        /* Round-robin across source addresses */
+        unsigned int idx = atomic_fetch_add(&g_next_addr, 1) % g_num_addrs;
+        bind(
+            sockfd,
+            (struct sockaddr*)&g_bind_addrs[idx],
+            sizeof(g_bind_addrs[idx]));
+      }
+    }
+  }
+
+  return real_connect(sockfd, addr, addrlen);
+}

--- a/packages/ucache_bench/traffic_dist_v2.json
+++ b/packages/ucache_bench/traffic_dist_v2.json
@@ -1,0 +1,15 @@
+{
+  "get_ratio": 0.8653235090950956,
+  "get_key_size_avg": 60.456520582209095,
+  "get_response_size_avg": 1374.1305313855405,
+  "get_response_size_p50": 19.09480854687209,
+  "get_response_size_p75": 393.39397567919957,
+  "get_response_size_p95": 5083.010829940661,
+  "get_response_size_p99": 15252.70237620074,
+  "set_key_size_avg": 67.31629338348435,
+  "set_value_size_avg": 2362.9158830569327,
+  "set_value_size_p50": 33.746281415626605,
+  "set_value_size_p75": 142.05573602325182,
+  "set_value_size_p95": 3715.534706787485,
+  "set_value_size_p99": 36263.30218840828
+}


### PR DESCRIPTION
Summary:

- bind_source.c: LD_PRELOAD library that round-robins connect() across
  multiple source IPv6 addresses, allowing a single client process to
  exceed the 64K ephemeral port limit per source IP
- automark integration: auto-discovers host IPv6, adds secondary IPs,
  sets LD_PRELOAD+BIND_ADDRESSES, cleans up on exit via trap
- New config param num_source_ips controls how many secondary IPs per client
- conntest config for 1-client testing with num_source_ips=2

Reviewed By: excelle08

Differential Revision: D99406079


