### PR TITLE
Fix benchpress skycastle entrypoint names to match workflow definitions (#688)

### DIFF
--- a/packages/ucache_bench/client/CMakeLists.txt
+++ b/packages/ucache_bench/client/CMakeLists.txt
@@ -23,6 +23,9 @@ target_include_directories(ucachebench_client PRIVATE
     ${STAGING_DIR}/include
 )
 
+# Suppress deprecation warnings from generated Thrift headers
+target_compile_options(ucachebench_client PRIVATE -Wno-deprecated-declarations)
+
 # Google Test/Mock libraries (needed by mcrouter headers)
 # Try lib64 first, then lib (some systems install to lib64)
 if(EXISTS "${STAGING_DIR}/lib64/libgmock.a")

--- a/packages/ucache_bench/install_ucache_bench.sh
+++ b/packages/ucache_bench/install_ucache_bench.sh
@@ -714,10 +714,43 @@ fi
 # by mcrouter's config file when resolving transitive dependencies
 FBCMAKE_MODULE_DIR="$DEPS_DIR/mcrouter/build/fbcode_builder/CMake"
 
+# Fix Thrift API compatibility issue with getWriteTransforms()
+# The generated code calls getWriteTransforms() which returns std::vector<uint16_t>&
+# (non-const reference), but payload.transform() expects a const reference.
+# This causes a compilation error with newer fbthrift versions.
+# We patch the generated files to use const_cast to fix the const-correctness issue.
+echo "  Patching generated protocol files for Thrift API compatibility..."
+for f in "$PROTOCOL_GEN_DIR"/*.cpp; do
+    if [ -f "$f" ]; then
+        # Fix getWriteTransforms() calls to use const_cast for const-correctness
+        # The API returns non-const reference but transform() expects const reference
+        sed -i 's/getWriteTransforms()/const_cast<const std::vector<uint16_t>\&>(getWriteTransforms())/g' "$f"
+        # Also fix with reqCtx->getHeader() prefix
+        sed -i 's/reqCtx->getHeader()->getWriteTransforms()/const_cast<const std::vector<uint16_t>\&>(reqCtx->getHeader()->getWriteTransforms())/g' "$f"
+        sed -i 's/reqCtx_->getHeader()->getWriteTransforms()/const_cast<const std::vector<uint16_t>\&>(reqCtx_->getHeader()->getWriteTransforms())/g' "$f"
+        sed -i 's/context->getHeader()->getWriteTransforms()/const_cast<const std::vector<uint16_t>\&>(context->getHeader()->getWriteTransforms())/g' "$f"
+        sed -i 's/context_->getHeader()->getWriteTransforms()/const_cast<const std::vector<uint16_t>\&>(context_->getHeader()->getWriteTransforms())/g' "$f"
+    fi
+done
+
+# Remove internal-only API calls (getPrivacyLibAgenticContext, getKcbIdentity)
+# from generated ThriftTransport code. These methods exist in Meta's internal
+# mcrouter but are not available in the OSS release at the same tag.
+# We remove the entire if-blocks since they're optional metadata headers.
+echo "  Removing internal-only API calls from UcacheBenchThriftTransport.h..."
+THRIFT_TRANSPORT_H="$PROTOCOL_GEN_DIR/UcacheBenchThriftTransport.h"
+if [ -f "$THRIFT_TRANSPORT_H" ] && grep -q "getKcbIdentity" "$THRIFT_TRANSPORT_H"; then
+    # Remove getPrivacyLibAgenticContext blocks (3 lines each: if, setWriteHeader, close-brace)
+    sed -i '/getPrivacyLibAgenticContext/,+3d' "$THRIFT_TRANSPORT_H"
+    # Remove getKcbIdentity blocks (3 lines each: if, setWriteHeader, close-brace)
+    sed -i '/getKcbIdentity/,+3d' "$THRIFT_TRANSPORT_H"
+fi
+
 cmake "$SCRIPT_DIR" \
     -DCMAKE_BUILD_TYPE=Release \
     -DCMAKE_PREFIX_PATH="$STAGING_DIR" \
     -DCMAKE_MODULE_PATH="$FBCMAKE_MODULE_DIR" \
+    -DCMAKE_CXX_FLAGS="-Wno-error=deprecated-declarations" \
     -DBUILD_SERVER=ON \
     -DBUILD_CLIENT=ON
 

--- a/packages/ucache_bench/protocol/CMakeLists.txt
+++ b/packages/ucache_bench/protocol/CMakeLists.txt
@@ -189,6 +189,13 @@ target_link_libraries(ucachebench_protocol PUBLIC
     fmt::fmt
 )
 
+# Suppress deprecation warnings in generated Thrift code (thrift1 generates
+# calls to getWriteTransforms() which is deprecated in favor of
+# getWriteTTransforms() in the same version's headers)
+target_compile_options(ucachebench_protocol PRIVATE
+    -Wno-deprecated-declarations
+)
+
 # Install target
 install(TARGETS ucachebench_protocol
     ARCHIVE DESTINATION lib

--- a/packages/ucache_bench/server/CMakeLists.txt
+++ b/packages/ucache_bench/server/CMakeLists.txt
@@ -35,6 +35,9 @@ target_include_directories(ucachebench_server PRIVATE
     ${STAGING_DIR}/include
 )
 
+# Suppress deprecation warnings from generated Thrift headers
+target_compile_options(ucachebench_server PRIVATE -Wno-deprecated-declarations)
+
 # CacheLib libraries - order matters for static linking
 set(CACHELIB_LIBS
     ${STAGING_DIR}/lib/libcachelib_allocator.a

--- a/scripts/install-deps.sh
+++ b/scripts/install-deps.sh
@@ -19,7 +19,20 @@ centos10() {
         $SUDO dnf install -y 'dnf-command(config-manager)'
         $SUDO dnf config-manager --set-enabled crb
     fi
-    $SUDO dnf group install -y "Development Tools" --exclude="texlive*"
+    # Remove perf first to avoid file conflict with kernel-headers
+    # Both packages provide /usr/include/perf/perf_dlfilter.h
+    $SUDO dnf remove -y perf || true
+    # Exclude rpm-build to avoid rpm version conflicts between hsx.el10 and BaseOS
+    # Also exclude el10 packages that conflict with installed hsx.el10 versions
+    # Exclude rpm-sign packages which depend on conflicting rpm-libs
+    # Note: kernel-headers is required by glibc-devel (which is required by gcc),
+    # so we cannot exclude it.
+    # Use --skip-broken to skip packages with broken dependencies
+    $SUDO dnf group install -y "Development Tools" --exclude="texlive*" --exclude="rpm-build" --exclude="rpm-sign*" --exclude="rpm-4.19.1.1-23*" --exclude="rpm-libs-4.19.1.1-23*" --allowerasing --skip-broken
+    # Reinstall perf to handle the file conflict with kernel-headers
+    # Both packages provide /usr/include/perf/perf_dlfilter.h
+    # Use --setopt=tsflags=replacefiles to allow overwriting files from kernel-headers
+    $SUDO dnf install -y perf --setopt=tsflags=replacefiles || true
 
     $SUDO dnf install -y openssl-devel
 }
@@ -36,7 +49,21 @@ centos9() {
         $SUDO dnf install -y 'dnf-command(config-manager)'
         $SUDO dnf config-manager --set-enabled crb
     fi
-    $SUDO dnf group install -y "Development Tools" --exclude="texlive*"
+    # Remove perf first to avoid file conflict with kernel-headers
+    # Both packages provide /usr/include/perf/perf_dlfilter.h
+    $SUDO dnf remove -y perf || true
+    # Exclude rpm-build to avoid rpm version conflicts between hsx.el10 and BaseOS
+    # Also exclude el10 packages to prevent repository metadata issues on Sandcastle
+    # Exclude specific rpm versions that conflict with installed hsx.el10 packages
+    # Exclude rpm-sign packages which depend on conflicting rpm-libs
+    # Note: kernel-headers is required by glibc-devel (which is required by gcc),
+    # so we cannot exclude it.
+    # Use --skip-broken to skip packages with broken dependencies
+    $SUDO dnf group install -y "Development Tools" --exclude="texlive*" --exclude="rpm-build" --exclude="rpm-sign*" --exclude="*.el10*" --exclude="rpm-4.19*" --exclude="rpm-libs-4.19*" --exclude="rpm-plugin-*4.19*" --allowerasing --skip-broken
+    # Reinstall perf to handle the file conflict with kernel-headers
+    # Both packages provide /usr/include/perf/perf_dlfilter.h
+    # Use --setopt=tsflags=replacefiles to allow overwriting files from kernel-headers
+    $SUDO dnf install -y perf --setopt=tsflags=replacefiles || true
 
     $SUDO dnf install -y openssl-devel
 }


### PR DESCRIPTION
Summary:

The BUCK file defined ci_skycastle targets with entrypoint names that did not match the entry_point names defined in tools/skycastle/workflows2/dc_perf/benchpress.sky.

Updated all 16 ci_skycastle targets to use the correct entrypoint names that match the entry_point definitions in the sky file

Reviewed By: excelle08

Differential Revision: D108346882


