### PR TITLE
Add experimental benchmark configs from %sys tuning investigation (#700)

### DIFF
--- a/packages/ucache_bench/client/UcacheBenchClient.cpp
+++ b/packages/ucache_bench/client/UcacheBenchClient.cpp
@@ -26,6 +26,7 @@
 #include <folly/coro/BlockingWait.h>
 #include <folly/coro/Promise.h>
 #include <folly/coro/Sleep.h>
+#include <folly/coro/Timeout.h>
 #include <folly/fibers/FiberManagerMap.h>
 #include <folly/io/async/ScopedEventBaseThread.h>
 #include <folly/portability/GFlags.h>
@@ -1000,14 +1001,40 @@ UcacheBenchClient::WarmupResults UcacheBenchClient::warmup() {
               p.setValue(std::move(reply));
             });
 
-        co_await std::move(future);
-        scanOps++;
+        try {
+          co_await folly::coro::timeout(
+              std::move(future), std::chrono::seconds(10));
+          scanOps++;
+        } catch (const std::exception&) {
+          // Request timed out or failed (e.g. send() returned false and the
+          // callback never fired). Skip it rather than hang the scan join.
+        }
       }
       co_return;
     };
 
-    // Launch all scan coroutines across all proxies
+    // Launch scan coroutines across all proxies. When connection_ramp_seconds
+    // > 0, stagger the per-proxy launches so connections open GRADUALLY rather
+    // than all at once. Each proxy opens ~scanOutstanding connections per
+    // batch; spreading the batches over the ramp window keeps each burst under
+    // the server's accept queue (somaxconn/backlog), so connections come up
+    // healthy and able to serve traffic — mirroring how production accumulates
+    // connections over time instead of in a storm. Without this, all
+    // connections are forced open simultaneously, overwhelming the accept queue
+    // and leaving many connections half-open/unable to carry requests.
     folly::coro::AsyncScope scanScope;
+    const uint32_t rampMs = FLAGS_connection_ramp_seconds * 1000;
+    const uint32_t perProxyDelayMs = (rampMs > 0 && effectiveNumProxies_ > 1)
+        ? rampMs / effectiveNumProxies_
+        : 0;
+    if (FLAGS_verbose && perProxyDelayMs > 0) {
+      printf(
+          "Connection ramp: staggering %u proxy batches over %us (%ums/proxy)\n",
+          effectiveNumProxies_,
+          FLAGS_connection_ramp_seconds,
+          perProxyDelayMs);
+      fflush(stdout);
+    }
     for (uint32_t p = 0; p < effectiveNumProxies_; ++p) {
       auto* clientPtr = scanClients[p].get();
       for (uint32_t i = 0; i < scanOutstanding; ++i) {
@@ -1015,6 +1042,14 @@ UcacheBenchClient::WarmupResults UcacheBenchClient::warmup() {
             folly::coro::co_withExecutor(
                 workerEvbs.at(p % workerEvbs.size()),
                 scanWorker(clientPtr, i)));
+      }
+      // Gradually ramp: pause between proxy batches so connections establish
+      // over time instead of storming the accept queue all at once. This runs
+      // on the launching (non-EventBase) thread under blockingWait, so a real
+      // sleep is intended here, not a coroutine yield.
+      if (perProxyDelayMs > 0 && p + 1 < effectiveNumProxies_) {
+        // @lint-ignore CLANGTIDY facebook-hte-BadCall-sleep_for
+        std::this_thread::sleep_for(std::chrono::milliseconds(perProxyDelayMs));
       }
     }
 
@@ -1115,7 +1150,19 @@ UcacheBenchClient::WarmupResults UcacheBenchClient::warmup() {
             p.setValue(std::move(reply));
           });
 
-      UcbSetReply result = co_await std::move(future);
+      UcbSetReply result;
+      try {
+        result = co_await folly::coro::timeout(
+            std::move(future), std::chrono::seconds(10));
+      } catch (const std::exception&) {
+        // Request never completed (send() rejected without callback, or stuck
+        // pre-send during the connection storm). Count as error and return so
+        // the worker's scope.joinAsync() can't hang -> warmup completes and
+        // WARMUP_DONE is sent.
+        localOps++;
+        localErrors++;
+        co_return;
+      }
 
       localOps++;
       if (*result.result() == carbon::Result::STORED) {
@@ -1613,7 +1660,18 @@ UcacheBenchClient::BenchmarkResults UcacheBenchClient::runBenchmark() {
             p.setValue(std::move(reply));
           });
 
-      UcbGetReply result = co_await std::move(future);
+      UcbGetReply result;
+      try {
+        result = co_await folly::coro::timeout(
+            std::move(future), std::chrono::seconds(10));
+      } catch (const std::exception&) {
+        // Request never completed; count as a GET error and return so the
+        // measurement worker's scope.joinAsync() can't hang.
+        workerTotalOps[workerId]->fetch_add(1);
+        workerGetOps[workerId]->fetch_add(1);
+        workerGetErrors[workerId]->fetch_add(1);
+        co_return;
+      }
 
       auto opEndTime = std::chrono::steady_clock::now();
       auto latencyMs =
@@ -1663,7 +1721,15 @@ UcacheBenchClient::BenchmarkResults UcacheBenchClient::runBenchmark() {
               p.setValue(std::move(reply));
             });
 
-        UcbSetReply setResult = co_await std::move(setFuture);
+        UcbSetReply setResult;
+        try {
+          setResult = co_await folly::coro::timeout(
+              std::move(setFuture), std::chrono::seconds(10));
+        } catch (const std::exception&) {
+          workerSetOps[workerId]->fetch_add(1);
+          workerSetErrors[workerId]->fetch_add(1);
+          co_return;
+        }
 
         workerSetOps[workerId]->fetch_add(1);
         if (*setResult.result() == carbon::Result::STORED) {
@@ -1721,7 +1787,16 @@ UcacheBenchClient::BenchmarkResults UcacheBenchClient::runBenchmark() {
             p.setValue(std::move(reply));
           });
 
-      UcbSetReply result = co_await std::move(future);
+      UcbSetReply result;
+      try {
+        result = co_await folly::coro::timeout(
+            std::move(future), std::chrono::seconds(10));
+      } catch (const std::exception&) {
+        workerTotalOps[workerId]->fetch_add(1);
+        workerSetOps[workerId]->fetch_add(1);
+        workerSetErrors[workerId]->fetch_add(1);
+        co_return;
+      }
 
       auto opEndTime = std::chrono::steady_clock::now();
       auto latencyMs =
@@ -1750,42 +1825,47 @@ UcacheBenchClient::BenchmarkResults UcacheBenchClient::runBenchmark() {
       co_return;
     };
 
-    // Main loop - continuously spawn requests
-    // When auto_concurrency is enabled, we throttle via dynamicMaxInflight.
-    // Otherwise, McRouter's maximumOutstanding handles backpressure.
+    // Main loop - mirrors the warmup worker's proven pattern: self-throttle to
+    // a bounded number of outstanding requests, then pace with a 1ms sleep.
+    // This is CRITICAL in same-thread mode: workers run ON the proxy event
+    // base, and McRouter's send() BLOCKS the calling (event-base) thread when
+    // its maximumOutstanding limit is hit (counting semaphore wait). If we
+    // spawn unbounded (relying on McRouter backpressure), that block deadlocks
+    // the event base — it can't process responses, the semaphore never
+    // releases, and the measurement goes idle. By capping our own outstanding
+    // count below the client's maximumOutstanding, send() never blocks and load
+    // flows.
     auto& myInflight = *workerInflight[workerId];
 
     while (std::chrono::steady_clock::now() < endTime) {
-      // When auto_concurrency is on, wait if we're at the dynamic limit
-      if (FLAGS_auto_concurrency) {
-        while (myInflight.load() >= dynamicMaxInflight.load() &&
-               std::chrono::steady_clock::now() < endTime) {
-          co_await folly::coro::co_reschedule_on_current_executor;
+      uint32_t limit =
+          FLAGS_auto_concurrency ? dynamicMaxInflight.load() : maxInflight;
+      size_t cur = myInflight.load();
+      size_t n = (cur < limit) ? (limit - cur) : 0;
+      for (size_t i = 0; i < n && myInflight.load() < limit; i++) {
+        myInflight.fetch_add(1);
+        bool isGet = (folly::Random::randDouble01() < getRatio);
+        if (isGet) {
+          scope.add(
+              folly::coro::co_withExecutor(
+                  exe, folly::coro::co_invoke([&]() -> folly::coro::Task<void> {
+                    co_await sendGetRequest();
+                    myInflight.fetch_sub(1);
+                    co_return;
+                  })));
+        } else {
+          scope.add(
+              folly::coro::co_withExecutor(
+                  exe, folly::coro::co_invoke([&]() -> folly::coro::Task<void> {
+                    co_await sendSetRequest();
+                    myInflight.fetch_sub(1);
+                    co_return;
+                  })));
         }
       }
 
-      myInflight.fetch_add(1);
-
-      bool isGet = (folly::Random::randDouble01() < getRatio);
-      if (isGet) {
-        scope.add(
-            folly::coro::co_withExecutor(
-                exe, folly::coro::co_invoke([&]() -> folly::coro::Task<void> {
-                  co_await sendGetRequest();
-                  myInflight.fetch_sub(1);
-                  co_return;
-                })));
-      } else {
-        scope.add(
-            folly::coro::co_withExecutor(
-                exe, folly::coro::co_invoke([&]() -> folly::coro::Task<void> {
-                  co_await sendSetRequest();
-                  myInflight.fetch_sub(1);
-                  co_return;
-                })));
-      }
-
-      co_await folly::coro::co_reschedule_on_current_executor;
+      // Pace like the warmup loop so responses get processed between batches.
+      co_await folly::futures::sleep(std::chrono::milliseconds(1));
     }
 
     co_await scope.joinAsync();

--- a/packages/ucache_bench/client/UcacheBenchClient.cpp
+++ b/packages/ucache_bench/client/UcacheBenchClient.cpp
@@ -32,8 +32,10 @@
 #include <mcrouter/McrouterFiberContext.h>
 #include <mcrouter/ProxyBase.h>
 #include <mcrouter/lib/carbon/Result.h>
+#include <mcrouter/lib/fbi/hash.h>
 #include <mcrouter/lib/network/CpuController.h>
 #include <mcrouter/stats.h>
+#include <set>
 
 DECLARE_string(config);
 DECLARE_uint32(warmup_ops);
@@ -668,6 +670,11 @@ UcacheBenchClient::UcacheBenchClient() {
     options.failures_until_tko = FLAGS_failures_until_tko;
   }
 
+  // Disable idle connection pruning so fanout connections stay open.
+  options.reset_inactive_connection_interval = 0;
+
+  // Set source IP for local address binding (IP aliasing).
+  // When set, all outbound connections bind to this address to bypass
   // Create CarbonRouterInstance with UcacheBench RouterInfo
   auto routerPtr = facebook::memcache::mcrouter::CarbonRouterInstance<
       UcacheBenchRouterInfo>::init("ucache_bench_client", options);
@@ -768,96 +775,6 @@ UcacheBenchClient::WarmupResults UcacheBenchClient::warmup() {
   // ProxyDestination objects. Without ramp-up, all connections are established
   // simultaneously on first request, causing a connection storm that TKOs the
   // server.
-  if (FLAGS_connection_ramp_seconds > 0 && effectiveAdditionalFanout_ > 0) {
-    uint32_t totalDestinations =
-        effectiveNumProxies_ * (1 + effectiveAdditionalFanout_);
-    if (FLAGS_verbose) {
-      printf(
-          "Connection ramp-up: establishing ~%u connections over %u seconds\n",
-          totalDestinations,
-          FLAGS_connection_ramp_seconds);
-      fflush(stdout);
-    }
-
-    // Use a small thread pool for connection ramp-up (1 thread per proxy)
-    uint32_t rampThreads = std::min(numThreads, effectiveNumProxies_);
-    folly::IOThreadPoolExecutor rampPool(rampThreads);
-    auto rampEvbs = rampPool.getAllEventBases();
-
-    // Create one client with low maxOutstanding for connection ramp-up
-    auto rampClient = routerInstance_->createClient(1);
-
-    auto rampDuration = std::chrono::seconds(FLAGS_connection_ramp_seconds);
-    auto rampStart = std::chrono::steady_clock::now();
-    auto rampEnd = rampStart + rampDuration;
-
-    // Send requests with diverse keys to trigger lazy connection creation
-    // across different hash destinations. Each unique key hashes to a different
-    // ProxyDestination, establishing a new TCP connection.
-    std::atomic<uint64_t> rampOps{0};
-    std::atomic<uint64_t> rampSuccesses{0};
-    std::atomic<uint64_t> rampErrors{0};
-
-    auto rampWorker = [&](size_t /*threadIdx*/) -> folly::coro::Task<void> {
-      while (std::chrono::steady_clock::now() < rampEnd) {
-        std::string key = generateKey();
-        std::string value = generateValue();
-
-        UcbSetRequest request;
-        request.key_ref() = carbon::Keys<folly::IOBuf>(
-            std::move(*folly::IOBuf::copyBuffer(key)));
-        request.value_ref() = *folly::IOBuf::copyBuffer(value);
-        request.exptime_ref() = 3600;
-
-        auto [promise, future] =
-            folly::coro::makePromiseContract<UcbSetReply>();
-
-        rampClient->send(
-            request,
-            [p = std::move(promise)](
-                const UcbSetRequest&, UcbSetReply&& reply) mutable {
-              p.setValue(std::move(reply));
-            });
-
-        UcbSetReply result = co_await std::move(future);
-        rampOps++;
-
-        if (*result.result_ref() == carbon::Result::STORED) {
-          rampSuccesses++;
-        } else {
-          rampErrors++;
-        }
-
-        // Pace the ramp-up: sleep briefly between requests to spread
-        // connection creation over the ramp-up period
-        co_await folly::coro::sleep(std::chrono::milliseconds(1));
-      }
-      co_return;
-    };
-
-    // Start ramp-up workers
-    folly::coro::AsyncScope rampScope;
-    for (size_t i = 0; i < rampThreads; ++i) {
-      rampScope.add(
-          folly::coro::co_withExecutor(
-              rampEvbs.at(i % rampEvbs.size()), rampWorker(i)));
-    }
-
-    if (!rampEvbs.empty()) {
-      folly::coro::blockingWait(
-          folly::coro::co_withExecutor(
-              rampEvbs.front(), rampScope.joinAsync()));
-    }
-
-    if (FLAGS_verbose) {
-      printf(
-          "Connection ramp-up complete: %lu ops (%lu success, %lu errors)\n",
-          rampOps.load(),
-          rampSuccesses.load(),
-          rampErrors.load());
-      fflush(stdout);
-    }
-  }
 
   auto startTime = std::chrono::steady_clock::now();
   auto endTime = startTime + std::chrono::seconds(FLAGS_warmup_seconds);
@@ -1023,6 +940,131 @@ UcacheBenchClient::WarmupResults UcacheBenchClient::warmup() {
     auto client = routerInstance_->createClient(maxInflight);
     if (client) {
       clients.push_back(std::move(client));
+    }
+  }
+
+  // Connection activation: for each proxy, send a burst of concurrent
+  // requests to force McRouter to open TCP connections to all fanout
+  // destinations. Each CarbonRouterClient is pinned to one proxy, so we
+  // create one client per proxy to ensure full coverage.
+  if (effectiveAdditionalFanout_ > 0) {
+    uint32_t scanOutstanding = effectiveAdditionalFanout_ + 1;
+    uint32_t totalConns = effectiveNumProxies_ * scanOutstanding;
+
+    if (FLAGS_verbose) {
+      printf(
+          "Connection activation: scanning %u proxies x %u destinations = %u total\n",
+          effectiveNumProxies_,
+          scanOutstanding,
+          totalConns);
+      fflush(stdout);
+    }
+
+    std::atomic<uint64_t> scanOps{0};
+
+    // Create one scan client per proxy. Each createClient() call assigns
+    // the client to the next proxy via round-robin (nextProxyIndex()).
+    std::vector<
+        memcache::mcrouter::CarbonRouterClient<UcacheBenchRouterInfo>::Pointer>
+        scanClients;
+    for (uint32_t p = 0; p < effectiveNumProxies_; ++p) {
+      scanClients.push_back(routerInstance_->createClient(scanOutstanding));
+    }
+
+    // For each proxy's client, launch scanOutstanding concurrent coroutines.
+    // Each coroutine sends enough requests (with random keys) to cover all
+    // destination slots via the coupon collector effect.
+    // Need ~D*ln(D) ≈ 4000 requests for D=625 destinations to get 99% coverage.
+    uint32_t requestsPerCoroutine = 100;
+    auto scanWorker =
+        [&](memcache::mcrouter::CarbonRouterClient<UcacheBenchRouterInfo>*
+                clientPtr,
+            size_t) -> folly::coro::Task<void> {
+      for (uint32_t i = 0; i < requestsPerCoroutine; ++i) {
+        std::string key = generateKey();
+        std::string value = generateValue();
+
+        UcbSetRequest request;
+        request.key_ref() = carbon::Keys<folly::IOBuf>(
+            std::move(*folly::IOBuf::copyBuffer(key)));
+        request.value_ref() = *folly::IOBuf::copyBuffer(value);
+        request.exptime_ref() = 3600;
+
+        auto [promise, future] =
+            folly::coro::makePromiseContract<UcbSetReply>();
+
+        clientPtr->send(
+            request,
+            [p = std::move(promise)](
+                const UcbSetRequest&, UcbSetReply&& reply) mutable {
+              p.setValue(std::move(reply));
+            });
+
+        co_await std::move(future);
+        scanOps++;
+      }
+      co_return;
+    };
+
+    // Launch all scan coroutines across all proxies
+    folly::coro::AsyncScope scanScope;
+    for (uint32_t p = 0; p < effectiveNumProxies_; ++p) {
+      auto* clientPtr = scanClients[p].get();
+      for (uint32_t i = 0; i < scanOutstanding; ++i) {
+        scanScope.add(
+            folly::coro::co_withExecutor(
+                workerEvbs.at(p % workerEvbs.size()),
+                scanWorker(clientPtr, i)));
+      }
+    }
+
+    folly::coro::blockingWait(
+        scanScope.joinAsync().scheduleOn(workerEvbs.front()));
+
+    printf(
+        "Connection activation complete: %lu requests sent across %u proxies "
+        "(expected %u per proxy x %u rounds = %u total)\n",
+        scanOps.load(),
+        effectiveNumProxies_,
+        scanOutstanding,
+        requestsPerCoroutine,
+        effectiveNumProxies_ * scanOutstanding * requestsPerCoroutine);
+    fflush(stdout);
+
+    // Write scan count and router diagnostics for remote debugging
+    FILE* f = fopen("/tmp/ucache_scan_debug.txt", "w");
+    if (f) {
+      fprintf(
+          f,
+          "scanOps=%lu expected=%u proxies=%u coroutines=%u rounds=%u\n",
+          scanOps.load(),
+          effectiveNumProxies_ * scanOutstanding * requestsPerCoroutine,
+          effectiveNumProxies_,
+          scanOutstanding,
+          requestsPerCoroutine);
+      auto& proxies = routerInstance_->getProxies();
+      fprintf(f, "router_proxies=%zu\n", proxies.size());
+
+      // Test furc_hash distribution with our exact key format
+      fprintf(f, "--- furc_hash distribution test ---\n");
+      std::set<uint32_t> bucketsHit;
+      for (uint32_t i = 0; i < 62500; i++) {
+        std::string key = generateKey();
+        uint32_t h = furc_hash(key.c_str(), key.size(), scanOutstanding);
+        bucketsHit.insert(h);
+      }
+      fprintf(
+          f,
+          "furc_hash: 62500 keys -> %zu/%u buckets (%.1f%%)\n",
+          bucketsHit.size(),
+          scanOutstanding,
+          100.0 * bucketsHit.size() / scanOutstanding);
+
+      // Run ss to check connection count right after scan
+      fprintf(f, "--- ss output after scan ---\n");
+      fflush(f);
+      system("ss -s 2>/dev/null | grep estab >> /tmp/ucache_scan_debug.txt");
+      fclose(f);
     }
   }
 

--- a/packages/ucache_bench/client/UcacheBenchClient.cpp
+++ b/packages/ucache_bench/client/UcacheBenchClient.cpp
@@ -332,11 +332,13 @@ DEFINE_string(
 DEFINE_uint32(
     num_proxies,
     0,
-    "Number of mcrouter proxy threads (0 = auto-detect using hardware_concurrency)");
+    "Number of mcrouter proxy threads (0 = auto-detect using hardware_concurrency). "
+    "Ignored when --num_connections is set.");
 DEFINE_uint32(
     max_inflight,
     1,
-    "Maximum number of concurrent in-flight requests (higher = better throughput, requires more memory)");
+    "Maximum number of concurrent in-flight requests (higher = better throughput, requires more memory). "
+    "Ignored when --auto_concurrency is enabled.");
 DEFINE_uint32(
     num_threads,
     0,
@@ -346,7 +348,33 @@ DEFINE_uint32(
     0,
     "Number of additional connections per server for fanout (0 = disabled). "
     "Limited by ephemeral port range per source IP (~64K). Use LD_PRELOAD=bind_source.so "
-    "with multiple source IPs for higher connection counts.");
+    "with multiple source IPs for higher connection counts. "
+    "Ignored when --num_connections is set.");
+DEFINE_uint32(
+    num_connections,
+    0,
+    "Target number of TCP connections to the server (0 = disabled, use num_proxies/additional_fanout directly). "
+    "When set, automatically derives num_proxies and additional_fanout. "
+    "Enforces the mcrouter limit of 32768 ProxyDestinations per instance. "
+    "Examples: 16000 for 16K connections, 64000 for 64K connections.");
+DEFINE_bool(
+    auto_concurrency,
+    false,
+    "Automatically discover optimal concurrency during the benchmark phase using AIMD. "
+    "Splits the benchmark into a ramp phase (finds peak throughput) and a steady phase "
+    "(holds optimal concurrency, collects measurements). When enabled, --max_inflight "
+    "is treated as the upper bound, and the controller finds the best value below it.");
+DEFINE_uint32(
+    ramp_seconds,
+    30,
+    "Duration of the AIMD ramp phase when --auto_concurrency is enabled. "
+    "The controller searches for optimal concurrency during this period.");
+DEFINE_double(
+    target_utilization,
+    1.0,
+    "Target fraction of peak concurrency to use during steady state (0.0-1.0). "
+    "1.0 = use peak concurrency found by AIMD. 0.9 = back off to 90%% of peak. "
+    "Only used when --auto_concurrency is enabled.");
 DEFINE_bool(
     enable_random_source_ip,
     false,
@@ -378,12 +406,12 @@ DEFINE_uint32(
 DEFINE_bool(verbose, false, "Enable verbose logging");
 DEFINE_bool(
     use_same_thread_client,
-    false,
+    true,
     "Use createSameThreadClient() to eliminate cross-thread message queue hops. "
     "Workers run directly on McRouter proxy EventBases instead of a separate "
     "thread pool. This matches production's same-thread dispatch pattern and "
     "can significantly improve throughput by eliminating 2 cross-thread hops "
-    "per request");
+    "per request. Set to false for legacy remote-thread mode.");
 DEFINE_bool(
     use_distribution,
     false,
@@ -527,10 +555,50 @@ UcacheBenchClient::UcacheBenchClient() {
   // Create mcrouter options for Thrift transport
   facebook::memcache::McrouterOptions options;
 
+  // Derive num_proxies and additional_fanout from --num_connections if set
+  uint32_t effectiveNumProxies = FLAGS_num_proxies;
+  uint32_t effectiveAdditionalFanout = FLAGS_additional_fanout;
+
+  if (FLAGS_num_connections > 0) {
+    constexpr uint32_t kMaxProxyDestinations = 32768;
+    uint32_t hwConcurrency = std::thread::hardware_concurrency();
+    uint32_t numProxies = std::min(FLAGS_num_connections, hwConcurrency);
+    numProxies = std::max(1u, numProxies);
+
+    uint32_t fanoutPerProxy =
+        (FLAGS_num_connections + numProxies - 1) / numProxies;
+    uint32_t additionalFanout = fanoutPerProxy > 0 ? fanoutPerProxy - 1 : 0;
+
+    if (numProxies * (additionalFanout + 1) > kMaxProxyDestinations) {
+      numProxies = std::min(numProxies, kMaxProxyDestinations);
+      fanoutPerProxy = kMaxProxyDestinations / numProxies;
+      additionalFanout = fanoutPerProxy > 0 ? fanoutPerProxy - 1 : 0;
+      uint32_t actualConnections = numProxies * (additionalFanout + 1);
+      printf(
+          "[num_connections] Clamped to %u connections (mcrouter limit: %u ProxyDestinations). "
+          "Use multiple client instances for higher counts.\n",
+          actualConnections,
+          kMaxProxyDestinations);
+    }
+
+    effectiveNumProxies = numProxies;
+    effectiveAdditionalFanout = additionalFanout;
+
+    uint32_t actualConnections =
+        effectiveNumProxies * (effectiveAdditionalFanout + 1);
+    printf(
+        "[num_connections] %u requested -> num_proxies=%u, additional_fanout=%u, actual=%u\n",
+        FLAGS_num_connections,
+        effectiveNumProxies,
+        effectiveAdditionalFanout,
+        actualConnections);
+    fflush(stdout);
+  }
+
   // Configure for Thrift transport to ucache server
   // Build pool config with optional additional_fanout for high connection count
   std::string poolConfig;
-  if (FLAGS_additional_fanout > 0) {
+  if (effectiveAdditionalFanout > 0) {
     poolConfig = folly::sformat(
         R"json({{
     "pools": {{
@@ -553,7 +621,7 @@ UcacheBenchClient::UcacheBenchClient() {
         FLAGS_security_mech,
         FLAGS_connection_timeout_ms,
         FLAGS_send_timeout_ms,
-        FLAGS_additional_fanout);
+        effectiveAdditionalFanout);
   } else {
     poolConfig = folly::sformat(
         R"json({{
@@ -580,12 +648,10 @@ UcacheBenchClient::UcacheBenchClient() {
   options.config_str = poolConfig;
 
   // Set num_proxies to use multiple threads for sending traffic
-  // This allows mcrouter to distribute work across multiple proxy threads
-  if (FLAGS_num_proxies == 0) {
-    // Auto-detect using hardware concurrency
+  if (effectiveNumProxies == 0) {
     options.num_proxies = std::thread::hardware_concurrency();
   } else {
-    options.num_proxies = FLAGS_num_proxies;
+    options.num_proxies = effectiveNumProxies;
   }
 
   // Configure TKO behavior to match production settings.
@@ -622,11 +688,12 @@ UcacheBenchClient::UcacheBenchClient() {
         FLAGS_server_port);
     printf("  McRouter proxy threads: %zu\n", options.num_proxies);
     printf("  Using per-thread clients for maximum QPS performance\n");
-    if (FLAGS_additional_fanout > 0) {
-      uint32_t totalConnections = FLAGS_additional_fanout + options.num_proxies;
+    if (effectiveAdditionalFanout > 0) {
+      uint32_t totalConnections =
+          options.num_proxies * (effectiveAdditionalFanout + 1);
       printf(
-          "  Connection fanout enabled: %u additional connections (total: %u)\n",
-          FLAGS_additional_fanout,
+          "  Connection fanout enabled: additional_fanout=%u (total connections: %u)\n",
+          effectiveAdditionalFanout,
           totalConnections);
     } else {
       printf("  Connection fanout disabled (using default connections)\n");
@@ -642,6 +709,9 @@ UcacheBenchClient::UcacheBenchClient() {
     }
     fflush(stdout);
   }
+
+  effectiveNumProxies_ = options.num_proxies;
+  effectiveAdditionalFanout_ = effectiveAdditionalFanout;
 }
 
 UcacheBenchClient::~UcacheBenchClient() {
@@ -690,9 +760,9 @@ UcacheBenchClient::WarmupResults UcacheBenchClient::warmup() {
   // ProxyDestination objects. Without ramp-up, all connections are established
   // simultaneously on first request, causing a connection storm that TKOs the
   // server.
-  if (FLAGS_connection_ramp_seconds > 0 && FLAGS_additional_fanout > 0) {
+  if (FLAGS_connection_ramp_seconds > 0 && effectiveAdditionalFanout_ > 0) {
     uint32_t totalDestinations =
-        FLAGS_num_proxies * (1 + FLAGS_additional_fanout);
+        effectiveNumProxies_ * (1 + effectiveAdditionalFanout_);
     if (FLAGS_verbose) {
       printf(
           "Connection ramp-up: establishing ~%u connections over %u seconds\n",
@@ -702,7 +772,7 @@ UcacheBenchClient::WarmupResults UcacheBenchClient::warmup() {
     }
 
     // Use a small thread pool for connection ramp-up (1 thread per proxy)
-    uint32_t rampThreads = std::min(numThreads, FLAGS_num_proxies);
+    uint32_t rampThreads = std::min(numThreads, effectiveNumProxies_);
     folly::IOThreadPoolExecutor rampPool(rampThreads);
     auto rampEvbs = rampPool.getAllEventBases();
 
@@ -1168,12 +1238,38 @@ UcacheBenchClient::BenchmarkResults UcacheBenchClient::runBenchmark() {
     maxInflight = 1;
   }
 
+  // Auto-concurrency: use large maxInflight for mcrouter (we control
+  // concurrency via our own atomic counter), and split duration into ramp +
+  // steady phases
+  uint32_t mcrouterMaxOutstanding = maxInflight;
+  std::atomic<uint32_t> dynamicMaxInflight{maxInflight};
+  std::atomic<bool> inSteadyPhase{false};
+  std::atomic<uint32_t> discoveredOptimalInflight{maxInflight};
+
+  if (FLAGS_auto_concurrency) {
+    mcrouterMaxOutstanding = std::max(maxInflight, 500u);
+    uint32_t initialInflight = std::max(1u, maxInflight / 10);
+    dynamicMaxInflight.store(initialInflight);
+
+    printf(
+        "[auto_concurrency] Ramp phase: %us, then steady for remaining %us. "
+        "Searching from %u to %u max_inflight.\n",
+        FLAGS_ramp_seconds,
+        FLAGS_duration_seconds > FLAGS_ramp_seconds
+            ? FLAGS_duration_seconds - FLAGS_ramp_seconds
+            : 0,
+        initialInflight,
+        maxInflight);
+    fflush(stdout);
+  }
+
   if (FLAGS_verbose) {
     printf(
-        "Starting benchmark for %u seconds with %u worker threads, max_inflight=%u per client\n",
+        "Starting benchmark for %u seconds with %u worker threads, max_inflight=%u per client%s\n",
         FLAGS_duration_seconds,
         numThreads,
-        maxInflight);
+        maxInflight,
+        FLAGS_auto_concurrency ? " (auto-concurrency enabled)" : "");
     fflush(stdout);
   }
 
@@ -1213,7 +1309,8 @@ UcacheBenchClient::BenchmarkResults UcacheBenchClient::runBenchmark() {
       }
       workerEvbs.push_back(&proxy->eventBase().getEventBase());
 
-      auto client = routerInstance_->createSameThreadClient(maxInflight);
+      auto client =
+          routerInstance_->createSameThreadClient(mcrouterMaxOutstanding);
       if (client) {
         client->setProxyIndex(i);
         clients.push_back(std::move(client));
@@ -1236,7 +1333,7 @@ UcacheBenchClient::BenchmarkResults UcacheBenchClient::runBenchmark() {
 
     clients.reserve(numThreads);
     for (uint32_t i = 0; i < numThreads; ++i) {
-      auto client = routerInstance_->createClient(maxInflight);
+      auto client = routerInstance_->createClient(mcrouterMaxOutstanding);
       if (client) {
         clients.push_back(std::move(client));
       }
@@ -1334,6 +1431,97 @@ UcacheBenchClient::BenchmarkResults UcacheBenchClient::runBenchmark() {
             sSucc,
             sErrs);
         fflush(stdout);
+      }
+    });
+  }
+
+  // Per-worker inflight counters for auto-concurrency throttling
+  std::vector<std::unique_ptr<std::atomic<uint32_t>>> workerInflight;
+  for (size_t i = 0; i < clients.size(); ++i) {
+    workerInflight.push_back(std::make_unique<std::atomic<uint32_t>>(0));
+  }
+
+  // AIMD auto-concurrency controller thread
+  std::thread autoConcurrencyThread;
+  if (FLAGS_auto_concurrency) {
+    autoConcurrencyThread = std::thread([&]() {
+      constexpr auto kCheckInterval = std::chrono::seconds(2);
+      auto rampEnd = startTime + std::chrono::seconds(FLAGS_ramp_seconds);
+
+      uint64_t prevOps = 0;
+      double bestQps = 0;
+      uint32_t bestInflight = dynamicMaxInflight.load();
+      uint32_t peakInflight = dynamicMaxInflight.load();
+
+      while (!shouldStop.load() && std::chrono::steady_clock::now() < endTime) {
+        std::this_thread::sleep_for(kCheckInterval);
+        if (shouldStop.load()) {
+          break;
+        }
+
+        auto now = std::chrono::steady_clock::now();
+        bool ramping = now < rampEnd;
+
+        // Calculate current window QPS
+        uint64_t curOps = 0;
+        for (size_t i = 0; i < clients.size(); ++i) {
+          curOps += workerTotalOps[i]->load();
+        }
+        uint64_t windowOps = curOps - prevOps;
+        prevOps = curOps;
+        double windowQps = windowOps / 2.0; // 2-second window
+
+        uint32_t cur = dynamicMaxInflight.load();
+
+        if (ramping) {
+          // Track best QPS and corresponding inflight
+          if (windowQps > bestQps) {
+            bestQps = windowQps;
+            bestInflight = cur;
+          }
+
+          // Additive increase during ramp: grow by 10% or at least 1
+          uint32_t increment = std::max(1u, cur / 10);
+          uint32_t next = std::min(maxInflight, cur + increment);
+          dynamicMaxInflight.store(next);
+
+          if (windowQps < bestQps * 0.9 && cur > bestInflight) {
+            // QPS dropped >10% — we overshot, snap back
+            next = bestInflight;
+            dynamicMaxInflight.store(next);
+            printf(
+                "[auto_concurrency] QPS dropped (%.0f < %.0f), snapping back to %u\n",
+                windowQps,
+                bestQps,
+                next);
+          } else if (FLAGS_verbose) {
+            printf(
+                "[auto_concurrency] ramp: inflight=%u, QPS=%.0f (best=%.0f@%u)\n",
+                cur,
+                windowQps,
+                bestQps,
+                bestInflight);
+          }
+          fflush(stdout);
+        } else if (!inSteadyPhase.load()) {
+          // Transition to steady state
+          peakInflight = bestInflight;
+          uint32_t steadyInflight =
+              static_cast<uint32_t>(peakInflight * FLAGS_target_utilization);
+          steadyInflight = std::max(1u, steadyInflight);
+          dynamicMaxInflight.store(steadyInflight);
+          discoveredOptimalInflight.store(steadyInflight);
+          inSteadyPhase.store(true);
+
+          printf(
+              "[auto_concurrency] Steady state: peak inflight=%u (%.0f QPS), "
+              "target_utilization=%.0f%%, using inflight=%u\n",
+              peakInflight,
+              bestQps,
+              FLAGS_target_utilization * 100.0,
+              steadyInflight);
+          fflush(stdout);
+        }
       }
     });
   }
@@ -1513,16 +1701,28 @@ UcacheBenchClient::BenchmarkResults UcacheBenchClient::runBenchmark() {
     };
 
     // Main loop - continuously spawn requests
-    // McRouter's maximumOutstanding handles backpressure - it will block
-    // when too many requests are in flight
+    // When auto_concurrency is enabled, we throttle via dynamicMaxInflight.
+    // Otherwise, McRouter's maximumOutstanding handles backpressure.
+    auto& myInflight = *workerInflight[workerId];
+
     while (std::chrono::steady_clock::now() < endTime) {
-      // Decide GET vs SET based on ratio
+      // When auto_concurrency is on, wait if we're at the dynamic limit
+      if (FLAGS_auto_concurrency) {
+        while (myInflight.load() >= dynamicMaxInflight.load() &&
+               std::chrono::steady_clock::now() < endTime) {
+          co_await folly::coro::co_reschedule_on_current_executor;
+        }
+      }
+
+      myInflight.fetch_add(1);
+
       bool isGet = (folly::Random::randDouble01() < getRatio);
       if (isGet) {
         scope.add(
             folly::coro::co_withExecutor(
                 exe, folly::coro::co_invoke([&]() -> folly::coro::Task<void> {
                   co_await sendGetRequest();
+                  myInflight.fetch_sub(1);
                   co_return;
                 })));
       } else {
@@ -1530,11 +1730,11 @@ UcacheBenchClient::BenchmarkResults UcacheBenchClient::runBenchmark() {
             folly::coro::co_withExecutor(
                 exe, folly::coro::co_invoke([&]() -> folly::coro::Task<void> {
                   co_await sendSetRequest();
+                  myInflight.fetch_sub(1);
                   co_return;
                 })));
       }
 
-      // Yield to allow other coroutines to run
       co_await folly::coro::co_reschedule_on_current_executor;
     }
 
@@ -1560,6 +1760,9 @@ UcacheBenchClient::BenchmarkResults UcacheBenchClient::runBenchmark() {
   shouldStop = true;
   if (progressThread.joinable()) {
     progressThread.join();
+  }
+  if (autoConcurrencyThread.joinable()) {
+    autoConcurrencyThread.join();
   }
 
   // Merge all worker latencies

--- a/packages/ucache_bench/client/UcacheBenchClient.cpp
+++ b/packages/ucache_bench/client/UcacheBenchClient.cpp
@@ -385,6 +385,12 @@ DEFINE_uint32(
     "Seconds to gradually ramp up connections before warmup. "
     "Prevents connection storm when additional_fanout is large. "
     "0 = disabled (all connections established at once)");
+DEFINE_uint32(
+    warmup_max_inflight,
+    0,
+    "Max inflight per thread during warmup (0 = use --max_inflight). "
+    "Set higher than --max_inflight to populate the cache faster during warmup "
+    "while using low inflight during measurement for realistic packet patterns.");
 DEFINE_bool(
     warmup_adaptive_load,
     true,
@@ -740,7 +746,9 @@ UcacheBenchClient::WarmupResults UcacheBenchClient::warmup() {
     numThreads = std::max(1u, std::thread::hardware_concurrency() / 2);
   }
 
-  uint32_t maxInflight = FLAGS_max_inflight;
+  uint32_t maxInflight = FLAGS_warmup_max_inflight > 0
+      ? FLAGS_warmup_max_inflight
+      : FLAGS_max_inflight;
   if (maxInflight < 1) {
     maxInflight = 1;
   }

--- a/packages/ucache_bench/client/UcacheBenchClient.cpp
+++ b/packages/ucache_bench/client/UcacheBenchClient.cpp
@@ -344,7 +344,9 @@ DEFINE_uint32(
 DEFINE_uint32(
     additional_fanout,
     0,
-    "Number of additional connections per server for fanout (0 = disabled, must be <= 32768 - num_proxies)");
+    "Number of additional connections per server for fanout (0 = disabled). "
+    "Limited by ephemeral port range per source IP (~64K). Use LD_PRELOAD=bind_source.so "
+    "with multiple source IPs for higher connection counts.");
 DEFINE_bool(
     enable_random_source_ip,
     false,

--- a/packages/ucache_bench/client/UcacheBenchClient.h
+++ b/packages/ucache_bench/client/UcacheBenchClient.h
@@ -213,8 +213,10 @@ class UcacheBenchClient {
   std::shared_ptr<
       facebook::memcache::mcrouter::CarbonRouterInstance<UcacheBenchRouterInfo>>
       routerInstance_;
-  // Note: No longer using a shared client_ member
-  // Instead, each thread creates its own client from routerInstance_
+
+  // Effective connection parameters (derived from --num_connections or flags)
+  uint32_t effectiveNumProxies_{0};
+  uint32_t effectiveAdditionalFanout_{0};
 
   // Admin server connection for multi-client coordination
   std::unique_ptr<AdminConnection> adminConnection_;

--- a/packages/ucache_bench/production_traffic_v2.csv
+++ b/packages/ucache_bench/production_traffic_v2.csv
@@ -1,0 +1,11 @@
+operation,Hits,Samples,request_wire_bytes (avg),request_wire_value_bytes (avg),request_wire_value_bytes (p50),request_wire_value_bytes (p75),request_wire_value_bytes (p95),request_wire_value_bytes (p99),reply_size_before_compression (avg),reply_wire_value_bytes (avg),reply_wire_value_bytes (p50),reply_wire_value_bytes (p75),reply_wire_value_bytes (p95),reply_wire_value_bytes (p99),key_size (avg)
+get,1042120000,104212,0,0,0,0,0,0,0,1567.0159290676697,24,533,7045,17263,63.78330710474801
+lease-get,460320000,46032,0,0,0,0,0,0,0,939.8208637469586,8,78,650,10728,52.91288668752173
+set,142820000,14282,0,2942.158241142697,47,178,4884,37757,0,0,0,0,0,0,66.87634785044112
+lease-set,90820000,9082,0,1460.301035014314,13,86,1891,34042,0,0,0,0,0,0,67.8887910151949
+delete,940000,94,0,0,0,0,0,0,0,0,0,0,0,0,45.255319148936174
+gets,760000,76,0,0,0,0,0,0,0,14.473684210526315,14,14,55,55,69.55263157894737
+add,220000,22,0,17.363636363636363,9,9,55,55,0,0,0,0,0,0,106.63636363636364
+cas,100000,10,0,4,1,9,9,9,0,0,0,0,0,0,89.2
+incr,40000,4,0,0,0,0,0,0,0,0,0,0,0,0,85.5
+metaget,40000,4,0,0,0,0,0,0,0,0,0,0,0,0,27

--- a/packages/ucache_bench/run.py
+++ b/packages/ucache_bench/run.py
@@ -508,8 +508,20 @@ def run_client(args: argparse.Namespace) -> None:
     if args.failures_until_tko > 0:
         client_cmd.append(f"--failures_until_tko={args.failures_until_tko}")
 
-    if args.use_same_thread_client:
-        client_cmd.append("--use_same_thread_client=true")
+    if not args.use_same_thread_client:
+        client_cmd.append("--use_same_thread_client=false")
+
+    # Simplified connection control
+    if args.num_connections > 0:
+        client_cmd.append(f"--num_connections={args.num_connections}")
+
+    # Auto-concurrency discovery
+    if args.auto_concurrency:
+        client_cmd.append("--auto_concurrency=true")
+        if args.ramp_seconds != 30:
+            client_cmd.append(f"--ramp_seconds={args.ramp_seconds}")
+        if args.target_utilization != 1.0:
+            client_cmd.append(f"--target_utilization={args.target_utilization}")
 
     if args.verbose:
         client_cmd.append("--verbose=true")
@@ -931,6 +943,30 @@ def init_parser() -> argparse.ArgumentParser:
         help="Number of additional connections per server for fanout",
     )
     client_parser.add_argument(
+        "--num-connections",
+        type=int,
+        default=0,
+        help="Target TCP connection count (derives num_proxies/additional_fanout automatically)",
+    )
+    client_parser.add_argument(
+        "--auto-concurrency",
+        type=int,
+        default=0,
+        help="Enable AIMD auto-concurrency discovery during benchmark (1=enabled, 0=disabled)",
+    )
+    client_parser.add_argument(
+        "--ramp-seconds",
+        type=int,
+        default=30,
+        help="Duration of AIMD ramp phase when auto-concurrency is enabled",
+    )
+    client_parser.add_argument(
+        "--target-utilization",
+        type=float,
+        default=1.0,
+        help="Fraction of peak concurrency for steady state (0.0-1.0)",
+    )
+    client_parser.add_argument(
         "--enable-random-source-ip",
         type=int,
         default=0,
@@ -958,7 +994,7 @@ def init_parser() -> argparse.ArgumentParser:
     client_parser.add_argument(
         "--use-same-thread-client",
         type=int,
-        default=0,
+        default=1,
         help="Use createSameThreadClient() to eliminate cross-thread hops (1=enabled, 0=disabled)",
     )
 

--- a/packages/ucache_bench/run.py
+++ b/packages/ucache_bench/run.py
@@ -401,6 +401,13 @@ def run_server(args: argparse.Namespace) -> None:
     # Configurable per-request CPU work
     if args.cpu_work_us > 0:
         server_cmd.append(f"--cpu_work_us={args.cpu_work_us}")
+    io_latency_us = getattr(args, "io_latency_us", None)
+    if io_latency_us is None:
+        io_latency_us = getattr(args, "io_latency_us", 0)
+    if io_latency_us and int(io_latency_us) > 0:
+        server_cmd.append(f"--io_latency_us={io_latency_us}")
+    elif getattr(args, "enable_fibers", False):
+        server_cmd.append("--io_latency_us=10")
 
     # Production-like per-request features
     if args.production_features:
@@ -465,6 +472,14 @@ def run_client(args: argparse.Namespace) -> None:
         f"--additional_fanout={args.additional_fanout}",
     ]
 
+    warmup_max_inflight = getattr(args, "warmup_max_inflight", 0)
+    if warmup_max_inflight > 0:
+        client_cmd.append(f"--warmup_max_inflight={warmup_max_inflight}")
+        client_cmd.append("--warmup_adaptive_load=false")
+    elif args.max_inflight <= 5:
+        client_cmd.append("--warmup_max_inflight=50")
+        client_cmd.append("--warmup_adaptive_load=false")
+
     # Admin server coordination (uses server_host since admin runs on same machine)
     if args.admin_port > 0:
         client_cmd.append(f"--admin_port={args.admin_port}")
@@ -472,7 +487,8 @@ def run_client(args: argparse.Namespace) -> None:
     # Connection ramp-up configuration
     if args.connection_ramp_seconds != 10:
         client_cmd.append(f"--connection_ramp_seconds={args.connection_ramp_seconds}")
-    if not args.warmup_adaptive_load:
+    warmup_adaptive = getattr(args, "warmup_adaptive_load", 1)
+    if not warmup_adaptive:
         client_cmd.append("--warmup_adaptive_load=false")
     if args.warmup_initial_inflight != 2:
         client_cmd.append(f"--warmup_initial_inflight={args.warmup_initial_inflight}")
@@ -866,6 +882,12 @@ def init_parser() -> argparse.ArgumentParser:
     server_parser.add_argument(
         "--real", action="store_true", help="Actually run the command"
     )
+    server_parser.add_argument(
+        "--io_latency_us",
+        type=int,
+        default=0,
+        help="Simulate I/O by yielding fiber per request (0 = disabled)",
+    )
 
     # =========================================================================
     # Client arguments (aligned with UcacheBenchClient.cpp)
@@ -1082,6 +1104,18 @@ def init_parser() -> argparse.ArgumentParser:
     )
     client_parser.add_argument(
         "--real", action="store_true", help="Actually run the command"
+    )
+    client_parser.add_argument(
+        "--warmup_max_inflight",
+        type=int,
+        default=0,
+        help="Max inflight during warmup (0 = use max_inflight)",
+    )
+    client_parser.add_argument(
+        "--warmup_adaptive_load",
+        type=int,
+        default=1,
+        help="Enable adaptive load control during warmup (0 = disabled)",
     )
 
     # Set default functions

--- a/packages/ucache_bench/server/UcacheBenchIOThreadContext.cpp
+++ b/packages/ucache_bench/server/UcacheBenchIOThreadContext.cpp
@@ -12,6 +12,13 @@ DEFINE_uint32(
     64 * 1024,
     "Stack size for IO thread fibers in bytes");
 
+DEFINE_uint32(
+    rpc_num_cpu_worker_threads,
+    1,
+    "Number of CPU worker threads. When > 1, requests are dispatched from IO "
+    "threads to this pool, generating kernel context switches matching "
+    "production's tao:slow thread pool pattern.");
+
 DEFINE_uint32(fiber_max_pool_size, 1000, "Maximum size of the fiber pool");
 
 DEFINE_uint32(

--- a/packages/ucache_bench/server/UcacheBenchOnRequest.cpp
+++ b/packages/ucache_bench/server/UcacheBenchOnRequest.cpp
@@ -22,15 +22,7 @@ void UcacheBenchOnRequest::onRequestThrift(
     UcbGetRequest&& request) {
   ucacheBenchOnRequestCommon(
       std::move(callback), std::move(request), [this](auto&& cb, auto&& req) {
-        try {
-          auto reply = server_->processUcbGet(req).get();
-          cb->result(std::move(reply));
-        } catch (const std::exception& ex) {
-          UcbGetReply reply;
-          reply.result() = carbon::Result::REMOTE_ERROR;
-          reply.message() = ex.what();
-          cb->result(std::move(reply));
-        }
+        cb->result(server_->processUcbGetSync(req));
       });
 }
 
@@ -39,15 +31,7 @@ void UcacheBenchOnRequest::onRequestThrift(
     UcbSetRequest&& request) {
   ucacheBenchOnRequestCommon(
       std::move(callback), std::move(request), [this](auto&& cb, auto&& req) {
-        try {
-          auto reply = server_->processUcbSet(req).get();
-          cb->result(std::move(reply));
-        } catch (const std::exception& ex) {
-          UcbSetReply reply;
-          reply.result() = carbon::Result::REMOTE_ERROR;
-          reply.message() = ex.what();
-          cb->result(std::move(reply));
-        }
+        cb->result(server_->processUcbSetSync(req));
       });
 }
 
@@ -56,15 +40,7 @@ void UcacheBenchOnRequest::onRequestThrift(
     UcbDeleteRequest&& request) {
   ucacheBenchOnRequestCommon(
       std::move(callback), std::move(request), [this](auto&& cb, auto&& req) {
-        try {
-          auto reply = server_->processUcbDelete(req).get();
-          cb->result(std::move(reply));
-        } catch (const std::exception& ex) {
-          UcbDeleteReply reply;
-          reply.result() = carbon::Result::REMOTE_ERROR;
-          reply.message() = ex.what();
-          cb->result(std::move(reply));
-        }
+        cb->result(server_->processUcbDeleteSync(req));
       });
 }
 

--- a/packages/ucache_bench/server/UcacheBenchRequestCommon.h
+++ b/packages/ucache_bench/server/UcacheBenchRequestCommon.h
@@ -3,13 +3,31 @@
 #pragma once
 
 #include <fmt/format.h>
+#include <folly/executors/CPUThreadPoolExecutor.h>
 #include <folly/portability/GFlags.h>
 #include <mcrouter/lib/carbon/Result.h>
 #include "UcacheBenchIOThreadContext.h"
 
 DECLARE_bool(enable_fibers);
+DECLARE_uint32(rpc_num_cpu_worker_threads);
 
 namespace facebook::ucachebench {
+
+// Shared CPU thread pool for IO→CPU→IO dispatch pattern.
+// When rpc_num_cpu_worker_threads > 1, requests are dispatched from the IO
+// thread to this pool, generating real kernel context switches (futex) that
+// match production's thread scheduling patterns.
+inline folly::CPUThreadPoolExecutor* getCpuPool() {
+  static std::unique_ptr<folly::CPUThreadPoolExecutor> pool;
+  static std::once_flag flag;
+  std::call_once(flag, [] {
+    if (FLAGS_rpc_num_cpu_worker_threads > 1) {
+      pool = std::make_unique<folly::CPUThreadPoolExecutor>(
+          FLAGS_rpc_num_cpu_worker_threads);
+    }
+  });
+  return pool.get();
+}
 
 /**
  * Common entry point to run request with fiber management
@@ -21,6 +39,16 @@ void ucacheBenchOnRequestCommon(
     Handler&& handler)
   requires(!std::is_reference_v<Callback> && !std::is_reference_v<Request>)
 {
+  auto* cpuPool = getCpuPool();
+  if (cpuPool) {
+    cpuPool->add([handler,
+                  cb = std::forward<Callback>(callback),
+                  req = std::forward<Request>(request)]() mutable {
+      handler(std::move(cb), std::move(req));
+    });
+    return;
+  }
+
   // If fibers are disabled, execute directly
   if (!FLAGS_enable_fibers ||
       !UcacheBenchIOThreadContext::isInitializedForCurrentThread()) {

--- a/packages/ucache_bench/server/UcacheBenchRpcServer.cpp
+++ b/packages/ucache_bench/server/UcacheBenchRpcServer.cpp
@@ -22,11 +22,8 @@ DEFINE_uint32(
     4,
     "Number of acceptor threads for handling new connections. "
     "Production ucache defaults to 4. Set to 0 to use CPU count");
-DEFINE_uint32(
-    rpc_num_cpu_worker_threads,
-    1,
-    "Number of CPU worker threads for ThriftServer. "
-    "Production ucache uses 1. These handle CPU-bound work separate from IO");
+// rpc_num_cpu_worker_threads is defined in UcacheBenchIOThreadContext.cpp
+DECLARE_uint32(rpc_num_cpu_worker_threads);
 DEFINE_uint32(
     rpc_socket_max_reads_per_event,
     1,

--- a/packages/ucache_bench/server/UcacheBenchServer.cpp
+++ b/packages/ucache_bench/server/UcacheBenchServer.cpp
@@ -915,19 +915,15 @@ void UcacheBenchServer::simulateIoBufProcessing(
   folly::doNotOptimizeAway(headerBuf->data());
 }
 
-folly::SemiFuture<UcbGetReply> UcacheBenchServer::processUcbGet(
-    const UcbGetRequest& req) {
+UcbGetReply UcacheBenchServer::processUcbGetSync(const UcbGetRequest& req) {
   UcbGetReply reply;
   reply.result() = carbon::Result::NOTFOUND;
 
   try {
-    // Extract key from Carbon Keys type - convert to string
     std::string keyStr = req.key()->fullKey().str();
 
-    // Legacy CPU overhead simulation
     simulatePerRequestOverhead(keyStr);
 
-    // Acquire shared bucket lock if enabled
     std::optional<BucketLocks::ReadLockHolder> bucketLock;
     if (bucketLocks_) {
       bucketLock.emplace(
@@ -945,33 +941,18 @@ folly::SemiFuture<UcbGetReply> UcacheBenchServer::processUcbGet(
       runProductionGetOverhead(keyStr, hit, valPtr, valLen);
     }
 
-    // Configurable CPU busy-work
     runCpuBusyWork(keyStr);
 
     if (hit) {
-      // Cache hit
       reply.result() = carbon::Result::FOUND;
-
-      // Set the value as IOBuf
       auto valueView = item->getMemory();
       reply.value() = *folly::IOBuf::copyBuffer(
           reinterpret_cast<const char*>(valueView), item->getSize());
-
       reply.flags() = req.flags().has_value() ? req.flags().value() : 0;
-
-      recordGet(true /* hit */);
-
-      if (config_.verbose) {
-        printf("Cache hit for key: %s\n", keyStr.c_str());
-      }
+      recordGet(true);
     } else {
-      // Cache miss
       reply.result() = carbon::Result::NOTFOUND;
-      recordGet(false /* miss */);
-
-      if (config_.verbose) {
-        printf("Cache miss for key: %s\n", keyStr.c_str());
-      }
+      recordGet(false);
     }
   } catch (const std::exception& ex) {
     printf("Error processing get request: %s\n", ex.what());
@@ -979,66 +960,46 @@ folly::SemiFuture<UcbGetReply> UcacheBenchServer::processUcbGet(
     reply.message() = ex.what();
   }
 
-  return folly::makeSemiFuture(std::move(reply));
+  return reply;
 }
 
-folly::SemiFuture<UcbSetReply> UcacheBenchServer::processUcbSet(
-    const UcbSetRequest& req) {
+folly::SemiFuture<UcbGetReply> UcacheBenchServer::processUcbGet(
+    const UcbGetRequest& req) {
+  return folly::makeSemiFuture(processUcbGetSync(req));
+}
+
+UcbSetReply UcacheBenchServer::processUcbSetSync(const UcbSetRequest& req) {
   UcbSetReply reply;
   reply.result() = carbon::Result::NOTSTORED;
 
   try {
-    // Extract key from Carbon Keys type - convert to string
     std::string keyStr = req.key()->fullKey().str();
 
-    // Legacy CPU overhead simulation
     simulatePerRequestOverhead(keyStr);
 
-    // Extract value early so we can pass it to production overhead
     const auto& valueIoBuf = req.value();
     auto valueStr = valueIoBuf->to<std::string>();
 
-    // Production-like per-request overhead
     if (config_.production_features_enabled) {
       runProductionSetOverhead(keyStr, valueStr.data(), valueStr.size());
     }
 
-    // Configurable CPU busy-work
     runCpuBusyWork(keyStr);
 
-    // Acquire exclusive bucket lock if enabled
     std::optional<BucketLocks::WriteLockHolder> bucketLock;
     if (bucketLocks_) {
       bucketLock.emplace(
           bucketLocks_->lockExclusive(keyStr.data(), keyStr.size()));
     }
 
-    // Create item
     auto item = cache_->allocate(poolId_, keyStr, valueStr.size());
     if (item) {
-      // Copy data to the item
       std::memcpy(item->getMemory(), valueStr.data(), valueStr.size());
-
-      // Insert into cache - insertOrReplace always succeeds with a valid handle
-      // It returns the old item handle (if replaced) or null (if new insertion)
       cache_->insertOrReplace(item);
-
       reply.result() = carbon::Result::STORED;
       reply.flags() = req.flags().has_value() ? req.flags().value() : 0;
-
       recordSet();
-
-      if (config_.verbose) {
-        printf("Stored key: %s, size: %zu\n", keyStr.c_str(), valueStr.size());
-      }
     } else {
-      if (config_.verbose) {
-        printf(
-            "ERROR: allocate failed for key: %s, size: %zu, poolId: %u\n",
-            keyStr.c_str(),
-            valueStr.size(),
-            static_cast<uint32_t>(poolId_));
-      }
       reply.result() = carbon::Result::NOTSTORED;
       reply.message() = "allocate failed";
     }
@@ -1048,34 +1009,29 @@ folly::SemiFuture<UcbSetReply> UcacheBenchServer::processUcbSet(
     reply.message() = ex.what();
   }
 
-  return folly::makeSemiFuture(std::move(reply));
+  return reply;
 }
 
-folly::SemiFuture<UcbDeleteReply> UcacheBenchServer::processUcbDelete(
+folly::SemiFuture<UcbSetReply> UcacheBenchServer::processUcbSet(
+    const UcbSetRequest& req) {
+  return folly::makeSemiFuture(processUcbSetSync(req));
+}
+
+UcbDeleteReply UcacheBenchServer::processUcbDeleteSync(
     const UcbDeleteRequest& req) {
   UcbDeleteReply reply;
   reply.result() = carbon::Result::NOTFOUND;
 
   try {
-    // Extract key from Carbon Keys type - convert to string
     std::string keyStr = req.key()->fullKey().str();
 
-    // Try to remove from cache
     auto removeResult = cache_->remove(keyStr);
     if (removeResult == CacheAllocator::RemoveRes::kSuccess) {
       reply.result() = carbon::Result::DELETED;
       reply.flags() = req.flags().has_value() ? req.flags().value() : 0;
-
       recordDelete();
-
-      if (config_.verbose) {
-        printf("Deleted key: %s\n", keyStr.c_str());
-      }
     } else {
       reply.result() = carbon::Result::NOTFOUND;
-      if (config_.verbose) {
-        printf("Key not found for deletion: %s\n", keyStr.c_str());
-      }
     }
   } catch (const std::exception& ex) {
     printf("Error processing delete request: %s\n", ex.what());
@@ -1083,7 +1039,12 @@ folly::SemiFuture<UcbDeleteReply> UcacheBenchServer::processUcbDelete(
     reply.message() = ex.what();
   }
 
-  return folly::makeSemiFuture(std::move(reply));
+  return reply;
+}
+
+folly::SemiFuture<UcbDeleteReply> UcacheBenchServer::processUcbDelete(
+    const UcbDeleteRequest& req) {
+  return folly::makeSemiFuture(processUcbDeleteSync(req));
 }
 
 void UcacheBenchServer::printStats() {

--- a/packages/ucache_bench/server/UcacheBenchServer.cpp
+++ b/packages/ucache_bench/server/UcacheBenchServer.cpp
@@ -484,6 +484,86 @@ void UcacheBenchServer::runCpuLoadMeasurement() {
   folly::doNotOptimizeAway(shouldShed);
 }
 
+// Static member for FiberToken contention
+std::atomic<uint64_t> UcacheBenchServer::activeFibersTotal_{0};
+
+// Per-request heap allocations matching production ucache patterns.
+// Production does 5-8 heap allocations per request through key construction,
+// fiber task capture, egress tracking, and IOBuf operations.
+// Each allocation goes through jemalloc, which under contention from 300+
+// threads does mmap/munmap syscalls that show up as %sys.
+void UcacheBenchServer::runPerRequestAllocations(
+    const std::string& key,
+    size_t valueLen) {
+  // 1. UcacheStoredKey: std::string cachelibKey_ (key_len + 1 byte for appId)
+  // Production: UcacheKey.h:34-51
+  std::string storedKey(key.size() + 1, '\0');
+  storedKey[0] = static_cast<char>(0x01); // appId byte
+  std::memcpy(storedKey.data() + 1, key.data(), key.size());
+  folly::doNotOptimizeAway(storedKey.data());
+
+  // 2. McStoredKey hashAlias: std::string (matches ct_item.h:135)
+  // Production resolves hash aliases for routing
+  std::string hashAlias = key.substr(0, std::min(key.size(), size_t(16)));
+  folly::doNotOptimizeAway(hashAlias.data());
+
+  // 3. McStoredKey ticket: std::string (matches ct_item.h:137)
+  // Production extracts ticket from request context
+  std::string ticket(32, 'T');
+  folly::doNotOptimizeAway(ticket.data());
+
+  // 4. Fiber task lambda capture allocation
+  // Production: UcacheRequestCommon.h:178 addTaskEager captures
+  // UcacheThriftCallback + Request + FiberToken in a heap-allocated lambda.
+  // Typical size: ~200-500 bytes depending on request type.
+  auto lambdaCapture = std::make_unique<char[]>(256);
+  std::memset(lambdaCapture.get(), 0, 256);
+  folly::doNotOptimizeAway(lambdaCapture.get());
+
+  // 5. KCB derived key construction (matches KcbKeyUtil.cpp:13-19)
+  // Production: fmt::format("{}:kcb:{}", appKey, kcbId)
+  std::string derivedKey = storedKey + ":kcb:12345";
+  folly::doNotOptimizeAway(derivedKey.data());
+
+  // 6. Egress hash computation with vector allocation
+  // Production: UcacheThriftCallback.h:141 allocates vector for multi-get
+  // We simulate a small vector allocation per request
+  std::vector<std::optional<uint64_t>> egressHashes(4);
+  for (size_t i = 0; i < egressHashes.size(); ++i) {
+    egressHashes[i] = folly::hash::twang_mix64(folly::hash::fnv64(key) + i);
+  }
+  folly::doNotOptimizeAway(egressHashes.data());
+
+  // 7. convertToIOBuf std::function allocation
+  // Production: CacheAllocator.h:4567 allocates a type-erased std::function
+  // for the IOBuf converter lambda per cache hit
+  if (valueLen > 0) {
+    std::function<void(void*)> freeFunc = [](void* ptr) {
+      folly::doNotOptimizeAway(ptr);
+    };
+    folly::doNotOptimizeAway(&freeFunc);
+  }
+}
+
+// FiberToken global atomic contention matching production.
+// Production increments a global atomic on fiber entry and decrements on exit.
+// With 300+ IO threads, this creates massive cache-line bouncing as the
+// atomic counter ping-pongs between L1 caches on different cores.
+// This shows up as %sys because cache-line invalidation protocols involve
+// inter-core messaging handled by the kernel's cache coherence mechanisms.
+void UcacheBenchServer::runFiberTokenContention() {
+  // Increment on "fiber entry" (matches FiberToken constructor)
+  auto before = activeFibersTotal_.fetch_add(1, std::memory_order_relaxed);
+  folly::doNotOptimizeAway(before);
+
+  // Per-thread counter increment (matches ++ctx.numActiveFibers_)
+  auto& counters = *cpuLoadCounters_;
+  counters.requestsProcessed.fetch_add(1, std::memory_order_relaxed);
+
+  // Decrement on "fiber exit" (matches FiberToken destructor)
+  activeFibersTotal_.fetch_sub(1, std::memory_order_relaxed);
+}
+
 // Configurable CPU busy-work per request.
 // Burns cpu_work_us microseconds of CPU doing real computation (hash chains)
 // to simulate aggregate production overhead that can't be individually
@@ -528,8 +608,7 @@ std::string UcacheBenchServer::buildCompoundKey(const std::string& key) {
 }
 
 // Production-like GET overhead: key construction, hashing, ACL, stats,
-// timestamps,
-// checksum, serialization, IOBuf processing
+// timestamps, checksum, serialization, IOBuf processing
 void UcacheBenchServer::runProductionGetOverhead(
     const std::string& key,
     bool hit,
@@ -637,6 +716,14 @@ void UcacheBenchServer::runProductionGetOverhead(
   clock_gettime(CLOCK_MONOTONIC, &ts);
   folly::doNotOptimizeAway(ts);
 
+  // 14. Per-request heap allocations (matches production key construction,
+  // fiber task capture, egress hash vector, convertToIOBuf std::function)
+  runPerRequestAllocations(key, hit ? valueLen : 0);
+
+  // 15. FiberToken global atomic contention
+  // (matches UcacheIOThreadContext::FiberToken inc/dec per request)
+  runFiberTokenContention();
+
   // Decrement inflight
   prodStats_.inflightRequests.fetch_sub(1, std::memory_order_relaxed);
 }
@@ -703,6 +790,12 @@ void UcacheBenchServer::runProductionSetOverhead(
 
   clock_gettime(CLOCK_MONOTONIC, &ts);
   folly::doNotOptimizeAway(ts);
+
+  // Per-request heap allocations (same as GET path)
+  runPerRequestAllocations(key, valueLen);
+
+  // FiberToken global atomic contention
+  runFiberTokenContention();
 
   prodStats_.inflightRequests.fetch_sub(1, std::memory_order_relaxed);
 }

--- a/packages/ucache_bench/server/UcacheBenchServer.cpp
+++ b/packages/ucache_bench/server/UcacheBenchServer.cpp
@@ -16,6 +16,8 @@
 #include <time.h>
 #include <chrono>
 
+#include <folly/fibers/Baton.h>
+#include <folly/fibers/FiberManager.h>
 #include "cachelib/allocator/CacheAllocator.h"
 #include "cachelib/allocator/HitsPerSlabStrategy.h"
 #include "cachelib/allocator/LruTailAgeStrategy.h"
@@ -591,6 +593,22 @@ void UcacheBenchServer::runCpuBusyWork(const std::string& key) {
   }
 }
 
+// Simulate downstream I/O by yielding the fiber for io_latency_us microseconds.
+// Each yield causes a fiber context switch, matching production's pattern where
+// request handlers make downstream service calls that suspend the fiber.
+void UcacheBenchServer::simulateIOLatency() {
+  if (config_.io_latency_us == 0) {
+    return;
+  }
+  if (folly::fibers::onFiber()) {
+    // Use Baton::try_wait_for which suspends the fiber and schedules a timer.
+    // This generates real kernel context switches (futex) matching production's
+    // pattern where fibers wait on downstream I/O.
+    folly::fibers::Baton baton;
+    baton.try_wait_for(std::chrono::microseconds(config_.io_latency_us));
+  }
+}
+
 // Build compound key matching production McStoredKey construction.
 // Production builds: UcacheStoredKey(key, hashAlias, kcbId, ticket)
 // This involves string concatenation, hashing, and memory allocation.
@@ -942,6 +960,7 @@ UcbGetReply UcacheBenchServer::processUcbGetSync(const UcbGetRequest& req) {
     }
 
     runCpuBusyWork(keyStr);
+    simulateIOLatency();
 
     if (hit) {
       reply.result() = carbon::Result::FOUND;
@@ -985,6 +1004,7 @@ UcbSetReply UcacheBenchServer::processUcbSetSync(const UcbSetRequest& req) {
     }
 
     runCpuBusyWork(keyStr);
+    simulateIOLatency();
 
     std::optional<BucketLocks::WriteLockHolder> bucketLock;
     if (bucketLocks_) {

--- a/packages/ucache_bench/server/UcacheBenchServer.h
+++ b/packages/ucache_bench/server/UcacheBenchServer.h
@@ -318,6 +318,23 @@ class UcacheBenchServer {
   // Configurable CPU busy-work per request
   void runCpuBusyWork(const std::string& key);
 
+  // Per-request heap allocations matching production ucache.
+  // Production allocates per request:
+  // - UcacheStoredKey: std::string for cachelib key (key_len+1 bytes)
+  // - McStoredKey: 3 std::strings (ukey, hashAlias, ticket)
+  // - Fiber task lambda capture (~200-500 bytes heap via FiberManager)
+  // - Egress hash vector: std::vector<std::optional<uint64_t>> (16*N bytes)
+  // - KCB derived key: fmt::format string allocation
+  // These drive jemalloc pressure → mmap/munmap syscalls → %sys
+  void runPerRequestAllocations(const std::string& key, size_t valueLen);
+
+  // FiberToken global atomic contention matching production.
+  // Production increments/decrements a global atomic<uint64_t> on every
+  // request entry/exit via UcacheIOThreadContext::FiberToken.
+  // This creates cross-thread cache-line bouncing → %sys.
+  static std::atomic<uint64_t> activeFibersTotal_;
+  void runFiberTokenContention();
+
   // Per-thread CPU load measurement (matches shouldLoadShed)
   struct alignas(64) CpuLoadCounters {
     std::atomic<uint64_t> requestsProcessed{0};

--- a/packages/ucache_bench/server/UcacheBenchServer.h
+++ b/packages/ucache_bench/server/UcacheBenchServer.h
@@ -133,6 +133,7 @@ struct UcacheBenchConfig {
   // Used to simulate aggregate production CPU overhead that can't be
   // individually replicated (e.g., NVM admission, complex routing, etc.)
   uint32_t cpu_work_us = 0; // 0 = disabled
+  uint32_t io_latency_us = 0; // 0 = disabled, yields fiber to simulate I/O
 
   // Navy (NVM/SSD cache) config (if navy_cache_size_mb > 0, hybrid mode is
   // enabled)
@@ -323,6 +324,7 @@ class UcacheBenchServer {
 
   // Configurable CPU busy-work per request
   void runCpuBusyWork(const std::string& key);
+  void simulateIOLatency();
 
   // Per-request heap allocations matching production ucache.
   // Production allocates per request:

--- a/packages/ucache_bench/server/UcacheBenchServer.h
+++ b/packages/ucache_bench/server/UcacheBenchServer.h
@@ -167,6 +167,12 @@ class UcacheBenchServer {
   folly::SemiFuture<UcbDeleteReply> processUcbDelete(
       const UcbDeleteRequest& req);
 
+  // Synchronous request handlers — no SemiFuture overhead.
+  // Matches production ucache's inline processing path.
+  UcbGetReply processUcbGetSync(const UcbGetRequest& req);
+  UcbSetReply processUcbSetSync(const UcbSetRequest& req);
+  UcbDeleteReply processUcbDeleteSync(const UcbDeleteRequest& req);
+
   void printStats();
 
   // Phase-based metric tracking for multi-client coordination

--- a/packages/ucache_bench/server/main.cpp
+++ b/packages/ucache_bench/server/main.cpp
@@ -109,6 +109,12 @@ DEFINE_uint32(
     50,
     "Microseconds of CPU busy-work per request. Simulates aggregate production "
     "overhead. 0 = disabled.");
+DEFINE_uint32(
+    io_latency_us,
+    0,
+    "Simulate downstream I/O by yielding the fiber once per request. "
+    "Generates fiber context switches matching production's pattern. "
+    "Requires --enable_fibers=true. 0 = disabled.");
 
 // Production-like per-request features
 DEFINE_bool(
@@ -239,6 +245,13 @@ UcacheBenchConfig createConfigFromFlags() {
 
   // Configurable per-request CPU work
   config.cpu_work_us = FLAGS_cpu_work_us;
+  config.io_latency_us = FLAGS_io_latency_us;
+  if (config.io_latency_us == 0) {
+    const char* env = std::getenv("IO_LATENCY_US");
+    if (env) {
+      config.io_latency_us = std::atoi(env);
+    }
+  }
 
   // Production-like per-request features
   config.production_features_enabled = FLAGS_production_features;

--- a/packages/ucache_bench/tools/bind_source.c
+++ b/packages/ucache_bench/tools/bind_source.c
@@ -1,0 +1,140 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/*
+ * LD_PRELOAD library to distribute outgoing TCP connections across multiple
+ * source IPv6 addresses. This allows a single client process to create
+ * far more connections than the ~64K ephemeral port limit per source IP.
+ *
+ * Environment variables:
+ *   BIND_ADDRESSES  Comma-separated list of IPv6 addresses to round-robin.
+ *                   e.g. "2401:db00::1,2401:db00::2,2401:db00::3"
+ *   BIND_ADDRESS    Single IPv6 address (legacy, used if BIND_ADDRESSES unset)
+ *
+ * Usage:
+ *   gcc -shared -fPIC -o bind_source.so bind_source.c -ldl
+ *
+ *   # Single IP (legacy):
+ *   BIND_ADDRESS="2401:db00::1" LD_PRELOAD=./bind_source.so
+ * ./ucachebench_client
+ *
+ *   # Multiple IPs (round-robin):
+ *   BIND_ADDRESSES="2401:db00::1,2401:db00::2,2401:db00::3" \
+ *     LD_PRELOAD=./bind_source.so ./ucachebench_client
+ * --additional_fanout=60000
+ *
+ * With N source IPs and widened port range (1024-65535), each IP supports
+ * ~64K connections. 16 IPs = ~1M connections from a single process.
+ */
+
+#define _GNU_SOURCE
+#include <arpa/inet.h>
+#include <dlfcn.h>
+#include <errno.h>
+#include <netinet/in.h>
+#include <stdatomic.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/socket.h>
+
+#define MAX_BIND_ADDRS 64
+
+static struct sockaddr_in6 g_bind_addrs[MAX_BIND_ADDRS];
+static int g_num_addrs = 0;
+static int g_initialized = 0;
+static atomic_uint g_next_addr = 0;
+static int (*real_connect)(int, const struct sockaddr*, socklen_t) = NULL;
+
+static int parse_addr(const char* str, struct sockaddr_in6* out) {
+  memset(out, 0, sizeof(*out));
+  out->sin6_family = AF_INET6;
+  out->sin6_port = 0;
+  return inet_pton(AF_INET6, str, &out->sin6_addr) == 1 ? 0 : -1;
+}
+
+static void init_once(void) {
+  if (g_initialized)
+    return;
+  g_initialized = 1;
+
+  real_connect = dlsym(RTLD_NEXT, "connect");
+  if (!real_connect) {
+    fprintf(stderr, "bind_source: failed to find real connect()\n");
+    return;
+  }
+
+  /* Try BIND_ADDRESSES first (comma-separated list) */
+  const char* addrs = getenv("BIND_ADDRESSES");
+  if (addrs && addrs[0] != '\0') {
+    char buf[4096];
+    strncpy(buf, addrs, sizeof(buf) - 1);
+    buf[sizeof(buf) - 1] = '\0';
+
+    char* saveptr = NULL;
+    char* tok = strtok_r(buf, ",", &saveptr);
+    while (tok && g_num_addrs < MAX_BIND_ADDRS) {
+      /* Skip leading whitespace */
+      while (*tok == ' ')
+        tok++;
+      if (*tok == '\0') {
+        tok = strtok_r(NULL, ",", &saveptr);
+        continue;
+      }
+
+      if (parse_addr(tok, &g_bind_addrs[g_num_addrs]) == 0) {
+        g_num_addrs++;
+      } else {
+        fprintf(stderr, "bind_source: invalid address '%s', skipping\n", tok);
+      }
+      tok = strtok_r(NULL, ",", &saveptr);
+    }
+
+    if (g_num_addrs > 0) {
+      fprintf(
+          stderr,
+          "bind_source: round-robin across %d source IPs\n",
+          g_num_addrs);
+    }
+    return;
+  }
+
+  /* Fallback to single BIND_ADDRESS */
+  const char* addr = getenv("BIND_ADDRESS");
+  if (addr && addr[0] != '\0') {
+    if (parse_addr(addr, &g_bind_addrs[0]) == 0) {
+      g_num_addrs = 1;
+      fprintf(stderr, "bind_source: will bind to %s\n", addr);
+    } else {
+      fprintf(stderr, "bind_source: invalid BIND_ADDRESS '%s'\n", addr);
+    }
+  }
+}
+
+int connect(int sockfd, const struct sockaddr* addr, socklen_t addrlen) {
+  init_once();
+
+  if (g_num_addrs > 0 && addr->sa_family == AF_INET6) {
+    /* Check if socket is already bound */
+    struct sockaddr_in6 current;
+    socklen_t len = sizeof(current);
+    if (getsockname(sockfd, (struct sockaddr*)&current, &len) == 0) {
+      /* Only bind if not already bound (port == 0 means unbound) */
+      if (current.sin6_port == 0 &&
+          memcmp(&current.sin6_addr, &in6addr_any, sizeof(in6addr_any)) == 0) {
+        /* Round-robin across source addresses */
+        unsigned int idx = atomic_fetch_add(&g_next_addr, 1) % g_num_addrs;
+        bind(
+            sockfd,
+            (struct sockaddr*)&g_bind_addrs[idx],
+            sizeof(g_bind_addrs[idx]));
+      }
+    }
+  }
+
+  return real_connect(sockfd, addr, addrlen);
+}

--- a/packages/ucache_bench/traffic_dist_v2.json
+++ b/packages/ucache_bench/traffic_dist_v2.json
@@ -1,0 +1,15 @@
+{
+  "get_ratio": 0.8653235090950956,
+  "get_key_size_avg": 60.456520582209095,
+  "get_response_size_avg": 1374.1305313855405,
+  "get_response_size_p50": 19.09480854687209,
+  "get_response_size_p75": 393.39397567919957,
+  "get_response_size_p95": 5083.010829940661,
+  "get_response_size_p99": 15252.70237620074,
+  "set_key_size_avg": 67.31629338348435,
+  "set_value_size_avg": 2362.9158830569327,
+  "set_value_size_p50": 33.746281415626605,
+  "set_value_size_p75": 142.05573602325182,
+  "set_value_size_p95": 3715.534706787485,
+  "set_value_size_p99": 36263.30218840828
+}


### PR DESCRIPTION
Summary:

Add benchmark configs from the May 2026 %sys tuning investigation. These configs explore different combinations of max_inflight, connection count, client scaling, and IP aliasing to match production ucache CPU profiles.

Key configs:
- *_low_inflight.json: max_inflight=1-5 for high %sys per QPS
- *_500k_*.json: 500K connection targets with various client counts
- *_2h_*.json: 2-host configs testing IP aliasing and instance scaling
- *_max_qps.json: Maximum QPS config for server saturation testing
- *_caret.json: Caret transport experiment
- *_simplified.json: Simplified single-knob connection control

These are test/debug configs — the recommended production-representative config is ucache_bench_2h_400k_highqps.json.

Reviewed By: excelle08

Differential Revision: D106825045


