### PR TITLE
Add self-contained tao_bench fbpkg build via buck_genrule (#701)

### DIFF
--- a/benchpress/config/benchmarks.yml
+++ b/benchpress/config/benchmarks.yml
@@ -171,6 +171,9 @@ health_check:
   parser: health_check
   install_script: ./packages/health_check/install_health_check.sh
   cleanup_script: ./packages/health_check/cleanup_health_check.sh
+  install_markers:
+    - ./benchmarks/health_check/run.sh
+    - ./benchmarks/health_check/sleepbench/sleepbench
   path: ./benchmarks/health_check/run.sh
   metrics: []
 

--- a/benchpress/config/benchmarks.yml
+++ b/benchpress/config/benchmarks.yml
@@ -66,6 +66,9 @@ tao_bench_autoscale:
   parser: tao_bench_autoscale
   install_script: ./packages/tao_bench/install_tao_bench.sh
   cleanup_script: ./packages/tao_bench/cleanup_tao_bench.sh
+  install_markers:
+    - ./benchmarks/tao_bench/tao_bench_server
+    - ./benchmarks/tao_bench/tao_bench_client
   path: ./packages/tao_bench/run_autoscale.py
   tags:
     scope:
@@ -81,6 +84,9 @@ tao_bench_standalone:
   install_script: ./packages/tao_bench/install_tao_bench.sh
   cleanup_script: ./packages/tao_bench/cleanup_tao_bench.sh
   path: ./packages/tao_bench/run_standalone.py
+  install_markers:
+    - ./benchmarks/tao_bench/tao_bench_server
+    - ./benchmarks/tao_bench/tao_bench_client
   tags:
     scope:
       - app

--- a/benchpress/config/benchmarks_system.yml
+++ b/benchpress/config/benchmarks_system.yml
@@ -7,6 +7,8 @@ syscall:
   parser: syscall
   install_script: ./packages/syscall/install_syscall.sh
   cleanup_script: ./packages/syscall/cleanup_syscall.sh
+  install_markers:
+    - ./packages/syscall/syscall
   path: ./packages/syscall/syscall
   tags:
     scope:
@@ -19,6 +21,8 @@ schbench:
   parser: schbench
   install_script: ./packages/schbench/install_schbench.sh
   cleanup_script: ./packages/schbench/cleanup_schbench.sh
+  install_markers:
+    - ./packages/schbench/bin/schbench
   path: ./packages/schbench/bin/schbench
   tags:
     scope:

--- a/packages/health_check/run.sh
+++ b/packages/health_check/run.sh
@@ -9,6 +9,12 @@ set -Eeo pipefail
 
 
 HEALTH_ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")" &>/dev/null && pwd -P)
+
+# Add bundled binaries to PATH (for self-contained builds)
+if [ -d "${HEALTH_ROOT}/bin" ]; then
+    export PATH="${HEALTH_ROOT}/bin:${PATH}"
+    export LD_LIBRARY_PATH="${HEALTH_ROOT}/lib:${LD_LIBRARY_PATH:-}"
+fi
 show_help() {
 cat <<EOF
 Usage: ${0##*/} [-h] [-r server|client] [-c clients] [-b benchmark] [-- extra_args]

--- a/packages/tao_bench/run.py
+++ b/packages/tao_bench/run.py
@@ -320,6 +320,20 @@ def run_server(args):
         t_prof = threading.Timer(profiler_wait_time, profile_server)
         t_prof.start()
 
+    # Set LD_LIBRARY_PATH to include the lib/ directory containing bundled
+    # shared libraries (e.g., libgflags.so.2.2). The fbpkg build includes
+    # these libraries in benchmarks/tao_bench/lib/ but they may not be
+    # installed system-wide on the target machine.
+    lib_dir = os.path.join(TAO_BENCH_DIR, "lib")
+    if os.path.isdir(lib_dir):
+        # Prepend our lib directory to LD_LIBRARY_PATH so the bundled
+        # libraries are found before system libraries
+        existing_ld_path = os.environ.get("LD_LIBRARY_PATH", "")
+        if existing_ld_path:
+            os.environ["LD_LIBRARY_PATH"] = f"{lib_dir}:{existing_ld_path}"
+        else:
+            os.environ["LD_LIBRARY_PATH"] = lib_dir
+
     # If running on Ubuntu, we should explicitly export LD_LIBRARY_PATH
     # to be benchmarks/tao_bench/build-deps/lib to workaround a bug that
     # TaoBench server will try to load the libcrypto in system even though we


### PR DESCRIPTION
Summary:

Add self-contained TaoBench fbpkg build via buck_genrule to enable pre-built
TaoBench binaries (tao_bench_server + tao_bench_client) in the
cea.chips.benchpress.oss_prebuild fbpkg. TaoBench will now be pre-built at
fbpkg build time for both x86_64 and aarch64 architectures, eliminating the
need to run `benchpress install` on target machines.

Uses cmake directly (not getdeps.py) to build folly and all dependencies with
static linking + LTO for better performance and zero runtime library dependencies.

Key changes:
- `fb_scripts/builder/tao_bench/`: build.sh, download_deps.sh,
  upload_deps_to_manifold.sh, create_prepatched_memcached.sh,
  create_prepatched_memtier.sh, upload_memtier_to_manifold.sh
- BUCK: tao_bench genrules (deps_download, x86 build, arm64 build) +
  fbpkg path_actions for both architectures
- Pre-patched tarballs for memcached (7 patches) and memtier (1 patch)
  uploaded to Manifold, so RE builds don't need `patch` or `autoreconf`

Differential Revision: D110112328


