### PR TITLE
Enhance Silo benchmark: package layout, parser, jobs

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,6 +204,27 @@ DCPerf's system bench focuses on system performance metrics (kernel scheduler an
   </tr>
 </table>
 
+### Internal benchmarks
+
+DCPerf also includes Meta-internal benchmarks that are defined in `benchpress/config/benchmarks_internal.yml` / `jobs_internal.yml` and are not part of the public release. They share the same install / run / report interface as the public benchmarks.
+
+<table>
+  <tr>
+   <td>Benchmarks </td>
+   <td>Programming Languages</td>
+   <td>Libraries / SW Stack</td>
+   <td>Application domain they represent</td>
+  </tr>
+  <tr>
+   <td>
+    <a href="packages/silo/README.md">Silo</a>
+   </td>
+   <td>C++</td>
+   <td>Masstree, jemalloc, libnuma, BerkeleyDB, OpenSSL, lz4</td>
+   <td>In-memory OLTP database; runs TPC-C, YCSB (A/B/C/E/F), and a KV microbenchmark. From <a href="https://github.com/stephentu/silo">stephentu/silo</a> (Tu et al., SOSP 2013).</td>
+  </tr>
+</table>
+
 ## Representativeness
 
 When designing DCPerf, our goal is to have it represent real-world production

--- a/benchpress/config/__init__.py
+++ b/benchpress/config/__init__.py
@@ -76,6 +76,7 @@ register_benchmark_suite("system")
 register_benchmark_suite("ai")
 register_benchmark_suite("ehw")
 register_benchmark_suite("dpu_perf")
+register_benchmark_suite("mem")
 
 
 class BenchpressConfig:

--- a/benchpress/config/benchmarks_mem.yml
+++ b/benchpress/config/benchmarks_mem.yml
@@ -11,3 +11,111 @@ xsbench:
       - Threads
       - Est. Memory Usage (MB)
       - Total XS Lookups
+
+gapbs_bc:
+  parser: gapbs
+  install_script: ./packages/gapbs/install_gapbs.sh
+  cleanup_script: ./packages/gapbs/cleanup_gapbs.sh
+  install_markers:
+    - ./benchmarks/gapbs/bc
+  path: ./benchmarks/gapbs/bc
+  tags:
+    scope:
+      - kernel
+    component:
+      - cpu
+  metrics:
+    - generate_time
+    - build_time
+    - trial_time
+    - average_time
+
+gapbs_bfs:
+  parser: gapbs
+  install_script: ./packages/gapbs/install_gapbs.sh
+  cleanup_script: ./packages/gapbs/cleanup_gapbs.sh
+  install_markers:
+    - ./benchmarks/gapbs/bfs
+  path: ./benchmarks/gapbs/bfs
+  tags:
+    scope:
+      - kernel
+    component:
+      - cpu
+  metrics:
+    - generate_time
+    - build_time
+    - trial_time
+    - average_time
+
+gapbs_cc:
+  parser: gapbs
+  install_script: ./packages/gapbs/install_gapbs.sh
+  cleanup_script: ./packages/gapbs/cleanup_gapbs.sh
+  install_markers:
+    - ./benchmarks/gapbs/cc
+  path: ./benchmarks/gapbs/cc
+  tags:
+    scope:
+      - kernel
+    component:
+      - cpu
+  metrics:
+    - generate_time
+    - build_time
+    - trial_time
+    - average_time
+
+gapbs_pr:
+  parser: gapbs
+  install_script: ./packages/gapbs/install_gapbs.sh
+  cleanup_script: ./packages/gapbs/cleanup_gapbs.sh
+  install_markers:
+    - ./benchmarks/gapbs/pr
+  path: ./benchmarks/gapbs/pr
+  tags:
+    scope:
+      - kernel
+    component:
+      - cpu
+  metrics:
+    - generate_time
+    - build_time
+    - trial_time
+    - average_time
+
+gapbs_sssp:
+  parser: gapbs
+  install_script: ./packages/gapbs/install_gapbs.sh
+  cleanup_script: ./packages/gapbs/cleanup_gapbs.sh
+  install_markers:
+    - ./benchmarks/gapbs/sssp
+  path: ./benchmarks/gapbs/sssp
+  tags:
+    scope:
+      - kernel
+    component:
+      - cpu
+  metrics:
+    - generate_time
+    - build_time
+    - trial_time
+    - average_time
+
+gapbs_tc:
+  parser: gapbs
+  install_script: ./packages/gapbs/install_gapbs.sh
+  cleanup_script: ./packages/gapbs/cleanup_gapbs.sh
+  install_markers:
+    - ./benchmarks/gapbs/tc
+  path: ./benchmarks/gapbs/tc
+  tags:
+    scope:
+      - kernel
+    component:
+      - cpu
+  metrics:
+    - generate_time
+    - build_time
+    - trial_time
+    - average_time

--- a/benchpress/config/jobs_mem.yml
+++ b/benchpress/config/jobs_mem.yml
@@ -11,3 +11,76 @@
     - "history=500000"
     #- "size=Large" # XL 120GB, XXL 225GB
     #- "gridpoints=11303"
+
+# GAPBS jobs - default to a synthetic Kronecker graph (-g {scale}, 2^scale
+# vertices, ~16 avg degree) so the job is self-contained and avoids the
+# multi-GB twitter download. The graph and trials are exposed as `vars` so
+# they can be tuned per run by editing the values below.
+#
+# Default scale=25 -> 2^25 ≈ 33M vertices, ~530M edges, ~4-8 GB CSR
+# footprint (more for sssp/pr which keep additional per-vertex state).
+# Bump scale to 27-28 for >32 GB working sets; each +1 in scale roughly
+# doubles memory. To run against a pre-built real-world graph instead,
+# replace the args block with e.g.:
+#   args:
+#     - -f ./benchmarks/graphs/twitter.sg
+#     - -n {trials}
+- benchmark: gapbs_bc
+  name: gapbs_bc
+  description: GAP bc benchmark (betweenness centrality) on a synthetic Kronecker graph
+  args:
+    - -g {scale}
+    - -n {trials}
+  vars:
+    - "scale=25"
+    - "trials=3"
+
+- benchmark: gapbs_bfs
+  name: gapbs_bfs
+  description: GAP bfs benchmark on a synthetic Kronecker graph
+  args:
+    - -g {scale}
+    - -n {trials}
+  vars:
+    - "scale=25"
+    - "trials=3"
+
+- benchmark: gapbs_cc
+  name: gapbs_cc
+  description: GAP cc benchmark (connected components) on a synthetic Kronecker graph
+  args:
+    - -g {scale}
+    - -n {trials}
+  vars:
+    - "scale=25"
+    - "trials=3"
+
+- benchmark: gapbs_tc
+  name: gapbs_tc
+  description: GAP tc benchmark (triangle count, requires undirected graph; -g auto-undirects)
+  args:
+    - -g {scale}
+    - -n {trials}
+  vars:
+    - "scale=25"
+    - "trials=3"
+
+- benchmark: gapbs_pr
+  name: gapbs_pr
+  description: GAP pr benchmark (PageRank) on a synthetic Kronecker graph
+  args:
+    - -g {scale}
+    - -n {trials}
+  vars:
+    - "scale=25"
+    - "trials=3"
+
+- benchmark: gapbs_sssp
+  name: gapbs_sssp
+  description: GAP sssp benchmark on a synthetic Kronecker graph
+  args:
+    - -g {scale}
+    - -n {trials}
+  vars:
+    - "scale=25"
+    - "trials=3"

--- a/benchpress/plugins/parsers/silo.py
+++ b/benchpress/plugins/parsers/silo.py
@@ -6,30 +6,147 @@
 
 # pyre-unsafe
 
+"""Parser for Silo's `dbtest` output.
+
+dbtest prints results to stderr in the form:
+
+    runtime: 1.00328 sec
+    memory delta: 58.2734 MB
+    memory delta rate: 58.0828 MB/sec
+    logical memory delta: 3.56796 MB
+    logical memory delta rate: 3.55628 MB/sec
+    agg_nosync_throughput: 55954.4 ops/sec
+    avg_nosync_per_core_throughput: 55954.4 ops/sec/core
+    agg_throughput: 55954.4 ops/sec
+    avg_per_core_throughput: 55954.4 ops/sec/core
+    agg_persist_throughput: 55954.4 ops/sec
+    avg_per_core_persist_throughput: 55954.4 ops/sec/core
+    avg_latency: 0.0177805 ms
+    avg_persist_latency: 0 ms
+    agg_abort_rate: 0 aborts/sec
+    avg_per_core_abort_rate: 0 aborts/sec/core
+    txn breakdown: [[Delivery, 2193], [NewOrder, 25386], ...]
+
+YCSB and the microbenchmarks omit some lines (e.g. no `txn breakdown` for
+YCSB). Each metric is extracted independently and silently skipped when
+absent, so the parser never raises on partial output.
+"""
+
+from __future__ import annotations
+
 import re
 
 from benchpress.lib.parser import Parser
 
 
-AGG_TPUT_REGEX = r"(agg_throughput):\s+(\d+\.?\d*e?[+-]?\d*)\s+([a-z/]+)"
-PER_CORE_TPUT_REGEX = r"(avg_per_core_throughput):\s+(\d+\.?\d*e?[+-]?\d*)\s+([a-z/]+)"
-LAT_REGEX = r"(avg_latency):\s+(\d+\.?\d*e?[+-]?\d*)\s+([a-z]+)"
+# Each rule is (group, metric_name, compiled regex). The regex must have a
+# single capture group that yields the float value.
+_FLOAT = r"([-+]?\d+(?:\.\d+)?(?:[eE][-+]?\d+)?)"
+
+_RULES: list[tuple[str, str, re.Pattern]] = [
+    ("throughput", "agg_throughput", re.compile(rf"^agg_throughput:\s+{_FLOAT}")),
+    (
+        "throughput",
+        "avg_per_core_throughput",
+        re.compile(rf"^avg_per_core_throughput:\s+{_FLOAT}"),
+    ),
+    (
+        "throughput",
+        "agg_nosync_throughput",
+        re.compile(rf"^agg_nosync_throughput:\s+{_FLOAT}"),
+    ),
+    (
+        "throughput",
+        "agg_persist_throughput",
+        re.compile(rf"^agg_persist_throughput:\s+{_FLOAT}"),
+    ),
+    (
+        "throughput",
+        "avg_per_core_persist_throughput",
+        re.compile(rf"^avg_per_core_persist_throughput:\s+{_FLOAT}"),
+    ),
+    ("latency", "avg_latency", re.compile(rf"^avg_latency:\s+{_FLOAT}")),
+    (
+        "latency",
+        "avg_persist_latency",
+        re.compile(rf"^avg_persist_latency:\s+{_FLOAT}"),
+    ),
+    ("abort", "agg_abort_rate", re.compile(rf"^agg_abort_rate:\s+{_FLOAT}")),
+    (
+        "abort",
+        "avg_per_core_abort_rate",
+        re.compile(rf"^avg_per_core_abort_rate:\s+{_FLOAT}"),
+    ),
+    ("memory", "memory_delta", re.compile(rf"^memory delta:\s+{_FLOAT}")),
+    (
+        "memory",
+        "memory_delta_rate",
+        re.compile(rf"^memory delta rate:\s+{_FLOAT}"),
+    ),
+    (
+        "memory",
+        "logical_memory_delta",
+        re.compile(rf"^logical memory delta:\s+{_FLOAT}"),
+    ),
+    (
+        "memory",
+        "logical_memory_delta_rate",
+        re.compile(rf"^logical memory delta rate:\s+{_FLOAT}"),
+    ),
+    ("runtime", "runtime_sec", re.compile(rf"^runtime:\s+{_FLOAT}")),
+]
+
+# `txn breakdown: [[Name1, N1], [Name2, N2], ...]`
+_TXN_BREAKDOWN_LINE = re.compile(r"^txn breakdown:\s*\[(.+)\]\s*$")
+_TXN_BREAKDOWN_ENTRY = re.compile(r"\[\s*([A-Za-z_][A-Za-z0-9_]*)\s*,\s*(\d+)\s*\]")
 
 
 class SiloParser(Parser):
     def parse(self, stdout, stderr, returncode):
-        output = "".join(stderr)  # Results output in stderr
-        metrics = {"throughput": {}, "latency": {}}
-        tput_metrics = [
-            re.findall(AGG_TPUT_REGEX, output)[0],
-            re.findall(PER_CORE_TPUT_REGEX, output)[0],
-        ]
-        lat_metrics = [re.findall(LAT_REGEX, output)[0]]
+        # dbtest writes its results to stderr. Accept either a list of lines or
+        # a single string. Iterate line-by-line to match each rule at most
+        # once and to keep the parser O(n) in the output size.
+        if isinstance(stderr, (list, tuple)):
+            lines = []
+            for chunk in stderr:
+                lines.extend(chunk.splitlines() if "\n" in chunk else [chunk])
+        else:
+            lines = (stderr or "").splitlines()
 
-        for tput_metric in tput_metrics:
-            metrics["throughput"][tput_metric[0]] = float(tput_metric[1])
+        metrics: dict = {
+            "throughput": {},
+            "latency": {},
+            "abort": {},
+            "memory": {},
+            "runtime": {},
+            "txn_breakdown": {},
+        }
 
-        for lat_metric in lat_metrics:
-            metrics["latency"][lat_metric[0]] = float(lat_metric[1])
+        # Track which rules we've already matched so a single line cannot fire
+        # the same rule twice (dbtest prints each metric once, but be safe).
+        matched: set[tuple[str, str]] = set()
+
+        for raw_line in lines:
+            line = raw_line.strip()
+            if not line:
+                continue
+
+            for group, name, pattern in _RULES:
+                key = (group, name)
+                if key in matched:
+                    continue
+                m = pattern.match(line)
+                if m:
+                    try:
+                        metrics[group][name] = float(m.group(1))
+                    except ValueError:
+                        continue
+                    matched.add(key)
+                    break
+
+            tb = _TXN_BREAKDOWN_LINE.match(line)
+            if tb:
+                for entry in _TXN_BREAKDOWN_ENTRY.finditer(tb.group(1)):
+                    metrics["txn_breakdown"][entry.group(1)] = int(entry.group(2))
 
         return metrics

--- a/packages/gapbs/cleanup_gapbs.sh
+++ b/packages/gapbs/cleanup_gapbs.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+set -Eeuo pipefail
+
+SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)
+BENCHPRESS_ROOT="$(readlink -f "${SCRIPT_DIR}/../..")"
+
+"${BENCHPRESS_ROOT}"/install_remove_git.sh remove
+
+GAPBS_INSTALLATION_PREFIX="$(pwd)/benchmarks/gapbs"
+rm -rf "${GAPBS_INSTALLATION_PREFIX}"

--- a/packages/gapbs/install_gapbs.sh
+++ b/packages/gapbs/install_gapbs.sh
@@ -1,0 +1,54 @@
+#!/bin/bash
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+#
+# Installs the GAP Benchmark Suite (gapbs) from upstream
+# https://github.com/sbeamer/gapbs (tag v1.1).
+#
+# Produces six benchmark binaries (bc, bfs, cc, pr, sssp, tc) plus the
+# `converter` utility in ${BENCHPRESS_ROOT}/benchmarks/gapbs/. Jobs can
+# either point at the synthetic Kronecker generator (`-g <SCALE>`) or at a
+# pre-built `.sg` / `.wsg` / `.sgU` graph file via `-f`. Building large
+# real-world graphs (e.g. twitter_rv) is intentionally NOT done here -
+# do it in a separate one-off step to keep this script idempotent and
+# cheap to re-run.
+
+set -Eeuo pipefail
+
+SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)
+BENCHPRESS_ROOT="$(readlink -f "${SCRIPT_DIR}/../..")"
+
+GAPBS_GIT_REPO_URL="https://github.com/sbeamer/gapbs.git"
+GAPBS_GIT_COMMIT_TAG="v1.1"
+
+# Install system deps. fb-fwdproxy-config gives `git clone` access to public
+# github via fwdproxy on Meta dev servers / sandboxes.
+dnf install -y fb-fwdproxy-config gcc gcc-c++ libstdc++
+
+BENCHMARKS_DIR="$(pwd)/benchmarks"
+mkdir -p "${BENCHMARKS_DIR}"
+
+GAPBS_INSTALLATION_PREFIX="${BENCHMARKS_DIR}/gapbs"
+
+rm -rf build
+mkdir -p build
+cd build/ || exit 1
+
+"${BENCHPRESS_ROOT}"/install_remove_git.sh install
+
+# shellcheck disable=SC2046
+git $(fwdproxy-config --git-command git) clone "${GAPBS_GIT_REPO_URL}"
+cd gapbs/ || exit 1
+git checkout -b benchpress "tags/${GAPBS_GIT_COMMIT_TAG}"
+
+make -j"$(nproc)"
+
+mkdir -p "${GAPBS_INSTALLATION_PREFIX}"
+mv bc bfs cc pr sssp tc converter "${GAPBS_INSTALLATION_PREFIX}"
+cd ../../ || exit 1
+
+rm -rf build/
+
+echo "GAP benchmark suite (${GAPBS_GIT_COMMIT_TAG}) installed into ${GAPBS_INSTALLATION_PREFIX}"

--- a/packages/silo/README.md
+++ b/packages/silo/README.md
@@ -1,0 +1,148 @@
+# Silo
+
+[Silo](https://github.com/stephentu/silo) is a high-performance in-memory OLTP database from MIT (Tu et al., SOSP 2013). It scales to many cores using optimistic concurrency control (OCC) over [Masstree](https://github.com/kohler/masstree-beta), an efficient concurrent trie of B+-trees. Silo's `dbtest` benchmark binary runs TPC-C, YCSB, and a small set of microbenchmarks against the database.
+
+This benchpress package builds `dbtest` from upstream at a pinned commit and wraps it with the standard install / cleanup / run interface.
+
+> **Note:** Silo lives in `benchpress/config/benchmarks_internal.yml` / `jobs_internal.yml`. It is part of Meta's internal benchpress suite and not shipped in the public DCPerf release.
+
+## System requirements
+
+| Item | Detail |
+|---|---|
+| OS | RHEL/CentOS 9 (tested), Ubuntu 22.04 (untested) |
+| CPU | Any x86_64 with multiple cores. Validated on 56-core Intel and AMD hosts. Silo is designed to scale to many cores. |
+| Memory | At least 8 GB; ~5 GB per warehouse for TPC-C scale-factor sweeps |
+| Compiler | GCC 11+ (the install script patches the upstream Makefile to tolerate modern `-Werror` defaults) |
+| Network | Outbound HTTPS to github.com via `fwdproxy` (the install script wires this up automatically with `fwdproxy-config`) |
+| Privileges | `sudo` for the initial `dnf install` of build dependencies |
+
+The install script declares the dnf deps it needs, but for reference: `jemalloc-devel`, `numactl-devel`, `libdb-cxx-devel`, `mysql-devel`, `libaio-devel`, `openssl-devel`, `zlib-devel`, `autoconf`, `automake`, `libtool`, `fb-fwdproxy-config`.
+
+## Install Silo
+
+```bash
+./benchpress_cli.py install silo_default
+```
+
+This (a) installs build dependencies via `dnf`, (b) clones `stephentu/silo` and its `masstree` submodule via `fwdproxy`, (c) builds `dbtest` in `MODE=perf` with `jemalloc`, and (d) places the binary at `./benchmarks/silo/dbtest`.
+
+The install is idempotent — re-running re-clones and rebuilds, then overwrites the binary. To uninstall:
+
+```bash
+./benchpress_cli.py clean silo_default
+```
+
+## Run Silo
+
+### Recommended jobs
+
+| Job | Workload | Threads | Scale | Runtime |
+|---|---|---|---|---|
+| `silo_default` | TPC-C smoke | 1 | 1 | 1s |
+| `silo_tpcc_1t` | TPC-C single-thread baseline | 1 | 1 | 30s |
+| `silo_tpcc_allcores` | TPC-C all cores (`--num-threads 0` → `$(nproc)`) | host | 32 | 30s |
+| `silo_tpcc_scale10` | TPC-C medium contention | 8 | 10 | 30s |
+
+### YCSB workloads
+
+The workload mix is passed via Silo's `--bench-opts '--workload-mix=READ,RMW,WRITE,SCAN'` (percentages summing to 100).
+
+| Job | Mix | Notes |
+|---|---|---|
+| `silo_ycsb_a` | 50r / 50 update | Session-store style |
+| `silo_ycsb_b` | 95r / 5 update | Photo-tagging style |
+| `silo_ycsb_c` | 100r | Pure read; expect ~10M+ ops/sec/core in-memory |
+| `silo_ycsb_e` | 95 scan / 5 insert | Threaded conversations style |
+| `silo_ycsb_f` | 50r / 50 rmw | User-database style |
+
+### Microbenchmark
+
+| Job | Description |
+|---|---|
+| `silo_queue` | dbtest's `queue` workload — simplest KV insert/delete loop |
+
+### Thread-count sweep
+
+`silo_tpcc_sweep_{1,2,4,8,16,32,64}t` — one warehouse per worker thread (Silo recommends this ratio to avoid pathological abort rates). Run with:
+
+```bash
+for t in 1 2 4 8 16 32 64; do
+    ./benchpress_cli.py run silo_tpcc_sweep_${t}t
+done
+```
+
+### Pinning / NUMA control
+
+`packages/silo/run.sh` honors three environment variables:
+
+| Env var | Effect |
+|---|---|
+| `SILO_NUMA_NODE=0` | Wraps in `numactl --membind=0 --cpunodebind=0` (single-socket run) |
+| `SILO_CPUS=0-27` | Wraps in `taskset -c 0-27` (specific CPU pinning) |
+| `SILO_BIN=/path/to/dbtest` | Override the binary path |
+
+Example: pin to NUMA node 0 for a single-socket TPC-C scan:
+
+```bash
+SILO_NUMA_NODE=0 ./benchpress_cli.py run silo_tpcc_allcores
+```
+
+## Reporting and measurement
+
+The Silo parser (`benchpress/plugins/parsers/silo.py`) extracts these metric groups from `dbtest`'s stderr:
+
+| Group | Fields |
+|---|---|
+| `throughput` | `agg_throughput`, `avg_per_core_throughput`, `agg_nosync_throughput`, `agg_persist_throughput`, `avg_per_core_persist_throughput` (all ops/sec) |
+| `latency` | `avg_latency`, `avg_persist_latency` (ms) |
+| `abort` | `agg_abort_rate`, `avg_per_core_abort_rate` (aborts/sec) |
+| `memory` | `memory_delta`, `memory_delta_rate`, `logical_memory_delta`, `logical_memory_delta_rate` (MB / MB/sec) |
+| `runtime` | `runtime_sec` |
+| `txn_breakdown` | map of txn name → count (TPC-C: `Delivery`, `NewOrder`, `OrderStatus`, `Payment`, `StockLevel`; YCSB: `Read`; queue micro: empty) |
+
+Missing fields are silently skipped — the parser does not crash on partial output, which lets the same parser handle TPC-C, YCSB, and the microbenchmarks.
+
+### Example output
+
+Sample `silo_default` result on a 56-core host:
+
+```
+agg_throughput:                 50510.9 ops/sec
+avg_latency:                    0.0197062 ms
+agg_abort_rate:                 0 aborts/sec
+memory_delta:                   429.898 MB
+runtime_sec:                    1.00018
+txn_breakdown:
+  Delivery=1980, NewOrder=22842, OrderStatus=1944, Payment=21677, StockLevel=2077
+```
+
+Sample `silo_ycsb_c` (4 threads, in-memory reads):
+
+```
+agg_throughput:                 1.16391e+07 ops/sec
+avg_per_core_throughput:        2.90979e+06 ops/sec/core
+avg_latency:                    0.000289753 ms
+txn_breakdown: Read=23280692
+```
+
+## Build notes
+
+- Pinned commit: `cc11ca1ea949ef266ee12a9b1c310392519d9e3b` (master tip from 2014).
+- Build flags: `MODE=perf DEBUG=0 CHECK_INVARIANTS=0 USE_MALLOC_MODE=1`, C++ standard `-std=gnu++0x`.
+- The masstree submodule's `.gitmodules` pins `git://` URLs that github no longer serves; the install script rewrites these to `https://`.
+- The install script `sed`-patches Silo's `Makefile` to drop `-Werror` from the `MODE=perf` branch. Without this, modern GCC (≥ 11 on EL9) escalates warnings in `masstree/string_base.hh` (`-Wformat-truncation` on a `snprintf` size mismatch) and `btree.cc` (`-Wmaybe-uninitialized` on a `memcmp` of stack-constructed varkey) to fatal errors that the existing `-Wno-error=maybe-uninitialized` flag cannot fully suppress.
+- The masstree `.so` is dynamically linked at runtime — do not delete `./silo_build/` if you want to keep running the binary. The cleanup script removes both the binary and the build tree.
+
+## Representativeness
+
+Silo represents the **in-memory OLTP database** workload class: many-core scaling, optimistic concurrency control, cache-conscious data structures, and the classic TPC-C / YCSB mix. It complements the existing DCPerf web/cache/analytics benchmarks by exercising the database tier directly without going through a SQL parser or wire protocol.
+
+## Files in this package
+
+| File | Purpose |
+|---|---|
+| `install_silo.sh` | Clones stephentu/silo at the pinned commit, builds `dbtest` with `MODE=perf USE_MALLOC_MODE=1`, installs the binary to `./benchmarks/silo/dbtest` |
+| `cleanup_silo.sh` | Removes `./benchmarks/silo/` and the `silo_build/` tree |
+| `run.sh` | Wrapper used as the benchmark `path:` — forwards all args to `dbtest`, rewrites `--num-threads 0` to `$(nproc)`, supports `SILO_NUMA_NODE` / `SILO_CPUS` / `SILO_BIN` |
+| `README.md` | This file |

--- a/packages/silo/cleanup_silo.sh
+++ b/packages/silo/cleanup_silo.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+#
+# Removes the Silo dbtest binary, the silo_build tree (which holds the
+# dynamically-linked masstree .so), and uninstalls git via the shared
+# install_remove_git.sh helper (matches the graph500 cleanup pattern).
+
+set -Eeuo pipefail
+
+SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)
+BENCHPRESS_ROOT="$(readlink -f "${SCRIPT_DIR}/../..")"
+
+"${BENCHPRESS_ROOT}"/install_remove_git.sh remove
+
+BENCHMARKS_DIR="${BENCHPRESS_ROOT}/benchmarks"
+SILO_INSTALLATION_PREFIX="${BENCHMARKS_DIR}/silo"
+
+rm -rf "${SILO_INSTALLATION_PREFIX}"
+rm -rf "${BENCHPRESS_ROOT}/silo_build"
+
+echo "Silo benchmark uninstalled from ${SILO_INSTALLATION_PREFIX}"

--- a/packages/silo/install_silo.sh
+++ b/packages/silo/install_silo.sh
@@ -1,0 +1,95 @@
+#!/bin/bash
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+#
+# Installs Silo's `dbtest` benchmark from https://github.com/stephentu/silo.
+# Silo is an in-memory OLTP database from MIT (SOSP 2013); `dbtest` is a
+# single binary that runs TPC-C, YCSB, and a handful of microbenchmarks
+# (queue, bid, ic3). We build it in MODE=perf with USE_MALLOC_MODE=1 so
+# the masstree variant is selected; the build output lands in
+# `out-perf.masstree/benchmarks/dbtest`.
+#
+# We install into ${BENCHPRESS_ROOT}/benchmarks/silo/dbtest so the binary
+# sits in its own subdirectory (matching the graph500/gapbs layout) and
+# `install_markers` in benchmarks_internal.yml can detect a completed
+# install.
+
+set -Eeuo pipefail
+
+SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)
+BENCHPRESS_ROOT="$(readlink -f "${SCRIPT_DIR}/../..")"
+
+# System deps. fb-fwdproxy-config provides the fwdproxy-config helper used
+# below to give git access to public github through fwdproxy. autoconf /
+# automake / libtool are required because masstree's build runs
+# `autoreconf -i`. zlib-devel is required for dbtest's `-lz` link step.
+dnf install -y \
+    fb-fwdproxy-config \
+    autoconf \
+    automake \
+    libtool \
+    jemalloc-devel \
+    numactl-devel \
+    libdb-cxx-devel \
+    mysql-devel \
+    libaio-devel \
+    openssl-devel \
+    zlib-devel
+
+SILO_GIT_REPO_URL="https://github.com/stephentu/silo.git"
+# Pinned to the last commit on stephentu/silo master as of the original
+# benchpress import; bump deliberately and re-test if you need a newer rev.
+SILO_GIT_COMMIT_TAG="cc11ca1ea949ef266ee12a9b1c310392519d9e3b"
+
+BENCHMARKS_DIR="$(pwd)/benchmarks"
+mkdir -p "$BENCHMARKS_DIR"
+
+SILO_INSTALLATION_PREFIX="${BENCHMARKS_DIR}/silo"
+SILO_BINARY_PATH="${SILO_INSTALLATION_PREFIX}/dbtest"
+
+# Silo's masstree submodule contains a `.so` that is dynamically linked at
+# runtime, so we cannot delete the build tree after install. We do, however,
+# wipe and recreate the build tree on each install so the install is
+# repeatable.
+rm -rf silo_build
+mkdir -p silo_build
+cd silo_build
+
+"${BENCHPRESS_ROOT}"/install_remove_git.sh install
+
+# shellcheck disable=SC2046
+git $(fwdproxy-config --git-command git) clone "$SILO_GIT_REPO_URL"
+cd silo
+git checkout -b benchpress "${SILO_GIT_COMMIT_TAG}"
+
+# The masstree submodule's .gitmodules pins git:// URLs that github no
+# longer serves. Rewrite to https:// before recursing.
+sed -i 's|git://|https://|g' .gitmodules
+# shellcheck disable=SC2046
+git $(fwdproxy-config --git-command git) submodule update --init --recursive
+
+# GCC >= 7 elevates -Wmaybe-uninitialized to a fatal error in masstree's
+# str.hh; suppress just that warning when the compiler supports the flag.
+MAYBE_UNINIT="$(echo | gcc -Wmaybe-uninitialized -E - >/dev/null 2>&1 \
+                && echo '-Wno-error=maybe-uninitialized')"
+CXX_CMD="g++ -std=gnu++0x ${MAYBE_UNINIT}"
+
+# Silo's MODE=perf Makefile branch adds `-Werror -O2`, which on modern GCC
+# (>= 11 on EL9) turns benign warnings (-Wformat-truncation in masstree's
+# string_base.hh snprintf, -Wmaybe-uninitialized in btree.cc) into fatal
+# errors. Because Silo's CXXFLAGS are appended after our CXX flags, a
+# trailing `-Werror` re-enables errors for warnings we tried to demote.
+# Strip the `-Werror` from the perf branch so our `-Wno-error=*` flags can
+# take effect. Idempotent.
+sed -i 's/-Werror -O2/-O2/g' Makefile
+
+CXX="${CXX_CMD}" MODE=perf DEBUG=0 CHECK_INVARIANTS=0 USE_MALLOC_MODE=1 make dbtest
+
+mkdir -p "${SILO_INSTALLATION_PREFIX}"
+mv out-perf.masstree/benchmarks/dbtest "${SILO_BINARY_PATH}"
+
+cd ../../
+
+echo "Silo dbtest (commit ${SILO_GIT_COMMIT_TAG}) installed into ${SILO_BINARY_PATH}"

--- a/packages/silo/run.sh
+++ b/packages/silo/run.sh
@@ -1,0 +1,79 @@
+#!/bin/bash
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+#
+# Wrapper that runs Silo's dbtest binary. Benchpress invokes this via the
+# `path:` entry in benchmarks_internal.yml; all args from the job config are
+# passed through.
+#
+# Convenience: `--num-threads 0` (or `--num-threads=0`) is rewritten to the
+# host's nproc so job configs can ask for "all cores" portably without
+# hard-coding a value. dbtest itself does not accept 0.
+#
+# Usage:
+#   ./run.sh <dbtest args...>
+#
+# Environment variables:
+#   SILO_NUMA_NODE  If set (e.g. "0" or "0,1"), wrap dbtest in
+#                   `numactl --membind=$NODE --cpunodebind=$NODE`.
+#   SILO_CPUS       If set (e.g. "0-15" or "0,2,4,6"), wrap dbtest in
+#                   `taskset -c $SILO_CPUS`. Applied after numactl.
+#   SILO_BIN        Override path to the dbtest binary.
+
+set -Eeuo pipefail
+
+BENCHPRESS_ROOT="$(pwd)"
+SILO_DIR="${BENCHPRESS_ROOT}/benchmarks/silo"
+SILO_BIN="${SILO_BIN:-${SILO_DIR}/dbtest}"
+
+if [[ ! -x "${SILO_BIN}" ]]; then
+    echo "Silo dbtest binary not found at ${SILO_BIN}." >&2
+    echo "Run \`./benchpress_cli.py install silo_default\` (or any other silo_* job) first." >&2
+    exit 1
+fi
+
+nproc_count="$(nproc)"
+
+args=()
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --num-threads)
+            if [[ $# -lt 2 ]]; then
+                echo "Error: --num-threads requires a value (use 0 to mean nproc)" >&2
+                exit 2
+            fi
+            args+=("--num-threads")
+            if [[ "$2" == "0" ]]; then
+                args+=("${nproc_count}")
+            else
+                args+=("$2")
+            fi
+            shift 2
+            ;;
+        --num-threads=0)
+            # Other --num-threads=N forms (N != 0) fall through to the
+            # default `*` case below and are passed to dbtest verbatim.
+            args+=("--num-threads=${nproc_count}")
+            shift
+            ;;
+        *)
+            args+=("$1")
+            shift
+            ;;
+    esac
+done
+
+cmd=("${SILO_BIN}" "${args[@]}")
+
+if [[ -n "${SILO_CPUS:-}" ]]; then
+    cmd=(taskset -c "${SILO_CPUS}" "${cmd[@]}")
+fi
+
+if [[ -n "${SILO_NUMA_NODE:-}" ]]; then
+    cmd=(numactl "--membind=${SILO_NUMA_NODE}" "--cpunodebind=${SILO_NUMA_NODE}" "${cmd[@]}")
+fi
+
+echo "Running: ${cmd[*]}" >&2
+exec "${cmd[@]}"


### PR DESCRIPTION
Summary:
Enhance the Silo benchmark in benchpress. Silo is a high-performance in-memory OLTP database from MIT (Tu et al., SOSP 2013) at https://github.com/stephentu/silo. Until now it was integrated as a single 1-thread/1-second TPC-C smoke job with a fragile parser that crashed on any output missing one of three regex hits.

Changes:

- **Repackage under `packages/silo/`** to match the modern `graph500`/`gapbs` layout: install/cleanup/run wrappers, install_markers for idempotency, binary in `./benchmarks/silo/dbtest`.
- **`run.sh` wrapper** that rewrites `--num-threads 0` to `$(nproc)` and supports `SILO_NUMA_NODE` / `SILO_CPUS` / `SILO_BIN` env knobs. Hardened arg parser with missing-value guard.
- **Rewrite the parser** to use a declarative `(group, name, regex)` rule list iterated per output line. Each field is extracted independently and silently skipped when absent. New metric groups: `throughput` (5 fields), `latency` (2), `abort` (2), `memory` (4), `runtime`, `txn_breakdown` (txn name → count map).
- **Add 16 new jobs**: `silo_tpcc_{1t,allcores,scale10}`, `silo_ycsb_{a,b,c,e,f}`, `silo_queue`, `silo_tpcc_sweep_{1,2,4,8,16,32,64}t`. `silo_default` is preserved unchanged for backward compatibility.
- **Modern-GCC build fixes** in install_silo.sh: add `autoconf`/`automake`/`libtool` (masstree needs `autoreconf`), `zlib-devel` (dbtest links `-lz`), and `sed`-patch silo's `Makefile` to drop `-Werror` from the perf branch so GCC 11+ warnings (`-Wformat-truncation` in masstree, `-Wmaybe-uninitialized` in btree.cc) don't fail the build.
- **Documentation**: comprehensive `packages/silo/README.md` covering install / jobs / metrics / pinning / build notes; new "Internal benchmarks" subsection in the top-level README pointing to it.

Differential Revision: D106599857


