### PR TITLE
Surface the applied accel backend in results

### DIFF
--- a/benchpress/plugins/parsers/dpu_accel_combined.py
+++ b/benchpress/plugins/parsers/dpu_accel_combined.py
@@ -42,6 +42,11 @@ from .stream import StreamParser
 
 _LEG_RE = re.compile(r"^##DPU_PERF_LEG=([a-z0-9_]+),([a-z0-9_]+)##\s*$")
 _FAIL_RE = re.compile(r"^##DPU_PERF_LEG_FAILED=([a-z0-9_]+)##\s*$")
+# Labels which backend actually produced a leg's numbers (driver name for the
+# DPDK legs, "host-openssl" for host legs, "spdk-accel" for the SPDK accel
+# legs) so a software-PMD / SPDK-software result is never mistaken for a DPU
+# result. Surfaced as <label>_applied_backend.
+_BACKEND_RE = re.compile(r"^##DPU_PERF_BACKEND=([a-z0-9_]+),(.+?)##\s*$")
 
 _SUBPARSERS = {
     "openssl_speed": OpensslSpeedParser,
@@ -108,8 +113,19 @@ def _split_sections(stdout):
         line = raw.rstrip("\r\n")
         m = _LEG_RE.match(line)
         if m:
-            cur = {"label": m.group(1), "sub": m.group(2), "lines": [], "failed": False}
+            cur = {
+                "label": m.group(1),
+                "sub": m.group(2),
+                "lines": [],
+                "failed": False,
+                "backend": None,
+            }
             sections.append(cur)
+            continue
+        mb = _BACKEND_RE.match(line)
+        if mb:
+            if cur is not None and cur["label"] == mb.group(1):
+                cur["backend"] = mb.group(2)
             continue
         mf = _FAIL_RE.match(line)
         if mf:
@@ -119,13 +135,15 @@ def _split_sections(stdout):
         if cur is not None:
             cur["lines"].append(line)
     for s in sections:
-        yield s["label"], s["sub"], s["lines"], s["failed"]
+        yield s["label"], s["sub"], s["lines"], s["failed"], s["backend"]
 
 
 class DpuAccelCombinedParser(Parser):
     def parse(self, stdout, stderr, returncode):
         metrics = {}
-        for label, sub, lines, failed in _split_sections(stdout):
+        for label, sub, lines, failed, backend in _split_sections(stdout):
+            if backend:
+                metrics[f"{label}_applied_backend"] = backend
             if failed:
                 metrics[f"{label}_failed"] = True
                 continue

--- a/benchpress/plugins/parsers/spdk_integrity.py
+++ b/benchpress/plugins/parsers/spdk_integrity.py
@@ -29,8 +29,16 @@ Emitted metrics:
 """
 
 import json
+import re
 
 from benchpress.lib.parser import Parser
+
+# Optional marker the runner prints to label which backend produced the
+# numbers (e.g. "spdk-nvmf" = SPDK-computed digest; a vendor HW-digest path is
+# a vendor SPDK build under the same marker) so an SPDK-software result is
+# never mistaken for a DPU result. Stripped before json.loads; surfaced as
+# applied_backend.
+_BACKEND_RE = re.compile(r"^##DPU_PERF_BACKEND=(.+?)##\s*$")
 
 
 def _job_iops_bw(job):
@@ -47,7 +55,16 @@ def _job_iops_bw(job):
 class SpdkIntegrityParser(Parser):
     def parse(self, stdout, stderr, returncode):
         metrics = {}
-        text = "".join(stdout)
+        # Strip the optional backend marker (non-JSON) before parsing the fio
+        # JSON document; record it as applied_backend.
+        json_lines = []
+        for raw in stdout:
+            m = _BACKEND_RE.match(raw.strip())
+            if m:
+                metrics["applied_backend"] = m.group(1)
+                continue
+            json_lines.append(raw)
+        text = "".join(json_lines)
         try:
             results = json.loads(text)
         except (ValueError, TypeError):


### PR DESCRIPTION
Summary:
**Context:**
The dpu_perf accel benches (crypto / compress / dmove / dif via
run_accel_combined, and ddgst via spdk_nvmf_fio) auto-select a software vs
hardware path: DPDK cryptodev/compressdev default to a software PMD, and SPDK
accel / NVMe-oF digest fall back to their software module when no HW engine is
present. The result did not record which backend actually ran, so a software /
SPDK-software number could be read as a DPU result — the opposite of the
suite's goal (assess the DPU, not the host CPU).

**Motivation:**
Vetting every Tier-1 bench against "assess the DPU + guide design" surfaced
this as the one place the implemented code diverged from the principle.
Labeling the applied backend makes every accel result self-describing: a
vendor HW PMD vs a software PMD vs the SPDK framework are now distinguishable
in the data.

**This diff:**
- run_accel_combined.sh: each leg emits ##DPU_PERF_BACKEND=<leg>,<backend>##
  (DPDK driver name for offload legs — crypto_openssl=software, a vendor PMD
  =HW; host-openssl for host legs; spdk-accel for SPDK accel legs).
- dpu_accel_combined parser: surfaces it as <leg>_applied_backend (captured,
  not leaked into leg data).
- spdk_nvmf_fio_runner.sh (accel_ddgst): emits ##DPU_PERF_BACKEND=spdk-nvmf##;
  the spdk_integrity parser strips the marker before json.loads and surfaces
  applied_backend.
- benchmarks_dpu_perf.yml: documents the new <leg>_applied_backend field.

Reviewed By: charles-typ

Differential Revision: D107833862


