### PR TITLE
Enable Pyrefly for fbcode/cea

### DIFF
--- a/benchpress/cli/commands/clean.py
+++ b/benchpress/cli/commands/clean.py
@@ -19,6 +19,7 @@ logger = logging.getLogger(__name__)
 
 
 class CleanCommand(BenchpressCommand):
+    # pyrefly: ignore [bad-override-param-name]
     def populate_parser(self, subparsers):
         parser = subparsers.add_parser("clean", help="remove benchmark dependencies")
         parser.set_defaults(command=self)

--- a/benchpress/cli/commands/info.py
+++ b/benchpress/cli/commands/info.py
@@ -17,6 +17,7 @@ from .command import BenchpressCommand, TABLE_FORMAT
 
 
 class InfoCommand(BenchpressCommand):
+    # pyrefly: ignore [bad-override-param-name]
     def populate_parser(self, subparsers):
         parser = subparsers.add_parser(
             "info", help="Provides more details about specific job."

--- a/benchpress/cli/commands/install.py
+++ b/benchpress/cli/commands/install.py
@@ -25,6 +25,7 @@ logger = logging.getLogger(__name__)
 
 
 class InstallCommand(BenchpressCommand):
+    # pyrefly: ignore [bad-override-param-name]
     def populate_parser(self, subparsers):
         parser = subparsers.add_parser("install", help="install benchmarks")
         parser.set_defaults(command=self)

--- a/benchpress/cli/commands/list.py
+++ b/benchpress/cli/commands/list.py
@@ -13,6 +13,7 @@ from .command import BenchpressCommand, TABLE_FORMAT
 
 
 class ListCommand(BenchpressCommand):
+    # pyrefly: ignore [bad-override-param-name]
     def populate_parser(self, subparsers):
         parser = subparsers.add_parser("list", help="list all configured jobs")
         parser.set_defaults(command=self)

--- a/benchpress/cli/commands/report.py
+++ b/benchpress/cli/commands/report.py
@@ -18,6 +18,7 @@ logger = logging.getLogger(__name__)
 
 
 class ReportCommand(BenchpressCommand):
+    # pyrefly: ignore [bad-override-param-name]
     def populate_parser(self, subparsers):
         parser = subparsers.add_parser("report", help="report job results")
         parser.set_defaults(command=self)

--- a/benchpress/cli/commands/run.py
+++ b/benchpress/cli/commands/run.py
@@ -141,6 +141,7 @@ class RunCommand(BenchpressCommand):
 
         return version_info
 
+    # pyrefly: ignore [bad-override-param-name]
     def populate_parser(self, subparsers):
         parser = subparsers.add_parser("run", help="run job(s)")
         parser.set_defaults(command=self)

--- a/benchpress/cli/commands/system_check.py
+++ b/benchpress/cli/commands/system_check.py
@@ -56,6 +56,7 @@ class SystemCheckCommand(BenchpressCommand):
         self.run_cmd = run_cmd
         self.fbk_version_regex: str = r"(\d+\.\d+\.\d+-\d+)_fbk(\d+)"
 
+    # pyrefly: ignore [bad-override-param-name]
     def populate_parser(self, subparsers):
         parser = subparsers.add_parser(
             "system_check",
@@ -368,6 +369,7 @@ class SystemCheckCommand(BenchpressCommand):
             result.value = "<not present>"
             self.fatal("Could not parse serf result as JSON")
 
+        # pyrefly: ignore [unbound-name]
         for item in result_json:
             match: bool = True
             for selector in selectors:

--- a/benchpress/lib/dmidecode.py
+++ b/benchpress/lib/dmidecode.py
@@ -124,6 +124,7 @@ def _parse_dmihandle_record(
 
         if in_list_state:
             if not list_element_match or kv_record_match or list_record_match:
+                # pyrefly: ignore [unsupported-operation]
                 dmihandle_data[list_acc_name] = list_acc
                 in_list_state = False
                 list_acc_name = ""

--- a/benchpress/plugins/hooks/perf.py
+++ b/benchpress/plugins/hooks/perf.py
@@ -70,6 +70,7 @@ AVAIL_MONITORS = {
 }
 
 if not open_source:
+    # pyrefly: ignore [unbound-name]
     AVAIL_MONITORS["fb_power"] = fb_power.FBPower
 
 logger = logging.getLogger(__name__)

--- a/benchpress/plugins/parsers/openssl_speed.py
+++ b/benchpress/plugins/parsers/openssl_speed.py
@@ -84,7 +84,9 @@ def _read_cipher_block(lines: Iterable[str]) -> dict:
         rates_MBps = [r * 1000.0 / 1_000_000.0 for r in rates_kBps]  # → MB/s decimal
         for i, mbps in enumerate(rates_MBps):
             block = bytes_columns[i] if i < len(bytes_columns) else i
+            # pyrefly: ignore [unsupported-operation]
             out[f"cipher_throughput_MBps_at_{block}B"] = mbps
+        # pyrefly: ignore [unsupported-operation]
         out["cipher_throughput_MBps_max"] = max(rates_MBps)
         return out
     return out

--- a/packages/ucache_bench/run.py
+++ b/packages/ucache_bench/run.py
@@ -401,6 +401,7 @@ def run_server(args: argparse.Namespace) -> None:
     print(stdout)
 
     if "DCPERF_PERF_RECORD" in os.environ and os.environ["DCPERF_PERF_RECORD"] == "1":
+        # pyrefly: ignore [unbound-name]
         t_prof.cancel()
 
 


### PR DESCRIPTION
Summary: Migrates `fbcode/cea` from Pyre to Pyrefly by removing the root `python.set_pyrefly(False)` opt-out so the tree inherits `set_pyrefly(True)` from the fbcode root default. Pre-existing type errors are suppressed via annotation-only `# pyrefly: ignore` comments; no runtime changes.

Reviewed By: grievejia

Differential Revision: D109080715


