### PR TITLE
Add self-contained Health check fbpkg build via buck_genrule (#697)

### DIFF
--- a/benchpress/config/benchmarks.yml
+++ b/benchpress/config/benchmarks.yml
@@ -171,6 +171,9 @@ health_check:
   parser: health_check
   install_script: ./packages/health_check/install_health_check.sh
   cleanup_script: ./packages/health_check/cleanup_health_check.sh
+  install_markers:
+    - ./benchmarks/health_check/run.sh
+    - ./benchmarks/health_check/sleepbench/sleepbench
   path: ./benchmarks/health_check/run.sh
   metrics: []
 

--- a/packages/health_check/run.sh
+++ b/packages/health_check/run.sh
@@ -9,6 +9,12 @@ set -Eeo pipefail
 
 
 HEALTH_ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")" &>/dev/null && pwd -P)
+
+# Add bundled binaries to PATH (for self-contained builds)
+if [ -d "${HEALTH_ROOT}/bin" ]; then
+    export PATH="${HEALTH_ROOT}/bin:${PATH}"
+    export LD_LIBRARY_PATH="${HEALTH_ROOT}/lib:${LD_LIBRARY_PATH:-}"
+fi
 show_help() {
 cat <<EOF
 Usage: ${0##*/} [-h] [-r server|client] [-c clients] [-b benchmark] [-- extra_args]


### PR DESCRIPTION
Summary:

Add self-contained HealthCheck fbpkg build via buck_genrule to enable pre-built HealthCheck binaries in the cea.chips.benchpress.oss_prebuild fbpkg. The HealthCheck benchmark will now be pre-built at fbpkg build time for both x86_64 and aarch64 architectures, eliminating the need to run benchpress install on target machines.

Reviewed By: excelle08

Differential Revision: D108812377


