### PR TITLE
accel_t10_dif/accel_ddgst: paired baseline-vs-integrity legs

### DIFF
--- a/benchpress/plugins/hooks/__init__.py
+++ b/benchpress/plugins/hooks/__init__.py
@@ -13,6 +13,7 @@ from .cpu_limit import CpuLimit
 from .cpu_mpstat import CpuMpstat
 from .emon import Emon
 from .file import FileHook
+from .netem import NetemHook
 from .perf import Perf
 from .result import ResultHook
 from .shell import ShellHook
@@ -33,6 +34,7 @@ def register_hooks(factory):
     factory.register("cpu-mpstat", CpuMpstat)
     factory.register("emon", Emon)
     factory.register("file", FileHook)
+    factory.register("netem", NetemHook)
     factory.register("perf", Perf)
     factory.register("result", ResultHook)
     factory.register("shell", ShellHook)

--- a/benchpress/plugins/hooks/netem.py
+++ b/benchpress/plugins/hooks/netem.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-unsafe
+
+"""netem hook — apply tc/netem network impairments before a job, clear after.
+
+Used by the dpu_perf suite's `rdma_lossy` benchmark to inject controlled
+loss / delay on a RoCE link so we can characterise SACK / receiver-CC
+behaviour. Generic enough to apply to any TCP/RDMA test that already
+exposes its own server + client roles.
+
+Job YAML:
+
+    hooks:
+      - hook: netem
+        options:
+          iface: eth0           # required; interface to qdisc on
+          loss: "0.1%"          # optional; netem loss arg
+          delay_us: 100         # optional; netem delay (microseconds)
+          jitter_us: 10         # optional; netem delay jitter
+          duplicate: ""         # optional; netem duplicate arg (e.g. "0.5%")
+          corrupt: ""           # optional; netem corrupt arg
+
+before_job() runs `tc qdisc add dev IFACE root netem ...`; after_job()
+runs `tc qdisc del dev IFACE root` regardless of test outcome (uses
+check=False so a missing qdisc on cleanup doesn't fail the run).
+
+Requires root or CAP_NET_ADMIN.
+"""
+
+import logging
+import subprocess
+
+from benchpress.lib.hook import Hook
+
+
+logger = logging.getLogger(__name__)
+
+
+def _build_netem_args(opts):
+    parts = []
+    if "loss" in opts and opts["loss"]:
+        parts += ["loss", str(opts["loss"])]
+    if "delay_us" in opts and opts["delay_us"]:
+        delay_arg = f"{opts['delay_us']}us"
+        if "jitter_us" in opts and opts["jitter_us"]:
+            delay_arg = f"{delay_arg} {opts['jitter_us']}us"
+        parts += ["delay"] + delay_arg.split()
+    if "duplicate" in opts and opts["duplicate"]:
+        parts += ["duplicate", str(opts["duplicate"])]
+    if "corrupt" in opts and opts["corrupt"]:
+        parts += ["corrupt", str(opts["corrupt"])]
+    return parts
+
+
+class NetemHook(Hook):
+    def before_job(self, opts, job=None):
+        if "iface" not in opts:
+            raise Exception("netem hook: 'iface' option is required")
+        iface = opts["iface"]
+        netem_args = _build_netem_args(opts)
+        if not netem_args:
+            logger.warning("netem hook: no impairment specified; skipping")
+            self._iface = None
+            return
+        # Best-effort clean of any pre-existing qdisc so the `add` succeeds
+        # even if a previous run was killed before its `after_job` ran.
+        subprocess.run(
+            ["tc", "qdisc", "del", "dev", iface, "root"],
+            check=False,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
+        cmd = ["tc", "qdisc", "add", "dev", iface, "root", "netem"] + netem_args
+        logger.info("netem hook: %s", " ".join(cmd))
+        subprocess.check_call(cmd)
+        self._iface = iface
+
+    def after_job(self, opts, job=None):
+        iface = getattr(self, "_iface", None) or opts.get("iface")
+        if not iface:
+            return
+        subprocess.run(
+            ["tc", "qdisc", "del", "dev", iface, "root"],
+            check=False,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )

--- a/benchpress/plugins/parsers/__init__.py
+++ b/benchpress/plugins/parsers/__init__.py
@@ -56,6 +56,7 @@ from .sigrid import SigridParser
 from .silo import SiloParser
 from .small_locks_bench import SmallLocksParser
 from .spark_standalone import SparkStandaloneParser
+from .spdk_accel_perf import SpdkAccelPerfParser
 from .spec_cpu2006 import SPECCPU2006Parser
 from .stream import StreamParser
 from .syscall import SyscallParser
@@ -105,6 +106,7 @@ def register_parsers(factory):
     factory.register("tao_bench", TaoBenchParser)
     factory.register("tao_bench_autoscale", TaoBenchAutoscaleParser)
     factory.register("speccpu2006", SPECCPU2006Parser)
+    factory.register("spdk_accel_perf", SpdkAccelPerfParser)
     factory.register("stream", StreamParser)
     factory.register("mlc", MlcParser)
     factory.register("iperf", IperfParser)

--- a/benchpress/plugins/parsers/__init__.py
+++ b/benchpress/plugins/parsers/__init__.py
@@ -36,6 +36,7 @@ from .health_check import HealthCheckParser
 from .iperf import IperfParser
 from .lmbench_lat_mem_rd import LmbenchLatMemRdParser
 from .ltp import LtpParser
+from .lzbench_perf import LzbenchPerfParser
 from .mediawiki import MediawikiParser
 from .memcached_bench import MemcachedBenchParser
 from .minebench import KMeansParser, PLSAParser, RSearchParser
@@ -45,6 +46,7 @@ from .multichase_pingpong import MultichasePingpongParser
 from .multichase_pointer import MultichasePointerParser
 from .nginx_wrk_bench import NginxWrkParser
 from .nnpi_net4 import NNPINet4Parser
+from .openssl_speed import OpensslSpeedParser
 from .perftest import PerftestParser
 from .pytorch_gemm_gpuless import PytorchGemmGpulessParser
 from .rebatch import RebatchParser
@@ -107,6 +109,8 @@ def register_parsers(factory):
     factory.register("mlc", MlcParser)
     factory.register("iperf", IperfParser)
     factory.register("lmbench_lat_mem_rd", LmbenchLatMemRdParser)
+    factory.register("lzbench_perf", LzbenchPerfParser)
+    factory.register("openssl_speed", OpensslSpeedParser)
     factory.register("checkmark", CheckmarkParser)
     factory.register("nnpi_net4", NNPINet4Parser)
     factory.register("perftest", PerftestParser)

--- a/benchpress/plugins/parsers/__init__.py
+++ b/benchpress/plugins/parsers/__init__.py
@@ -19,6 +19,7 @@ from .cloudsuite_graph import CloudSuiteGraphParser
 from .compression_parser import CompressionParser
 from .deser import DeserParser
 from .django_workload import DjangoWorkloadParser
+from .dpdk_compress_perf import DpdkCompressPerfParser
 from .embedding import EmbeddingParser
 from .encryption import EncryptionParser
 from .fb_fiosynth import Fiosynth_Parser
@@ -72,6 +73,7 @@ def register_parsers(factory):
     factory.register("clang", ClangParser)
     factory.register("compression_parser", CompressionParser)
     factory.register("django_workload", DjangoWorkloadParser)
+    factory.register("dpdk_compress_perf", DpdkCompressPerfParser)
     factory.register("encryption", EncryptionParser)
     factory.register("fb_fiosynth", Fiosynth_Parser)
     factory.register("fbgemm", FbgemmParser)

--- a/benchpress/plugins/parsers/__init__.py
+++ b/benchpress/plugins/parsers/__init__.py
@@ -21,6 +21,7 @@ from .deser import DeserParser
 from .django_workload import DjangoWorkloadParser
 from .dpdk_compress_perf import DpdkCompressPerfParser
 from .dpdk_crypto_perf import DpdkCryptoPerfParser
+from .dpdk_testpmd import DpdkTestpmdParser
 from .embedding import EmbeddingParser
 from .encryption import EncryptionParser
 from .fb_fiosynth import Fiosynth_Parser
@@ -79,6 +80,7 @@ def register_parsers(factory):
     factory.register("django_workload", DjangoWorkloadParser)
     factory.register("dpdk_compress_perf", DpdkCompressPerfParser)
     factory.register("dpdk_crypto_perf", DpdkCryptoPerfParser)
+    factory.register("dpdk_testpmd", DpdkTestpmdParser)
     factory.register("encryption", EncryptionParser)
     factory.register("fb_fiosynth", Fiosynth_Parser)
     factory.register("fbgemm", FbgemmParser)

--- a/benchpress/plugins/parsers/__init__.py
+++ b/benchpress/plugins/parsers/__init__.py
@@ -20,6 +20,7 @@ from .compression_parser import CompressionParser
 from .deser import DeserParser
 from .django_workload import DjangoWorkloadParser
 from .dpdk_compress_perf import DpdkCompressPerfParser
+from .dpdk_crypto_perf import DpdkCryptoPerfParser
 from .embedding import EmbeddingParser
 from .encryption import EncryptionParser
 from .fb_fiosynth import Fiosynth_Parser
@@ -74,6 +75,7 @@ def register_parsers(factory):
     factory.register("compression_parser", CompressionParser)
     factory.register("django_workload", DjangoWorkloadParser)
     factory.register("dpdk_compress_perf", DpdkCompressPerfParser)
+    factory.register("dpdk_crypto_perf", DpdkCryptoPerfParser)
     factory.register("encryption", EncryptionParser)
     factory.register("fb_fiosynth", Fiosynth_Parser)
     factory.register("fbgemm", FbgemmParser)

--- a/benchpress/plugins/parsers/__init__.py
+++ b/benchpress/plugins/parsers/__init__.py
@@ -60,6 +60,7 @@ from .silo import SiloParser
 from .small_locks_bench import SmallLocksParser
 from .spark_standalone import SparkStandaloneParser
 from .spdk_accel_perf import SpdkAccelPerfParser
+from .spdk_integrity import SpdkIntegrityParser
 from .spec_cpu2006 import SPECCPU2006Parser
 from .stream import StreamParser
 from .syscall import SyscallParser
@@ -112,6 +113,7 @@ def register_parsers(factory):
     factory.register("tao_bench_autoscale", TaoBenchAutoscaleParser)
     factory.register("speccpu2006", SPECCPU2006Parser)
     factory.register("spdk_accel_perf", SpdkAccelPerfParser)
+    factory.register("spdk_integrity", SpdkIntegrityParser)
     factory.register("stream", StreamParser)
     factory.register("mlc", MlcParser)
     factory.register("iperf", IperfParser)

--- a/benchpress/plugins/parsers/__init__.py
+++ b/benchpress/plugins/parsers/__init__.py
@@ -22,6 +22,7 @@ from .django_workload import DjangoWorkloadParser
 from .dpdk_compress_perf import DpdkCompressPerfParser
 from .dpdk_crypto_perf import DpdkCryptoPerfParser
 from .dpdk_testpmd import DpdkTestpmdParser
+from .dpu_accel_combined import DpuAccelCombinedParser
 from .embedding import EmbeddingParser
 from .encryption import EncryptionParser
 from .fb_fiosynth import Fiosynth_Parser
@@ -82,6 +83,7 @@ def register_parsers(factory):
     factory.register("dpdk_compress_perf", DpdkCompressPerfParser)
     factory.register("dpdk_crypto_perf", DpdkCryptoPerfParser)
     factory.register("dpdk_testpmd", DpdkTestpmdParser)
+    factory.register("dpu_accel_combined", DpuAccelCombinedParser)
     factory.register("encryption", EncryptionParser)
     factory.register("fb_fiosynth", Fiosynth_Parser)
     factory.register("fbgemm", FbgemmParser)

--- a/benchpress/plugins/parsers/__init__.py
+++ b/benchpress/plugins/parsers/__init__.py
@@ -43,6 +43,7 @@ from .multichase_pingpong import MultichasePingpongParser
 from .multichase_pointer import MultichasePointerParser
 from .nginx_wrk_bench import NginxWrkParser
 from .nnpi_net4 import NNPINet4Parser
+from .perftest import PerftestParser
 from .pytorch_gemm_gpuless import PytorchGemmGpulessParser
 from .rebatch import RebatchParser
 from .returncode import ReturncodeParser
@@ -104,6 +105,7 @@ def register_parsers(factory):
     factory.register("lmbench_lat_mem_rd", LmbenchLatMemRdParser)
     factory.register("checkmark", CheckmarkParser)
     factory.register("nnpi_net4", NNPINet4Parser)
+    factory.register("perftest", PerftestParser)
     factory.register("feedsim", FeedSimParser)
     factory.register("feedsim_autoscale", FeedSimAutoscaleParser)
     factory.register("tailbench_imgdnn", TailBenchParser)

--- a/benchpress/plugins/parsers/__init__.py
+++ b/benchpress/plugins/parsers/__init__.py
@@ -48,6 +48,7 @@ from .multichase_pointer import MultichasePointerParser
 from .nginx_wrk_bench import NginxWrkParser
 from .nnpi_net4 import NNPINet4Parser
 from .openssl_speed import OpensslSpeedParser
+from .ovs_ofperf import OvsOfperfParser
 from .perftest import PerftestParser
 from .pytorch_gemm_gpuless import PytorchGemmGpulessParser
 from .rebatch import RebatchParser
@@ -115,6 +116,7 @@ def register_parsers(factory):
     factory.register("lmbench_lat_mem_rd", LmbenchLatMemRdParser)
     factory.register("lzbench_perf", LzbenchPerfParser)
     factory.register("openssl_speed", OpensslSpeedParser)
+    factory.register("ovs_ofperf", OvsOfperfParser)
     factory.register("checkmark", CheckmarkParser)
     factory.register("nnpi_net4", NNPINet4Parser)
     factory.register("perftest", PerftestParser)

--- a/benchpress/plugins/parsers/dpdk_compress_perf.py
+++ b/benchpress/plugins/parsers/dpdk_compress_perf.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-unsafe
+
+"""Parser for DPDK's `dpdk-test-compress-perf` in throughput mode.
+
+The throughput-mode table (from app/test-compress-perf/comp_perf_test_throughput.c)
+is emitted after the EAL banner and per-lcore device-pairing lines. Real
+DPDK 25.11 output looks like:
+
+      lcore id Level   Comp size   Comp ratio [%]    Comp [Gbps]   Decomp [Gbps]
+             1     1        1595             2.43           8.04           23.22
+             4     1        1595             2.43           7.96           22.81
+             ...
+
+Columns:
+  0. lcore id              integer
+  1. Level                 integer (compression level used)
+  2. Comp size             integer (compressed payload size, bytes)
+  3. Comp ratio [%]        float   (compressed / original × 100; lower = denser)
+  4. Comp [Gbps]           float   (compression throughput on that lcore)
+  5. Decomp [Gbps]         float   (decompression throughput on that lcore)
+
+We aggregate across lcores into:
+  - per-lcore_rows: list of [lcore_id, level, comp_size, ratio_pct, comp_gbps, decomp_gbps]
+  - compress_throughput_Gbps_avg / _min / _max
+  - decompress_throughput_Gbps_avg / _min / _max
+  - compression_ratio_pct (constant across rows — recorded from the first row)
+  - num_lcores
+"""
+
+from benchpress.lib.parser import Parser
+
+
+def _is_header_line(line: str) -> bool:
+    return (
+        "lcore" in line
+        and "Level" in line
+        and "Comp" in line
+        and "ratio" in line
+        and "Gbps" in line
+    )
+
+
+class DpdkCompressPerfParser(Parser):
+    def parse(self, stdout, stderr, returncode):
+        metrics = {}
+        in_table = False
+        rows = []
+        for raw in stdout:
+            line = raw.strip()
+            if not line:
+                continue
+            if not in_table:
+                if _is_header_line(line):
+                    in_table = True
+                continue
+            parts = line.split()
+            # First non-row line after header ends the table; per-lcore data
+            # rows always start with an integer (lcore id).
+            try:
+                lcore = int(parts[0])
+            except (ValueError, IndexError):
+                in_table = False
+                continue
+            if len(parts) < 6:
+                continue
+            try:
+                level = int(parts[1])
+                comp_size = int(parts[2])
+                ratio_pct = float(parts[3])
+                comp_gbps = float(parts[4])
+                decomp_gbps = float(parts[5])
+            except ValueError:
+                continue
+            rows.append([lcore, level, comp_size, ratio_pct, comp_gbps, decomp_gbps])
+
+        if not rows:
+            return metrics
+
+        comp_vals = [r[4] for r in rows]
+        decomp_vals = [r[5] for r in rows]
+        metrics["num_lcores"] = len(rows)
+        metrics["compression_ratio_pct"] = rows[0][3]
+        metrics["compressed_size_bytes"] = rows[0][2]
+        metrics["compression_level"] = rows[0][1]
+        metrics["compress_throughput_Gbps_avg"] = sum(comp_vals) / len(comp_vals)
+        metrics["compress_throughput_Gbps_min"] = min(comp_vals)
+        metrics["compress_throughput_Gbps_max"] = max(comp_vals)
+        metrics["decompress_throughput_Gbps_avg"] = sum(decomp_vals) / len(decomp_vals)
+        metrics["decompress_throughput_Gbps_min"] = min(decomp_vals)
+        metrics["decompress_throughput_Gbps_max"] = max(decomp_vals)
+        metrics["per_lcore_rows"] = rows
+        return metrics

--- a/benchpress/plugins/parsers/dpdk_crypto_perf.py
+++ b/benchpress/plugins/parsers/dpdk_crypto_perf.py
@@ -30,13 +30,26 @@ The columns are positional (10 fields):
 
 We parse by column position once we've identified the header.
 
+When --buffer-sz is given as a comma-separated sweep (e.g.
+"64,256,1024,4096,8192,16384"), DPDK prints one row per (lcore, buf-size)
+under a single header. We bucket rows by buffer size, then:
+  - report the per-bucket avg/min/max as `throughput_Gbps_avg_at_<sz>` etc.
+  - report the bucket with the highest avg as `throughput_Gbps_avg` (peak)
+    so single-scalar consumers see the headline number, not a mix of 64 B
+    and 16 KB results.
+
 Emitted metrics:
-  - per_lcore_rows: list of [lcore_id, mops, gbps, cycles_per_buf]
-  - num_lcores
-  - buffer_size, burst_size (constant across rows)
-  - throughput_Gbps_avg / _min / _max
-  - mops_avg / _min / _max
-  - cycles_per_buf_avg
+  - per_lcore_rows: list of [lcore_id, buf_size, mops, gbps, cycles_per_buf]
+  - num_lcores                    (rows per buffer size; assumed constant)
+  - buffer_sizes                  (list of buf sizes observed)
+  - burst_size                    (constant across rows)
+  - throughput_Gbps_avg           (peak bucket avg across buffer sizes)
+  - throughput_Gbps_min / _max    (across all rows)
+  - throughput_Gbps_avg_at_<sz>   (per-bucket avg)
+  - mops_avg                      (peak bucket avg across buffer sizes)
+  - mops_min / _max               (across all rows)
+  - mops_avg_at_<sz>              (per-bucket avg)
+  - cycles_per_buf_avg            (across all rows)
   - failed_enqueued_total, failed_dequeued_total (zero on success)
 """
 
@@ -90,21 +103,46 @@ class DpdkCryptoPerfParser(Parser):
         if not rows:
             return metrics
 
+        # Bucket rows by buffer size so a sweep doesn't average 64 B and
+        # 16 KB results together.
+        by_buf = {}
+        for r in rows:
+            by_buf.setdefault(r[1], []).append(r)
+
         gbps_vals = [r[4] for r in rows]
         mops_vals = [r[3] for r in rows]
         cyc_vals = [r[5] for r in rows]
-        metrics["num_lcores"] = len(rows)
-        metrics["buffer_size"] = rows[0][1]
+        metrics["num_lcores"] = len(next(iter(by_buf.values())))
+        metrics["buffer_sizes"] = sorted(by_buf.keys())
         metrics["burst_size"] = rows[0][2]
-        metrics["throughput_Gbps_avg"] = sum(gbps_vals) / len(gbps_vals)
+
+        peak_gbps_bucket_avg = 0.0
+        peak_mops_bucket_avg = 0.0
+        for buf_size in sorted(by_buf):
+            bucket = by_buf[buf_size]
+            bg = [r[4] for r in bucket]
+            bm = [r[3] for r in bucket]
+            bg_avg = sum(bg) / len(bg)
+            bm_avg = sum(bm) / len(bm)
+            metrics[f"throughput_Gbps_avg_at_{buf_size}"] = bg_avg
+            metrics[f"mops_avg_at_{buf_size}"] = bm_avg
+            if bg_avg > peak_gbps_bucket_avg:
+                peak_gbps_bucket_avg = bg_avg
+            if bm_avg > peak_mops_bucket_avg:
+                peak_mops_bucket_avg = bm_avg
+
+        # Headline single-scalar metrics are the peak bucket's per-lcore
+        # average so a sweep summary doesn't get dragged down by the 64 B
+        # tail. Single-buffer-size runs collapse to the same thing.
+        metrics["throughput_Gbps_avg"] = peak_gbps_bucket_avg
         metrics["throughput_Gbps_min"] = min(gbps_vals)
         metrics["throughput_Gbps_max"] = max(gbps_vals)
-        metrics["mops_avg"] = sum(mops_vals) / len(mops_vals)
+        metrics["mops_avg"] = peak_mops_bucket_avg
         metrics["mops_min"] = min(mops_vals)
         metrics["mops_max"] = max(mops_vals)
         metrics["cycles_per_buf_avg"] = sum(cyc_vals) / len(cyc_vals)
         metrics["failed_enqueued_total"] = failed_enq_total
         metrics["failed_dequeued_total"] = failed_deq_total
-        # per-lcore row: [lcore_id, mops, gbps, cycles_per_buf]
-        metrics["per_lcore_rows"] = [[r[0], r[3], r[4], r[5]] for r in rows]
+        # per-lcore row: [lcore_id, buf_size, mops, gbps, cycles_per_buf]
+        metrics["per_lcore_rows"] = [[r[0], r[1], r[3], r[4], r[5]] for r in rows]
         return metrics

--- a/benchpress/plugins/parsers/dpdk_crypto_perf.py
+++ b/benchpress/plugins/parsers/dpdk_crypto_perf.py
@@ -1,0 +1,110 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-unsafe
+
+"""Parser for DPDK's `dpdk-test-crypto-perf` in throughput mode.
+
+Throughput-mode output (from app/test-crypto-perf/cperf_test_throughput.c)
+emits a fixed per-lcore table after the EAL banner and per-option dump. Real
+DPDK 25.11 output looks like:
+
+      lcore id    Buf Size  Burst Size    Enqueued    Dequeued  Failed Enq  Failed Deq        MOps        Gbps  Cycles/Buf
+             1        1024          32      100000      100000           0           0    4.583819   37.550642      218.16
+             2        1024          32      100000      100000           0           0    4.568119   37.422031      218.91
+
+The columns are positional (10 fields):
+  0. lcore id        (int)
+  1. Buf Size        (int)
+  2. Burst Size      (int)
+  3. Enqueued        (int)
+  4. Dequeued        (int)
+  5. Failed Enq      (int)
+  6. Failed Deq      (int)
+  7. MOps            (float, millions of ops/sec)
+  8. Gbps            (float, throughput)
+  9. Cycles/Buf      (float)
+
+We parse by column position once we've identified the header.
+
+Emitted metrics:
+  - per_lcore_rows: list of [lcore_id, mops, gbps, cycles_per_buf]
+  - num_lcores
+  - buffer_size, burst_size (constant across rows)
+  - throughput_Gbps_avg / _min / _max
+  - mops_avg / _min / _max
+  - cycles_per_buf_avg
+  - failed_enqueued_total, failed_dequeued_total (zero on success)
+"""
+
+from benchpress.lib.parser import Parser
+
+
+def _is_header_line(line: str) -> bool:
+    return "lcore" in line and "Burst" in line and "MOps" in line and "Gbps" in line
+
+
+class DpdkCryptoPerfParser(Parser):
+    def parse(self, stdout, stderr, returncode):
+        metrics = {}
+        in_table = False
+        rows = []
+        failed_enq_total = 0
+        failed_deq_total = 0
+        for raw in stdout:
+            line = raw.strip()
+            if not line:
+                continue
+            if not in_table:
+                if _is_header_line(line):
+                    in_table = True
+                continue
+            parts = line.split()
+            try:
+                lcore = int(parts[0])
+            except (ValueError, IndexError):
+                in_table = False
+                continue
+            # 10-column DPDK >= ~21.05 throughput schema. Skip rows that
+            # don't match (e.g. an unexpected footer line that begins with
+            # a digit but has fewer columns).
+            if len(parts) < 10:
+                continue
+            try:
+                buf_size = int(parts[1])
+                burst_size = int(parts[2])
+                failed_enq = int(parts[5])
+                failed_deq = int(parts[6])
+                mops = float(parts[7])
+                gbps = float(parts[8])
+                cycles_per_buf = float(parts[9])
+            except ValueError:
+                continue
+            rows.append([lcore, buf_size, burst_size, mops, gbps, cycles_per_buf])
+            failed_enq_total += failed_enq
+            failed_deq_total += failed_deq
+
+        if not rows:
+            return metrics
+
+        gbps_vals = [r[4] for r in rows]
+        mops_vals = [r[3] for r in rows]
+        cyc_vals = [r[5] for r in rows]
+        metrics["num_lcores"] = len(rows)
+        metrics["buffer_size"] = rows[0][1]
+        metrics["burst_size"] = rows[0][2]
+        metrics["throughput_Gbps_avg"] = sum(gbps_vals) / len(gbps_vals)
+        metrics["throughput_Gbps_min"] = min(gbps_vals)
+        metrics["throughput_Gbps_max"] = max(gbps_vals)
+        metrics["mops_avg"] = sum(mops_vals) / len(mops_vals)
+        metrics["mops_min"] = min(mops_vals)
+        metrics["mops_max"] = max(mops_vals)
+        metrics["cycles_per_buf_avg"] = sum(cyc_vals) / len(cyc_vals)
+        metrics["failed_enqueued_total"] = failed_enq_total
+        metrics["failed_dequeued_total"] = failed_deq_total
+        # per-lcore row: [lcore_id, mops, gbps, cycles_per_buf]
+        metrics["per_lcore_rows"] = [[r[0], r[3], r[4], r[5]] for r in rows]
+        return metrics

--- a/benchpress/plugins/parsers/dpdk_testpmd.py
+++ b/benchpress/plugins/parsers/dpdk_testpmd.py
@@ -36,9 +36,19 @@ _PORT_HDR_RE = re.compile(r"Forward statistics for port\s+(\d+)")
 _RX_RE = re.compile(r"RX-packets:\s+(\d+)\s+RX-dropped:\s+(\d+)")
 _TX_RE = re.compile(r"TX-packets:\s+(\d+)\s+TX-dropped:\s+(\d+)")
 
+# Trailing summary lines emitted by run_nic_sriov.sh after the per-VF
+# testpmd outputs. Optional; absent for plain emu_virtio_net runs.
+_SRIOV_KV_KEYS = {
+    "num_vfs",
+    "aggregate_rx_packets_total",
+    "aggregate_tx_packets_total",
+    "aggregate_rx_dropped_total",
+}
+_KV_RE = re.compile(r"^([a-z_]+):\s*(\d+)\s*$")
+
 
 class DpdkTestpmdParser(Parser):
-    def parse(self, stdout, stderr, returncode):
+    def parse(self, stdout, stderr, returncode):  # noqa: C901
         metrics: Dict = {}
         # Track per-port latest counters; testpmd may emit multiple snapshots
         # under --stats-period, so we want the most recent one.
@@ -52,6 +62,10 @@ class DpdkTestpmdParser(Parser):
             if m:
                 current_port = int(m.group(1))
                 latest_per_port.setdefault(current_port, {})
+                continue
+            m = _KV_RE.match(line)
+            if m and m.group(1) in _SRIOV_KV_KEYS:
+                metrics[m.group(1)] = int(m.group(2))
                 continue
             if current_port is None:
                 continue

--- a/benchpress/plugins/parsers/dpdk_testpmd.py
+++ b/benchpress/plugins/parsers/dpdk_testpmd.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-unsafe
+
+"""Parser for DPDK testpmd's `--stats-period` periodic-stats output.
+
+testpmd prints a per-port stats block every `--stats-period` seconds:
+
+  ---------------------- Forward statistics for port 0  ----------------------
+    RX-packets: 12345              RX-dropped: 0             RX-total: 12345
+    TX-packets: 12345              TX-dropped: 0             TX-total: 12345
+    ----------------------------------------------------------------------------
+
+We extract the last RX/TX counts (the snapshot taken just before testpmd
+exits) and compute pps from `--stats-period`-derived duration where we
+can. Limitations:
+  - testpmd reports cumulative packet counts, not pps directly; the
+    parser captures the final cumulative counts and the operator supplies
+    the duration externally (job knows it; benchpress passes the args).
+  - When testpmd runs against the DPU-emulated virtio-net SDI the bench
+    is fundamentally DPU-gated; see README's "Tier 1 benches deferred or
+    skipped" section.
+"""
+
+import re
+from typing import Dict, List
+
+from benchpress.lib.parser import Parser
+
+
+_PORT_HDR_RE = re.compile(r"Forward statistics for port\s+(\d+)")
+_RX_RE = re.compile(r"RX-packets:\s+(\d+)\s+RX-dropped:\s+(\d+)")
+_TX_RE = re.compile(r"TX-packets:\s+(\d+)\s+TX-dropped:\s+(\d+)")
+
+
+class DpdkTestpmdParser(Parser):
+    def parse(self, stdout, stderr, returncode):
+        metrics: Dict = {}
+        # Track per-port latest counters; testpmd may emit multiple snapshots
+        # under --stats-period, so we want the most recent one.
+        latest_per_port: Dict[int, Dict[str, int]] = {}
+        current_port = None
+        for raw in stdout:
+            line = raw.strip()
+            if not line:
+                continue
+            m = _PORT_HDR_RE.search(line)
+            if m:
+                current_port = int(m.group(1))
+                latest_per_port.setdefault(current_port, {})
+                continue
+            if current_port is None:
+                continue
+            m = _RX_RE.search(line)
+            if m:
+                latest_per_port[current_port]["rx_packets"] = int(m.group(1))
+                latest_per_port[current_port]["rx_dropped"] = int(m.group(2))
+                continue
+            m = _TX_RE.search(line)
+            if m:
+                latest_per_port[current_port]["tx_packets"] = int(m.group(1))
+                latest_per_port[current_port]["tx_dropped"] = int(m.group(2))
+                continue
+
+        if not latest_per_port:
+            return metrics
+        ports: List[List] = []
+        rx_total = 0
+        tx_total = 0
+        rx_dropped_total = 0
+        tx_dropped_total = 0
+        for port, counts in sorted(latest_per_port.items()):
+            ports.append(
+                [
+                    port,
+                    counts.get("rx_packets", 0),
+                    counts.get("rx_dropped", 0),
+                    counts.get("tx_packets", 0),
+                    counts.get("tx_dropped", 0),
+                ]
+            )
+            rx_total += counts.get("rx_packets", 0)
+            rx_dropped_total += counts.get("rx_dropped", 0)
+            tx_total += counts.get("tx_packets", 0)
+            tx_dropped_total += counts.get("tx_dropped", 0)
+        metrics["num_ports"] = len(ports)
+        metrics["per_port_counts"] = ports
+        metrics["rx_packets_total"] = rx_total
+        metrics["tx_packets_total"] = tx_total
+        metrics["rx_dropped_total"] = rx_dropped_total
+        metrics["tx_dropped_total"] = tx_dropped_total
+        return metrics

--- a/benchpress/plugins/parsers/dpu_accel_combined.py
+++ b/benchpress/plugins/parsers/dpu_accel_combined.py
@@ -1,0 +1,108 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-unsafe
+
+"""Parser for run_accel_combined.sh multi-leg output.
+
+run_accel_combined.sh runs a workload through more than one path in a
+single job (host vs offload for crypto/compress; copy vs crc32c for the
+SPDK data-mover) and wraps each leg in a marker line:
+
+    ##DPU_PERF_LEG=<label>,<subparser>##
+    <raw output of that leg, in the sub-tool's native format>
+
+This parser splits on those markers, runs the named sub-parser on each
+section (reusing the exact same parsing as the standalone jobs), and
+namespaces every metric as ``<label>_<metric>`` — e.g.
+``host_cipher_throughput_MBps_max``, ``offload_throughput_Gbps_avg``,
+``copy_total_throughput_MiBps``.
+
+When both a ``host`` and an ``offload`` leg are present and expose a
+comparable throughput metric, it also emits ``offload_vs_host_speedup``
+(offload / host, with the host figure unit-converted to match). A leg
+that printed ``##DPU_PERF_LEG_FAILED=<label>##`` contributes a
+``<label>_failed = True`` marker and is skipped for speedup.
+"""
+
+import re
+
+from benchpress.lib.parser import Parser
+
+from .dpdk_compress_perf import DpdkCompressPerfParser
+from .dpdk_crypto_perf import DpdkCryptoPerfParser
+from .lzbench_perf import LzbenchPerfParser
+from .openssl_speed import OpensslSpeedParser
+from .spdk_accel_perf import SpdkAccelPerfParser
+
+_LEG_RE = re.compile(r"^##DPU_PERF_LEG=([a-z0-9_]+),([a-z0-9_]+)##\s*$")
+_FAIL_RE = re.compile(r"^##DPU_PERF_LEG_FAILED=([a-z0-9_]+)##\s*$")
+
+_SUBPARSERS = {
+    "openssl_speed": OpensslSpeedParser,
+    "dpdk_crypto_perf": DpdkCryptoPerfParser,
+    "dpdk_compress_perf": DpdkCompressPerfParser,
+    "lzbench_perf": LzbenchPerfParser,
+    "spdk_accel_perf": SpdkAccelPerfParser,
+}
+
+# Ordered list of (offload_key, host_key, host_to_offload_factor) tuples
+# tried for the offload-vs-host speedup. The factor converts the host
+# metric into the offload metric's unit:
+#   - crypto: openssl reports decimal MB/s, dpdk reports Gb/s
+#     -> Gbps = MBps * 8 / 1000  => factor 0.008
+#   - compress: same MB/s -> Gb/s conversion on the host (lzbench) side
+_SPEEDUP_PAIRS = [
+    ("offload_throughput_Gbps_avg", "host_cipher_throughput_MBps_max", 0.008),
+    ("offload_compress_throughput_Gbps_avg", "host_best_compress_MBps", 0.008),
+]
+
+
+def _split_sections(stdout):
+    """Yield (label, subparser_name, lines, failed) per leg."""
+    sections = []
+    cur = None
+    failed = set()
+    for raw in stdout:
+        line = raw.rstrip("\n")
+        m = _LEG_RE.match(line)
+        if m:
+            cur = {"label": m.group(1), "sub": m.group(2), "lines": []}
+            sections.append(cur)
+            continue
+        mf = _FAIL_RE.match(line)
+        if mf:
+            failed.add(mf.group(1))
+            continue
+        if cur is not None:
+            cur["lines"].append(line)
+    for s in sections:
+        yield s["label"], s["sub"], s["lines"], (s["label"] in failed)
+
+
+class DpuAccelCombinedParser(Parser):
+    def parse(self, stdout, stderr, returncode):
+        metrics = {}
+        for label, sub, lines, failed in _split_sections(stdout):
+            if failed:
+                metrics[f"{label}_failed"] = True
+                continue
+            parser_cls = _SUBPARSERS.get(sub)
+            if parser_cls is None:
+                continue
+            leg_metrics = parser_cls().parse(lines, [], 0)
+            for k, v in leg_metrics.items():
+                metrics[f"{label}_{k}"] = v
+
+        for off_key, host_key, factor in _SPEEDUP_PAIRS:
+            off = metrics.get(off_key)
+            host = metrics.get(host_key)
+            if isinstance(off, (int, float)) and isinstance(host, (int, float)):
+                denom = host * factor
+                if denom > 0:
+                    metrics["offload_vs_host_speedup"] = off / denom
+                    break
+        return metrics

--- a/benchpress/plugins/parsers/dpu_accel_combined.py
+++ b/benchpress/plugins/parsers/dpu_accel_combined.py
@@ -60,6 +60,23 @@ _SPEEDUP_PAIRS = [
     ("offload_compress_throughput_Gbps_avg", "host_best_compress_MBps", 0.008),
 ]
 
+# (baseline_key, treatment_key, out_key) — emit a percent overhead
+# (baseline - treatment) / baseline * 100 when both legs are present.
+# Used by --kind=dif, where the legs are a baseline memcpy and the DIF
+# generate/verify SPDK accel workloads (same MiB/s unit).
+_OVERHEAD_PAIRS = [
+    (
+        "baseline_total_throughput_MiBps",
+        "dif_generate_copy_total_throughput_MiBps",
+        "dif_generate_overhead_pct",
+    ),
+    (
+        "baseline_total_throughput_MiBps",
+        "dif_verify_total_throughput_MiBps",
+        "dif_verify_overhead_pct",
+    ),
+]
+
 
 def _split_sections(stdout):
     """Yield (label, subparser_name, lines, failed) per leg."""
@@ -105,4 +122,11 @@ class DpuAccelCombinedParser(Parser):
                 if denom > 0:
                     metrics["offload_vs_host_speedup"] = off / denom
                     break
+
+        for base_key, treat_key, out_key in _OVERHEAD_PAIRS:
+            base = metrics.get(base_key)
+            treat = metrics.get(treat_key)
+            if isinstance(base, (int, float)) and isinstance(treat, (int, float)):
+                if base > 0:
+                    metrics[out_key] = (base - treat) / base * 100.0
         return metrics

--- a/benchpress/plugins/parsers/lzbench_perf.py
+++ b/benchpress/plugins/parsers/lzbench_perf.py
@@ -1,0 +1,94 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-unsafe
+
+"""Parser for `lzbench` standard (raw) output as used by the dpu_perf suite.
+
+lzbench prints a header + per-codec rows:
+
+    lzbench 1.8.1 (64-bit Linux)   Assembled by P.Skibinski
+    Compressor name          Compress. Decompress. Compr. size  Ratio Filename
+    memcpy                    8889 MB/s   8930 MB/s   211957760 100.00 silesia.tar
+    zstd 1.5.4 -1              450 MB/s    1300 MB/s    72445832  34.18 silesia.tar
+    zstd 1.5.4 -3              340 MB/s    1280 MB/s    68000000  32.08 silesia.tar
+
+We use a single regex anchored on the last 4 numeric fields so the variable
+"Compressor name" column (which may contain spaces, version tags, and a
+"-N" level suffix) can be captured as the leading slice.
+
+Emitted metrics:
+  - codecs: list of [name, compress_MBps, decompress_MBps, comp_size, ratio_pct]
+  - best_compress_MBps / best_decompress_MBps (excluding the memcpy reference
+    row, which represents the raw IO ceiling, not compression)
+  - best_compress_codec / best_decompress_codec
+  - memcpy_compress_MBps / memcpy_decompress_MBps (if present)
+"""
+
+import re
+from typing import List, Optional, Tuple
+
+from benchpress.lib.parser import Parser
+
+
+# Capture: leading-name, comp_MBps, decomp_MBps, comp_size, ratio
+_ROW_RE = re.compile(
+    r"^(?P<name>\S.*?)\s+"
+    r"(?P<comp>\d+(?:\.\d+)?)\s*MB/s\s+"
+    r"(?P<decomp>\d+(?:\.\d+)?)\s*MB/s\s+"
+    r"(?P<size>\d+)\s+"
+    r"(?P<ratio>\d+\.\d+)"
+)
+
+
+def _parse_row(line: str) -> Optional[Tuple[str, float, float, int, float]]:
+    m = _ROW_RE.match(line.rstrip())
+    if not m:
+        return None
+    return (
+        m.group("name").strip(),
+        float(m.group("comp")),
+        float(m.group("decomp")),
+        int(m.group("size")),
+        float(m.group("ratio")),
+    )
+
+
+class LzbenchPerfParser(Parser):
+    def parse(self, stdout, stderr, returncode):
+        metrics = {}
+        codecs: List[list] = []
+        for raw in stdout:
+            parsed = _parse_row(raw)
+            if parsed is None:
+                continue
+            name, comp, decomp, size, ratio = parsed
+            codecs.append([name, comp, decomp, size, ratio])
+
+        if not codecs:
+            return metrics
+
+        metrics["codecs"] = codecs
+        metrics["num_codecs"] = len(codecs)
+
+        # memcpy is lzbench's reference row — captures raw IO ceiling. Record
+        # separately and exclude from best-compression aggregation.
+        non_memcpy = []
+        for row in codecs:
+            if row[0].lower().startswith("memcpy"):
+                metrics["memcpy_compress_MBps"] = row[1]
+                metrics["memcpy_decompress_MBps"] = row[2]
+            else:
+                non_memcpy.append(row)
+
+        if non_memcpy:
+            best_comp = max(non_memcpy, key=lambda r: r[1])
+            best_dec = max(non_memcpy, key=lambda r: r[2])
+            metrics["best_compress_codec"] = best_comp[0]
+            metrics["best_compress_MBps"] = best_comp[1]
+            metrics["best_decompress_codec"] = best_dec[0]
+            metrics["best_decompress_MBps"] = best_dec[2]
+        return metrics

--- a/benchpress/plugins/parsers/openssl_speed.py
+++ b/benchpress/plugins/parsers/openssl_speed.py
@@ -1,0 +1,162 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-unsafe
+
+"""Parser for `openssl speed` output as used by the dpu_perf suite.
+
+Handles three distinct openssl-speed output shapes:
+
+  1) Symmetric / hash table (`openssl speed -evp aes-256-gcm`):
+
+       type             16 bytes     64 bytes    256 bytes   1024 bytes   8192 bytes  16384 bytes
+       aes-256-gcm    1234567.89k  2345678.90k   3456789.01k   4567890.12k   5678901.23k  6789012.34k
+
+     Throughput at each buffer size in 1000-byte/sec (the `k` is decimal
+     kilobytes/sec per openssl convention, not 1024).
+
+  2) Diffie-Hellman / signature ops table (`openssl speed ecdh`):
+
+                                     op      op/s
+        160 bits ecdh (secp160r1)   0.0001s   123456.7
+        256 bits ecdh (nistp256)    0.0001s   123456.7
+
+  3) Sign/verify ops table (`openssl speed ecdsa rsa`):
+
+                                     sign    verify    sign/s verify/s
+        160 bits ecdsa (secp160r1)   0.0001s   0.0002s   12345.6    9876.5
+
+We emit:
+  - cipher_throughput_MBps_at_<N>B  (for each block-size column)
+  - cipher_throughput_MBps_max      (max across block sizes)
+  - cipher_algo                     (the EVP algo name)
+  - asym_ops: list of [algo, op_type, ops_per_sec]
+  - asym_best_ops_per_sec / asym_best_algo
+"""
+
+import re
+from typing import Iterable, List
+
+from benchpress.lib.parser import Parser
+
+
+# Cipher/hash header looks like: "type 16 bytes 64 bytes 256 bytes ..."
+_CIPHER_HEADER_RE = re.compile(r"^\s*type\b")
+# Per-row: "<algo>  <val>k  <val>k  ...". The `k` suffix is openssl convention
+# for 1000-byte/sec (decimal). We capture algo + every "<num>k" token.
+_CIPHER_K_RE = re.compile(r"([0-9]+\.[0-9]+|[0-9]+)k\b")
+
+# Header that introduces a "op / op/s" or "sign/verify" asym table.
+_ASYM_HEADER_RE = re.compile(r"^\s+(op\b|sign\b)")
+# Per-row: leading algo name, then time/sec pairs ending in numeric op/s.
+# We grab the last float as op/s (or two trailing floats for sign+verify).
+
+
+def _read_cipher_block(lines: Iterable[str]) -> dict:
+    """Parse the symmetric/hash table starting from the header line."""
+    out = {}
+    header = None
+    bytes_columns: List[int] = []
+    for raw in lines:
+        line = raw.rstrip()
+        if not line.strip():
+            continue
+        if _CIPHER_HEADER_RE.match(line):
+            header = line
+            # Pull every "<N> bytes" into bytes_columns.
+            bytes_columns = [int(b) for b in re.findall(r"(\d+)\s*bytes", header)]
+            continue
+        if header is None:
+            continue
+        # First token is the algo name; subsequent tokens are <num>k values.
+        parts = line.strip().split()
+        if not parts:
+            continue
+        algo = parts[0]
+        # The "k" suffix is openssl convention for 1000 B/s.
+        rates_kBps = [float(m) for m in _CIPHER_K_RE.findall(line)]
+        if not rates_kBps:
+            continue
+        out["cipher_algo"] = algo
+        rates_MBps = [r * 1000.0 / 1_000_000.0 for r in rates_kBps]  # → MB/s decimal
+        for i, mbps in enumerate(rates_MBps):
+            block = bytes_columns[i] if i < len(bytes_columns) else i
+            out[f"cipher_throughput_MBps_at_{block}B"] = mbps
+        out["cipher_throughput_MBps_max"] = max(rates_MBps)
+        return out
+    return out
+
+
+# Trailing time-per-op token, e.g. "0.0000s" or "0s".
+_TIME_TOK_RE = re.compile(r"^\d+(?:\.\d+)?s$")
+# Pure float / int (no 's' suffix) — op/s column tokens.
+_FLOAT_TOK_RE = re.compile(r"^\d+(?:\.\d+)?$")
+
+
+def _read_asym_block(lines: Iterable[str]) -> dict:
+    """Parse the asym (ecdh / ecdsa / rsa / dh) op/s tables.
+
+    Sample row (ECDH): "256 bits ecdh (nistp256)   0.0001s  24468.7"
+    Sample row (ECDSA sign+verify):
+        "256 bits ecdsa (nistp256)   0.0001s   0.0002s   12345.6    9876.5"
+
+    We split on whitespace, then walk the token list to find the first
+    time-format token ("Ns" / "N.NNNNs"). Algo label = everything before
+    that; ops/s columns = pure floats after the time tokens.
+    """
+    out: dict = {}
+    asym_rows: List[list] = []
+    in_block = False
+    for raw in lines:
+        line = raw.rstrip()
+        if not line.strip():
+            in_block = False
+            continue
+        if _ASYM_HEADER_RE.match(line):
+            in_block = True
+            continue
+        if not in_block:
+            continue
+        toks = line.strip().split()
+        # Find the first time-format token; everything before it is the algo
+        # label.
+        first_time_idx = next(
+            (i for i, t in enumerate(toks) if _TIME_TOK_RE.match(t)),
+            None,
+        )
+        if first_time_idx is None or first_time_idx == 0:
+            continue
+        algo = " ".join(toks[:first_time_idx]).strip()
+        # After the time column(s), the trailing pure-float tokens are op/s.
+        ops_per_sec = [
+            float(t) for t in toks[first_time_idx:] if _FLOAT_TOK_RE.match(t)
+        ]
+        if not ops_per_sec:
+            continue
+        if len(ops_per_sec) == 1:
+            asym_rows.append([algo, "op", ops_per_sec[0]])
+        else:
+            # First is sign/s, second is verify/s (any extras are ignored).
+            asym_rows.append([algo, "sign", ops_per_sec[0]])
+            asym_rows.append([algo, "verify", ops_per_sec[1]])
+
+    if asym_rows:
+        out["asym_ops"] = asym_rows
+        best = max(asym_rows, key=lambda r: r[2])
+        out["asym_best_algo"] = best[0]
+        out["asym_best_op"] = best[1]
+        out["asym_best_ops_per_sec"] = best[2]
+    return out
+
+
+class OpensslSpeedParser(Parser):
+    def parse(self, stdout, stderr, returncode):
+        metrics = {}
+        # Materialise so we can scan twice (cipher block, asym block).
+        lines = list(stdout)
+        metrics.update(_read_cipher_block(lines))
+        metrics.update(_read_asym_block(lines))
+        return metrics

--- a/benchpress/plugins/parsers/ovs_ofperf.py
+++ b/benchpress/plugins/parsers/ovs_ofperf.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-unsafe
+
+"""Parser for the dpu_perf `ovs_ofperf` wrapper.
+
+run_ovs.sh's `ovs_ofperf` mode prints parser-friendly key=value lines:
+
+    ovs_ofperf: num_flows=10000
+    ovs_ofperf: bridge=dpu_perf_brX
+    ovs_ofperf: elapsed_sec=2.345678
+    ovs_ofperf: flows_per_sec=4263.45
+
+Emitted metrics: num_flows (int), elapsed_sec (float),
+flows_per_sec (float).
+"""
+
+import re
+
+from benchpress.lib.parser import Parser
+
+
+_KV_RE = re.compile(r"^\s*ovs_ofperf:\s*([a-z_]+)=([^\s]+)\s*$")
+
+
+class OvsOfperfParser(Parser):
+    def parse(self, stdout, stderr, returncode):
+        metrics = {}
+        for raw in stdout:
+            m = _KV_RE.match(raw)
+            if not m:
+                continue
+            key = m.group(1)
+            raw_val = m.group(2)
+            if key == "num_flows":
+                try:
+                    metrics["num_flows"] = int(raw_val)
+                except ValueError:
+                    pass
+            elif key in ("elapsed_sec", "flows_per_sec"):
+                try:
+                    metrics[key] = float(raw_val)
+                except ValueError:
+                    pass
+            elif key == "bridge":
+                metrics["bridge"] = raw_val
+        return metrics

--- a/benchpress/plugins/parsers/ovs_ofperf.py
+++ b/benchpress/plugins/parsers/ovs_ofperf.py
@@ -6,17 +6,23 @@
 
 # pyre-unsafe
 
-"""Parser for the dpu_perf `ovs_ofperf` wrapper.
+"""Parser for the dpu_perf vSwitch benches (run_ovs.sh).
 
-run_ovs.sh's `ovs_ofperf` mode prints parser-friendly key=value lines:
+Each tool in run_ovs.sh emits parser-friendly `<tool>: key=value` lines:
 
     ovs_ofperf: num_flows=10000
-    ovs_ofperf: bridge=dpu_perf_brX
     ovs_ofperf: elapsed_sec=2.345678
     ovs_ofperf: flows_per_sec=4263.45
 
-Emitted metrics: num_flows (int), elapsed_sec (float),
-flows_per_sec (float).
+    acl_scale: num_rules=10000
+    acl_scale: sender_mbps=8231.7
+    acl_scale: receiver_mbps=8228.1
+
+Values that parse as ints stay ints; values that parse as floats become
+floats; everything else stays a string. The class name is kept as
+`OvsOfperfParser` for backward compatibility with the existing
+benchmarks_dpu_perf.yml entry; new ovs_* benches reference the same
+parser key.
 """
 
 import re
@@ -24,7 +30,19 @@ import re
 from benchpress.lib.parser import Parser
 
 
-_KV_RE = re.compile(r"^\s*ovs_ofperf:\s*([a-z_]+)=([^\s]+)\s*$")
+_KV_RE = re.compile(r"^\s*[a-z_][a-z0-9_]*:\s*([a-z_][a-z0-9_]*)=([^\s]+)\s*$")
+
+
+def _coerce(s: str):
+    try:
+        return int(s)
+    except ValueError:
+        pass
+    try:
+        return float(s)
+    except ValueError:
+        pass
+    return s
 
 
 class OvsOfperfParser(Parser):
@@ -34,18 +52,5 @@ class OvsOfperfParser(Parser):
             m = _KV_RE.match(raw)
             if not m:
                 continue
-            key = m.group(1)
-            raw_val = m.group(2)
-            if key == "num_flows":
-                try:
-                    metrics["num_flows"] = int(raw_val)
-                except ValueError:
-                    pass
-            elif key in ("elapsed_sec", "flows_per_sec"):
-                try:
-                    metrics[key] = float(raw_val)
-                except ValueError:
-                    pass
-            elif key == "bridge":
-                metrics["bridge"] = raw_val
+            metrics[m.group(1)] = _coerce(m.group(2))
         return metrics

--- a/benchpress/plugins/parsers/perftest.py
+++ b/benchpress/plugins/parsers/perftest.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-unsafe
+
+"""Parser for OFED perftest tools (ib_write_bw / ib_read_bw / ib_send_lat).
+
+perftest writes a fixed-format table inside two `--------` separator lines.
+There are two header shapes:
+
+  BW mode (ib_write_bw, ib_read_bw, ib_send_bw):
+     #bytes  #iterations  BW peak[MB/sec]  BW average[MB/sec]  MsgRate[Mpps]
+     65536   5000         11800.50         11750.25            0.179
+
+  Latency mode (ib_send_lat, ib_write_lat, ib_read_lat):
+     #bytes  #iterations  t_min[usec]  t_max[usec]  t_typical[usec]  t_avg[usec]  t_stdev[usec]  99% percentile[usec]  99.9% percentile[usec]
+     2       1000         1.10         1.50         1.20             1.22         0.05           1.40                  1.45
+
+We pick the mode by inspecting the header line that names the columns, then
+parse the immediately following data row.
+"""
+
+from benchpress.lib.parser import Parser
+
+
+class PerftestParser(Parser):
+    def parse(self, stdout, stderr, returncode):  # noqa: C901
+        metrics = {}
+        header = None
+        # Some perftest builds report BW units in either MB/sec or Gb/sec
+        # depending on the --report_gbits flag. We record whichever appears.
+        bw_unit = None
+        for raw in stdout:
+            line = raw.strip()
+            if not line:
+                continue
+            if "#bytes" in line and "#iterations" in line:
+                header = line
+                if "Gb/sec" in line:
+                    bw_unit = "Gbps"
+                elif "MB/sec" in line:
+                    bw_unit = "MBps"
+                continue
+            if header is None:
+                continue
+            parts = line.split()
+            # First non-header row that begins with a number is our data.
+            try:
+                float(parts[0])
+            except (ValueError, IndexError):
+                continue
+            # BW row
+            if "BW peak" in header:
+                try:
+                    metrics["bytes"] = int(parts[0])
+                    metrics["iterations"] = int(parts[1])
+                    bw_peak = float(parts[2])
+                    bw_avg = float(parts[3])
+                    msg_rate = float(parts[4])
+                    suffix = bw_unit or "MBps"
+                    metrics[f"bw_peak_{suffix}"] = bw_peak
+                    metrics[f"bw_avg_{suffix}"] = bw_avg
+                    metrics["msg_rate_Mpps"] = msg_rate
+                except (ValueError, IndexError):
+                    pass
+                header = None
+                continue
+            # Latency row
+            if "t_min" in header:
+                try:
+                    metrics["bytes"] = int(parts[0])
+                    metrics["iterations"] = int(parts[1])
+                    metrics["t_min_us"] = float(parts[2])
+                    metrics["t_max_us"] = float(parts[3])
+                    metrics["t_typical_us"] = float(parts[4])
+                    metrics["t_avg_us"] = float(parts[5])
+                    metrics["t_stdev_us"] = float(parts[6])
+                    if len(parts) > 7:
+                        metrics["t_p99_us"] = float(parts[7])
+                    if len(parts) > 8:
+                        metrics["t_p99_9_us"] = float(parts[8])
+                except (ValueError, IndexError):
+                    pass
+                header = None
+                continue
+        return metrics

--- a/benchpress/plugins/parsers/perftest.py
+++ b/benchpress/plugins/parsers/perftest.py
@@ -41,6 +41,8 @@ class PerftestParser(Parser):
                 header = line
                 if "Gb/sec" in line:
                     bw_unit = "Gbps"
+                elif "MiB/sec" in line:
+                    bw_unit = "MiBps"
                 elif "MB/sec" in line:
                     bw_unit = "MBps"
                 continue

--- a/benchpress/plugins/parsers/spdk_accel_perf.py
+++ b/benchpress/plugins/parsers/spdk_accel_perf.py
@@ -1,0 +1,137 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-unsafe
+
+"""Parser for SPDK's `accel_perf` (examples/accel/perf/accel_perf).
+
+accel_perf prints a setup block followed by a per-core CSV-shaped table
+and a Total summary. Real SPDK 25.05 output:
+
+  Accel Perf Configuration:
+  Workload Type:  copy
+  Transfer size:  4096 bytes
+  ...
+  Run time:       3 seconds
+
+  Core,Thread             Transfers        Bandwidth           Failed      Miscompares
+  ------------------------------------------------------------------------------------
+  0,0                    10533642/s      41147 MiB/s                0                0
+  ====================================================================================
+  Total                  10533642/s      41147 MiB/s                0                0
+
+Per-row layout: <core>,<thread>  <transfers>/s  <bandwidth> MiB/s
+<failed>  <miscompares>
+
+The `Total` row uses the literal string "Total" in place of "<core>,<thread>".
+
+Emitted metrics:
+  - workload, buffer_size_bytes, queue_depth, runtime_s
+  - total_transfers_per_sec, total_throughput_MiBps
+  - total_failed, total_miscompares
+  - num_threads, per_thread_rows
+"""
+
+import re
+from typing import List
+
+from benchpress.lib.parser import Parser
+
+
+_NUMERIC_RE = re.compile(r"^[0-9]+(?:\.[0-9]+)?$")
+# Per-row: `<core>,<thread>  <transfers>/s  <bandwidth> MiB/s  <failed>  <miscompares>`
+# Tolerant of decimal forms and whitespace runs.
+_ROW_RE = re.compile(
+    r"^\s*(?P<core>\d+),(?P<thread>\d+)\s+"
+    r"(?P<xfers>[0-9]+(?:\.[0-9]+)?)/s\s+"
+    r"(?P<bw>[0-9]+(?:\.[0-9]+)?)\s+MiB/s\s+"
+    r"(?P<failed>\d+)\s+(?P<misc>\d+)\s*$"
+)
+_TOTAL_RE = re.compile(
+    r"^\s*Total\s+"
+    r"(?P<xfers>[0-9]+(?:\.[0-9]+)?)/s\s+"
+    r"(?P<bw>[0-9]+(?:\.[0-9]+)?)\s+MiB/s\s+"
+    r"(?P<failed>\d+)\s+(?P<misc>\d+)\s*$"
+)
+
+
+def _maybe_int(s: str):
+    try:
+        return int(s)
+    except ValueError:
+        return None
+
+
+_HEADER_KEYS = {
+    "workload type:": ("workload", str),
+    "transfer size:": ("buffer_size_bytes", int),
+    "buffer size:": ("buffer_size_bytes", int),
+    "queue depth:": ("queue_depth", int),
+    "run time:": ("runtime_s", int),
+    "runtime:": ("runtime_s", int),
+}
+
+
+def _parse_header(stripped: str, metrics: dict) -> bool:
+    lower = stripped.lower()
+    for prefix, (name, kind) in _HEADER_KEYS.items():
+        if lower.startswith(prefix):
+            rhs = stripped.split(":", 1)[1].strip()
+            if kind is int:
+                v = _maybe_int(rhs.split()[0])
+                if v is not None:
+                    metrics[name] = v
+            else:
+                metrics[name] = rhs
+            return True
+    return False
+
+
+def _record_total(m, metrics: dict) -> None:
+    metrics["total_transfers_per_sec"] = float(m.group("xfers"))
+    metrics["total_throughput_MiBps"] = float(m.group("bw"))
+    metrics["total_failed"] = int(m.group("failed"))
+    metrics["total_miscompares"] = int(m.group("misc"))
+
+
+def _row_tuple(m) -> list:
+    return [
+        int(m.group("core")),
+        int(m.group("thread")),
+        float(m.group("xfers")),
+        float(m.group("bw")),
+        int(m.group("failed")),
+        int(m.group("misc")),
+    ]
+
+
+class SpdkAccelPerfParser(Parser):
+    def parse(self, stdout, stderr, returncode):
+        metrics = {}
+        per_thread: List[list] = []
+        for raw in stdout:
+            line = raw.rstrip()
+            stripped = line.strip()
+            if not stripped:
+                continue
+            if _parse_header(stripped, metrics):
+                continue
+            m = _TOTAL_RE.match(line)
+            if m:
+                _record_total(m, metrics)
+                continue
+            m = _ROW_RE.match(line)
+            if m:
+                per_thread.append(_row_tuple(m))
+
+        if per_thread:
+            metrics["num_threads"] = len(per_thread)
+            metrics["per_thread_rows"] = per_thread
+            if "total_throughput_MiBps" not in metrics:
+                metrics["total_throughput_MiBps"] = sum(r[3] for r in per_thread)
+            if "total_transfers_per_sec" not in metrics:
+                metrics["total_transfers_per_sec"] = sum(r[2] for r in per_thread)
+        return metrics

--- a/benchpress/plugins/parsers/spdk_integrity.py
+++ b/benchpress/plugins/parsers/spdk_integrity.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-unsafe
+
+"""Parser for the dpu_perf storage-integrity runner (spdk_nvmf_fio_runner.sh).
+
+The runner emits one fio JSON document with two named jobs:
+  - "baseline"  — no integrity (plain malloc bdev / plain NVMe-oF)
+  - "dif" or "ddgst" — the integrity-enabled leg
+
+This parser pulls IOPS + bandwidth for each leg (summing read+write so it's
+workload-agnostic) and computes the isolated integrity overhead:
+
+    <treatment>_overhead_pct = (baseline_iops - treatment_iops)
+                               / baseline_iops * 100
+
+Because the backing bdev is an in-DRAM malloc bdev, neither leg depends on
+any real storage medium — the overhead reflects the DIF/digest cost on this
+DPU's data path, not disk speed.
+
+Emitted metrics:
+  - baseline_iops, baseline_bw_MiBps
+  - <treatment>_iops, <treatment>_bw_MiBps   (treatment in {dif, ddgst})
+  - <treatment>_overhead_pct
+"""
+
+import json
+
+from benchpress.lib.parser import Parser
+
+
+def _job_iops_bw(job):
+    """Sum read+write IOPS and bandwidth (KiB/s -> MiB/s) for a fio job."""
+    iops = 0.0
+    bw_kibps = 0.0
+    for direction in ("read", "write"):
+        d = job.get(direction, {})
+        iops += float(d.get("iops", 0.0))
+        bw_kibps += float(d.get("bw", 0.0))  # fio reports bw in KiB/s
+    return iops, bw_kibps / 1024.0
+
+
+class SpdkIntegrityParser(Parser):
+    def parse(self, stdout, stderr, returncode):
+        metrics = {}
+        text = "".join(stdout)
+        try:
+            results = json.loads(text)
+        except (ValueError, TypeError):
+            return metrics
+
+        jobs = {j.get("jobname"): j for j in results.get("jobs", [])}
+        if "baseline" not in jobs:
+            return metrics
+
+        base_iops, base_bw = _job_iops_bw(jobs["baseline"])
+        metrics["baseline_iops"] = base_iops
+        metrics["baseline_bw_MiBps"] = base_bw
+
+        for treatment in ("dif", "ddgst"):
+            if treatment not in jobs:
+                continue
+            t_iops, t_bw = _job_iops_bw(jobs[treatment])
+            metrics[f"{treatment}_iops"] = t_iops
+            metrics[f"{treatment}_bw_MiBps"] = t_bw
+            if base_iops > 0:
+                metrics[f"{treatment}_overhead_pct"] = (
+                    (base_iops - t_iops) / base_iops * 100.0
+                )
+        return metrics


### PR DESCRIPTION
Summary:
**Context:**
The storage-integrity benches reported throughput with integrity ON, but
that conflates the DIF/digest cost with the data-path cost (DRAM
bandwidth + SPDK bdev overhead). To isolate the DPU's integrity-engine
cost — and keep it storage-agnostic — each bench now runs a no-integrity
baseline leg alongside the integrity leg and reports the delta.

The backing bdev was already an in-DRAM malloc bdev (no real storage
medium), so the result was storage-agnostic; this diff makes it
data-path-agnostic too by subtracting the baseline.

**This diff:**
- spdk_nvmf_fio_runner.sh: each mode now runs TWO stonewalled legs in one
  fio invocation.
    - dif: two malloc bdevs (plain "baseline" + DIF "dif"); the plugin
      runs both, baseline then dif.
    - ddgst: spdk_tgt serves two malloc-backed subsystems; the plugin
      attaches two SPDK NVMe-oF initiators (no-digest "baseline" +
      hdgst/ddgst "ddgst") and runs both legs.
  One fio JSON with two named jobs is emitted.
- New spdk_integrity parser: pulls baseline + treatment IOPS/bandwidth
  (read+write summed, workload-agnostic) and computes
  <treatment>_overhead_pct = (baseline_iops - treatment_iops)/baseline*100.
- benchmarks_dpu_perf.yml: accel_t10_dif / accel_ddgst parser ->
  spdk_integrity; metrics are baseline_iops, <t>_iops, <t>_overhead_pct.
- jobs + README: descriptions updated to the two-leg / isolated-overhead
  shape.
- BUCK: list the new parser.

Differential Revision: D106711513


