### PR TITLE
add kcb_identity field on RequestCommon + thrift header write

### DIFF
--- a/packages/ucache_bench/protocol/gen/UcacheBenchThriftTransport.h
+++ b/packages/ucache_bench/protocol/gen/UcacheBenchThriftTransport.h
@@ -58,6 +58,10 @@ folly::Try<apache::thrift::RpcResponseComplete<ucachebench::UcbDeleteReply>> sen
     rpcOptions.setWriteHeader(
         std::string{carbon::MessageCommon::kPrivacyLibAgenticContextHeader}, request.getPrivacyLibAgenticContext().value());
   }
+  if (FOLLY_UNLIKELY(request.getKcbIdentity().has_value())) {
+    rpcOptions.setWriteHeader(
+        std::string{carbon::MessageCommon::kKcbIdentityHeader}, request.getKcbIdentity().value());
+  }
   rpcOptions.setContextPropMask(0);
 
 #ifndef LIBMC_FBTRACE_DISABLE
@@ -101,6 +105,10 @@ folly::Try<apache::thrift::RpcResponseComplete<ucachebench::UcbGetReply>> sendSy
   if (FOLLY_UNLIKELY(request.getPrivacyLibAgenticContext().has_value())) {
     rpcOptions.setWriteHeader(
         std::string{carbon::MessageCommon::kPrivacyLibAgenticContextHeader}, request.getPrivacyLibAgenticContext().value());
+  }
+  if (FOLLY_UNLIKELY(request.getKcbIdentity().has_value())) {
+    rpcOptions.setWriteHeader(
+        std::string{carbon::MessageCommon::kKcbIdentityHeader}, request.getKcbIdentity().value());
   }
   rpcOptions.setContextPropMask(0);
 
@@ -146,6 +154,10 @@ folly::Try<apache::thrift::RpcResponseComplete<ucachebench::UcbSetReply>> sendSy
     rpcOptions.setWriteHeader(
         std::string{carbon::MessageCommon::kPrivacyLibAgenticContextHeader}, request.getPrivacyLibAgenticContext().value());
   }
+  if (FOLLY_UNLIKELY(request.getKcbIdentity().has_value())) {
+    rpcOptions.setWriteHeader(
+        std::string{carbon::MessageCommon::kKcbIdentityHeader}, request.getKcbIdentity().value());
+  }
   rpcOptions.setContextPropMask(0);
 
 #ifndef LIBMC_FBTRACE_DISABLE
@@ -189,6 +201,10 @@ folly::Try<apache::thrift::RpcResponseComplete<McVersionReply>> sendSyncHelper(
   if (FOLLY_UNLIKELY(request.getPrivacyLibAgenticContext().has_value())) {
     rpcOptions.setWriteHeader(
         std::string{carbon::MessageCommon::kPrivacyLibAgenticContextHeader}, request.getPrivacyLibAgenticContext().value());
+  }
+  if (FOLLY_UNLIKELY(request.getKcbIdentity().has_value())) {
+    rpcOptions.setWriteHeader(
+        std::string{carbon::MessageCommon::kKcbIdentityHeader}, request.getKcbIdentity().value());
   }
   rpcOptions.setContextPropMask(0);
 


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebook/mcrouter/pull/480

Adds the `kcbIdentity` field to `carbon::RequestCommon` (mirrors the existing `clientIdentifier` and `cryptoAuthToken` fields), and updates the carbon compiler template to emit a `setWriteHeader(kKcbIdentityHeader, ...)` block in every generated `*ThriftTransport.h`. This is the wire-format support for Generalized KCB: callers set `request.setKcbIdentity(aclName)` and the transport writes the `kcb_identity` thrift header on the outgoing thrift call so the UCache server can bind the cache key to the named ACL group

Reviewed By: antonf

Differential Revision: D104245265


