### PR TITLE
Add RDMA microbench category (perftest)

### DIFF
--- a/benchpress/plugins/parsers/__init__.py
+++ b/benchpress/plugins/parsers/__init__.py
@@ -43,6 +43,7 @@ from .multichase_pingpong import MultichasePingpongParser
 from .multichase_pointer import MultichasePointerParser
 from .nginx_wrk_bench import NginxWrkParser
 from .nnpi_net4 import NNPINet4Parser
+from .perftest import PerftestParser
 from .pytorch_gemm_gpuless import PytorchGemmGpulessParser
 from .rebatch import RebatchParser
 from .returncode import ReturncodeParser
@@ -104,6 +105,7 @@ def register_parsers(factory):
     factory.register("lmbench_lat_mem_rd", LmbenchLatMemRdParser)
     factory.register("checkmark", CheckmarkParser)
     factory.register("nnpi_net4", NNPINet4Parser)
+    factory.register("perftest", PerftestParser)
     factory.register("feedsim", FeedSimParser)
     factory.register("feedsim_autoscale", FeedSimAutoscaleParser)
     factory.register("tailbench_imgdnn", TailBenchParser)

--- a/benchpress/plugins/parsers/perftest.py
+++ b/benchpress/plugins/parsers/perftest.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-unsafe
+
+"""Parser for OFED perftest tools (ib_write_bw / ib_read_bw / ib_send_lat).
+
+perftest writes a fixed-format table inside two `--------` separator lines.
+There are two header shapes:
+
+  BW mode (ib_write_bw, ib_read_bw, ib_send_bw):
+     #bytes  #iterations  BW peak[MB/sec]  BW average[MB/sec]  MsgRate[Mpps]
+     65536   5000         11800.50         11750.25            0.179
+
+  Latency mode (ib_send_lat, ib_write_lat, ib_read_lat):
+     #bytes  #iterations  t_min[usec]  t_max[usec]  t_typical[usec]  t_avg[usec]  t_stdev[usec]  99% percentile[usec]  99.9% percentile[usec]
+     2       1000         1.10         1.50         1.20             1.22         0.05           1.40                  1.45
+
+We pick the mode by inspecting the header line that names the columns, then
+parse the immediately following data row.
+"""
+
+from benchpress.lib.parser import Parser
+
+
+class PerftestParser(Parser):
+    def parse(self, stdout, stderr, returncode):  # noqa: C901
+        metrics = {}
+        header = None
+        # Some perftest builds report BW units in either MB/sec or Gb/sec
+        # depending on the --report_gbits flag. We record whichever appears.
+        bw_unit = None
+        for raw in stdout:
+            line = raw.strip()
+            if not line:
+                continue
+            if "#bytes" in line and "#iterations" in line:
+                header = line
+                if "Gb/sec" in line:
+                    bw_unit = "Gbps"
+                elif "MB/sec" in line:
+                    bw_unit = "MBps"
+                continue
+            if header is None:
+                continue
+            parts = line.split()
+            # First non-header row that begins with a number is our data.
+            try:
+                float(parts[0])
+            except (ValueError, IndexError):
+                continue
+            # BW row
+            if "BW peak" in header:
+                try:
+                    metrics["bytes"] = int(parts[0])
+                    metrics["iterations"] = int(parts[1])
+                    bw_peak = float(parts[2])
+                    bw_avg = float(parts[3])
+                    msg_rate = float(parts[4])
+                    suffix = bw_unit or "MBps"
+                    metrics[f"bw_peak_{suffix}"] = bw_peak
+                    metrics[f"bw_avg_{suffix}"] = bw_avg
+                    metrics["msg_rate_Mpps"] = msg_rate
+                except (ValueError, IndexError):
+                    pass
+                header = None
+                continue
+            # Latency row
+            if "t_min" in header:
+                try:
+                    metrics["bytes"] = int(parts[0])
+                    metrics["iterations"] = int(parts[1])
+                    metrics["t_min_us"] = float(parts[2])
+                    metrics["t_max_us"] = float(parts[3])
+                    metrics["t_typical_us"] = float(parts[4])
+                    metrics["t_avg_us"] = float(parts[5])
+                    metrics["t_stdev_us"] = float(parts[6])
+                    if len(parts) > 7:
+                        metrics["t_p99_us"] = float(parts[7])
+                    if len(parts) > 8:
+                        metrics["t_p99_9_us"] = float(parts[8])
+                except (ValueError, IndexError):
+                    pass
+                header = None
+                continue
+        return metrics


### PR DESCRIPTION
Summary:
**Context:**
Stacked on top of D105762201 (cpu_atomic_noisy via wdl_bench reuse). This
adds the RDMA category — perftest's `ib_write_bw`, `ib_read_bw`, and
`ib_send_lat` — under the same `_<category>.sh` convention as `_micro.sh`
and `_nic.sh`. RDMA throughput/latency is one of the headline DPU metrics
(MetaRoCE/RoCEv2 transport, NVMe-oF, RDMA collectives).

**Motivation:**
- Land the RDMA scaffolding under the same install/run/cleanup pattern so
  later RDMA-specific work (Meta-RoCE, packet-spray, lossy, QP-scale) can
  drop in as new tools/jobs without re-litigating the wiring.
- perftest is the standard OFED probe; ib_write_bw / ib_read_bw / ib_send_lat
  give us BW peak/avg + msg rate + multi-percentile latency in one package.

**This diff:**
- Adds `packages/dpu_perf/{install,run,cleanup}_rdma.sh`. install does
  idempotent `dnf install -y perftest libibverbs-utils` (or
  `apt-get install -y perftest ibverbs-utils`) and copies the three binaries
  into `bin/` for stable install_markers. Dispatcher accepts
  `--tool=ib_write_bw|ib_read_bw|ib_send_lat`,
  `--role=server|client`, `--target=HOST`, plus
  `--size`/`--iters`/`--port`/`--duration`.
- Adds a new `perftest` parser (`benchpress/plugins/parsers/perftest.py`).
  Auto-detects BW vs latency mode from the column header and emits either
  bw_peak/bw_avg/msg_rate (with unit suffix that flips between MBps and Gbps
  depending on perftest's --report_gbits flag) or
  t_min/t_max/t_typical/t_avg/t_stdev/t_p99/t_p99_9. Registered in
  `benchpress/plugins/parsers/__init__.py` and added to the `:plugins`
  BUCK rule's srcs.
- Adds three benchmarks (`rdma_write_bw`, `rdma_read_bw`, `rdma_send_lat`)
  and matching jobs to the dpu_perf YAML pair. Each has server + client
  roles with the same `server_hostname=127.0.0.1` default-via-vars pattern
  used by `nic_iperf_tcp`.
- README updated with the new category, the three new benches, and a
  note that running these requires an RDMA fabric (real RoCE/IB NIC or
  soft-RoCE `rdma_rxe`).

Differential Revision: D105762376


