### PR TITLE
Add self-contained FeedSim fbpkg build via buck_genrule (#685)

### DIFF
--- a/benchpress/config/benchmarks.yml
+++ b/benchpress/config/benchmarks.yml
@@ -116,6 +116,9 @@ feedsim_autoscale:
   parser: feedsim_autoscale
   install_script: ./packages/feedsim/install_feedsim.sh
   cleanup_script: ./packages/feedsim/cleanup_feedsim.sh
+  install_markers:
+    - ./benchmarks/feedsim/src/build/workloads/ranking/LeafNodeRank
+    - ./benchmarks/feedsim/src/build/workloads/ranking/DriverNodeRank
   path: ./benchmarks/feedsim/run-feedsim-multi.sh
   tags:
     scope:

--- a/packages/feedsim/run-feedsim-multi.sh
+++ b/packages/feedsim/run-feedsim-multi.sh
@@ -14,6 +14,14 @@ if [[ "$THIS_CMD" =~ -q.*[0-9]+ ]]; then
 fi
 
 FEEDSIM_ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")" &>/dev/null && pwd -P)
+# Load custom-built shared libraries from staging (for self-contained fbpkg).
+# Must be set before any feedsim binary (LeafNodeRank, DriverNodeRank) runs.
+if [ -d "${FEEDSIM_ROOT}/staging/lib" ]; then
+    export LD_LIBRARY_PATH="${FEEDSIM_ROOT}/staging/lib:${FEEDSIM_ROOT}/staging/lib64:${LD_LIBRARY_PATH:-}"
+fi
+if [ -d "${FEEDSIM_ROOT}/third_party/libtorch/lib" ]; then
+    export LD_LIBRARY_PATH="${FEEDSIM_ROOT}/third_party/libtorch/lib:${LD_LIBRARY_PATH:-}"
+fi
 FEEDSIM_LOG_PREFIX="${FEEDSIM_ROOT}/feedsim-multi-inst-${FIXQPS_SUFFIX}"
 # Calculate number of instances based on physical cores (1 instance per 50 physical cores).
 # nproc returns logical cores; divide by 2 when SMT is active to get physical cores.

--- a/packages/feedsim/run.sh
+++ b/packages/feedsim/run.sh
@@ -30,6 +30,15 @@ FEEDSIM_ROOT_SRC="${FEEDSIM_ROOT}/src"
 BENCHPRESS_ROOT="$(readlink -f "$FEEDSIM_ROOT/../..")"
 BREAKDOWN_FOLDER="$FEEDSIM_ROOT"
 
+# Load custom-built libraries from staging (for self-contained fbpkg)
+if [ -d "${FEEDSIM_ROOT}/staging/lib" ]; then
+    export LD_LIBRARY_PATH="${FEEDSIM_ROOT}/staging/lib:${FEEDSIM_ROOT}/staging/lib64:${LD_LIBRARY_PATH:-}"
+fi
+# LibTorch shared libs (needed unconditionally when built with DLRM support)
+if [ -d "${FEEDSIM_ROOT}/third_party/libtorch/lib" ]; then
+    export LD_LIBRARY_PATH="${FEEDSIM_ROOT}/third_party/libtorch/lib:${LD_LIBRARY_PATH:-}"
+fi
+
 # Source runtime breakdown utilities
 source "${BENCHPRESS_ROOT}/packages/common/runtime_breakdown_utils.sh"
 

--- a/packages/feedsim/third_party/src/CMake/build-config.cmake
+++ b/packages/feedsim/third_party/src/CMake/build-config.cmake
@@ -4,3 +4,20 @@
 # LICENSE file in the root directory of this source tree.
 
 set(OLDISIM_STAGING_DIR "${oldisim_BINARY_DIR}/staging/usr/local")
+
+# Default parallel jobs for ExternalProject builds.
+# Overridden by -DBUILD_PARALLEL_JOBS=N from the build script to prevent OOM.
+if(NOT DEFINED BUILD_PARALLEL_JOBS)
+    include(ProcessorCount)
+    ProcessorCount(BUILD_PARALLEL_JOBS)
+    if(BUILD_PARALLEL_JOBS EQUAL 0)
+        set(BUILD_PARALLEL_JOBS 1)
+    endif()
+endif()
+message(STATUS "Build parallel jobs: ${BUILD_PARALLEL_JOBS}")
+
+# CMake 4.x requires minimum version >= 3.5. Pass this to all ExternalProject
+# builds so older CMakeLists.txt files (e.g., gflags, glog) don't fail.
+if(NOT DEFINED CMAKE_POLICY_VERSION_MINIMUM)
+    set(CMAKE_POLICY_VERSION_MINIMUM "3.5")
+endif()

--- a/packages/feedsim/third_party/src/CMake/build-fbthrift.cmake
+++ b/packages/feedsim/third_party/src/CMake/build-fbthrift.cmake
@@ -7,18 +7,29 @@ set(FBTHRIFT_ROOT_DIR ${oldisim_SOURCE_DIR}/third_party/fbthrift)
 
 include(ExternalProject)
 
+# Escape semicolons in CMAKE_PREFIX_PATH for ExternalProject
+string(REPLACE ";" "|" _ESCAPED_PREFIX_PATH "${CMAKE_PREFIX_PATH}")
+
+if(CMAKE_PREFIX_PATH)
+    set(_fbthrift_prefix_path_opt "-DCMAKE_PREFIX_PATH:PATH=<INSTALL_DIR>|${_ESCAPED_PREFIX_PATH}")
+else()
+    set(_fbthrift_prefix_path_opt "")
+endif()
+
 ExternalProject_Add(fbthrift
     SOURCE_DIR "${FBTHRIFT_ROOT_DIR}"
     DOWNLOAD_COMMAND ""
     INSTALL_DIR ${OLDISIM_STAGING_DIR}
+    LIST_SEPARATOR |
     CMAKE_ARGS
         -Dthriftpy3:BOOL=OFF
         -DCMAKE_BUILD_TYPE:STRING=Release
+        -DCMAKE_POLICY_VERSION_MINIMUM:STRING=${CMAKE_POLICY_VERSION_MINIMUM}
         -DCMAKE_C_COMPILER:STRING=${CMAKE_C_COMPILER}
         -DCMAKE_CXX_COMPILER:STRING=${CMAKE_CXX_COMPILER}
         -DCMAKE_CXX_FLAGS_RELEASE:STRING=${CMAKE_CXX_FLAGS_RELEASE}
         -DCMAKE_EXE_LINKER_FLAGS:STRING=${CMAKE_EXE_LINKER_FLAGS}
-        -DCMAKE_PREFIX_PATH:PATH=<INSTALL_DIR>
+        ${_fbthrift_prefix_path_opt}
         -DCMAKE_INSTALL_PREFIX:PATH=<INSTALL_DIR>
         -DCMAKE_POSITION_INDEPENDENT_CODE:BOOL=True
         -DCXX_STD:STRING=gnu++17
@@ -39,11 +50,20 @@ ExternalProject_Add(fbthrift
         <INSTALL_DIR>/lib/libthrift-core.a
         <INSTALL_DIR>/lib/libcompiler_base.a
         <INSTALL_DIR>/lib/libconcurrency.a
+        <INSTALL_DIR>/lib/librpcmetadata.a
+        <INSTALL_DIR>/lib/libthriftmetadata.a
+        <INSTALL_DIR>/lib/libthrifttype.a
+        <INSTALL_DIR>/lib/libthrifttyperep.a
+        <INSTALL_DIR>/lib/libthriftanyrep.a
+        <INSTALL_DIR>/lib/libthriftannotation.a
+        <INSTALL_DIR>/lib/libcommon.a
+        <INSTALL_DIR>/lib/libruntime.a
+        <INSTALL_DIR>/lib/libserverdbginfo.a
     BUILD_COMMAND
-        cmake --build .
+        cmake --build . --parallel ${BUILD_PARALLEL_JOBS}
     )
 
-ExternalProject_Add_StepDependencies(fbthrift configure folly wangle fmt mvfst)
+ExternalProject_Add_StepDependencies(fbthrift configure folly wangle mvfst fmt mvfst)
 
 ExternalProject_Get_Property(fbthrift SOURCE_DIR)
 ExternalProject_Get_Property(fbthrift INSTALL_DIR)
@@ -61,9 +81,15 @@ set(FBTHRIFT_LIBRARIES
     ${INSTALL_DIR}/lib/libasync.a
     ${INSTALL_DIR}/lib/libconcurrency.a
     ${INSTALL_DIR}/lib/libthriftfrozen2.a
-    ${INSTALL_DIR}/lib/libcompiler_ast.a
-    ${INSTALL_DIR}/lib/libcompiler_lib.a
-    ${INSTALL_DIR}/lib/libcompiler_base.a
+    ${INSTALL_DIR}/lib/librpcmetadata.a
+    ${INSTALL_DIR}/lib/libthriftmetadata.a
+    ${INSTALL_DIR}/lib/libthrifttype.a
+    ${INSTALL_DIR}/lib/libthrifttyperep.a
+    ${INSTALL_DIR}/lib/libthriftanyrep.a
+    ${INSTALL_DIR}/lib/libthriftannotation.a
+    ${INSTALL_DIR}/lib/libcommon.a
+    ${INSTALL_DIR}/lib/libruntime.a
+    ${INSTALL_DIR}/lib/libserverdbginfo.a
 )
 
 set(FBTHRIFT_INCLUDE_DIR

--- a/packages/feedsim/third_party/src/CMake/build-fizz.cmake
+++ b/packages/feedsim/third_party/src/CMake/build-fizz.cmake
@@ -7,20 +7,31 @@ set(FIZZ_ROOT_DIR ${oldisim_SOURCE_DIR}/third_party/fizz/fizz)
 
 include(ExternalProject)
 
+# Escape semicolons in CMAKE_PREFIX_PATH for ExternalProject
+string(REPLACE ";" "|" _ESCAPED_PREFIX_PATH "${CMAKE_PREFIX_PATH}")
+
+if(CMAKE_PREFIX_PATH)
+    set(_fizz_prefix_path_opt "-DCMAKE_PREFIX_PATH:PATH=<INSTALL_DIR>|${_ESCAPED_PREFIX_PATH}")
+else()
+    set(_fizz_prefix_path_opt "")
+endif()
+
 ExternalProject_Add(fizz
     PREFIX fizz
     SOURCE_DIR "${FIZZ_ROOT_DIR}"
     BUILD_ALWAYS OFF
     DOWNLOAD_COMMAND ""
     INSTALL_DIR ${OLDISIM_STAGING_DIR}
+    LIST_SEPARATOR |
     CMAKE_ARGS
         -DCMAKE_BUILD_TYPE:STRING=Release
+        -DCMAKE_POLICY_VERSION_MINIMUM:STRING=${CMAKE_POLICY_VERSION_MINIMUM}
         -DCMAKE_C_COMPILER:STRING=${CMAKE_C_COMPILER}
         -DCMAKE_CXX_COMPILER:STRING=${CMAKE_CXX_COMPILER}
         -DCMAKE_CXX_FLAGS_RELEASE:STRING=${CMAKE_CXX_FLAGS_RELEASE}
         -DCMAKE_EXE_LINKER_FLAGS:STRING=${CMAKE_EXE_LINKER_FLAGS}
         -DCMAKE_POSITION_INDEPENDENT_CODE:BOOL=True
-        -DCMAKE_PREFIX_PATH:PATH=<INSTALL_DIR>
+        ${_fizz_prefix_path_opt}
         -DCMAKE_INSTALL_PREFIX:PATH=<INSTALL_DIR>
         -DBUILD_TESTS:BOOL=OFF
         -DBOOST_ROOT:PATH=${BOOST_ROOT}
@@ -29,7 +40,7 @@ ExternalProject_Add(fizz
     BINARY_DIR ${oldisim_BINARY_DIR}/third_party/fizz
     BUILD_BYPRODUCTS <INSTALL_DIR>/lib/libfizz.a
     BUILD_COMMAND
-        cmake --build .
+        cmake --build . --parallel ${BUILD_PARALLEL_JOBS}
     )
 
 

--- a/packages/feedsim/third_party/src/CMake/build-fmt.cmake
+++ b/packages/feedsim/third_party/src/CMake/build-fmt.cmake
@@ -12,6 +12,7 @@ ExternalProject_Add(fmt
     INSTALL_DIR ${OLDISIM_STAGING_DIR}
     CMAKE_ARGS
         -DCMAKE_BUILD_TYPE:STRING=Release
+        -DCMAKE_POLICY_VERSION_MINIMUM:STRING=${CMAKE_POLICY_VERSION_MINIMUM}
         -DCMAKE_POSITION_INDEPENDENT_CODE:BOOL=True
         -DCMAKE_CXX_STANDARD:BOOL=20
         -DCMAKE_INSTALL_PREFIX:PATH=<INSTALL_DIR>
@@ -19,6 +20,8 @@ ExternalProject_Add(fmt
         -DFMT_TEST:BOOL=OFF
     BINARY_DIR ${oldisim_BINARY_DIR}/third_party/fmt
     BUILD_BYPRODUCTS <INSTALL_DIR>/lib/libfmt.a
+    BUILD_COMMAND
+        cmake --build . --parallel ${BUILD_PARALLEL_JOBS}
     )
 
 # Specify include dir

--- a/packages/feedsim/third_party/src/CMake/build-folly.cmake
+++ b/packages/feedsim/third_party/src/CMake/build-folly.cmake
@@ -11,26 +11,46 @@ if(thriftpy3)
   set(_folly_cmake_extra_opts "-DPYTHON_EXTENSIONS=True")
 endif()
 
+# Escape semicolons in CMAKE_PREFIX_PATH for ExternalProject
+string(REPLACE ";" "|" _ESCAPED_PREFIX_PATH "${CMAKE_PREFIX_PATH}")
+
+# Pass through CMAKE_PREFIX_PATH to ExternalProject builds when set.
+if(_ESCAPED_PREFIX_PATH)
+    set(_folly_prefix_path_opt "-DCMAKE_PREFIX_PATH:PATH=<INSTALL_DIR>|${_ESCAPED_PREFIX_PATH}")
+else()
+    set(_folly_prefix_path_opt "")
+endif()
+
+# Only use BOOST_LINK_STATIC in self-contained builds where we built
+# static Boost and gflags. The traditional install uses system shared libs.
+if(FEEDSIM_SELF_CONTAINED)
+    set(_folly_boost_static_opt "-DBOOST_LINK_STATIC:STRING=ON")
+else()
+    set(_folly_boost_static_opt "")
+endif()
 
 ExternalProject_Add(folly
     SOURCE_DIR "${FOLLY_ROOT_DIR}"
     BUILD_ALWAYS OFF
     DOWNLOAD_COMMAND ""
     INSTALL_DIR ${OLDISIM_STAGING_DIR}
+    LIST_SEPARATOR |
     CMAKE_ARGS
         -DCMAKE_BUILD_TYPE:STRING=Release
+        -DCMAKE_POLICY_VERSION_MINIMUM:STRING=${CMAKE_POLICY_VERSION_MINIMUM}
         -DCMAKE_C_COMPILER:STRING=${CMAKE_C_COMPILER}
         -DCMAKE_CXX_COMPILER:STRING=${CMAKE_CXX_COMPILER}
         -DCMAKE_CXX_FLAGS_RELEASE:STRING=${CMAKE_CXX_FLAGS_RELEASE}
         -DCMAKE_POSITION_INDEPENDENT_CODE:BOOL=True
         -DCXX_STD:STRING=gnu++17
         -DCMAKE_CXX_STANDARD:STRING=20
-        -DCMAKE_PREFIX_PATH:PATH=<INSTALL_DIR>
+        ${_folly_prefix_path_opt}
         -DCMAKE_INSTALL_PREFIX:PATH=<INSTALL_DIR>
+        ${_folly_boost_static_opt}
     BINARY_DIR ${oldisim_BINARY_DIR}/third_party/folly
     BUILD_BYPRODUCTS <INSTALL_DIR>/lib/libfolly.a
     BUILD_COMMAND
-        cmake --build .
+        cmake --build . --parallel ${BUILD_PARALLEL_JOBS}
     )
 add_dependencies(folly fmt)
 

--- a/packages/feedsim/third_party/src/CMake/build-libaegis.cmake
+++ b/packages/feedsim/third_party/src/CMake/build-libaegis.cmake
@@ -4,55 +4,74 @@
 # LICENSE file in the root directory of this source tree.
 
 # Build libaegis library for fizz's AEGIS cipher support
+# If libaegis is pre-installed (e.g., via conda), skip the Zig-based build.
 
 include(ExternalProject)
 
-# Determine architecture for Zig download
-if(CMAKE_SYSTEM_PROCESSOR MATCHES "aarch64")
-    set(ZIG_ARCH "aarch64")
+# Check if libaegis is already available in staging or CMAKE_PREFIX_PATH
+find_library(LIBAEGIS_PREINSTALLED NAMES aegis
+    PATHS ${OLDISIM_STAGING_DIR}/lib ${CMAKE_PREFIX_PATH}
+    PATH_SUFFIXES lib lib64
+    NO_DEFAULT_PATH)
+if(LIBAEGIS_PREINSTALLED)
+    message(STATUS "Using pre-installed libaegis: ${LIBAEGIS_PREINSTALLED}")
+    set(LIBAEGIS_LIBRARIES ${LIBAEGIS_PREINSTALLED})
+    # Find include dir
+    find_path(LIBAEGIS_INCLUDE_DIR NAMES aegis.h aegis256.h
+        PATHS ${OLDISIM_STAGING_DIR}/include NO_DEFAULT_PATH)
+    if(NOT LIBAEGIS_INCLUDE_DIR)
+        set(LIBAEGIS_INCLUDE_DIR ${OLDISIM_STAGING_DIR}/include)
+    endif()
+    # Create a dummy target so ExternalProject_Add_StepDependencies works
+    add_custom_target(libaegis)
 else()
-    set(ZIG_ARCH "x86_64")
+    # Determine architecture for Zig download
+    if(CMAKE_SYSTEM_PROCESSOR MATCHES "aarch64")
+        set(ZIG_ARCH "aarch64")
+    else()
+        set(ZIG_ARCH "x86_64")
+    endif()
+
+    set(ZIG_VERSION "0.15.2")
+    set(ZIG_URL "https://ziglang.org/download/${ZIG_VERSION}/zig-${ZIG_ARCH}-linux-${ZIG_VERSION}.tar.xz")
+    set(LIBAEGIS_REPO "https://github.com/aegis-aead/libaegis.git")
+    set(LIBAEGIS_TAG "0.4.2")
+
+    # Download and extract Zig compiler
+    ExternalProject_Add(zig
+        PREFIX zig
+        URL ${ZIG_URL}
+        CONFIGURE_COMMAND ""
+        BUILD_COMMAND ""
+        INSTALL_COMMAND ""
+        BUILD_IN_SOURCE TRUE
+    )
+
+    ExternalProject_Get_Property(zig SOURCE_DIR)
+    set(ZIG_EXECUTABLE ${SOURCE_DIR}/zig)
+
+    # Build libaegis using Zig
+    ExternalProject_Add(libaegis
+        PREFIX libaegis
+        GIT_REPOSITORY ${LIBAEGIS_REPO}
+        GIT_TAG ${LIBAEGIS_TAG}
+        CONFIGURE_COMMAND ""
+        BUILD_COMMAND ${ZIG_EXECUTABLE} build -Drelease -Dfavor-performance
+        BUILD_IN_SOURCE TRUE
+        INSTALL_DIR ${OLDISIM_STAGING_DIR}
+        INSTALL_COMMAND
+            ${CMAKE_COMMAND} -E copy_directory <SOURCE_DIR>/zig-out/include <INSTALL_DIR>/include
+            COMMAND ${CMAKE_COMMAND} -E copy_directory <SOURCE_DIR>/zig-out/lib <INSTALL_DIR>/lib
+    )
+
+    ExternalProject_Add_StepDependencies(libaegis build zig)
+
+    ExternalProject_Get_Property(libaegis SOURCE_DIR)
+    ExternalProject_Get_Property(libaegis INSTALL_DIR)
+
+    set(LIBAEGIS_INCLUDE_DIR ${INSTALL_DIR}/include)
+    set(LIBAEGIS_LIBRARIES ${INSTALL_DIR}/lib/libaegis.a)
 endif()
-
-set(ZIG_VERSION "0.15.2")
-set(ZIG_URL "https://ziglang.org/download/${ZIG_VERSION}/zig-${ZIG_ARCH}-linux-${ZIG_VERSION}.tar.xz")
-set(LIBAEGIS_REPO "https://github.com/aegis-aead/libaegis.git")
-set(LIBAEGIS_TAG "0.4.2")
-
-# Download and extract Zig compiler
-ExternalProject_Add(zig
-    PREFIX zig
-    URL ${ZIG_URL}
-    CONFIGURE_COMMAND ""
-    BUILD_COMMAND ""
-    INSTALL_COMMAND ""
-    BUILD_IN_SOURCE TRUE
-)
-
-ExternalProject_Get_Property(zig SOURCE_DIR)
-set(ZIG_EXECUTABLE ${SOURCE_DIR}/zig)
-
-# Build libaegis using Zig
-ExternalProject_Add(libaegis
-    PREFIX libaegis
-    GIT_REPOSITORY ${LIBAEGIS_REPO}
-    GIT_TAG ${LIBAEGIS_TAG}
-    CONFIGURE_COMMAND ""
-    BUILD_COMMAND ${ZIG_EXECUTABLE} build -Drelease -Dfavor-performance
-    BUILD_IN_SOURCE TRUE
-    INSTALL_DIR ${OLDISIM_STAGING_DIR}
-    INSTALL_COMMAND
-        ${CMAKE_COMMAND} -E copy_directory <SOURCE_DIR>/zig-out/include <INSTALL_DIR>/include
-        COMMAND ${CMAKE_COMMAND} -E copy_directory <SOURCE_DIR>/zig-out/lib <INSTALL_DIR>/lib
-)
-
-ExternalProject_Add_StepDependencies(libaegis build zig)
-
-ExternalProject_Get_Property(libaegis SOURCE_DIR)
-ExternalProject_Get_Property(libaegis INSTALL_DIR)
-
-set(LIBAEGIS_INCLUDE_DIR ${INSTALL_DIR}/include)
-set(LIBAEGIS_LIBRARIES ${INSTALL_DIR}/lib/libaegis.a)
 
 message(STATUS "LibAegis Include: ${LIBAEGIS_INCLUDE_DIR}")
 message(STATUS "LibAegis Library: ${LIBAEGIS_LIBRARIES}")

--- a/packages/feedsim/third_party/src/CMake/build-mvfst.cmake
+++ b/packages/feedsim/third_party/src/CMake/build-mvfst.cmake
@@ -7,25 +7,36 @@ set(MVFST_ROOT_DIR ${oldisim_SOURCE_DIR}/third_party/mvfst)
 
 include(ExternalProject)
 
+# Escape semicolons in CMAKE_PREFIX_PATH for ExternalProject
+string(REPLACE ";" "|" _ESCAPED_PREFIX_PATH "${CMAKE_PREFIX_PATH}")
+
+if(CMAKE_PREFIX_PATH)
+    set(_mvfst_prefix_path_opt "-DCMAKE_PREFIX_PATH:PATH=<INSTALL_DIR>|${_ESCAPED_PREFIX_PATH}")
+else()
+    set(_mvfst_prefix_path_opt "")
+endif()
 
 ExternalProject_Add(mvfst
     SOURCE_DIR "${MVFST_ROOT_DIR}"
     BUILD_ALWAYS OFF
     DOWNLOAD_COMMAND ""
     INSTALL_DIR ${OLDISIM_STAGING_DIR}
+    LIST_SEPARATOR |
     CMAKE_ARGS
         -DCMAKE_BUILD_TYPE:STRING=Release
+        -DCMAKE_POLICY_VERSION_MINIMUM:STRING=${CMAKE_POLICY_VERSION_MINIMUM}
         -DCMAKE_C_COMPILER:STRING=${CMAKE_C_COMPILER}
         -DCMAKE_CXX_COMPILER:STRING=${CMAKE_CXX_COMPILER}
         -DCMAKE_CXX_FLAGS_RELEASE:STRING=${CMAKE_CXX_FLAGS_RELEASE}
         -DCMAKE_POSITION_INDEPENDENT_CODE:BOOL=True
         -DCXX_STD:STRING=gnu++17
         -DCMAKE_CXX_STANDARD:STRING=20
+        ${_mvfst_prefix_path_opt}
         -DCMAKE_INSTALL_PREFIX:PATH=<INSTALL_DIR>
         -DBOOST_ROOT:PATH=${BOOST_ROOT}
         -DBoost_INCLUDE_DIR:PATH=${Boost_INCLUDE_DIR}
         -DBoost_NO_BOOST_CMAKE:BOOL=${Boost_NO_BOOST_CMAKE}
     BUILD_COMMAND
-        cmake --build .
+        cmake --build . --parallel ${BUILD_PARALLEL_JOBS}
     )
 ExternalProject_Add_StepDependencies(mvfst configure fmt folly fizz)

--- a/packages/feedsim/third_party/src/CMake/build-wangle.cmake
+++ b/packages/feedsim/third_party/src/CMake/build-wangle.cmake
@@ -12,6 +12,7 @@ ExternalProject_Add(wangle
     DOWNLOAD_COMMAND ""
     CMAKE_ARGS
         -DCMAKE_BUILD_TYPE:STRING=Release
+        -DCMAKE_POLICY_VERSION_MINIMUM:STRING=${CMAKE_POLICY_VERSION_MINIMUM}
         -DCMAKE_PREFIX_PATH:STRING=${CMAKE_PREFIX_PATH}
         -DCMAKE_C_COMPILER:STRING=${CMAKE_C_COMPILER}
         -DCMAKE_CXX_COMPILER:STRING=${CMAKE_CXX_COMPILER}
@@ -25,7 +26,7 @@ ExternalProject_Add(wangle
     BINARY_DIR ${oldisim_BINARY_DIR}/third_party/wangle
     BUILD_BYPRODUCTS ${OLDISIM_STAGING_DIR}/lib/libwangle.a
     BUILD_COMMAND
-        cmake --build .
+        cmake --build . --parallel ${BUILD_PARALLEL_JOBS}
 )
 
 ExternalProject_Get_Property(wangle BINARY_DIR)

--- a/packages/feedsim/third_party/src/third_party/CMakeLists.txt
+++ b/packages/feedsim/third_party/src/third_party/CMakeLists.txt
@@ -13,9 +13,11 @@ if(NOT EXISTS "${PROJECT_SOURCE_DIR}/cereal/CMakeLists.txt" OR
 endif()
 
 
-# Apply gapbs patches
+# Apply gapbs patches (skip if `patch` command is not available, e.g., on RE hosts
+# where patches were pre-applied during the deps download stage)
+find_program(PATCH_EXECUTABLE patch)
 file(GLOB PATCHES "${CMAKE_SOURCE_DIR}/patches/*.patch")
-if(PATCHES)
+if(PATCHES AND PATCH_EXECUTABLE)
     message(STATUS "Patches: ${PATCHES}")
     foreach(PATCH ${PATCHES})
         message(STATUS "Applying ${PATCH}")

--- a/packages/feedsim/third_party/src/workloads/ranking/CMakeLists.txt
+++ b/packages/feedsim/third_party/src/workloads/ranking/CMakeLists.txt
@@ -21,6 +21,15 @@ find_package(Boost 1.53.0
 find_package(OpenSSL REQUIRED)
 find_package(DoubleConversion REQUIRED)
 find_package(Glog REQUIRED)
+find_package(gflags REQUIRED)
+find_library(XXHASH_LIBRARY NAMES xxhash)
+# Use gflags_static when building the self-contained fbpkg (FEEDSIM_SELF_CONTAINED=ON).
+# The traditional install path uses system-installed shared gflags.
+if(FEEDSIM_SELF_CONTAINED)
+    set(GFLAGS_TARGET gflags_static)
+else()
+    set(GFLAGS_TARGET gflags)
+endif()
 find_package(BZip2 REQUIRED)
 find_package(ZLIB REQUIRED)
 find_package(Zstd REQUIRED)
@@ -210,6 +219,23 @@ target_link_libraries(LeafNodeRank
 )
 target_compile_options(LeafNodeRank PUBLIC -fno-omit-frame-pointer -ffunction-sections -fdata-sections)
 target_link_options(LeafNodeRank PRIVATE -Wl,--gc-sections -Wl,--allow-multiple-definition)
+# Re-link libraries at the end to resolve circular static library dependencies
+# (folly/glog use gflags DEFINE_* macros, fbthrift has internal cross-lib refs)
+target_link_libraries(LeafNodeRank PRIVATE
+    ${FBTHRIFT_LIBRARIES}
+    ${FOLLY_LIBRARIES}
+    glog::glog
+    ${GFLAGS_TARGET}
+    ${XXHASH_LIBRARY}
+    ${DOUBLE_CONVERSION_LIBRARY}
+    ${FBTHRIFT_LIBRARIES}
+    ${FOLLY_LIBRARIES}
+    Boost::context Boost::filesystem Boost::system
+    OpenSSL::SSL OpenSSL::Crypto
+    ${FIZZ_LIBRARIES} ${WANGLE_LIBRARIES}
+    ${FMT_LIBRARIES} ${IBERTY_LIBRARIES}
+    ${CMAKE_DL_LIBS} Threads::Threads
+)
 
 
 # Generate getopts for ParentNodeRank
@@ -274,6 +300,29 @@ target_link_libraries(
         ${LIBEVENT_LIB}
         ${JEMALLOC_LIB}
         ${FBTHRIFT_LIBRARIES}
+)
+# Re-link to resolve circular deps (static libs need explicit transitive deps)
+target_link_libraries(ParentNodeRank PRIVATE
+    ${FBTHRIFT_LIBRARIES}
+    ${FOLLY_LIBRARIES}
+    glog::glog
+    ${GFLAGS_TARGET}
+    ${XXHASH_LIBRARY}
+    ${DOUBLE_CONVERSION_LIBRARY}
+    ${FBTHRIFT_LIBRARIES}
+    Boost::context
+    Boost::filesystem
+    Boost::atomic
+    Boost::system
+    Boost::program_options
+    Boost::regex
+    OpenSSL::SSL OpenSSL::Crypto
+    ${FIZZ_LIBRARIES}
+    ${WANGLE_LIBRARIES}
+    ${FBTHRIFT_LIBRARIES}
+    ${FOLLY_LIBRARIES}
+    ${IBERTY_LIBRARIES}
+    ${FMT_LIBRARIES}
 )
 
 # Generate getops for DriverNodeRank
@@ -374,4 +423,18 @@ target_link_libraries(
         ${FIZZ_LIBRARIES}
         ${WANGLE_LIBRARIES}
         ${FMT_LIBRARIES}
+)
+target_compile_options(DriverNodeRank PUBLIC -fno-omit-frame-pointer)
+target_link_options(DriverNodeRank PRIVATE -Wl,--gc-sections -Wl,--allow-multiple-definition)
+# Re-link to resolve circular deps (static libs need explicit ordering).
+# Use --whole-archive for OpenSSL to ensure all symbols are included.
+target_link_libraries(DriverNodeRank PRIVATE
+    ${FBTHRIFT_LIBRARIES} ${FOLLY_LIBRARIES} glog::glog ${GFLAGS_TARGET}
+    ${XXHASH_LIBRARY} ${DOUBLE_CONVERSION_LIBRARY} ${FBTHRIFT_LIBRARIES}
+    ${FOLLY_LIBRARIES}
+    Boost::context Boost::filesystem Boost::system
+    -Wl,--whole-archive OpenSSL::SSL OpenSSL::Crypto -Wl,--no-whole-archive
+    ${FIZZ_LIBRARIES} ${WANGLE_LIBRARIES}
+    ${FMT_LIBRARIES} ${IBERTY_LIBRARIES}
+    ${CMAKE_DL_LIBS} Threads::Threads
 )


### PR DESCRIPTION
Summary:

Pre-build FeedSim at fbpkg build time so the package runs without
`benchpress install`. Both x86_64 and aarch64 use the same two-stage
offline build:

1. `feedsim_deps_download` — runs on x86 with network, downloads source
   tarballs and pre-packed conda env from Manifold
2. `feedsim_oss_build[_aarch64]` — runs on arch-specific RE host, extracts
   conda env (GCC 15.2, cmake, ninja), builds all deps from source, compiles
   FeedSim with DLRM support

Key changes:
- `build.sh`: standalone build script — extracts pre-packed conda env,
  builds Boost/gflags/glog/jemalloc/libevent/folly/fbthrift, compiles FeedSim
- `download_deps.sh`: downloads from Manifold (no internet fallback needed)
- BUCK: three genrules (deps_download, x86 build, aarch64 build) with
  `select()` in fbpkg path_actions for architecture dispatch
- CMake: pass-through CMAKE_PREFIX_PATH for staging dir in ExternalProject
- `run.sh`/`run-feedsim-multi.sh`: LD_LIBRARY_PATH for conda runtime libs

Performance (feedsim_autoscale, 3 iterations each):
- x86 Bergamo: 395.20 QPS self-contained vs 380.92 QPS master (+3.7%)
- ARM Grace:   324.57 QPS self-contained vs 322.48 QPS master (+0.6%)

Reviewed By: gandhijayneel

Differential Revision: D93702226


