### PR TITLE
Fix deployment issues for Py3.14 + Cassandra protocol

### DIFF
--- a/packages/django_workload/install_django_workload.sh
+++ b/packages/django_workload/install_django_workload.sh
@@ -148,6 +148,9 @@ set +u
 source ./venv_cpython/bin/activate
 set -u
 
+# Python 3.14 venvs don't bundle setuptools by default — install it first
+pip install setuptools wheel
+
 sed -i 's/django-cassandra-engine/django-cassandra-engine >= 1.5, < 1.6/' setup.py
 
 # Install dependencies using third_party pip dependencies from manifold
@@ -164,6 +167,9 @@ pushd "${OUT}/django-workload/django-workload"  # Make sure we're in the right d
 export CPATH="${OUT}/django-workload/django-workload/cinder/cinder-build/include:${OUT}/django-workload/django-workload/cinder/Include"
 source ./venv_cinder/bin/activate
 set -u
+
+# Python 3.14 venvs don't bundle setuptools by default — install it first
+pip install setuptools wheel
 
 # Install dependencies using third_party pip dependencies from manifold
 pip install "django-statsd-mozilla" --no-index --find-links file://"$OUT/django-workload/django-workload/third_party"

--- a/packages/django_workload/install_django_workload_aarch64.sh
+++ b/packages/django_workload/install_django_workload_aarch64.sh
@@ -372,8 +372,12 @@ set +u
 source ./venv_cpython/bin/activate
 set -u
 
+# CPython 3.14 is built as a shared library — pip3.14 needs libpython3.14.so
 export LD_LIBRARY_PATH="${CPYTHON_INSTALL_PREFIX}/lib"
 export CMAKE_LIBRARY_PATH="${CPYTHON_INSTALL_PREFIX}/lib"
+
+# Python 3.14 venvs don't bundle setuptools by default — install it first
+pip3.14 install setuptools wheel
 export CPATH="${DJANGO_SERVER_ROOT}/Python-3.14.2/python-build/include:${DJANGO_SERVER_ROOT}/Python-3.14.2/Include"
 # Set LIBRARY_PATH and LDFLAGS to ensure packages link against CPython's libpython
 export LIBRARY_PATH="${CPYTHON_INSTALL_PREFIX}/lib"
@@ -425,6 +429,9 @@ export LIBRARY_PATH="${CINDER_INSTALL_PREFIX}/lib"
 export LDFLAGS="-L${CINDER_INSTALL_PREFIX}/lib -Wl,-rpath,${CINDER_INSTALL_PREFIX}/lib"
 source ./venv_cinder/bin/activate
 set -u
+
+# Python 3.14 venvs don't bundle setuptools by default — install it first
+pip3.14 install setuptools wheel
 
 # Install pylibmc (required by django-workload)
 cd "${PYLIBMC_DIR}"

--- a/packages/django_workload/install_django_workload_aarch64_ubuntu22_24.sh
+++ b/packages/django_workload/install_django_workload_aarch64_ubuntu22_24.sh
@@ -407,8 +407,12 @@ set +u
 source ./venv_cpython/bin/activate
 set -u
 
+# CPython 3.14 is built as a shared library — pip3.14 needs libpython3.14.so
 export LD_LIBRARY_PATH="${CPYTHON_INSTALL_PREFIX}/lib"
 export CMAKE_LIBRARY_PATH="${CPYTHON_INSTALL_PREFIX}/lib"
+
+# Python 3.14 venvs don't bundle setuptools by default — install it first
+pip3.14 install setuptools wheel
 export CPATH="${DJANGO_SERVER_ROOT}/Python-3.14.2/python-build/include:${DJANGO_SERVER_ROOT}/Python-3.14.2/Include"
 # Set LIBRARY_PATH and LDFLAGS to ensure packages link against CPython's libpython
 export LIBRARY_PATH="${CPYTHON_INSTALL_PREFIX}/lib"
@@ -460,6 +464,10 @@ export LIBRARY_PATH="${CINDER_INSTALL_PREFIX}/lib"
 export LDFLAGS="-L${CINDER_INSTALL_PREFIX}/lib -Wl,-rpath,${CINDER_INSTALL_PREFIX}/lib"
 source ./venv_cinder/bin/activate
 set -u
+
+# Python 3.14 venvs don't bundle setuptools by default — install it first
+pip3.14 install setuptools wheel
+
 # Install pylibmc (required by django-workload)
 cd "${PYLIBMC_DIR}"
 pip3.14 install -e .

--- a/packages/django_workload/install_django_workload_x86_64_centos.sh
+++ b/packages/django_workload/install_django_workload_x86_64_centos.sh
@@ -384,8 +384,12 @@ set +u
 source ./venv_cpython/bin/activate
 set -u
 
+# CPython 3.14 is built as a shared library — pip3.14 needs libpython3.14.so
 export LD_LIBRARY_PATH="${CPYTHON_INSTALL_PREFIX}/lib"
 export CMAKE_LIBRARY_PATH="${CPYTHON_INSTALL_PREFIX}/lib"
+
+# Python 3.14 venvs don't bundle setuptools by default — install it first
+pip3.14 install setuptools wheel
 export CPATH="${DJANGO_SERVER_ROOT}/Python-3.14.2/python-build/include:${DJANGO_SERVER_ROOT}/Python-3.14.2/Include"
 # Set LIBRARY_PATH and LDFLAGS to ensure packages link against CPython's libpython
 export LIBRARY_PATH="${CPYTHON_INSTALL_PREFIX}/lib"
@@ -436,6 +440,9 @@ export LIBRARY_PATH="${CINDER_INSTALL_PREFIX}/lib"
 export LDFLAGS="-L${CINDER_INSTALL_PREFIX}/lib -Wl,-rpath,${CINDER_INSTALL_PREFIX}/lib"
 source ./venv_cinder/bin/activate
 set -u
+
+# Python 3.14 venvs don't bundle setuptools by default — install it first
+pip3.14 install setuptools wheel
 
 # Install pylibmc (required by django-workload)
 cd "${PYLIBMC_DIR}"

--- a/packages/django_workload/install_django_workload_x86_64_ubuntu22_24.sh
+++ b/packages/django_workload/install_django_workload_x86_64_ubuntu22_24.sh
@@ -409,8 +409,12 @@ set +u
 source ./venv_cpython/bin/activate
 set -u
 
+# CPython 3.14 is built as a shared library — pip3.14 needs libpython3.14.so
 export LD_LIBRARY_PATH="${CPYTHON_INSTALL_PREFIX}/lib"
 export CMAKE_LIBRARY_PATH="${CPYTHON_INSTALL_PREFIX}/lib"
+
+# Python 3.14 venvs don't bundle setuptools by default — install it first
+pip3.14 install setuptools wheel
 export CPATH="${DJANGO_SERVER_ROOT}/Python-3.14.2/python-build/include:${DJANGO_SERVER_ROOT}/Python-3.14.2/Include"
 # Set LIBRARY_PATH and LDFLAGS to ensure packages link against CPython's libpython
 export LIBRARY_PATH="${CPYTHON_INSTALL_PREFIX}/lib"
@@ -462,6 +466,9 @@ export LIBRARY_PATH="${CINDER_INSTALL_PREFIX}/lib"
 export LDFLAGS="-L${CINDER_INSTALL_PREFIX}/lib -Wl,-rpath,${CINDER_INSTALL_PREFIX}/lib"
 source ./venv_cinder/bin/activate
 set -u
+
+# Python 3.14 venvs don't bundle setuptools by default — install it first
+pip3.14 install setuptools wheel
 
 # Install pylibmc (required by django-workload)
 cd "${PYLIBMC_DIR}"

--- a/packages/django_workload/srcs/bin/run.sh
+++ b/packages/django_workload/srcs/bin/run.sh
@@ -327,7 +327,11 @@ run_benchmark() {
       collect_perf_record &
   fi
 
+  # Use 5x connections vs threads to increase pipeline depth and CPU utilization
+  local _wrk_connections
+  _wrk_connections=${WRK_CONNECTIONS:-$(( _num_workers * 5 ))}
   WORKERS="$_num_workers" \
+  WRK_CONNECTIONS="$_wrk_connections" \
   DURATION="$_duration" \
   LOG="$_siege_logs_path" \
   SOURCE="$_urls_path" \

--- a/packages/django_workload/srcs/django-workload/client/run-wrk
+++ b/packages/django_workload/srcs/django-workload/client/run-wrk
@@ -158,7 +158,10 @@ def run_wrk(options):
         exit(1)
 
     # Build wrk command
-    cmd = [wrk_path, '-c', str(WORKERS), '-t', str(WORKERS)]
+    # WRK_CONNECTIONS allows setting more connections than threads to increase
+    # concurrency without proportionally increasing thread count.
+    connections = os.environ.get("WRK_CONNECTIONS", str(WORKERS))
+    cmd = [wrk_path, '-c', str(connections), '-t', str(WORKERS)]
 
     if options.reps > 0:
         cmd.extend(['-r', str(options.reps)])

--- a/packages/django_workload/srcs/django-workload/django-workload/django_workload/settings.py
+++ b/packages/django_workload/srcs/django-workload/django-workload/django_workload/settings.py
@@ -85,7 +85,11 @@ DATABASES = {
         "TEST_NAME": "test_db",
         "HOST": "localhost",
         "OPTIONS": {
-            "replication": {"strategy_class": "SimpleStrategy", "replication_factor": 1}
+            "replication": {
+                "strategy_class": "SimpleStrategy",
+                "replication_factor": 1,
+            },
+            "connection": {"protocol_version": 4},
         },
     }
 }

--- a/packages/django_workload/srcs/django-workload/django-workload/django_workload/thrift/manage_servers.sh
+++ b/packages/django_workload/srcs/django-workload/django-workload/django_workload/thrift/manage_servers.sh
@@ -288,10 +288,21 @@ generate_haproxy_config() {
 
 # Start HAProxy load balancer
 start_haproxy() {
-    # Check if HAProxy is already running
+    # Check if HAProxy is already running — verify BOTH the PID and the port
+    # Using kill -0 alone is unreliable because PIDs get recycled by other processes
     if [ -f "$HAPROXY_PID" ] && kill -0 "$(cat "$HAPROXY_PID")" 2>/dev/null; then
-        log_warn "HAProxy is already running (PID: $(cat "$HAPROXY_PID"))"
-        return 0
+        # Also verify port 9090 is actually listening (guards against recycled PIDs)
+        if ss -tln | grep -q ":${HAPROXY_FRONTEND_PORT} " 2>/dev/null; then
+            log_warn "HAProxy is already running (PID: $(cat "$HAPROXY_PID"))"
+            return 0
+        else
+            log_warn "Stale HAProxy PID file (PID $(cat "$HAPROXY_PID") alive but port $HAPROXY_FRONTEND_PORT not listening) — restarting"
+            kill "$(cat "$HAPROXY_PID")" 2>/dev/null || true
+            rm -f "$HAPROXY_PID"
+        fi
+    elif [ -f "$HAPROXY_PID" ]; then
+        log_warn "Removing stale HAProxy PID file (PID $(cat "$HAPROXY_PID") not running)"
+        rm -f "$HAPROXY_PID"
     fi
 
     # Generate config from running servers

--- a/packages/django_workload/srcs/django-workload/django-workload/uwsgi.ini
+++ b/packages/django_workload/srcs/django-workload/django-workload/uwsgi.ini
@@ -7,7 +7,10 @@
 # placeholders, use set-ph / set-placeholder to update
 hostname = [::]:8000
 
-http-socket = %(hostname)
+http = %(hostname)
+http-keepalive = 1
+http-processes = 8
+add-header = Connection: keep-alive
 chdir = %d
 wsgi-file = django_workload/wsgi.py
 env= DJANGO_SETTINGS_MODULE=cluster_settings


### PR DESCRIPTION
Summary:
Fix deployment issues discovered during BGM validation:

1. Python 3.14 venvs no longer bundle setuptools by default, causing `BackendUnavailable: Cannot import 'setuptools.build_meta'` during `pip install -e .`. Added `pip install setuptools wheel` after venv activation in all install scripts.

2. cassandra-driver from trunk defaults to protocol v5-beta which Cassandra 3.11 doesn't support. Pinned `protocol_version: 4` in Django settings.

3. HAProxy thrift load balancer PID check used bare `kill -0` which passes if the PID was recycled by an unrelated process. Added port verification to detect stale PID files.

4. uWSGI `http-socket` mode doesn't support HTTP keep-alive — every response ended with ECONNRESET (error 104), limiting throughput to ~182 QPS. Switched to `http` mode with `http-keepalive = 1` and `http-processes = 8`, which spawns dedicated HTTP router processes that maintain persistent connections. QPS went from 182 to 4783 for N=5.

5. wrk connection count was tied to thread count (both set to nproc=176). With fast responses, max QPS was capped by connection count. Added `WRK_CONNECTIONS` env var to `run-wrk` and `run.sh` (default: 5x nproc) so connections can be scaled independently of threads.

Differential Revision: D101043551


