### PR TITLE
Use Unix sockets for DjangoBench Proxygen workers

### DIFF
--- a/packages/django_workload/README.md
+++ b/packages/django_workload/README.md
@@ -46,10 +46,9 @@ In addition, we require a series of ports to be available:
   * Main HTTP server port: 8000
   * Load balancer stats port: 8001 (configurable via `-T`)
   * Memcached port: 11811
-  * Server worker ports: The range of \[`base_port`, `base_port` \+ `server_workers`)
-    (`server_workers` is equal to the number of CPU logical cores).
-  * Base port (default 16668) and stats port are adjustable via `--base-port` and `-T`,
-    but the continuous range of server worker ports must be available.
+  * Server worker backends use Unix sockets by default, so the `base_port` worker range
+    is not required. TCP worker mode is still available with `--worker-transport tcp`
+    and uses the range \[`base_port`, `base_port` + `server_workers`).
 
 ## Install django workload
 

--- a/packages/django_workload/install_django_workload.sh
+++ b/packages/django_workload/install_django_workload.sh
@@ -148,6 +148,9 @@ set +u
 source ./venv_cpython/bin/activate
 set -u
 
+# Python 3.14 venvs don't bundle setuptools by default — install it first
+pip install setuptools wheel
+
 sed -i 's/django-cassandra-engine/django-cassandra-engine >= 1.5, < 1.6/' setup.py
 
 # Install dependencies using third_party pip dependencies from manifold
@@ -164,6 +167,9 @@ pushd "${OUT}/django-workload/django-workload"  # Make sure we're in the right d
 export CPATH="${OUT}/django-workload/django-workload/cinder/cinder-build/include:${OUT}/django-workload/django-workload/cinder/Include"
 source ./venv_cinder/bin/activate
 set -u
+
+# Python 3.14 venvs don't bundle setuptools by default — install it first
+pip install setuptools wheel
 
 # Install dependencies using third_party pip dependencies from manifold
 pip install "django-statsd-mozilla" --no-index --find-links file://"$OUT/django-workload/django-workload/third_party"

--- a/packages/django_workload/install_django_workload_aarch64.sh
+++ b/packages/django_workload/install_django_workload_aarch64.sh
@@ -372,8 +372,12 @@ set +u
 source ./venv_cpython/bin/activate
 set -u
 
+# CPython 3.14 is built as a shared library — pip3.14 needs libpython3.14.so
 export LD_LIBRARY_PATH="${CPYTHON_INSTALL_PREFIX}/lib"
 export CMAKE_LIBRARY_PATH="${CPYTHON_INSTALL_PREFIX}/lib"
+
+# Python 3.14 venvs don't bundle setuptools by default — install it first
+pip3.14 install setuptools wheel
 export CPATH="${DJANGO_SERVER_ROOT}/Python-3.14.2/python-build/include:${DJANGO_SERVER_ROOT}/Python-3.14.2/Include"
 # Set LIBRARY_PATH and LDFLAGS to ensure packages link against CPython's libpython
 export LIBRARY_PATH="${CPYTHON_INSTALL_PREFIX}/lib"
@@ -425,6 +429,9 @@ export LIBRARY_PATH="${CINDER_INSTALL_PREFIX}/lib"
 export LDFLAGS="-L${CINDER_INSTALL_PREFIX}/lib -Wl,-rpath,${CINDER_INSTALL_PREFIX}/lib"
 source ./venv_cinder/bin/activate
 set -u
+
+# Python 3.14 venvs don't bundle setuptools by default — install it first
+pip3.14 install setuptools wheel
 
 # Install pylibmc (required by django-workload)
 cd "${PYLIBMC_DIR}"

--- a/packages/django_workload/install_django_workload_aarch64_ubuntu22_24.sh
+++ b/packages/django_workload/install_django_workload_aarch64_ubuntu22_24.sh
@@ -407,8 +407,12 @@ set +u
 source ./venv_cpython/bin/activate
 set -u
 
+# CPython 3.14 is built as a shared library — pip3.14 needs libpython3.14.so
 export LD_LIBRARY_PATH="${CPYTHON_INSTALL_PREFIX}/lib"
 export CMAKE_LIBRARY_PATH="${CPYTHON_INSTALL_PREFIX}/lib"
+
+# Python 3.14 venvs don't bundle setuptools by default — install it first
+pip3.14 install setuptools wheel
 export CPATH="${DJANGO_SERVER_ROOT}/Python-3.14.2/python-build/include:${DJANGO_SERVER_ROOT}/Python-3.14.2/Include"
 # Set LIBRARY_PATH and LDFLAGS to ensure packages link against CPython's libpython
 export LIBRARY_PATH="${CPYTHON_INSTALL_PREFIX}/lib"
@@ -460,6 +464,10 @@ export LIBRARY_PATH="${CINDER_INSTALL_PREFIX}/lib"
 export LDFLAGS="-L${CINDER_INSTALL_PREFIX}/lib -Wl,-rpath,${CINDER_INSTALL_PREFIX}/lib"
 source ./venv_cinder/bin/activate
 set -u
+
+# Python 3.14 venvs don't bundle setuptools by default — install it first
+pip3.14 install setuptools wheel
+
 # Install pylibmc (required by django-workload)
 cd "${PYLIBMC_DIR}"
 pip3.14 install -e .

--- a/packages/django_workload/install_django_workload_x86_64_centos.sh
+++ b/packages/django_workload/install_django_workload_x86_64_centos.sh
@@ -384,8 +384,12 @@ set +u
 source ./venv_cpython/bin/activate
 set -u
 
+# CPython 3.14 is built as a shared library — pip3.14 needs libpython3.14.so
 export LD_LIBRARY_PATH="${CPYTHON_INSTALL_PREFIX}/lib"
 export CMAKE_LIBRARY_PATH="${CPYTHON_INSTALL_PREFIX}/lib"
+
+# Python 3.14 venvs don't bundle setuptools by default — install it first
+pip3.14 install setuptools wheel
 export CPATH="${DJANGO_SERVER_ROOT}/Python-3.14.2/python-build/include:${DJANGO_SERVER_ROOT}/Python-3.14.2/Include"
 # Set LIBRARY_PATH and LDFLAGS to ensure packages link against CPython's libpython
 export LIBRARY_PATH="${CPYTHON_INSTALL_PREFIX}/lib"
@@ -436,6 +440,9 @@ export LIBRARY_PATH="${CINDER_INSTALL_PREFIX}/lib"
 export LDFLAGS="-L${CINDER_INSTALL_PREFIX}/lib -Wl,-rpath,${CINDER_INSTALL_PREFIX}/lib"
 source ./venv_cinder/bin/activate
 set -u
+
+# Python 3.14 venvs don't bundle setuptools by default — install it first
+pip3.14 install setuptools wheel
 
 # Install pylibmc (required by django-workload)
 cd "${PYLIBMC_DIR}"

--- a/packages/django_workload/install_django_workload_x86_64_ubuntu22_24.sh
+++ b/packages/django_workload/install_django_workload_x86_64_ubuntu22_24.sh
@@ -409,8 +409,12 @@ set +u
 source ./venv_cpython/bin/activate
 set -u
 
+# CPython 3.14 is built as a shared library — pip3.14 needs libpython3.14.so
 export LD_LIBRARY_PATH="${CPYTHON_INSTALL_PREFIX}/lib"
 export CMAKE_LIBRARY_PATH="${CPYTHON_INSTALL_PREFIX}/lib"
+
+# Python 3.14 venvs don't bundle setuptools by default — install it first
+pip3.14 install setuptools wheel
 export CPATH="${DJANGO_SERVER_ROOT}/Python-3.14.2/python-build/include:${DJANGO_SERVER_ROOT}/Python-3.14.2/Include"
 # Set LIBRARY_PATH and LDFLAGS to ensure packages link against CPython's libpython
 export LIBRARY_PATH="${CPYTHON_INSTALL_PREFIX}/lib"
@@ -462,6 +466,9 @@ export LIBRARY_PATH="${CINDER_INSTALL_PREFIX}/lib"
 export LDFLAGS="-L${CINDER_INSTALL_PREFIX}/lib -Wl,-rpath,${CINDER_INSTALL_PREFIX}/lib"
 source ./venv_cinder/bin/activate
 set -u
+
+# Python 3.14 venvs don't bundle setuptools by default — install it first
+pip3.14 install setuptools wheel
 
 # Install pylibmc (required by django-workload)
 cd "${PYLIBMC_DIR}"

--- a/packages/django_workload/srcs/bin/run.sh
+++ b/packages/django_workload/srcs/bin/run.sh
@@ -8,7 +8,7 @@
 SCRIPT_ROOT="$(dirname "$(readlink -f "$0")")"
 # Abs path to DCPerf root
 BENCHPRESS_ROOT="$(readlink -f "${SCRIPT_ROOT}/../../..")"
-DJANGO_PKG_SRC_ROOT="${BENCHPRESS_ROOT}/packages/django_workload/srcs"
+export DJANGO_PKG_SRC_ROOT="${BENCHPRESS_ROOT}/packages/django_workload/srcs"
 DJANGO_SERVER_ROOT="$(readlink -f "${SCRIPT_ROOT}/../django-workload/django-workload")"
 CPYTHON_PATH="${DJANGO_SERVER_ROOT}/Python-3.14.2/python-build"
 CINDER_PATH="${DJANGO_SERVER_ROOT}/cinder/cinder-build"
@@ -21,6 +21,7 @@ KEY_SPACE_NAME="db"
 BREAKDOWN_FOLDER="${SCRIPT_ROOT}/.."
 
 # Source runtime breakdown utilities
+# shellcheck disable=SC1091
 source "${BENCHPRESS_ROOT}/packages/common/runtime_breakdown_utils.sh"
 
 if [ -z "$JAVA_HOME" ]; then
@@ -207,7 +208,8 @@ check_port_available() {
   # Only check for LISTENING sockets — use ss -tln (not ss -tan which
   # also matches TIME_WAIT/CLOSE_WAIT sockets that don't block binding).
   # With SO_REUSEADDR, TIME_WAIT sockets won't prevent binding.
-  local pid=$(ss -tlnp | grep ":${port} " | grep -oP 'pid=\K[0-9]+' | head -1)
+  local pid
+  pid=$(ss -tlnp | grep ":${port} " | grep -oP 'pid=\K[0-9]+' | head -1)
 
   if [ -n "$pid" ]; then
     echo "ERROR: Port ${port} (${port_name}) has an active LISTENING socket!"
@@ -224,6 +226,7 @@ check_port_range_available() {
   local num_workers=$2
   local lb_port=8000
   local stats_port=$3
+  local worker_transport=${4:-tcp}
 
   echo "Checking port availability..."
 
@@ -237,15 +240,18 @@ check_port_range_available() {
     return 1
   fi
 
-  # Check worker ports (base_port to base_port + num_workers - 1)
-  for ((i=0; i<num_workers; i++)); do
-    local port=$((base_port + i))
-    if ! check_port_available "$port" "Worker $((i+1))"; then
-      return 1
-    fi
-  done
+  # Unix socket worker mode does not reserve one TCP port per worker.
+  if [ "${worker_transport}" != "unix" ]; then
+    # Check worker ports (base_port to base_port + num_workers - 1)
+    for ((i=0; i<num_workers; i++)); do
+      local port=$((base_port + i))
+      if ! check_port_available "$port" "Worker $((i+1))"; then
+        return 1
+      fi
+    done
+  fi
 
-  echo "All ports are available."
+  echo "All required ports are available."
   return 0
 }
 
@@ -255,7 +261,8 @@ Usage: ${0##*/} [-h] [-r role] [-w number of workers] [-i number of iterations] 
 [-d duration of workload] [-p number of repetitions] [-l siege logfile path] \
 [-s urls path] [-c cassandra host ip] [-S skip database setup] [-L snapshot loading] \
 [-t snapshot taking] [--interpreter cpython|cinder] [--base-port port] [-T stats port] \
-[--thrift-server-workers num] [--use-async 0|1] [--use-jit 0|1] [--skip-datagen 0|1]
+[--worker-transport unix|tcp] [--thrift-server-workers num] [--use-async 0|1] \
+[--use-jit 0|1] [--skip-datagen 0|1]
 
 Proxy shell script to executes django-workload benchmark
     -r          role (clientserver, client, server or db, default is clientserver)
@@ -266,7 +273,9 @@ For role "server", "clientserver":
     --interpreter
                 python interpreter to use (cpython or cinder, default is cpython)
     --base-port
-                base port for Proxygen workers (default 16668)
+                base port for Proxygen workers when --worker-transport=tcp (default 16668)
+    --worker-transport
+                backend transport for Proxygen workers (unix or tcp, default unix)
     -T          HAProxy stats port (default 8001)
     --use-async
                 set to 1 to enable async mode with load balancing (default 1)
@@ -375,6 +384,7 @@ load_snapshot(){
   #echo "Refreshing tables in ${KEY_SPACE_NAME}..."
   for table in ${TABLE_NAMES}; do
     #echo "Refreshing table: ${table}"
+    # shellcheck disable=SC2086
     "${BENCHPRESS_ROOT}"/benchmarks/django_workload/apache-cassandra/bin/nodetool \
       ${extra_options} refresh -- "${KEY_SPACE_NAME}" "${table}" || exit 1
   done
@@ -443,8 +453,10 @@ take_snapshot(){
   command_options="-t ${snapshot_name}"
   # Our nodetool is v3, so unfortunately the new nodetool commands for taking a snapshot and importing a snapshot does not work, so we need to use the following commands based on the following documentation
   #https://docs.datastax.com/en/cassandra-oss/3.0/cassandra/operations/opsBackupTakesSnapshot.html
+  # shellcheck disable=SC2086
   "${BENCHPRESS_ROOT}"/benchmarks/django_workload/apache-cassandra/bin/nodetool \
     ${extra_options} cleanup "${KEY_SPACE_NAME}" || exit 1
+  # shellcheck disable=SC2086
   "${BENCHPRESS_ROOT}"/benchmarks/django_workload/apache-cassandra/bin/nodetool \
     ${extra_options} snapshot "${KEY_SPACE_NAME}" "${command_options}" || exit 1
 
@@ -516,6 +528,7 @@ start_django_server() {
   local interpreter=${3:-cpython}
   local use_async=${4:-0}
   local use_jit=${5:-0}
+  local worker_transport=${6:-unix}
 
   # Export FBTHRIFT_PREFIX for thrift Python bindings
   export FBTHRIFT_PREFIX="${SCRIPT_ROOT}/../proxygen/proxygen/_build/deps"
@@ -561,7 +574,7 @@ start_django_server() {
   # shellcheck disable=SC1090,SC1091
   source "${DJANGO_SERVER_ROOT}/${venv_dir}/bin/activate"
 
-  wait_for_cassandra_to_start
+  wait_for_cassandra_to_start "${cassandra_addr}"
 
   # Create database schema
   export PYTHONPATH="${SCRIPT_ROOT}/../django-workload/django-workload/"
@@ -592,13 +605,14 @@ ${python_libs}${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}
     echo "Running django server with uWSGI + HAProxy load balancing"
     echo "  Workers: ${num_server_workers}"
     echo "  Interpreter: ${interpreter}"
+    echo "  Worker transport: ${worker_transport}"
     echo "  Base port: ${base_port}"
     echo "  Stats port: ${stats_port}"
     echo "  Load balancer: http://127.0.0.1:8000"
     echo "  HAProxy stats: http://127.0.0.1:${stats_port}/stats"
 
     # Check port availability before starting
-    if ! check_port_range_available "${base_port}" "${num_server_workers}" "${stats_port}"; then
+    if ! check_port_range_available "${base_port}" "${num_server_workers}" "${stats_port}" "${worker_transport}"; then
       echo "ERROR: Cannot start server due to port conflicts"
       exit 1
     fi
@@ -610,6 +624,7 @@ ${python_libs}${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}
         --workers "${num_server_workers}" \
         --stats-port "${stats_port}" \
         --base-port "${base_port}" \
+        --worker-transport "${worker_transport}" \
         --log-dir load_balancer_logs \
         > lb.log 2>&1
   else
@@ -647,18 +662,21 @@ start_client() {
   python_libs="${CPYTHON_PATH}/lib"
   export LD_LIBRARY_PATH="${python_libs}:${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
 
-  # Wait for load balancer to be ready (try to connect to the server)
-  local retries=60
-  echo "Waiting for server to be ready at http://localhost:8000..."
-  while ! curl -s -f http://localhost:8000/feed_timeline > /dev/null 2>&1; do
-    sleep 1
-    retries=$((retries-1))
-    if [[ "$retries" -le 0 ]]; then
-      echo "Server did not become ready within 60 seconds"
+  # Wait for the load balancer and Django workers to accept HTTP traffic.
+  # Use the cheap index endpoint here; workload endpoints can spend their
+  # first request doing CPU-heavy interpreter/JIT warmup on slower hosts.
+  local readiness_timeout=120
+  local readiness_start
+  readiness_start=$(date +%s)
+  echo "Waiting for server to accept HTTP traffic at http://localhost:8000..."
+  while ! curl -s -f --max-time 2 http://localhost:8000/ > /dev/null 2>&1; do
+    if [[ "$(($(date +%s) - readiness_start))" -ge "$readiness_timeout" ]]; then
+      echo "Server did not become ready within ${readiness_timeout} seconds"
       exit 1
     fi
+    sleep 1
   done
-  echo "Server is ready!"
+  echo "Server is accepting HTTP traffic!"
 
   # Wait for HAProxy to mark all backend workers as healthy
   # HAProxy health checks run every 2s and need 2 successful checks (rise 2)
@@ -722,11 +740,12 @@ start_clientserver() {
   local interpreter="${9:-cpython}"
   local use_async="${10:-0}"
   local use_jit="${11:-0}"
+  local worker_transport="${12:-unix}"
 
   create_breakdown_csv "$BREAKDOWN_FOLDER"
   log_preprocessing_start "$BREAKDOWN_FOLDER" "$$"
 
-  start_django_server "${cassandra_addr}" "${num_server_workers}" "${interpreter}" "${use_async}" "${use_jit}" &
+  start_django_server "${cassandra_addr}" "${num_server_workers}" "${interpreter}" "${use_async}" "${use_jit}" "${worker_transport}" &
   server_pid="$!"
 
   # Wait for the server to start
@@ -851,6 +870,9 @@ main() {
   local use_jit
   use_jit=0
 
+  local worker_transport
+  worker_transport=unix
+
   local skip_datagen
   skip_datagen=0
 
@@ -904,6 +926,14 @@ main() {
         ;;
       --skip-datagen=*)
         skip_datagen="${1#*=}"
+        shift
+        ;;
+      --worker-transport)
+        worker_transport="$2"
+        shift 2
+        ;;
+      --worker-transport=*)
+        worker_transport="${1#*=}"
         shift
         ;;
       --)
@@ -1007,6 +1037,11 @@ main() {
   done
   shift "$((OPTIND - 1))"
 
+  if [ "${worker_transport}" != "unix" ] && [ "${worker_transport}" != "tcp" ]; then
+    echo "Invalid --worker-transport '${worker_transport}', expected 'unix' or 'tcp'"
+    exit 1
+  fi
+
   # Check if $cassandra_addr is in IPv4 format, if so convert to IPv6 format
   if [[ $cassandra_addr =~ ^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
     # IPv4 format detected, convert to IPv6 format
@@ -1032,6 +1067,7 @@ main() {
   readonly load_a_snapshot
   readonly use_async
   readonly use_jit
+  readonly worker_transport
   readonly skip_datagen
 
   # Export skip_datagen as environment variable for use in start_django_server
@@ -1043,12 +1079,12 @@ main() {
     start_cassandra "$num_cassandra_writes" "$cassandra_bind_addr";
   elif [ "$role" = "clientserver" ]; then
     start_clientserver "$cassandra_addr" "$num_server_workers" "$num_client_workers" \
-      "$duration" "$siege_logs_path" "$urls_path" "$iterations" "$reps" "${interpreter}" "${use_async}" "${use_jit}";
+      "$duration" "$siege_logs_path" "$urls_path" "$iterations" "$reps" "${interpreter}" "${use_async}" "${use_jit}" "${worker_transport}";
   elif [ "$role" = "client" ]; then
     start_client "$num_client_workers" "$duration" "$siege_logs_path" \
       "$urls_path" "$server_addr" "$iterations" "$reps";
   elif [ "$role" = "server" ]; then
-    start_django_server "$cassandra_addr" "$num_server_workers" "$interpreter" "${use_async}" "${use_jit}";
+    start_django_server "$cassandra_addr" "$num_server_workers" "$interpreter" "${use_async}" "${use_jit}" "${worker_transport}";
     # Report interpreter type
     echo "Interpreter: ${interpreter}"
   elif [ "$role" = "standalone" ]; then
@@ -1056,7 +1092,7 @@ main() {
     start_cassandra "$num_cassandra_writes" 127.0.0.1 &
     start_clientserver "$cassandra_addr" "$num_server_workers" "$num_client_workers" \
       "$duration" "$siege_logs_path" "$urls_path" "$iterations" "$reps" "$interpreter" \
-      "${use_async}" "${use_jit}";
+      "${use_async}" "${use_jit}" "${worker_transport}";
     pgrep -f cassandra | xargs kill
 
   else

--- a/packages/django_workload/srcs/bin/run.sh
+++ b/packages/django_workload/srcs/bin/run.sh
@@ -327,7 +327,11 @@ run_benchmark() {
       collect_perf_record &
   fi
 
+  # Use 5x connections vs threads to increase pipeline depth and CPU utilization
+  local _wrk_connections
+  _wrk_connections=${WRK_CONNECTIONS:-$(( _num_workers * 5 ))}
   WORKERS="$_num_workers" \
+  WRK_CONNECTIONS="$_wrk_connections" \
   DURATION="$_duration" \
   LOG="$_siege_logs_path" \
   SOURCE="$_urls_path" \

--- a/packages/django_workload/srcs/django-workload/client/run-wrk
+++ b/packages/django_workload/srcs/django-workload/client/run-wrk
@@ -158,7 +158,10 @@ def run_wrk(options):
         exit(1)
 
     # Build wrk command
-    cmd = [wrk_path, '-c', str(WORKERS), '-t', str(WORKERS)]
+    # WRK_CONNECTIONS allows setting more connections than threads to increase
+    # concurrency without proportionally increasing thread count.
+    connections = os.environ.get("WRK_CONNECTIONS", str(WORKERS))
+    cmd = [wrk_path, '-c', str(connections), '-t', str(WORKERS)]
 
     if options.reps > 0:
         cmd.extend(['-r', str(options.reps)])

--- a/packages/django_workload/srcs/django-workload/django-workload/django_workload/settings.py
+++ b/packages/django_workload/srcs/django-workload/django-workload/django_workload/settings.py
@@ -85,7 +85,11 @@ DATABASES = {
         "TEST_NAME": "test_db",
         "HOST": "localhost",
         "OPTIONS": {
-            "replication": {"strategy_class": "SimpleStrategy", "replication_factor": 1}
+            "replication": {
+                "strategy_class": "SimpleStrategy",
+                "replication_factor": 1,
+            },
+            "connection": {"protocol_version": 4},
         },
     }
 }

--- a/packages/django_workload/srcs/django-workload/django-workload/django_workload/thrift/manage_servers.sh
+++ b/packages/django_workload/srcs/django-workload/django-workload/django_workload/thrift/manage_servers.sh
@@ -288,10 +288,21 @@ generate_haproxy_config() {
 
 # Start HAProxy load balancer
 start_haproxy() {
-    # Check if HAProxy is already running
+    # Check if HAProxy is already running — verify BOTH the PID and the port
+    # Using kill -0 alone is unreliable because PIDs get recycled by other processes
     if [ -f "$HAPROXY_PID" ] && kill -0 "$(cat "$HAPROXY_PID")" 2>/dev/null; then
-        log_warn "HAProxy is already running (PID: $(cat "$HAPROXY_PID"))"
-        return 0
+        # Also verify port 9090 is actually listening (guards against recycled PIDs)
+        if ss -tln | grep -q ":${HAPROXY_FRONTEND_PORT} " 2>/dev/null; then
+            log_warn "HAProxy is already running (PID: $(cat "$HAPROXY_PID"))"
+            return 0
+        else
+            log_warn "Stale HAProxy PID file (PID $(cat "$HAPROXY_PID") alive but port $HAPROXY_FRONTEND_PORT not listening) — restarting"
+            kill "$(cat "$HAPROXY_PID")" 2>/dev/null || true
+            rm -f "$HAPROXY_PID"
+        fi
+    elif [ -f "$HAPROXY_PID" ]; then
+        log_warn "Removing stale HAProxy PID file (PID $(cat "$HAPROXY_PID") not running)"
+        rm -f "$HAPROXY_PID"
     fi
 
     # Generate config from running servers

--- a/packages/django_workload/srcs/django-workload/django-workload/proxygen_wsgi.py
+++ b/packages/django_workload/srcs/django-workload/django-workload/proxygen_wsgi.py
@@ -60,11 +60,39 @@ logger = logging.getLogger(__name__)
 
 # Global server instance for this worker process
 _proxygen_server = None
-_server_thread = None
 _shutdown_event = threading.Event()
 
 
-def start_proxygen_server(port=None, threads=None):
+def _get_uwsgi_worker_id():
+    try:
+        import uwsgi
+
+        return uwsgi.worker_id()
+    except (ImportError, AttributeError):
+        return None
+
+
+def _get_unix_socket_path(explicit_path=None):
+    if explicit_path:
+        return explicit_path
+
+    if "PROXYGEN_UNIX_SOCKET" in os.environ:
+        return os.environ["PROXYGEN_UNIX_SOCKET"]
+
+    socket_dir = os.environ.get("PROXYGEN_SOCKET_DIR")
+    if not socket_dir:
+        return None
+
+    worker_id = _get_uwsgi_worker_id()
+    if worker_id is None or worker_id <= 0:
+        raise RuntimeError(
+            "PROXYGEN_SOCKET_DIR requires a positive uWSGI worker id; "
+            "set PROXYGEN_UNIX_SOCKET for explicit standalone Unix socket mode"
+        )
+    return os.path.join(socket_dir, f"worker{worker_id}.sock")
+
+
+def start_proxygen_server(port=None, threads=None, unix_socket_path=None):
     """
     Start Proxygen server in this uWSGI worker process or standalone.
 
@@ -75,12 +103,16 @@ def start_proxygen_server(port=None, threads=None):
     Args:
         port: Port to listen on (overrides environment variable and uWSGI worker_id calculation)
         threads: Number of threads (overrides environment variable, 0=auto-detect)
+        unix_socket_path: Unix socket path to listen on instead of a TCP port
 
-    Port Selection Logic (in order of precedence):
-        1. Explicit port argument (for standalone mode)
-        2. PROXYGEN_PORT environment variable
-        3. Calculate from uWSGI worker_id: PROXYGEN_BASE_PORT + worker_id - 1
-        4. Default to 8000
+    Listen Address Selection Logic (in order of precedence):
+        1. Explicit unix_socket_path argument
+        2. PROXYGEN_UNIX_SOCKET environment variable
+        3. PROXYGEN_SOCKET_DIR + uWSGI worker_id
+        4. Explicit port argument
+        5. PROXYGEN_PORT environment variable
+        6. Calculate from uWSGI worker_id: PROXYGEN_BASE_PORT + worker_id - 1
+        7. Default to 8000
 
     Architecture:
         Proxygen RequestData
@@ -91,43 +123,45 @@ def start_proxygen_server(port=None, threads=None):
             ↓
         Django views/middleware
     """
-    global _proxygen_server, _server_thread
+    global _proxygen_server
 
     # Get configuration from environment or arguments
     ip = os.environ.get("PROXYGEN_IP", "0.0.0.0")
+    unix_socket_path = _get_unix_socket_path(unix_socket_path)
 
-    # Determine port with precedence: argument > env > uWSGI worker_id > default
-    if port is not None:
+    # Determine port with precedence: argument > env > uWSGI worker_id > default.
+    # Unix socket mode still passes a placeholder port to the binding for
+    # backward-compatible constructor arguments, but the port is not bound.
+    if unix_socket_path:
+        port = port if port is not None else 0
+    elif port is not None:
         # Explicit port argument (standalone mode)
         port = port
     elif "PROXYGEN_PORT" in os.environ:
         # Environment variable (explicit port)
         port = int(os.environ["PROXYGEN_PORT"])
     else:
-        # Try to calculate from uWSGI worker_id
-        try:
-            import uwsgi
-
-            worker_id = uwsgi.worker_id()
+        worker_id = _get_uwsgi_worker_id()
+        if worker_id is not None:
             base_port = int(os.environ.get("PROXYGEN_BASE_PORT", "8001"))
             port = base_port + worker_id - 1
             logger.info(
                 f"uWSGI worker {worker_id}: calculated port {port} "
                 f"(base_port={base_port} + worker_id={worker_id} - 1)"
             )
-        except (ImportError, AttributeError):
+        else:
             # Not running under uWSGI or uwsgi.worker_id() not available
-            port = int(os.environ.get("PROXYGEN_PORT", "8000"))
+            port = 8000
 
     threads = (
         threads if threads is not None else int(os.environ.get("PROXYGEN_THREADS", "0"))
     )  # 0 = auto-detect
 
+    listen_target = unix_socket_path if unix_socket_path else f"{ip}:{port}"
     logger.info(
-        "Initializing Proxygen server in worker %d: %s:%d with %d threads",
+        "Initializing Proxygen server in worker %d: %s with %d threads",
         os.getpid(),
-        ip,
-        port,
+        listen_target,
         threads,
     )
 
@@ -153,12 +187,13 @@ def start_proxygen_server(port=None, threads=None):
             threads=threads,
             async_callback=django_handler,
             is_async=True,
+            unix_socket_path=unix_socket_path or "",
         )
 
         # Start server
         _proxygen_server.start()
         logger.info(
-            "Proxygen server started in worker %d on %s:%d", os.getpid(), ip, port
+            "Proxygen server started in worker %d on %s", os.getpid(), listen_target
         )
 
     except Exception as e:
@@ -222,10 +257,18 @@ if __name__ == "__main__":
         default=0,
         help="Number of threads (0 = auto-detect based on CPU cores)",
     )
+    parser.add_argument(
+        "--unix-socket",
+        type=str,
+        default=None,
+        help="Unix socket path to listen on instead of a TCP port",
+    )
 
     args = parser.parse_args()
 
-    start_proxygen_server(port=args.port, threads=args.threads)
+    start_proxygen_server(
+        port=args.port, threads=args.threads, unix_socket_path=args.unix_socket
+    )
 
     try:
         # Keep process alive

--- a/packages/django_workload/srcs/django-workload/django-workload/start_loadbalanced_server.py
+++ b/packages/django_workload/srcs/django-workload/django-workload/start_loadbalanced_server.py
@@ -53,6 +53,8 @@ class UWSGIManager:
         haproxy_config: Optional[str] = None,
         uwsgi_config: Optional[str] = None,
         log_dir: Optional[str] = None,
+        worker_transport: str = "tcp",
+        socket_dir: Optional[str] = None,
     ):
         """
         Initialize uWSGI manager.
@@ -66,6 +68,8 @@ class UWSGIManager:
             haproxy_config: Path to HAProxy config (auto-generated if None)
             uwsgi_config: Path to uWSGI config (default: uwsgi_loadbalanced.ini)
             log_dir: Directory for log files (None = logs to stdout only)
+            worker_transport: Worker backend transport (tcp or unix)
+            socket_dir: Directory for worker Unix sockets (auto-generated if None)
         """
         self.num_workers = num_workers
         self.base_port = base_port
@@ -75,6 +79,14 @@ class UWSGIManager:
         self.haproxy_config = haproxy_config
         self.uwsgi_config = uwsgi_config
         self.log_dir = Path(log_dir) if log_dir else None
+        self.worker_transport = worker_transport
+        if self.worker_transport not in ("tcp", "unix"):
+            raise ValueError("worker_transport must be 'tcp' or 'unix'")
+        self.socket_dir = (
+            Path(socket_dir)
+            if socket_dir
+            else Path(f"/tmp/django-proxygen-{os.getpid()}")
+        )
 
         # Process tracking
         self.uwsgi_process: Optional[subprocess.Popen] = None
@@ -99,6 +111,43 @@ class UWSGIManager:
         # Validate prerequisites
         self._validate_setup()
 
+    def _uses_unix_sockets(self) -> bool:
+        return self.worker_transport == "unix"
+
+    def _worker_socket_path(self, worker_id: int) -> Path:
+        return self.socket_dir / f"worker{worker_id}.sock"
+
+    def _prepare_socket_dir(self) -> None:
+        if not self._uses_unix_sockets():
+            return
+
+        self.socket_dir.mkdir(parents=True, exist_ok=True)
+        for worker_id in range(1, self.num_workers + 1):
+            socket_path = self._worker_socket_path(worker_id)
+            if not socket_path.exists():
+                continue
+            if socket_path.is_socket() or socket_path.is_file():
+                socket_path.unlink()
+                continue
+            raise RuntimeError(f"Refusing to remove non-socket path: {socket_path}")
+
+    def _cleanup_socket_dir(self) -> None:
+        if not self._uses_unix_sockets() or not self.socket_dir.exists():
+            return
+
+        for worker_id in range(1, self.num_workers + 1):
+            socket_path = self._worker_socket_path(worker_id)
+            if socket_path.exists() and (
+                socket_path.is_socket() or socket_path.is_file()
+            ):
+                socket_path.unlink()
+        try:
+            self.socket_dir.rmdir()
+        except OSError:
+            logger.info(
+                "Leaving non-empty socket directory in place: %s", self.socket_dir
+            )
+
     def start_uwsgi(self) -> None:
         """Start uWSGI with workers."""
         # Determine config path
@@ -117,9 +166,13 @@ class UWSGIManager:
 
         # Prepare environment variables
         env = os.environ.copy()
-        env["PROXYGEN_BASE_PORT"] = str(self.base_port)
         env["PROXYGEN_THREADS"] = str(self.threads_per_worker)
         env["PYTHONUNBUFFERED"] = "1"
+        env["PROXYGEN_WORKER_TRANSPORT"] = self.worker_transport
+        if self._uses_unix_sockets():
+            env["PROXYGEN_SOCKET_DIR"] = str(self.socket_dir)
+        else:
+            env["PROXYGEN_BASE_PORT"] = str(self.base_port)
 
         # Ensure LD_LIBRARY_PATH is set for Python 3.14 shared library
         # This is critical for uWSGI workers to find libpython3.14.so
@@ -144,10 +197,16 @@ class UWSGIManager:
             bufsize=1,
         )
 
+        worker_target = (
+            f"Unix sockets in {self.socket_dir}"
+            if self._uses_unix_sockets()
+            else f"Ports: {self.base_port}-{self.base_port + self.num_workers - 1}"
+        )
         logger.info(
             f"uWSGI started (PID: {self.uwsgi_process.pid})\n"
             f"  Workers: {self.num_workers}\n"
-            f"  Ports: {self.base_port}-{self.base_port + self.num_workers - 1}\n"
+            f"  Worker transport: {self.worker_transport}\n"
+            f"  {worker_target}\n"
             f"  Threads per worker: {self.threads_per_worker}"
         )
 
@@ -204,6 +263,8 @@ class UWSGIManager:
                 logger.warning(f"Error closing log file: {e}")
 
         logger.info("All processes stopped")
+
+        self._cleanup_socket_dir()
 
         if self.log_dir:
             logger.info(f"Logs saved to: {self.log_dir}")
@@ -299,10 +360,11 @@ class UWSGIManager:
             )
             raise RuntimeError("HAProxy not installed")
 
-        # Check port availability
-        ports_to_check = [self.lb_port, self.stats_port] + [
-            self.base_port + i for i in range(self.num_workers)
-        ]
+        # Check port availability. Unix worker mode only needs HAProxy's
+        # public frontend and stats ports. Worker backends are socket paths.
+        ports_to_check = [self.lb_port, self.stats_port]
+        if not self._uses_unix_sockets():
+            ports_to_check.extend(self.base_port + i for i in range(self.num_workers))
 
         unavailable_ports = []
         for port in ports_to_check:
@@ -324,6 +386,8 @@ class UWSGIManager:
             )
             raise RuntimeError("Required ports are not available")
 
+        self._prepare_socket_dir()
+
     def generate_haproxy_config(self) -> Path:
         """Generate HAProxy configuration dynamically."""
         config_path = self.script_dir / "haproxy_generated.cfg"
@@ -331,9 +395,12 @@ class UWSGIManager:
         # Generate server entries for all workers
         server_lines = []
         for i in range(1, self.num_workers + 1):
-            port = self.base_port + (i - 1)
+            if self._uses_unix_sockets():
+                backend_addr = str(self._worker_socket_path(i))
+            else:
+                backend_addr = f"127.0.0.1:{self.base_port + (i - 1)}"
             server_lines.append(
-                f"    server worker{i} 127.0.0.1:{port} "
+                f"    server worker{i} {backend_addr} "
                 f"check weight 1 maxconn 10000 inter 2s fall 3 rise 2"
             )
 
@@ -405,12 +472,16 @@ listen stats
             all_ready = True
 
             for i in range(self.num_workers):
-                port = self.base_port + i
-                sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+                if self._uses_unix_sockets():
+                    sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+                    target = str(self._worker_socket_path(i + 1))
+                else:
+                    sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+                    target = ("127.0.0.1", self.base_port + i)
                 sock.settimeout(0.5)
 
                 try:
-                    result = sock.connect_ex(("127.0.0.1", port))
+                    result = sock.connect_ex(target)
                     if result != 0:
                         all_ready = False
                 except Exception:
@@ -486,7 +557,7 @@ listen stats
                 "\n" + "=" * 60 + "\n"
                 f"Load-balanced Django server with uWSGI is running!\n"
                 f"  Access via: http://127.0.0.1:{self.lb_port}\n"
-                f"  uWSGI workers: {self.num_workers} (ports {self.base_port}-{self.base_port + self.num_workers - 1})\n"
+                f"  uWSGI workers: {self.num_workers} ({self.worker_transport} backends)\n"
                 f"  Stats UI: http://127.0.0.1:{self.stats_port}/stats\n"
                 f"  Threads per worker: {self.threads_per_worker}\n"
                 "\n"
@@ -1100,6 +1171,20 @@ def main():
     )
 
     parser.add_argument(
+        "--worker-transport",
+        choices=["tcp", "unix"],
+        default="tcp",
+        help="Transport for worker backends when using uWSGI",
+    )
+
+    parser.add_argument(
+        "--socket-dir",
+        type=str,
+        default=None,
+        help="Directory for worker Unix sockets (auto-generated if not provided)",
+    )
+
+    parser.add_argument(
         "--uwsgi-config",
         type=str,
         default=None,
@@ -1120,6 +1205,8 @@ def main():
             haproxy_config=args.haproxy_config,
             uwsgi_config=args.uwsgi_config,
             log_dir=args.log_dir,
+            worker_transport=args.worker_transport,
+            socket_dir=args.socket_dir,
         )
     else:
         # Direct Python worker processes

--- a/packages/django_workload/srcs/django-workload/django-workload/uwsgi.ini
+++ b/packages/django_workload/srcs/django-workload/django-workload/uwsgi.ini
@@ -7,7 +7,10 @@
 # placeholders, use set-ph / set-placeholder to update
 hostname = [::]:8000
 
-http-socket = %(hostname)
+http = %(hostname)
+http-keepalive = 1
+http-processes = 8
+add-header = Connection: keep-alive
 chdir = %d
 wsgi-file = django_workload/wsgi.py
 env= DJANGO_SETTINGS_MODULE=cluster_settings

--- a/packages/django_workload/srcs/django-workload/django-workload/uwsgi_loadbalanced.ini
+++ b/packages/django_workload/srcs/django-workload/django-workload/uwsgi_loadbalanced.ini
@@ -1,7 +1,7 @@
 [uwsgi]
 # uWSGI + HAProxy Load Balanced Configuration
-# This config starts N uWSGI workers, each running a Proxygen server on a unique port
-# HAProxy load balances requests across all workers
+# This config starts N uWSGI workers, each running a Proxygen server.
+# HAProxy load balances requests across all workers using TCP or Unix sockets.
 
 # =============================================================================
 # Core Settings
@@ -46,16 +46,16 @@ vacuum = true
 # =============================================================================
 
 # Environment variables are set by start_loadbalanced_server.py:
-#   PROXYGEN_BASE_PORT - Starting port for workers (default: 8001)
+#   PROXYGEN_SOCKET_DIR - Unix socket directory for worker backends
+#   PROXYGEN_BASE_PORT - Starting port for TCP workers (fallback mode)
 #   PROXYGEN_THREADS - Number of threads per worker (default: 14)
 #
 # These are passed via the Python subprocess environment and should NOT be
 # redefined here using "env =" directives, as that would override the values.
 #
-# Port calculation in proxygen_wsgi.py:
-#   Worker 1 port = PROXYGEN_BASE_PORT + 1 - 1 = base_port
-#   Worker 2 port = PROXYGEN_BASE_PORT + 2 - 1 = base_port + 1
-#   Worker N port = PROXYGEN_BASE_PORT + N - 1
+# Default worker addressing in proxygen_wsgi.py:
+#   Unix mode: PROXYGEN_SOCKET_DIR/worker<worker_id>.sock
+#   TCP mode: PROXYGEN_BASE_PORT + worker_id - 1
 
 # =============================================================================
 # Process Management
@@ -148,14 +148,14 @@ env = PYTHONUNBUFFERED=1
 #
 # Usage:
 #   1. Start uWSGI with this config:
-#      UWSGI_WORKERS=8 PROXYGEN_BASE_PORT=8001 uwsgi --ini uwsgi_loadbalanced.ini
+#      PROXYGEN_SOCKET_DIR=/tmp/django-proxygen uwsgi --ini uwsgi_loadbalanced.ini
 #
 #   2. Each worker will automatically:
-#      - Calculate its port: PROXYGEN_BASE_PORT + worker_id - 1
-#      - Start Proxygen server on that port
+#      - Calculate its socket path: PROXYGEN_SOCKET_DIR/worker<worker_id>.sock
+#      - Start Proxygen server on that socket
 #      - Handle requests asynchronously via Proxygen
 #
-#   3. HAProxy load balances across all worker ports (8001-8008)
+#   3. HAProxy load balances across all worker sockets
 #
 # Architecture:
 #   Client → HAProxy:8000
@@ -169,7 +169,8 @@ env = PYTHONUNBUFFERED=1
 #    1      2      3      4
 #    ↓      ↓      ↓      ↓
 # Proxygen Proxygen Proxygen Proxygen
-#  :8001   :8002   :8003   :8004
+# worker1  worker2  worker3  worker4
+#  .sock    .sock    .sock    .sock
 #
 # Benefits:
 #   - uWSGI process management (harakiri, memory limits, graceful reload)

--- a/packages/django_workload/srcs/proxygen_binding/proxygen_binding.cpp
+++ b/packages/django_workload/srcs/proxygen_binding/proxygen_binding.cpp
@@ -39,13 +39,41 @@ class ProxygenServer {
       const std::string& ip,
       int port,
       int threads,
-      PythonRequestCallback callback)
+      PythonRequestCallback callback,
+      const std::string& unix_socket_path)
       : ip_(ip),
         port_(port),
         threads_(threads),
+        unix_socket_path_(unix_socket_path),
         sync_callback_(std::move(callback)),
         async_callback_(nullptr),
         is_async_(false),
+        server_(nullptr),
+        server_thread_(nullptr) {}
+
+  // Constructor for synchronous callback (deprecated)
+  ProxygenServer(
+      const std::string& ip,
+      int port,
+      int threads,
+      PythonRequestCallback callback)
+      : ProxygenServer(ip, port, threads, std::move(callback), "") {}
+
+  // Constructor for asynchronous callback (recommended)
+  ProxygenServer(
+      const std::string& ip,
+      int port,
+      int threads,
+      PythonAsyncRequestCallback async_callback,
+      bool is_async,
+      const std::string& unix_socket_path)
+      : ip_(ip),
+        port_(port),
+        threads_(threads),
+        unix_socket_path_(unix_socket_path),
+        sync_callback_(nullptr),
+        async_callback_(std::move(async_callback)),
+        is_async_(is_async),
         server_(nullptr),
         server_thread_(nullptr) {}
 
@@ -56,14 +84,13 @@ class ProxygenServer {
       int threads,
       PythonAsyncRequestCallback async_callback,
       bool is_async)
-      : ip_(ip),
-        port_(port),
-        threads_(threads),
-        sync_callback_(nullptr),
-        async_callback_(std::move(async_callback)),
-        is_async_(is_async),
-        server_(nullptr),
-        server_thread_(nullptr) {}
+      : ProxygenServer(
+            ip,
+            port,
+            threads,
+            std::move(async_callback),
+            is_async,
+            "") {}
 
   ~ProxygenServer() {
     stop();
@@ -76,18 +103,29 @@ class ProxygenServer {
 
     py::gil_scoped_release release;
 
-    // Configure socket options for robust port handling:
-    // - SO_REUSEPORT: Allows multiple worker processes to bind to the same port
-    //   (essential for uWSGI multi-worker setup)
-    // - SO_REUSEADDR: Allows binding to ports in TIME_WAIT state
-    //   (enables immediate restart without "Address already in use" errors)
-    folly::SocketOptionMap socket_options;
-    socket_options[{SOL_SOCKET, SO_REUSEPORT}] = 1;
-    socket_options[{SOL_SOCKET, SO_REUSEADDR}] = 1;
+    folly::SocketAddress address;
+    if (!unix_socket_path_.empty()) {
+      // AF_UNIX bind fails if a stale socket path is left from a previous run.
+      ::unlink(unix_socket_path_.c_str());
+      address = folly::SocketAddress::makeFromPath(unix_socket_path_);
+    } else {
+      address = folly::SocketAddress(ip_, port_, true);
+    }
 
-    HTTPServer::IPConfig ip_config(
-        folly::SocketAddress(ip_, port_, true), HTTPServer::Protocol::HTTP);
-    ip_config.acceptorSocketOptions = socket_options;
+    HTTPServer::IPConfig ip_config(address, HTTPServer::Protocol::HTTP);
+
+    if (unix_socket_path_.empty()) {
+      // Configure socket options for robust port handling:
+      // - SO_REUSEPORT: Allows multiple worker processes to bind to the same
+      // port
+      //   (essential for uWSGI multi-worker setup)
+      // - SO_REUSEADDR: Allows binding to ports in TIME_WAIT state
+      //   (enables immediate restart without "Address already in use" errors)
+      folly::SocketOptionMap socket_options;
+      socket_options[{SOL_SOCKET, SO_REUSEPORT}] = 1;
+      socket_options[{SOL_SOCKET, SO_REUSEADDR}] = 1;
+      ip_config.acceptorSocketOptions = socket_options;
+    }
 
     std::vector<HTTPServer::IPConfig> IPs = {ip_config};
 
@@ -133,9 +171,8 @@ class ProxygenServer {
     server_thread_ =
         std::make_unique<std::thread>([this]() { server_->start(); });
 
-    LOG(INFO) << "Proxygen server started on " << ip_ << ":" << port_
-              << " with " << actual_threads
-              << " threads (SO_REUSEPORT + SO_REUSEADDR enabled)";
+    LOG(INFO) << "Proxygen server started on " << address.describe() << " with "
+              << actual_threads << " threads";
   }
 
   void stop() {
@@ -150,6 +187,10 @@ class ProxygenServer {
 
       server_.reset();
       server_thread_.reset();
+
+      if (!unix_socket_path_.empty()) {
+        ::unlink(unix_socket_path_.c_str());
+      }
 
       LOG(INFO) << "Proxygen server stopped";
     }
@@ -184,6 +225,7 @@ class ProxygenServer {
   std::string ip_;
   int port_;
   int threads_;
+  std::string unix_socket_path_;
   PythonRequestCallback sync_callback_;
   PythonAsyncRequestCallback async_callback_;
   bool is_async_;
@@ -221,11 +263,17 @@ PYBIND11_MODULE(proxygen_binding, m) {
   py::class_<ProxygenServer>(m, "ProxygenServer")
       // Synchronous callback constructor (deprecated)
       .def(
-          py::init<const std::string&, int, int, PythonRequestCallback>(),
+          py::init<
+              const std::string&,
+              int,
+              int,
+              PythonRequestCallback,
+              const std::string&>(),
           py::arg("ip") = "127.0.0.1",
           py::arg("port") = 8000,
           py::arg("threads") = 0,
           py::arg("callback"),
+          py::arg("unix_socket_path") = "",
           "Create server with synchronous callback (deprecated - use async_callback)")
       // Asynchronous callback constructor (recommended)
       .def(
@@ -234,12 +282,14 @@ PYBIND11_MODULE(proxygen_binding, m) {
               int,
               int,
               PythonAsyncRequestCallback,
-              bool>(),
+              bool,
+              const std::string&>(),
           py::arg("ip") = "127.0.0.1",
           py::arg("port") = 8000,
           py::arg("threads") = 0,
           py::arg("async_callback"),
           py::arg("is_async") = true,
+          py::arg("unix_socket_path") = "",
           "Create server with asynchronous callback (recommended)")
       .def("start", &ProxygenServer::start, "Start the HTTP server")
       .def("stop", &ProxygenServer::stop, "Stop the HTTP server")


### PR DESCRIPTION
Summary: Switch DjangoBench v2 async uWSGI worker backends to Unix sockets by default from the runner, thus eliminating the requirement for large continuous range of available TCP ports; add optional Unix socket binding to the Proxygen Python binding, and keep TCP worker ports available through `--worker-transport tcp` as a rollback path.

Differential Revision: D108099076


