### PR TITLE
Add self-contained syscall and schbench fbpkg build via buck_genrule

### DIFF
--- a/benchpress/config/benchmarks.yml
+++ b/benchpress/config/benchmarks.yml
@@ -171,6 +171,9 @@ health_check:
   parser: health_check
   install_script: ./packages/health_check/install_health_check.sh
   cleanup_script: ./packages/health_check/cleanup_health_check.sh
+  install_markers:
+    - ./benchmarks/health_check/run.sh
+    - ./benchmarks/health_check/sleepbench/sleepbench
   path: ./benchmarks/health_check/run.sh
   metrics: []
 

--- a/benchpress/config/benchmarks_system.yml
+++ b/benchpress/config/benchmarks_system.yml
@@ -7,6 +7,8 @@ syscall:
   parser: syscall
   install_script: ./packages/syscall/install_syscall.sh
   cleanup_script: ./packages/syscall/cleanup_syscall.sh
+  install_markers:
+    - ./packages/syscall/syscall
   path: ./packages/syscall/syscall
   tags:
     scope:
@@ -19,6 +21,8 @@ schbench:
   parser: schbench
   install_script: ./packages/schbench/install_schbench.sh
   cleanup_script: ./packages/schbench/cleanup_schbench.sh
+  install_markers:
+    - ./packages/schbench/bin/schbench
   path: ./packages/schbench/bin/schbench
   tags:
     scope:

--- a/packages/health_check/run.sh
+++ b/packages/health_check/run.sh
@@ -9,6 +9,12 @@ set -Eeo pipefail
 
 
 HEALTH_ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")" &>/dev/null && pwd -P)
+
+# Add bundled binaries to PATH (for self-contained builds)
+if [ -d "${HEALTH_ROOT}/bin" ]; then
+    export PATH="${HEALTH_ROOT}/bin:${PATH}"
+    export LD_LIBRARY_PATH="${HEALTH_ROOT}/lib:${LD_LIBRARY_PATH:-}"
+fi
 show_help() {
 cat <<EOF
 Usage: ${0##*/} [-h] [-r server|client] [-c clients] [-b benchmark] [-- extra_args]


### PR DESCRIPTION
Summary:
Pre-build syscall and schbench at fbpkg build time so the package runs
without `benchpress install`.

**Syscall**: custom genrule build (same two-stage pattern as feedsim/health_check).
Downloads gflags from Manifold, compiles syscall.cpp with static gflags linkage.

**Schbench**: uses existing `//third-party/schbench:schbench` cpp_binary target
directly via fbpkg.copy(). No custom build scripts or Manifold deps needed since
the source is already in fbsource.

Key changes:
- `fb_scripts/builder/syscall/`: build.sh, download_deps.sh,
  upload_deps_to_manifold.sh for syscall genrule build
- BUCK: syscall genrules (deps_download, x86 build, arm64 build) +
  schbench via fbpkg.copy from //third-party/schbench:schbench
- `benchmarks_system.yml`: added install_markers for prebuild detection

Reviewed By: excelle08

Differential Revision: D108812394


