### PR TITLE
Simplify client tuning: add --num_connections and --auto_concurrency (#648)

### DIFF
--- a/packages/ucache_bench/client/UcacheBenchClient.cpp
+++ b/packages/ucache_bench/client/UcacheBenchClient.cpp
@@ -332,11 +332,13 @@ DEFINE_string(
 DEFINE_uint32(
     num_proxies,
     0,
-    "Number of mcrouter proxy threads (0 = auto-detect using hardware_concurrency)");
+    "Number of mcrouter proxy threads (0 = auto-detect using hardware_concurrency). "
+    "Ignored when --num_connections is set.");
 DEFINE_uint32(
     max_inflight,
     1,
-    "Maximum number of concurrent in-flight requests (higher = better throughput, requires more memory)");
+    "Maximum number of concurrent in-flight requests (higher = better throughput, requires more memory). "
+    "Ignored when --auto_concurrency is enabled.");
 DEFINE_uint32(
     num_threads,
     0,
@@ -346,7 +348,33 @@ DEFINE_uint32(
     0,
     "Number of additional connections per server for fanout (0 = disabled). "
     "Limited by ephemeral port range per source IP (~64K). Use LD_PRELOAD=bind_source.so "
-    "with multiple source IPs for higher connection counts.");
+    "with multiple source IPs for higher connection counts. "
+    "Ignored when --num_connections is set.");
+DEFINE_uint32(
+    num_connections,
+    0,
+    "Target number of TCP connections to the server (0 = disabled, use num_proxies/additional_fanout directly). "
+    "When set, automatically derives num_proxies and additional_fanout. "
+    "Enforces the mcrouter limit of 32768 ProxyDestinations per instance. "
+    "Examples: 16000 for 16K connections, 64000 for 64K connections.");
+DEFINE_bool(
+    auto_concurrency,
+    false,
+    "Automatically discover optimal concurrency during the benchmark phase using AIMD. "
+    "Splits the benchmark into a ramp phase (finds peak throughput) and a steady phase "
+    "(holds optimal concurrency, collects measurements). When enabled, --max_inflight "
+    "is treated as the upper bound, and the controller finds the best value below it.");
+DEFINE_uint32(
+    ramp_seconds,
+    30,
+    "Duration of the AIMD ramp phase when --auto_concurrency is enabled. "
+    "The controller searches for optimal concurrency during this period.");
+DEFINE_double(
+    target_utilization,
+    1.0,
+    "Target fraction of peak concurrency to use during steady state (0.0-1.0). "
+    "1.0 = use peak concurrency found by AIMD. 0.9 = back off to 90%% of peak. "
+    "Only used when --auto_concurrency is enabled.");
 DEFINE_bool(
     enable_random_source_ip,
     false,
@@ -378,12 +406,12 @@ DEFINE_uint32(
 DEFINE_bool(verbose, false, "Enable verbose logging");
 DEFINE_bool(
     use_same_thread_client,
-    false,
+    true,
     "Use createSameThreadClient() to eliminate cross-thread message queue hops. "
     "Workers run directly on McRouter proxy EventBases instead of a separate "
     "thread pool. This matches production's same-thread dispatch pattern and "
     "can significantly improve throughput by eliminating 2 cross-thread hops "
-    "per request");
+    "per request. Set to false for legacy remote-thread mode.");
 DEFINE_bool(
     use_distribution,
     false,
@@ -527,10 +555,50 @@ UcacheBenchClient::UcacheBenchClient() {
   // Create mcrouter options for Thrift transport
   facebook::memcache::McrouterOptions options;
 
+  // Derive num_proxies and additional_fanout from --num_connections if set
+  uint32_t effectiveNumProxies = FLAGS_num_proxies;
+  uint32_t effectiveAdditionalFanout = FLAGS_additional_fanout;
+
+  if (FLAGS_num_connections > 0) {
+    constexpr uint32_t kMaxProxyDestinations = 32768;
+    uint32_t hwConcurrency = std::thread::hardware_concurrency();
+    uint32_t numProxies = std::min(FLAGS_num_connections, hwConcurrency);
+    numProxies = std::max(1u, numProxies);
+
+    uint32_t fanoutPerProxy =
+        (FLAGS_num_connections + numProxies - 1) / numProxies;
+    uint32_t additionalFanout = fanoutPerProxy > 0 ? fanoutPerProxy - 1 : 0;
+
+    if (numProxies * (additionalFanout + 1) > kMaxProxyDestinations) {
+      numProxies = std::min(numProxies, kMaxProxyDestinations);
+      fanoutPerProxy = kMaxProxyDestinations / numProxies;
+      additionalFanout = fanoutPerProxy > 0 ? fanoutPerProxy - 1 : 0;
+      uint32_t actualConnections = numProxies * (additionalFanout + 1);
+      printf(
+          "[num_connections] Clamped to %u connections (mcrouter limit: %u ProxyDestinations). "
+          "Use multiple client instances for higher counts.\n",
+          actualConnections,
+          kMaxProxyDestinations);
+    }
+
+    effectiveNumProxies = numProxies;
+    effectiveAdditionalFanout = additionalFanout;
+
+    uint32_t actualConnections =
+        effectiveNumProxies * (effectiveAdditionalFanout + 1);
+    printf(
+        "[num_connections] %u requested -> num_proxies=%u, additional_fanout=%u, actual=%u\n",
+        FLAGS_num_connections,
+        effectiveNumProxies,
+        effectiveAdditionalFanout,
+        actualConnections);
+    fflush(stdout);
+  }
+
   // Configure for Thrift transport to ucache server
   // Build pool config with optional additional_fanout for high connection count
   std::string poolConfig;
-  if (FLAGS_additional_fanout > 0) {
+  if (effectiveAdditionalFanout > 0) {
     poolConfig = folly::sformat(
         R"json({{
     "pools": {{
@@ -553,7 +621,7 @@ UcacheBenchClient::UcacheBenchClient() {
         FLAGS_security_mech,
         FLAGS_connection_timeout_ms,
         FLAGS_send_timeout_ms,
-        FLAGS_additional_fanout);
+        effectiveAdditionalFanout);
   } else {
     poolConfig = folly::sformat(
         R"json({{
@@ -580,12 +648,10 @@ UcacheBenchClient::UcacheBenchClient() {
   options.config_str = poolConfig;
 
   // Set num_proxies to use multiple threads for sending traffic
-  // This allows mcrouter to distribute work across multiple proxy threads
-  if (FLAGS_num_proxies == 0) {
-    // Auto-detect using hardware concurrency
+  if (effectiveNumProxies == 0) {
     options.num_proxies = std::thread::hardware_concurrency();
   } else {
-    options.num_proxies = FLAGS_num_proxies;
+    options.num_proxies = effectiveNumProxies;
   }
 
   // Configure TKO behavior to match production settings.
@@ -622,11 +688,12 @@ UcacheBenchClient::UcacheBenchClient() {
         FLAGS_server_port);
     printf("  McRouter proxy threads: %zu\n", options.num_proxies);
     printf("  Using per-thread clients for maximum QPS performance\n");
-    if (FLAGS_additional_fanout > 0) {
-      uint32_t totalConnections = FLAGS_additional_fanout + options.num_proxies;
+    if (effectiveAdditionalFanout > 0) {
+      uint32_t totalConnections =
+          options.num_proxies * (effectiveAdditionalFanout + 1);
       printf(
-          "  Connection fanout enabled: %u additional connections (total: %u)\n",
-          FLAGS_additional_fanout,
+          "  Connection fanout enabled: additional_fanout=%u (total connections: %u)\n",
+          effectiveAdditionalFanout,
           totalConnections);
     } else {
       printf("  Connection fanout disabled (using default connections)\n");
@@ -642,6 +709,9 @@ UcacheBenchClient::UcacheBenchClient() {
     }
     fflush(stdout);
   }
+
+  effectiveNumProxies_ = options.num_proxies;
+  effectiveAdditionalFanout_ = effectiveAdditionalFanout;
 }
 
 UcacheBenchClient::~UcacheBenchClient() {
@@ -690,9 +760,9 @@ UcacheBenchClient::WarmupResults UcacheBenchClient::warmup() {
   // ProxyDestination objects. Without ramp-up, all connections are established
   // simultaneously on first request, causing a connection storm that TKOs the
   // server.
-  if (FLAGS_connection_ramp_seconds > 0 && FLAGS_additional_fanout > 0) {
+  if (FLAGS_connection_ramp_seconds > 0 && effectiveAdditionalFanout_ > 0) {
     uint32_t totalDestinations =
-        FLAGS_num_proxies * (1 + FLAGS_additional_fanout);
+        effectiveNumProxies_ * (1 + effectiveAdditionalFanout_);
     if (FLAGS_verbose) {
       printf(
           "Connection ramp-up: establishing ~%u connections over %u seconds\n",
@@ -702,7 +772,7 @@ UcacheBenchClient::WarmupResults UcacheBenchClient::warmup() {
     }
 
     // Use a small thread pool for connection ramp-up (1 thread per proxy)
-    uint32_t rampThreads = std::min(numThreads, FLAGS_num_proxies);
+    uint32_t rampThreads = std::min(numThreads, effectiveNumProxies_);
     folly::IOThreadPoolExecutor rampPool(rampThreads);
     auto rampEvbs = rampPool.getAllEventBases();
 
@@ -1168,12 +1238,38 @@ UcacheBenchClient::BenchmarkResults UcacheBenchClient::runBenchmark() {
     maxInflight = 1;
   }
 
+  // Auto-concurrency: use large maxInflight for mcrouter (we control
+  // concurrency via our own atomic counter), and split duration into ramp +
+  // steady phases
+  uint32_t mcrouterMaxOutstanding = maxInflight;
+  std::atomic<uint32_t> dynamicMaxInflight{maxInflight};
+  std::atomic<bool> inSteadyPhase{false};
+  std::atomic<uint32_t> discoveredOptimalInflight{maxInflight};
+
+  if (FLAGS_auto_concurrency) {
+    mcrouterMaxOutstanding = std::max(maxInflight, 500u);
+    uint32_t initialInflight = std::max(1u, maxInflight / 10);
+    dynamicMaxInflight.store(initialInflight);
+
+    printf(
+        "[auto_concurrency] Ramp phase: %us, then steady for remaining %us. "
+        "Searching from %u to %u max_inflight.\n",
+        FLAGS_ramp_seconds,
+        FLAGS_duration_seconds > FLAGS_ramp_seconds
+            ? FLAGS_duration_seconds - FLAGS_ramp_seconds
+            : 0,
+        initialInflight,
+        maxInflight);
+    fflush(stdout);
+  }
+
   if (FLAGS_verbose) {
     printf(
-        "Starting benchmark for %u seconds with %u worker threads, max_inflight=%u per client\n",
+        "Starting benchmark for %u seconds with %u worker threads, max_inflight=%u per client%s\n",
         FLAGS_duration_seconds,
         numThreads,
-        maxInflight);
+        maxInflight,
+        FLAGS_auto_concurrency ? " (auto-concurrency enabled)" : "");
     fflush(stdout);
   }
 
@@ -1213,7 +1309,8 @@ UcacheBenchClient::BenchmarkResults UcacheBenchClient::runBenchmark() {
       }
       workerEvbs.push_back(&proxy->eventBase().getEventBase());
 
-      auto client = routerInstance_->createSameThreadClient(maxInflight);
+      auto client =
+          routerInstance_->createSameThreadClient(mcrouterMaxOutstanding);
       if (client) {
         client->setProxyIndex(i);
         clients.push_back(std::move(client));
@@ -1236,7 +1333,7 @@ UcacheBenchClient::BenchmarkResults UcacheBenchClient::runBenchmark() {
 
     clients.reserve(numThreads);
     for (uint32_t i = 0; i < numThreads; ++i) {
-      auto client = routerInstance_->createClient(maxInflight);
+      auto client = routerInstance_->createClient(mcrouterMaxOutstanding);
       if (client) {
         clients.push_back(std::move(client));
       }
@@ -1334,6 +1431,97 @@ UcacheBenchClient::BenchmarkResults UcacheBenchClient::runBenchmark() {
             sSucc,
             sErrs);
         fflush(stdout);
+      }
+    });
+  }
+
+  // Per-worker inflight counters for auto-concurrency throttling
+  std::vector<std::unique_ptr<std::atomic<uint32_t>>> workerInflight;
+  for (size_t i = 0; i < clients.size(); ++i) {
+    workerInflight.push_back(std::make_unique<std::atomic<uint32_t>>(0));
+  }
+
+  // AIMD auto-concurrency controller thread
+  std::thread autoConcurrencyThread;
+  if (FLAGS_auto_concurrency) {
+    autoConcurrencyThread = std::thread([&]() {
+      constexpr auto kCheckInterval = std::chrono::seconds(2);
+      auto rampEnd = startTime + std::chrono::seconds(FLAGS_ramp_seconds);
+
+      uint64_t prevOps = 0;
+      double bestQps = 0;
+      uint32_t bestInflight = dynamicMaxInflight.load();
+      uint32_t peakInflight = dynamicMaxInflight.load();
+
+      while (!shouldStop.load() && std::chrono::steady_clock::now() < endTime) {
+        std::this_thread::sleep_for(kCheckInterval);
+        if (shouldStop.load()) {
+          break;
+        }
+
+        auto now = std::chrono::steady_clock::now();
+        bool ramping = now < rampEnd;
+
+        // Calculate current window QPS
+        uint64_t curOps = 0;
+        for (size_t i = 0; i < clients.size(); ++i) {
+          curOps += workerTotalOps[i]->load();
+        }
+        uint64_t windowOps = curOps - prevOps;
+        prevOps = curOps;
+        double windowQps = windowOps / 2.0; // 2-second window
+
+        uint32_t cur = dynamicMaxInflight.load();
+
+        if (ramping) {
+          // Track best QPS and corresponding inflight
+          if (windowQps > bestQps) {
+            bestQps = windowQps;
+            bestInflight = cur;
+          }
+
+          // Additive increase during ramp: grow by 10% or at least 1
+          uint32_t increment = std::max(1u, cur / 10);
+          uint32_t next = std::min(maxInflight, cur + increment);
+          dynamicMaxInflight.store(next);
+
+          if (windowQps < bestQps * 0.9 && cur > bestInflight) {
+            // QPS dropped >10% — we overshot, snap back
+            next = bestInflight;
+            dynamicMaxInflight.store(next);
+            printf(
+                "[auto_concurrency] QPS dropped (%.0f < %.0f), snapping back to %u\n",
+                windowQps,
+                bestQps,
+                next);
+          } else if (FLAGS_verbose) {
+            printf(
+                "[auto_concurrency] ramp: inflight=%u, QPS=%.0f (best=%.0f@%u)\n",
+                cur,
+                windowQps,
+                bestQps,
+                bestInflight);
+          }
+          fflush(stdout);
+        } else if (!inSteadyPhase.load()) {
+          // Transition to steady state
+          peakInflight = bestInflight;
+          uint32_t steadyInflight =
+              static_cast<uint32_t>(peakInflight * FLAGS_target_utilization);
+          steadyInflight = std::max(1u, steadyInflight);
+          dynamicMaxInflight.store(steadyInflight);
+          discoveredOptimalInflight.store(steadyInflight);
+          inSteadyPhase.store(true);
+
+          printf(
+              "[auto_concurrency] Steady state: peak inflight=%u (%.0f QPS), "
+              "target_utilization=%.0f%%, using inflight=%u\n",
+              peakInflight,
+              bestQps,
+              FLAGS_target_utilization * 100.0,
+              steadyInflight);
+          fflush(stdout);
+        }
       }
     });
   }
@@ -1513,16 +1701,28 @@ UcacheBenchClient::BenchmarkResults UcacheBenchClient::runBenchmark() {
     };
 
     // Main loop - continuously spawn requests
-    // McRouter's maximumOutstanding handles backpressure - it will block
-    // when too many requests are in flight
+    // When auto_concurrency is enabled, we throttle via dynamicMaxInflight.
+    // Otherwise, McRouter's maximumOutstanding handles backpressure.
+    auto& myInflight = *workerInflight[workerId];
+
     while (std::chrono::steady_clock::now() < endTime) {
-      // Decide GET vs SET based on ratio
+      // When auto_concurrency is on, wait if we're at the dynamic limit
+      if (FLAGS_auto_concurrency) {
+        while (myInflight.load() >= dynamicMaxInflight.load() &&
+               std::chrono::steady_clock::now() < endTime) {
+          co_await folly::coro::co_reschedule_on_current_executor;
+        }
+      }
+
+      myInflight.fetch_add(1);
+
       bool isGet = (folly::Random::randDouble01() < getRatio);
       if (isGet) {
         scope.add(
             folly::coro::co_withExecutor(
                 exe, folly::coro::co_invoke([&]() -> folly::coro::Task<void> {
                   co_await sendGetRequest();
+                  myInflight.fetch_sub(1);
                   co_return;
                 })));
       } else {
@@ -1530,11 +1730,11 @@ UcacheBenchClient::BenchmarkResults UcacheBenchClient::runBenchmark() {
             folly::coro::co_withExecutor(
                 exe, folly::coro::co_invoke([&]() -> folly::coro::Task<void> {
                   co_await sendSetRequest();
+                  myInflight.fetch_sub(1);
                   co_return;
                 })));
       }
 
-      // Yield to allow other coroutines to run
       co_await folly::coro::co_reschedule_on_current_executor;
     }
 
@@ -1560,6 +1760,9 @@ UcacheBenchClient::BenchmarkResults UcacheBenchClient::runBenchmark() {
   shouldStop = true;
   if (progressThread.joinable()) {
     progressThread.join();
+  }
+  if (autoConcurrencyThread.joinable()) {
+    autoConcurrencyThread.join();
   }
 
   // Merge all worker latencies

--- a/packages/ucache_bench/client/UcacheBenchClient.cpp
+++ b/packages/ucache_bench/client/UcacheBenchClient.cpp
@@ -344,7 +344,9 @@ DEFINE_uint32(
 DEFINE_uint32(
     additional_fanout,
     0,
-    "Number of additional connections per server for fanout (0 = disabled, must be <= 32768 - num_proxies)");
+    "Number of additional connections per server for fanout (0 = disabled). "
+    "Limited by ephemeral port range per source IP (~64K). Use LD_PRELOAD=bind_source.so "
+    "with multiple source IPs for higher connection counts.");
 DEFINE_bool(
     enable_random_source_ip,
     false,

--- a/packages/ucache_bench/client/UcacheBenchClient.h
+++ b/packages/ucache_bench/client/UcacheBenchClient.h
@@ -213,8 +213,10 @@ class UcacheBenchClient {
   std::shared_ptr<
       facebook::memcache::mcrouter::CarbonRouterInstance<UcacheBenchRouterInfo>>
       routerInstance_;
-  // Note: No longer using a shared client_ member
-  // Instead, each thread creates its own client from routerInstance_
+
+  // Effective connection parameters (derived from --num_connections or flags)
+  uint32_t effectiveNumProxies_{0};
+  uint32_t effectiveAdditionalFanout_{0};
 
   // Admin server connection for multi-client coordination
   std::unique_ptr<AdminConnection> adminConnection_;

--- a/packages/ucache_bench/production_traffic_v2.csv
+++ b/packages/ucache_bench/production_traffic_v2.csv
@@ -1,0 +1,11 @@
+operation,Hits,Samples,request_wire_bytes (avg),request_wire_value_bytes (avg),request_wire_value_bytes (p50),request_wire_value_bytes (p75),request_wire_value_bytes (p95),request_wire_value_bytes (p99),reply_size_before_compression (avg),reply_wire_value_bytes (avg),reply_wire_value_bytes (p50),reply_wire_value_bytes (p75),reply_wire_value_bytes (p95),reply_wire_value_bytes (p99),key_size (avg)
+get,1042120000,104212,0,0,0,0,0,0,0,1567.0159290676697,24,533,7045,17263,63.78330710474801
+lease-get,460320000,46032,0,0,0,0,0,0,0,939.8208637469586,8,78,650,10728,52.91288668752173
+set,142820000,14282,0,2942.158241142697,47,178,4884,37757,0,0,0,0,0,0,66.87634785044112
+lease-set,90820000,9082,0,1460.301035014314,13,86,1891,34042,0,0,0,0,0,0,67.8887910151949
+delete,940000,94,0,0,0,0,0,0,0,0,0,0,0,0,45.255319148936174
+gets,760000,76,0,0,0,0,0,0,0,14.473684210526315,14,14,55,55,69.55263157894737
+add,220000,22,0,17.363636363636363,9,9,55,55,0,0,0,0,0,0,106.63636363636364
+cas,100000,10,0,4,1,9,9,9,0,0,0,0,0,0,89.2
+incr,40000,4,0,0,0,0,0,0,0,0,0,0,0,0,85.5
+metaget,40000,4,0,0,0,0,0,0,0,0,0,0,0,0,27

--- a/packages/ucache_bench/run.py
+++ b/packages/ucache_bench/run.py
@@ -508,8 +508,20 @@ def run_client(args: argparse.Namespace) -> None:
     if args.failures_until_tko > 0:
         client_cmd.append(f"--failures_until_tko={args.failures_until_tko}")
 
-    if args.use_same_thread_client:
-        client_cmd.append("--use_same_thread_client=true")
+    if not args.use_same_thread_client:
+        client_cmd.append("--use_same_thread_client=false")
+
+    # Simplified connection control
+    if args.num_connections > 0:
+        client_cmd.append(f"--num_connections={args.num_connections}")
+
+    # Auto-concurrency discovery
+    if args.auto_concurrency:
+        client_cmd.append("--auto_concurrency=true")
+        if args.ramp_seconds != 30:
+            client_cmd.append(f"--ramp_seconds={args.ramp_seconds}")
+        if args.target_utilization != 1.0:
+            client_cmd.append(f"--target_utilization={args.target_utilization}")
 
     if args.verbose:
         client_cmd.append("--verbose=true")
@@ -931,6 +943,30 @@ def init_parser() -> argparse.ArgumentParser:
         help="Number of additional connections per server for fanout",
     )
     client_parser.add_argument(
+        "--num-connections",
+        type=int,
+        default=0,
+        help="Target TCP connection count (derives num_proxies/additional_fanout automatically)",
+    )
+    client_parser.add_argument(
+        "--auto-concurrency",
+        type=int,
+        default=0,
+        help="Enable AIMD auto-concurrency discovery during benchmark (1=enabled, 0=disabled)",
+    )
+    client_parser.add_argument(
+        "--ramp-seconds",
+        type=int,
+        default=30,
+        help="Duration of AIMD ramp phase when auto-concurrency is enabled",
+    )
+    client_parser.add_argument(
+        "--target-utilization",
+        type=float,
+        default=1.0,
+        help="Fraction of peak concurrency for steady state (0.0-1.0)",
+    )
+    client_parser.add_argument(
         "--enable-random-source-ip",
         type=int,
         default=0,
@@ -958,7 +994,7 @@ def init_parser() -> argparse.ArgumentParser:
     client_parser.add_argument(
         "--use-same-thread-client",
         type=int,
-        default=0,
+        default=1,
         help="Use createSameThreadClient() to eliminate cross-thread hops (1=enabled, 0=disabled)",
     )
 

--- a/packages/ucache_bench/server/UcacheBenchServer.cpp
+++ b/packages/ucache_bench/server/UcacheBenchServer.cpp
@@ -484,6 +484,86 @@ void UcacheBenchServer::runCpuLoadMeasurement() {
   folly::doNotOptimizeAway(shouldShed);
 }
 
+// Static member for FiberToken contention
+std::atomic<uint64_t> UcacheBenchServer::activeFibersTotal_{0};
+
+// Per-request heap allocations matching production ucache patterns.
+// Production does 5-8 heap allocations per request through key construction,
+// fiber task capture, egress tracking, and IOBuf operations.
+// Each allocation goes through jemalloc, which under contention from 300+
+// threads does mmap/munmap syscalls that show up as %sys.
+void UcacheBenchServer::runPerRequestAllocations(
+    const std::string& key,
+    size_t valueLen) {
+  // 1. UcacheStoredKey: std::string cachelibKey_ (key_len + 1 byte for appId)
+  // Production: UcacheKey.h:34-51
+  std::string storedKey(key.size() + 1, '\0');
+  storedKey[0] = static_cast<char>(0x01); // appId byte
+  std::memcpy(storedKey.data() + 1, key.data(), key.size());
+  folly::doNotOptimizeAway(storedKey.data());
+
+  // 2. McStoredKey hashAlias: std::string (matches ct_item.h:135)
+  // Production resolves hash aliases for routing
+  std::string hashAlias = key.substr(0, std::min(key.size(), size_t(16)));
+  folly::doNotOptimizeAway(hashAlias.data());
+
+  // 3. McStoredKey ticket: std::string (matches ct_item.h:137)
+  // Production extracts ticket from request context
+  std::string ticket(32, 'T');
+  folly::doNotOptimizeAway(ticket.data());
+
+  // 4. Fiber task lambda capture allocation
+  // Production: UcacheRequestCommon.h:178 addTaskEager captures
+  // UcacheThriftCallback + Request + FiberToken in a heap-allocated lambda.
+  // Typical size: ~200-500 bytes depending on request type.
+  auto lambdaCapture = std::make_unique<char[]>(256);
+  std::memset(lambdaCapture.get(), 0, 256);
+  folly::doNotOptimizeAway(lambdaCapture.get());
+
+  // 5. KCB derived key construction (matches KcbKeyUtil.cpp:13-19)
+  // Production: fmt::format("{}:kcb:{}", appKey, kcbId)
+  std::string derivedKey = storedKey + ":kcb:12345";
+  folly::doNotOptimizeAway(derivedKey.data());
+
+  // 6. Egress hash computation with vector allocation
+  // Production: UcacheThriftCallback.h:141 allocates vector for multi-get
+  // We simulate a small vector allocation per request
+  std::vector<std::optional<uint64_t>> egressHashes(4);
+  for (size_t i = 0; i < egressHashes.size(); ++i) {
+    egressHashes[i] = folly::hash::twang_mix64(folly::hash::fnv64(key) + i);
+  }
+  folly::doNotOptimizeAway(egressHashes.data());
+
+  // 7. convertToIOBuf std::function allocation
+  // Production: CacheAllocator.h:4567 allocates a type-erased std::function
+  // for the IOBuf converter lambda per cache hit
+  if (valueLen > 0) {
+    std::function<void(void*)> freeFunc = [](void* ptr) {
+      folly::doNotOptimizeAway(ptr);
+    };
+    folly::doNotOptimizeAway(&freeFunc);
+  }
+}
+
+// FiberToken global atomic contention matching production.
+// Production increments a global atomic on fiber entry and decrements on exit.
+// With 300+ IO threads, this creates massive cache-line bouncing as the
+// atomic counter ping-pongs between L1 caches on different cores.
+// This shows up as %sys because cache-line invalidation protocols involve
+// inter-core messaging handled by the kernel's cache coherence mechanisms.
+void UcacheBenchServer::runFiberTokenContention() {
+  // Increment on "fiber entry" (matches FiberToken constructor)
+  auto before = activeFibersTotal_.fetch_add(1, std::memory_order_relaxed);
+  folly::doNotOptimizeAway(before);
+
+  // Per-thread counter increment (matches ++ctx.numActiveFibers_)
+  auto& counters = *cpuLoadCounters_;
+  counters.requestsProcessed.fetch_add(1, std::memory_order_relaxed);
+
+  // Decrement on "fiber exit" (matches FiberToken destructor)
+  activeFibersTotal_.fetch_sub(1, std::memory_order_relaxed);
+}
+
 // Configurable CPU busy-work per request.
 // Burns cpu_work_us microseconds of CPU doing real computation (hash chains)
 // to simulate aggregate production overhead that can't be individually
@@ -528,8 +608,7 @@ std::string UcacheBenchServer::buildCompoundKey(const std::string& key) {
 }
 
 // Production-like GET overhead: key construction, hashing, ACL, stats,
-// timestamps,
-// checksum, serialization, IOBuf processing
+// timestamps, checksum, serialization, IOBuf processing
 void UcacheBenchServer::runProductionGetOverhead(
     const std::string& key,
     bool hit,
@@ -637,6 +716,14 @@ void UcacheBenchServer::runProductionGetOverhead(
   clock_gettime(CLOCK_MONOTONIC, &ts);
   folly::doNotOptimizeAway(ts);
 
+  // 14. Per-request heap allocations (matches production key construction,
+  // fiber task capture, egress hash vector, convertToIOBuf std::function)
+  runPerRequestAllocations(key, hit ? valueLen : 0);
+
+  // 15. FiberToken global atomic contention
+  // (matches UcacheIOThreadContext::FiberToken inc/dec per request)
+  runFiberTokenContention();
+
   // Decrement inflight
   prodStats_.inflightRequests.fetch_sub(1, std::memory_order_relaxed);
 }
@@ -703,6 +790,12 @@ void UcacheBenchServer::runProductionSetOverhead(
 
   clock_gettime(CLOCK_MONOTONIC, &ts);
   folly::doNotOptimizeAway(ts);
+
+  // Per-request heap allocations (same as GET path)
+  runPerRequestAllocations(key, valueLen);
+
+  // FiberToken global atomic contention
+  runFiberTokenContention();
 
   prodStats_.inflightRequests.fetch_sub(1, std::memory_order_relaxed);
 }

--- a/packages/ucache_bench/server/UcacheBenchServer.h
+++ b/packages/ucache_bench/server/UcacheBenchServer.h
@@ -318,6 +318,23 @@ class UcacheBenchServer {
   // Configurable CPU busy-work per request
   void runCpuBusyWork(const std::string& key);
 
+  // Per-request heap allocations matching production ucache.
+  // Production allocates per request:
+  // - UcacheStoredKey: std::string for cachelib key (key_len+1 bytes)
+  // - McStoredKey: 3 std::strings (ukey, hashAlias, ticket)
+  // - Fiber task lambda capture (~200-500 bytes heap via FiberManager)
+  // - Egress hash vector: std::vector<std::optional<uint64_t>> (16*N bytes)
+  // - KCB derived key: fmt::format string allocation
+  // These drive jemalloc pressure → mmap/munmap syscalls → %sys
+  void runPerRequestAllocations(const std::string& key, size_t valueLen);
+
+  // FiberToken global atomic contention matching production.
+  // Production increments/decrements a global atomic<uint64_t> on every
+  // request entry/exit via UcacheIOThreadContext::FiberToken.
+  // This creates cross-thread cache-line bouncing → %sys.
+  static std::atomic<uint64_t> activeFibersTotal_;
+  void runFiberTokenContention();
+
   // Per-thread CPU load measurement (matches shouldLoadShed)
   struct alignas(64) CpuLoadCounters {
     std::atomic<uint64_t> requestsProcessed{0};

--- a/packages/ucache_bench/tools/bind_source.c
+++ b/packages/ucache_bench/tools/bind_source.c
@@ -1,0 +1,140 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/*
+ * LD_PRELOAD library to distribute outgoing TCP connections across multiple
+ * source IPv6 addresses. This allows a single client process to create
+ * far more connections than the ~64K ephemeral port limit per source IP.
+ *
+ * Environment variables:
+ *   BIND_ADDRESSES  Comma-separated list of IPv6 addresses to round-robin.
+ *                   e.g. "2401:db00::1,2401:db00::2,2401:db00::3"
+ *   BIND_ADDRESS    Single IPv6 address (legacy, used if BIND_ADDRESSES unset)
+ *
+ * Usage:
+ *   gcc -shared -fPIC -o bind_source.so bind_source.c -ldl
+ *
+ *   # Single IP (legacy):
+ *   BIND_ADDRESS="2401:db00::1" LD_PRELOAD=./bind_source.so
+ * ./ucachebench_client
+ *
+ *   # Multiple IPs (round-robin):
+ *   BIND_ADDRESSES="2401:db00::1,2401:db00::2,2401:db00::3" \
+ *     LD_PRELOAD=./bind_source.so ./ucachebench_client
+ * --additional_fanout=60000
+ *
+ * With N source IPs and widened port range (1024-65535), each IP supports
+ * ~64K connections. 16 IPs = ~1M connections from a single process.
+ */
+
+#define _GNU_SOURCE
+#include <arpa/inet.h>
+#include <dlfcn.h>
+#include <errno.h>
+#include <netinet/in.h>
+#include <stdatomic.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/socket.h>
+
+#define MAX_BIND_ADDRS 64
+
+static struct sockaddr_in6 g_bind_addrs[MAX_BIND_ADDRS];
+static int g_num_addrs = 0;
+static int g_initialized = 0;
+static atomic_uint g_next_addr = 0;
+static int (*real_connect)(int, const struct sockaddr*, socklen_t) = NULL;
+
+static int parse_addr(const char* str, struct sockaddr_in6* out) {
+  memset(out, 0, sizeof(*out));
+  out->sin6_family = AF_INET6;
+  out->sin6_port = 0;
+  return inet_pton(AF_INET6, str, &out->sin6_addr) == 1 ? 0 : -1;
+}
+
+static void init_once(void) {
+  if (g_initialized)
+    return;
+  g_initialized = 1;
+
+  real_connect = dlsym(RTLD_NEXT, "connect");
+  if (!real_connect) {
+    fprintf(stderr, "bind_source: failed to find real connect()\n");
+    return;
+  }
+
+  /* Try BIND_ADDRESSES first (comma-separated list) */
+  const char* addrs = getenv("BIND_ADDRESSES");
+  if (addrs && addrs[0] != '\0') {
+    char buf[4096];
+    strncpy(buf, addrs, sizeof(buf) - 1);
+    buf[sizeof(buf) - 1] = '\0';
+
+    char* saveptr = NULL;
+    char* tok = strtok_r(buf, ",", &saveptr);
+    while (tok && g_num_addrs < MAX_BIND_ADDRS) {
+      /* Skip leading whitespace */
+      while (*tok == ' ')
+        tok++;
+      if (*tok == '\0') {
+        tok = strtok_r(NULL, ",", &saveptr);
+        continue;
+      }
+
+      if (parse_addr(tok, &g_bind_addrs[g_num_addrs]) == 0) {
+        g_num_addrs++;
+      } else {
+        fprintf(stderr, "bind_source: invalid address '%s', skipping\n", tok);
+      }
+      tok = strtok_r(NULL, ",", &saveptr);
+    }
+
+    if (g_num_addrs > 0) {
+      fprintf(
+          stderr,
+          "bind_source: round-robin across %d source IPs\n",
+          g_num_addrs);
+    }
+    return;
+  }
+
+  /* Fallback to single BIND_ADDRESS */
+  const char* addr = getenv("BIND_ADDRESS");
+  if (addr && addr[0] != '\0') {
+    if (parse_addr(addr, &g_bind_addrs[0]) == 0) {
+      g_num_addrs = 1;
+      fprintf(stderr, "bind_source: will bind to %s\n", addr);
+    } else {
+      fprintf(stderr, "bind_source: invalid BIND_ADDRESS '%s'\n", addr);
+    }
+  }
+}
+
+int connect(int sockfd, const struct sockaddr* addr, socklen_t addrlen) {
+  init_once();
+
+  if (g_num_addrs > 0 && addr->sa_family == AF_INET6) {
+    /* Check if socket is already bound */
+    struct sockaddr_in6 current;
+    socklen_t len = sizeof(current);
+    if (getsockname(sockfd, (struct sockaddr*)&current, &len) == 0) {
+      /* Only bind if not already bound (port == 0 means unbound) */
+      if (current.sin6_port == 0 &&
+          memcmp(&current.sin6_addr, &in6addr_any, sizeof(in6addr_any)) == 0) {
+        /* Round-robin across source addresses */
+        unsigned int idx = atomic_fetch_add(&g_next_addr, 1) % g_num_addrs;
+        bind(
+            sockfd,
+            (struct sockaddr*)&g_bind_addrs[idx],
+            sizeof(g_bind_addrs[idx]));
+      }
+    }
+  }
+
+  return real_connect(sockfd, addr, addrlen);
+}

--- a/packages/ucache_bench/traffic_dist_v2.json
+++ b/packages/ucache_bench/traffic_dist_v2.json
@@ -1,0 +1,15 @@
+{
+  "get_ratio": 0.8653235090950956,
+  "get_key_size_avg": 60.456520582209095,
+  "get_response_size_avg": 1374.1305313855405,
+  "get_response_size_p50": 19.09480854687209,
+  "get_response_size_p75": 393.39397567919957,
+  "get_response_size_p95": 5083.010829940661,
+  "get_response_size_p99": 15252.70237620074,
+  "set_key_size_avg": 67.31629338348435,
+  "set_value_size_avg": 2362.9158830569327,
+  "set_value_size_p50": 33.746281415626605,
+  "set_value_size_p75": 142.05573602325182,
+  "set_value_size_p95": 3715.534706787485,
+  "set_value_size_p99": 36263.30218840828
+}


### PR DESCRIPTION
Summary:

Simplify ucachebench client configuration by replacing the interacting knobs (num_proxies, additional_fanout, max_inflight) with two high-level controls:

1. `--num_connections=N`: Specify the target TCP connection count directly. Internally derives num_proxies and additional_fanout, enforcing the mcrouter 32768 ProxyDestination limit. Example: `--num_connections=16000` instead of `--num_proxies=32 --additional_fanout=500`.

2. `--auto_concurrency`: Automatically discovers optimal concurrency during the benchmark using AIMD (Additive Increase, Multiplicative Decrease). Splits the benchmark into a ramp phase (searches for peak QPS) and a steady phase (holds optimal concurrency). Replaces manual max_inflight tuning. Supports `--target_utilization=0.9` to back off from peak.

Also:
- Default `use_same_thread_client` to true (matches production, +4% QPS in testing)
- Add flags to run.py argument parser and CLIENT_ONLY_PARAMS
- Regenerate carbon protocol files

Reviewed By: excelle08

Differential Revision: D106825050


