### PR TITLE
Bump Spark 4.0.2 -> 4.0.3 (fix dlcdn 404)

### DIFF
--- a/benchpress/config/benchmarks.yml
+++ b/benchpress/config/benchmarks.yml
@@ -140,7 +140,7 @@ spark_standalone:
   install_script: ./packages/spark_standalone/install_spark_standalone.sh
   cleanup_script: ./packages/spark_standalone/cleanup_spark_standalone.sh
   install_markers:
-    - ./benchmarks/spark_standalone/spark-4.0.2-bin-hadoop3/bin/spark-sql
+    - ./benchmarks/spark_standalone/spark-4.0.3-bin-hadoop3/bin/spark-sql
     - ./benchmarks/spark_standalone/scripts/run_perf_common.py
     - /usr/lib/jvm/graalvm-community-openjdk-17.0.9+9.1/bin/java
   path: ./packages/spark_standalone/templates/runner.py

--- a/packages/spark_standalone/README.md
+++ b/packages/spark_standalone/README.md
@@ -398,7 +398,7 @@ please remove the data from previous runs so that SparkBench can rebuild databas
 
 ```bash
 rm -rf /flash23/warehouse
-rm -rf <benchpressPath>/benchmarks/spark_standalone/spark-4.0.2-bin-hadoop3/metastore_db
+rm -rf <benchpressPath>/benchmarks/spark_standalone/spark-4.0.3-bin-hadoop3/metastore_db
 ```
 
 4. Create the `/flash23` folder. Copy `bpc_t93586_s2_synthetic_5GB`
@@ -408,7 +408,7 @@ Note that SparkBench mini does not require the high I/O throughput
 
 5. Run `spark_standalone_remote_mini` job on a real machine.
 This will create data in `/flash23/warehouse`
-and `<benchpressPath>/benchmarks/spark_standalone/spark-4.0.2-bin-hadoop3/metastore_db`.
+and `<benchpressPath>/benchmarks/spark_standalone/spark-4.0.3-bin-hadoop3/metastore_db`.
 Create a backup of these two folders. By default, this job uses the 5GB dataset.
 If you want to use the 1GB dataset, run the job with specifying the
 `dataset_name` parameter like this:
@@ -425,12 +425,12 @@ with the same commands and options.
 Building database takes a considerable amount of time, so it's advisable to consider
 using the same set of storage nodes and NVMe drives when running SparkBench on another
 compute node server. If you choose to reuse the Spark database in `/flash23/warehouse`,
-please also make sure to copy the folder `metastore_db` under `benchmarks/spark_standalone/spark-4.0.2-bin-hadoop3`
+please also make sure to copy the folder `metastore_db` under `benchmarks/spark_standalone/spark-4.0.3-bin-hadoop3`
 to the new machine's same location, for example:
 
 ```
 # Under the DCPerf folder
-rsync -a benchmarks/spark_standalone/spark-4.0.2-bin-hadoop3/metastore_db root@<target-hostname>:~/DCPerf/benchmarks/spark_standalone/spark-4.0.2-bin-hadoop3/
+rsync -a benchmarks/spark_standalone/spark-4.0.3-bin-hadoop3/metastore_db root@<target-hostname>:~/DCPerf/benchmarks/spark_standalone/spark-4.0.3-bin-hadoop3/
 ```
 
 If you do not copy over the `metastore_db` folder, you will see errors like the following

--- a/packages/spark_standalone/install_spark_standalone.sh
+++ b/packages/spark_standalone/install_spark_standalone.sh
@@ -41,10 +41,10 @@ fi
 
 # download spark
 pushd "${OUT}" || exit 1
-if [ ! -f spark-4.0.2-bin-hadoop3.tgz ]; then
-  wget https://dlcdn.apache.org/spark/spark-4.0.2/spark-4.0.2-bin-hadoop3.tgz
+if [ ! -f spark-4.0.3-bin-hadoop3.tgz ]; then
+  wget https://dlcdn.apache.org/spark/spark-4.0.3/spark-4.0.3-bin-hadoop3.tgz
 fi
-tar xzf spark-4.0.2-bin-hadoop3.tgz
+tar xzf spark-4.0.3-bin-hadoop3.tgz
 popd || exit 1
 
 # create sub directories

--- a/packages/spark_standalone/templates/proj_root/scripts/utils.py
+++ b/packages/spark_standalone/templates/proj_root/scripts/utils.py
@@ -106,7 +106,7 @@ def read_environ() -> Dict[str, str]:
     env_vars["PROJ_ROOT"] = "/".join(os.path.abspath(__file__).split("/")[:-2])
     env_vars["JAVA_HOME"] = find_java_home()
     env_vars["SPARK_HOME"] = os.path.join(
-        env_vars["PROJ_ROOT"], "spark-4.0.2-bin-hadoop3"
+        env_vars["PROJ_ROOT"], "spark-4.0.3-bin-hadoop3"
     )
     # read from actual environment
     for k in env_vars:

--- a/packages/spark_standalone/templates/runner.py
+++ b/packages/spark_standalone/templates/runner.py
@@ -56,7 +56,7 @@ def download_dataset(args):
 
 
 def install_database(args):
-    metadata_dir = os.path.join(SPARK_DIR, "spark-4.0.2-bin-hadoop3", "metastore_db")
+    metadata_dir = os.path.join(SPARK_DIR, "spark-4.0.3-bin-hadoop3", "metastore_db")
     database_dir = os.path.join(args.warehouse_dir, f"{args.dataset_name.lower()}.db")
     if os.path.exists(metadata_dir):
         print("Removing stale metastore_db to ensure tables are recreated")


### PR DESCRIPTION
Summary:
install_spark_standalone.sh downloads Spark from dlcdn.apache.org, which only
mirrors the *current* Apache release. Spark 4.0.2 has been superseded and
removed from the mirror, so the install (and the public DCPerf "Spark CI"
GitHub job that runs on every diff) fails:

  + wget https://dlcdn.apache.org/spark/spark-4.0.2/spark-4.0.2-bin-hadoop3.tgz
  ERROR 404: Not Found.
  Exception: Failed to run '.../packages/spark_standalone/install_spark_standalone.sh'

Bump to the current release, 4.0.3, and update every reference to the extracted
directory name (spark-4.0.2-bin-hadoop3 -> spark-4.0.3-bin-hadoop3) so the
download path and all downstream paths stay in sync:

- packages/spark_standalone/install_spark_standalone.sh: download URL, cached
  tarball check, and tar extract.
- benchpress/config/benchmarks.yml: spark-sql binary path.
- packages/spark_standalone/templates/proj_root/scripts/utils.py and
  templates/runner.py: SPARK_DIR / metastore_db runtime paths.
- packages/spark_standalone/README.md: documented metastore_db paths.

Differential Revision: D109883537


