### PR TITLE
Detect Phoenix as Neoverse V3 for perf hook

### DIFF
--- a/benchpress/plugins/hooks/perf_monitors/topdown.py
+++ b/benchpress/plugins/hooks/perf_monitors/topdown.py
@@ -676,8 +676,23 @@ def choose_perfspect():
         return DummyPerfUtil
 
 
+def _is_neoversev3_string(value: str) -> bool:
+    normalized = value.lower().replace("_", "-")
+    return "neoverse-v3" in normalized
+
+
 def is_neoversev3():
-    """Detect ARM Neoverse V3 platforms via DMI system-family or system-version."""
+    """Detect ARM Neoverse V3 platforms.
+
+    Phoenix/Rainier reports the CPU as `Neoverse-V3AE` in `lscpu`'s
+    `Model name`, while DMI fields may not include a Neoverse string. Check
+    the CPU model first so these hosts use the packaged Neoverse V3 perfutils
+    instead of falling back to the generic ARM topdown-tool path.
+    """
+    model_name = get_cpuinfo().get("Model name", "")
+    if _is_neoversev3_string(model_name):
+        return True
+
     for dmi_field in ("system-family", "system-version"):
         try:
             p = subprocess.Popen(
@@ -687,7 +702,7 @@ def is_neoversev3():
                 encoding="utf-8",
             )
             out, _ = p.communicate()
-            if "neoverse-v3" in out.lower() or "neoverse_v3" in out.lower():
+            if _is_neoversev3_string(out):
                 return True
         except Exception:
             pass


### PR DESCRIPTION
Summary:
Phoenix/Rainier hosts report the CPU as `Neoverse-V3AE` in `lscpu` Model name, but the Benchpress perf hook only detected Neoverse V3 from DMI system-family/system-version strings.

When DMI detection missed Phoenix, the `perf` hook fell back to the generic ARM topdown-tool path. That path can install/run Arm topdown-tool at benchmark time and emit setup output to stdout before Automark JSON.

Teach the Neoverse V3 selector to also recognize `lscpu` Model name strings such as `Neoverse-V3AE`, while preserving the existing DMI checks. This makes Phoenix use the packaged Neoverse V3 perfutils (`collect_neoversev3_perf_counters.sh` and `generate_arm_neoversev3_perf_report.py`) instead of generic ARM topdown-tool.

Differential Revision: D108616598


