### PR TITLE
Extend accel category with DPDK cryptodev (accel_crypto)

### DIFF
--- a/benchpress/plugins/parsers/__init__.py
+++ b/benchpress/plugins/parsers/__init__.py
@@ -19,6 +19,7 @@ from .cloudsuite_graph import CloudSuiteGraphParser
 from .compression_parser import CompressionParser
 from .deser import DeserParser
 from .django_workload import DjangoWorkloadParser
+from .dpdk_compress_perf import DpdkCompressPerfParser
 from .embedding import EmbeddingParser
 from .encryption import EncryptionParser
 from .fb_fiosynth import Fiosynth_Parser
@@ -72,6 +73,7 @@ def register_parsers(factory):
     factory.register("clang", ClangParser)
     factory.register("compression_parser", CompressionParser)
     factory.register("django_workload", DjangoWorkloadParser)
+    factory.register("dpdk_compress_perf", DpdkCompressPerfParser)
     factory.register("encryption", EncryptionParser)
     factory.register("fb_fiosynth", Fiosynth_Parser)
     factory.register("fbgemm", FbgemmParser)

--- a/benchpress/plugins/parsers/__init__.py
+++ b/benchpress/plugins/parsers/__init__.py
@@ -20,6 +20,7 @@ from .compression_parser import CompressionParser
 from .deser import DeserParser
 from .django_workload import DjangoWorkloadParser
 from .dpdk_compress_perf import DpdkCompressPerfParser
+from .dpdk_crypto_perf import DpdkCryptoPerfParser
 from .embedding import EmbeddingParser
 from .encryption import EncryptionParser
 from .fb_fiosynth import Fiosynth_Parser
@@ -74,6 +75,7 @@ def register_parsers(factory):
     factory.register("compression_parser", CompressionParser)
     factory.register("django_workload", DjangoWorkloadParser)
     factory.register("dpdk_compress_perf", DpdkCompressPerfParser)
+    factory.register("dpdk_crypto_perf", DpdkCryptoPerfParser)
     factory.register("encryption", EncryptionParser)
     factory.register("fb_fiosynth", Fiosynth_Parser)
     factory.register("fbgemm", FbgemmParser)

--- a/benchpress/plugins/parsers/__init__.py
+++ b/benchpress/plugins/parsers/__init__.py
@@ -43,6 +43,7 @@ from .multichase_pingpong import MultichasePingpongParser
 from .multichase_pointer import MultichasePointerParser
 from .nginx_wrk_bench import NginxWrkParser
 from .nnpi_net4 import NNPINet4Parser
+from .perftest import PerftestParser
 from .pytorch_gemm_gpuless import PytorchGemmGpulessParser
 from .rebatch import RebatchParser
 from .returncode import ReturncodeParser
@@ -104,6 +105,7 @@ def register_parsers(factory):
     factory.register("lmbench_lat_mem_rd", LmbenchLatMemRdParser)
     factory.register("checkmark", CheckmarkParser)
     factory.register("nnpi_net4", NNPINet4Parser)
+    factory.register("perftest", PerftestParser)
     factory.register("feedsim", FeedSimParser)
     factory.register("feedsim_autoscale", FeedSimAutoscaleParser)
     factory.register("tailbench_imgdnn", TailBenchParser)

--- a/benchpress/plugins/parsers/dpdk_compress_perf.py
+++ b/benchpress/plugins/parsers/dpdk_compress_perf.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-unsafe
+
+"""Parser for DPDK's `dpdk-test-compress-perf` in throughput mode.
+
+The throughput-mode table (from app/test-compress-perf/comp_perf_test_throughput.c)
+is emitted after the EAL banner and per-lcore device-pairing lines. Real
+DPDK 25.11 output looks like:
+
+      lcore id Level   Comp size   Comp ratio [%]    Comp [Gbps]   Decomp [Gbps]
+             1     1        1595             2.43           8.04           23.22
+             4     1        1595             2.43           7.96           22.81
+             ...
+
+Columns:
+  0. lcore id              integer
+  1. Level                 integer (compression level used)
+  2. Comp size             integer (compressed payload size, bytes)
+  3. Comp ratio [%]        float   (compressed / original × 100; lower = denser)
+  4. Comp [Gbps]           float   (compression throughput on that lcore)
+  5. Decomp [Gbps]         float   (decompression throughput on that lcore)
+
+We aggregate across lcores into:
+  - per-lcore_rows: list of [lcore_id, level, comp_size, ratio_pct, comp_gbps, decomp_gbps]
+  - compress_throughput_Gbps_avg / _min / _max
+  - decompress_throughput_Gbps_avg / _min / _max
+  - compression_ratio_pct (constant across rows — recorded from the first row)
+  - num_lcores
+"""
+
+from benchpress.lib.parser import Parser
+
+
+def _is_header_line(line: str) -> bool:
+    return (
+        "lcore" in line
+        and "Level" in line
+        and "Comp" in line
+        and "ratio" in line
+        and "Gbps" in line
+    )
+
+
+class DpdkCompressPerfParser(Parser):
+    def parse(self, stdout, stderr, returncode):
+        metrics = {}
+        in_table = False
+        rows = []
+        for raw in stdout:
+            line = raw.strip()
+            if not line:
+                continue
+            if not in_table:
+                if _is_header_line(line):
+                    in_table = True
+                continue
+            parts = line.split()
+            # First non-row line after header ends the table; per-lcore data
+            # rows always start with an integer (lcore id).
+            try:
+                lcore = int(parts[0])
+            except (ValueError, IndexError):
+                in_table = False
+                continue
+            if len(parts) < 6:
+                continue
+            try:
+                level = int(parts[1])
+                comp_size = int(parts[2])
+                ratio_pct = float(parts[3])
+                comp_gbps = float(parts[4])
+                decomp_gbps = float(parts[5])
+            except ValueError:
+                continue
+            rows.append([lcore, level, comp_size, ratio_pct, comp_gbps, decomp_gbps])
+
+        if not rows:
+            return metrics
+
+        comp_vals = [r[4] for r in rows]
+        decomp_vals = [r[5] for r in rows]
+        metrics["num_lcores"] = len(rows)
+        metrics["compression_ratio_pct"] = rows[0][3]
+        metrics["compressed_size_bytes"] = rows[0][2]
+        metrics["compression_level"] = rows[0][1]
+        metrics["compress_throughput_Gbps_avg"] = sum(comp_vals) / len(comp_vals)
+        metrics["compress_throughput_Gbps_min"] = min(comp_vals)
+        metrics["compress_throughput_Gbps_max"] = max(comp_vals)
+        metrics["decompress_throughput_Gbps_avg"] = sum(decomp_vals) / len(decomp_vals)
+        metrics["decompress_throughput_Gbps_min"] = min(decomp_vals)
+        metrics["decompress_throughput_Gbps_max"] = max(decomp_vals)
+        metrics["per_lcore_rows"] = rows
+        return metrics

--- a/benchpress/plugins/parsers/dpdk_crypto_perf.py
+++ b/benchpress/plugins/parsers/dpdk_crypto_perf.py
@@ -1,0 +1,110 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-unsafe
+
+"""Parser for DPDK's `dpdk-test-crypto-perf` in throughput mode.
+
+Throughput-mode output (from app/test-crypto-perf/cperf_test_throughput.c)
+emits a fixed per-lcore table after the EAL banner and per-option dump. Real
+DPDK 25.11 output looks like:
+
+      lcore id    Buf Size  Burst Size    Enqueued    Dequeued  Failed Enq  Failed Deq        MOps        Gbps  Cycles/Buf
+             1        1024          32      100000      100000           0           0    4.583819   37.550642      218.16
+             2        1024          32      100000      100000           0           0    4.568119   37.422031      218.91
+
+The columns are positional (10 fields):
+  0. lcore id        (int)
+  1. Buf Size        (int)
+  2. Burst Size      (int)
+  3. Enqueued        (int)
+  4. Dequeued        (int)
+  5. Failed Enq      (int)
+  6. Failed Deq      (int)
+  7. MOps            (float, millions of ops/sec)
+  8. Gbps            (float, throughput)
+  9. Cycles/Buf      (float)
+
+We parse by column position once we've identified the header.
+
+Emitted metrics:
+  - per_lcore_rows: list of [lcore_id, mops, gbps, cycles_per_buf]
+  - num_lcores
+  - buffer_size, burst_size (constant across rows)
+  - throughput_Gbps_avg / _min / _max
+  - mops_avg / _min / _max
+  - cycles_per_buf_avg
+  - failed_enqueued_total, failed_dequeued_total (zero on success)
+"""
+
+from benchpress.lib.parser import Parser
+
+
+def _is_header_line(line: str) -> bool:
+    return "lcore" in line and "Burst" in line and "MOps" in line and "Gbps" in line
+
+
+class DpdkCryptoPerfParser(Parser):
+    def parse(self, stdout, stderr, returncode):
+        metrics = {}
+        in_table = False
+        rows = []
+        failed_enq_total = 0
+        failed_deq_total = 0
+        for raw in stdout:
+            line = raw.strip()
+            if not line:
+                continue
+            if not in_table:
+                if _is_header_line(line):
+                    in_table = True
+                continue
+            parts = line.split()
+            try:
+                lcore = int(parts[0])
+            except (ValueError, IndexError):
+                in_table = False
+                continue
+            # 10-column DPDK >= ~21.05 throughput schema. Skip rows that
+            # don't match (e.g. an unexpected footer line that begins with
+            # a digit but has fewer columns).
+            if len(parts) < 10:
+                continue
+            try:
+                buf_size = int(parts[1])
+                burst_size = int(parts[2])
+                failed_enq = int(parts[5])
+                failed_deq = int(parts[6])
+                mops = float(parts[7])
+                gbps = float(parts[8])
+                cycles_per_buf = float(parts[9])
+            except ValueError:
+                continue
+            rows.append([lcore, buf_size, burst_size, mops, gbps, cycles_per_buf])
+            failed_enq_total += failed_enq
+            failed_deq_total += failed_deq
+
+        if not rows:
+            return metrics
+
+        gbps_vals = [r[4] for r in rows]
+        mops_vals = [r[3] for r in rows]
+        cyc_vals = [r[5] for r in rows]
+        metrics["num_lcores"] = len(rows)
+        metrics["buffer_size"] = rows[0][1]
+        metrics["burst_size"] = rows[0][2]
+        metrics["throughput_Gbps_avg"] = sum(gbps_vals) / len(gbps_vals)
+        metrics["throughput_Gbps_min"] = min(gbps_vals)
+        metrics["throughput_Gbps_max"] = max(gbps_vals)
+        metrics["mops_avg"] = sum(mops_vals) / len(mops_vals)
+        metrics["mops_min"] = min(mops_vals)
+        metrics["mops_max"] = max(mops_vals)
+        metrics["cycles_per_buf_avg"] = sum(cyc_vals) / len(cyc_vals)
+        metrics["failed_enqueued_total"] = failed_enq_total
+        metrics["failed_dequeued_total"] = failed_deq_total
+        # per-lcore row: [lcore_id, mops, gbps, cycles_per_buf]
+        metrics["per_lcore_rows"] = [[r[0], r[3], r[4], r[5]] for r in rows]
+        return metrics

--- a/benchpress/plugins/parsers/perftest.py
+++ b/benchpress/plugins/parsers/perftest.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-unsafe
+
+"""Parser for OFED perftest tools (ib_write_bw / ib_read_bw / ib_send_lat).
+
+perftest writes a fixed-format table inside two `--------` separator lines.
+There are two header shapes:
+
+  BW mode (ib_write_bw, ib_read_bw, ib_send_bw):
+     #bytes  #iterations  BW peak[MB/sec]  BW average[MB/sec]  MsgRate[Mpps]
+     65536   5000         11800.50         11750.25            0.179
+
+  Latency mode (ib_send_lat, ib_write_lat, ib_read_lat):
+     #bytes  #iterations  t_min[usec]  t_max[usec]  t_typical[usec]  t_avg[usec]  t_stdev[usec]  99% percentile[usec]  99.9% percentile[usec]
+     2       1000         1.10         1.50         1.20             1.22         0.05           1.40                  1.45
+
+We pick the mode by inspecting the header line that names the columns, then
+parse the immediately following data row.
+"""
+
+from benchpress.lib.parser import Parser
+
+
+class PerftestParser(Parser):
+    def parse(self, stdout, stderr, returncode):  # noqa: C901
+        metrics = {}
+        header = None
+        # Some perftest builds report BW units in either MB/sec or Gb/sec
+        # depending on the --report_gbits flag. We record whichever appears.
+        bw_unit = None
+        for raw in stdout:
+            line = raw.strip()
+            if not line:
+                continue
+            if "#bytes" in line and "#iterations" in line:
+                header = line
+                if "Gb/sec" in line:
+                    bw_unit = "Gbps"
+                elif "MB/sec" in line:
+                    bw_unit = "MBps"
+                continue
+            if header is None:
+                continue
+            parts = line.split()
+            # First non-header row that begins with a number is our data.
+            try:
+                float(parts[0])
+            except (ValueError, IndexError):
+                continue
+            # BW row
+            if "BW peak" in header:
+                try:
+                    metrics["bytes"] = int(parts[0])
+                    metrics["iterations"] = int(parts[1])
+                    bw_peak = float(parts[2])
+                    bw_avg = float(parts[3])
+                    msg_rate = float(parts[4])
+                    suffix = bw_unit or "MBps"
+                    metrics[f"bw_peak_{suffix}"] = bw_peak
+                    metrics[f"bw_avg_{suffix}"] = bw_avg
+                    metrics["msg_rate_Mpps"] = msg_rate
+                except (ValueError, IndexError):
+                    pass
+                header = None
+                continue
+            # Latency row
+            if "t_min" in header:
+                try:
+                    metrics["bytes"] = int(parts[0])
+                    metrics["iterations"] = int(parts[1])
+                    metrics["t_min_us"] = float(parts[2])
+                    metrics["t_max_us"] = float(parts[3])
+                    metrics["t_typical_us"] = float(parts[4])
+                    metrics["t_avg_us"] = float(parts[5])
+                    metrics["t_stdev_us"] = float(parts[6])
+                    if len(parts) > 7:
+                        metrics["t_p99_us"] = float(parts[7])
+                    if len(parts) > 8:
+                        metrics["t_p99_9_us"] = float(parts[8])
+                except (ValueError, IndexError):
+                    pass
+                header = None
+                continue
+        return metrics


### PR DESCRIPTION
Summary:
**Context:**
Stacked on top of D105764848 (accel_compress / DPDK compressdev). Extends
the `_accel.sh` category with the second DPDK perf test app —
`dpdk-test-crypto-perf` — and the corresponding `accel_crypto` benchmark.
Together with the host-only openssl baseline and vendor-native crypto SDKs,
this is the *standard-abstraction* leg of the three-path crypto
measurement model from `IMPLEMENTATION.md §6`.

**Motivation:**
- AES-GCM throughput on the lookaside path is one of the two headline
  ROI questions for MDPU-v2 (the other being compression, addressed in
  the parent diff).
- DPDK cryptodev is the standard, vendor-portable abstraction; swapping
  `--driver=crypto_qat` / `crypto_mlx5` etc. measures vendor PMDs on the
  same harness, same parser, same metric schema.

**This diff:**
- `install_accel.sh` appends a second `install_dpdk_app dpdk-test-crypto-perf`
  call; the existing `build_dpdk_if_needed` caches the DPDK build dir so
  a single source build produces both apps in one pass.
- `run_accel.sh` gains a `dpdk_crypto` dispatch case with crypto-specific
  knobs (`--optype`, `--aead-algo`, `--aead-op`, `--aead-{key,iv,aad}-sz`,
  `--digest-sz`, `--buffer-sz`, `--total-ops`). Common EAL args are now
  factored into `build_common_eal_args` (huge-dir / socket-mem / lcores)
  and shared between the compress and crypto cases.
- New `--lcores=SPEC` EAL knob exposed at the dispatcher level — required
  for software PMDs with a small queue-pair budget (e.g. crypto_openssl
  caps at 8 qps per device).
- `cleanup_accel.sh` extended to also remove `dpdk-test-crypto-perf`.
- New `dpdk_crypto_perf` parser
  (`benchpress/plugins/parsers/dpdk_crypto_perf.py`, registered in
  `__init__.py` and BUCK srcs). Positional column parsing of the 10-field
  throughput-mode table (DPDK ≥ 21.05 schema): emits per-lcore rows plus
  aggregated `throughput_Gbps_{avg,min,max}`, `mops_{avg,min,max}`,
  `cycles_per_buf_avg`, `failed_enqueued_total`, `failed_dequeued_total`.
- New `accel_crypto` benchmark + `accel_crypto_openssl_aesgcm_default`
  job (AES-GCM AEAD encrypt, 16 B key / 12 B IV / 16 B AAD / 16 B digest,
  1 KiB buffer, 100K ops, lcores 0-3). Standard-abstraction path; the
  job is the template vendor PMDs slot into.
- README updated: new bench in the table; the script-trio listing now
  shows both compress + crypto tools under `_accel.sh`.

Reviewed By: excelle08

Differential Revision: D105765461


