### PR TITLE
Add per-monitor 'enabled' flag to Perf hook

### DIFF
--- a/benchpress/plugins/hooks/perf.py
+++ b/benchpress/plugins/hooks/perf.py
@@ -32,23 +32,30 @@ if not open_source:
 DEFAULT_OPTIONS = {
     "mpstat": {
         "interval": 5,
+        "enabled": True,
     },
     "cpufreq_scaling": {
         "interval": 5,
+        "enabled": True,
     },
     "cpufreq_cpuinfo": {
         "interval": 5,
+        "enabled": True,
     },
-    "perfstat": {"interval": 5, "additional_events": []},
-    "netstat": {"interval": 5, "additional_counters": []},
-    "memstat": {"interval": 5, "additional_counters": []},
-    "topdown": {"interval": 5},
-    "power": {"interval": 1},
-    "vmstat": {"interval": 5},
+    "perfstat": {"interval": 5, "additional_events": [], "enabled": True},
+    "netstat": {"interval": 5, "additional_counters": [], "enabled": True},
+    "memstat": {"interval": 5, "additional_counters": [], "enabled": True},
+    "topdown": {"interval": 5, "enabled": True},
+    "power": {"interval": 1, "enabled": True},
+    "vmstat": {"interval": 5, "enabled": True},
 }
 
 if not open_source:
-    DEFAULT_OPTIONS["fb_power"] = {"interval": 10, "post_process": True}
+    DEFAULT_OPTIONS["fb_power"] = {
+        "interval": 10,
+        "post_process": True,
+        "enabled": True,
+    }
 
 AVAIL_MONITORS = {
     "mpstat": mpstat.MPStat,
@@ -86,9 +93,14 @@ class Perf(Hook):
         should_run_perf_stat = True
         self.monitors = []
         for mon_name in AVAIL_MONITORS.keys():
+            # `enabled` is a perf-hook-level flag, not a monitor constructor
+            # arg. Pop it out before passing the rest to the monitor class.
+            init_args = dict(self.opts[mon_name])
+            if not init_args.pop("enabled", True):
+                logger.info(f"Perf monitor {mon_name} is disabled by config")
+                continue
             try:
                 MonitorClass = AVAIL_MONITORS[mon_name]
-                init_args = self.opts[mon_name]
                 monitor = MonitorClass(job_uuid=job.uuid, **init_args)
                 # We should disable PerfStat (and not run anything that uses PMU)
                 # if IntelPerfSpect3 is enabled.


### PR DESCRIPTION
Summary:
PerfSpect cannot collect uArch metrics on hosts where another perf consumer (PerfStat, dynologd, etc.) is also using the PMU — the hardware counters get multiplexed and most TMA/IPC fields end up NaN. The Perf hook used to bake in a hardcoded "if PerfSpect is on, skip PerfStat" rule, but that doesn't help when other PMU consumers (like dynologd, fb_power Intel events, etc.) are active or when we want PerfStat off for other reasons.

This diff exposes a generic per-monitor `enabled` flag in DEFAULT_OPTIONS (default True for all monitors) and pops it before constructing the monitor. Disabled monitors are not instantiated and not run. The existing "auto-disable PerfStat when PerfSpect3 is detected" behavior is preserved.

Differential Revision: D103055059


