### PR TITLE
Add Silesia corpus client-server story pipeline (#707)

### DIFF
--- a/benchpress/config/jobs.yml
+++ b/benchpress/config/jobs.yml
@@ -646,6 +646,10 @@
     - '--client-feature-seed={client_feature_seed}'
     - '--client-num-dense={client_num_dense}'
     - '--client-num-sparse={client_num_sparse}'
+    - '--feature-extractors={feature_extractors}'
+    - '--feature-complexity={feature_complexity}'
+    - '--num-stories={num_stories}'
+    - '--extractors-per-story={extractors_per_story}'
   vars:
     - 'port=11222'
     - 'output=feedsim_results.txt'
@@ -662,6 +666,10 @@
     - 'client_feature_seed=42'
     - 'client_num_dense=13'
     - 'client_num_sparse=26'
+    - 'feature_extractors=0'
+    - 'feature_complexity=5'
+    - 'num_stories=100'
+    - 'extractors_per_story=50'
   hooks:
     - hook: cpu-mpstat
       options:
@@ -731,6 +739,10 @@
     - '--client-feature-seed={client_feature_seed}'
     - '--client-num-dense={client_num_dense}'
     - '--client-num-sparse={client_num_sparse}'
+    - '--feature-extractors={feature_extractors}'
+    - '--feature-complexity={feature_complexity}'
+    - '--num-stories={num_stories}'
+    - '--extractors-per-story={extractors_per_story}'
     - '{extra_args}'
   vars:
     - 'num_instances=-1'
@@ -747,6 +759,10 @@
     - 'client_feature_seed=42'
     - 'client_num_dense=13'
     - 'client_num_sparse=26'
+    - 'feature_extractors=0'
+    - 'feature_complexity=5'
+    - 'num_stories=100'
+    - 'extractors_per_story=50'
     - 'extra_args='
   hooks:
     - hook: cpu-mpstat

--- a/benchpress/config/jobs.yml
+++ b/benchpress/config/jobs.yml
@@ -743,6 +743,8 @@
     - '--feature-complexity={feature_complexity}'
     - '--num-stories={num_stories}'
     - '--extractors-per-story={extractors_per_story}'
+    - '--silesia-dir={silesia_dir}'
+    - '--stories-per-request={stories_per_request}'
     - '{extra_args}'
   vars:
     - 'num_instances=-1'
@@ -763,6 +765,8 @@
     - 'feature_complexity=5'
     - 'num_stories=100'
     - 'extractors_per_story=50'
+    - 'silesia_dir=silesia'
+    - 'stories_per_request=10'
     - 'extra_args='
   hooks:
     - hook: cpu-mpstat

--- a/packages/feedsim/generate_dlrm_models.py
+++ b/packages/feedsim/generate_dlrm_models.py
@@ -1,0 +1,171 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Generate DLRM medium and large TorchScript models with random weights.
+
+For benchmarking, trained weights aren't needed — the compute pattern
+(embedding lookups, MLP forward passes, feature interactions) is identical
+regardless of weight values. These models are architecture-compatible with
+the existing dlrm_small.pt model used by FeedSim's DLRM inference path.
+
+Usage:
+    python3 generate_dlrm_models.py <output_dir>
+"""
+
+import os
+import sys
+
+import torch
+from torch import nn
+
+
+class DLRM(nn.Module):
+    """Simplified DLRM model matching production inference patterns."""
+
+    def __init__(
+        self,
+        emb_dim: int = 64,
+        num_dense: int = 13,
+        num_sparse: int = 26,
+        max_emb_rows: int = 250000,
+        bottom_mlp_dims: list = None,
+        top_mlp_dims: list = None,
+    ):
+        super().__init__()
+        if bottom_mlp_dims is None:
+            bottom_mlp_dims = [256, 128, emb_dim]
+        if top_mlp_dims is None:
+            top_mlp_dims = [256, 128, 1]
+
+        # Bottom MLP: dense features -> embedding dimension
+        layers = []
+        in_dim = num_dense
+        for out_dim in bottom_mlp_dims:
+            layers.append(nn.Linear(in_dim, out_dim))
+            layers.append(nn.ReLU())
+            in_dim = out_dim
+        self.bottom_mlp = nn.Sequential(*layers)
+
+        # Embedding tables for sparse features
+        emb_sizes = [
+            40000000,
+            39060,
+            17295,
+            7424,
+            20265,
+            3,
+            7122,
+            1543,
+            63,
+            40000000,
+            3067956,
+            405282,
+            10,
+            2209,
+            11938,
+            155,
+            4,
+            976,
+            14,
+            40000000,
+            40000000,
+            40000000,
+            590152,
+            12973,
+            108,
+            36,
+        ]
+        # Use min(actual_size, max_emb_rows) to control model size
+        self.embeddings = nn.ModuleList(
+            [
+                nn.EmbeddingBag(min(s, max_emb_rows), emb_dim, mode="sum")
+                for s in emb_sizes[:num_sparse]
+            ]
+        )
+
+        # Top MLP: interaction output -> prediction. ReLU only on hidden
+        # layers; the final Linear feeds raw logits into sigmoid in forward().
+        n = 1 + num_sparse  # bottom_mlp output + embedding outputs
+        interaction_size = emb_dim + (n * (n - 1)) // 2
+        top_layers = []
+        in_dim = interaction_size
+        for i, out_dim in enumerate(top_mlp_dims):
+            top_layers.append(nn.Linear(in_dim, out_dim))
+            if i < len(top_mlp_dims) - 1:
+                top_layers.append(nn.ReLU())
+            in_dim = out_dim
+        self.top_mlp = nn.Sequential(*top_layers)
+
+    def forward(self, dense: torch.Tensor, sparse: torch.Tensor) -> torch.Tensor:
+        # Bottom MLP
+        d = self.bottom_mlp(dense)
+
+        # Embedding lookups
+        embs = [emb(sparse[:, i].unsqueeze(1)) for i, emb in enumerate(self.embeddings)]
+
+        # Feature interaction (dot product)
+        combined = torch.cat([d.unsqueeze(1)] + [e.unsqueeze(1) for e in embs], dim=1)
+        interact = torch.bmm(combined, combined.transpose(1, 2))
+        n = combined.size(1)
+        idx = torch.triu_indices(n, n, offset=1)
+        flat = interact[:, idx[0], idx[1]]
+
+        # Top MLP
+        x = torch.cat([d, flat], dim=1)
+        return torch.sigmoid(self.top_mlp(x))
+
+
+def generate_model(output_path: str, **kwargs):
+    """Generate and save a TorchScript DLRM model."""
+    model = DLRM(**kwargs)
+    param_bytes = sum(p.numel() * p.element_size() for p in model.parameters())
+    print(f"  Parameters: {sum(p.numel() for p in model.parameters()):,}")
+    print(f"  Model size: {param_bytes / 1e6:.0f} MB")
+
+    scripted = torch.jit.script(model)
+    scripted.save(output_path)
+    file_size = os.path.getsize(output_path)
+    print(f"  Saved to: {output_path} ({file_size / 1e6:.0f} MB on disk)")
+
+
+def main():
+    if len(sys.argv) < 2:
+        print(f"Usage: {sys.argv[0]} <output_dir>")
+        sys.exit(1)
+
+    output_dir = sys.argv[1]
+    os.makedirs(output_dir, exist_ok=True)
+
+    # Medium model: larger embeddings (~500MB)
+    medium_path = os.path.join(output_dir, "dlrm_medium.pt")
+    if not os.path.exists(medium_path):
+        print("Generating DLRM medium model...")
+        generate_model(
+            medium_path,
+            emb_dim=64,
+            max_emb_rows=500000,
+            bottom_mlp_dims=[256, 128, 64],
+            top_mlp_dims=[256, 128, 1],
+        )
+    else:
+        print(f"[SKIPPED] {medium_path} already exists")
+
+    # Large model: even larger embeddings (~1GB)
+    large_path = os.path.join(output_dir, "dlrm_large.pt")
+    if not os.path.exists(large_path):
+        print("Generating DLRM large model...")
+        generate_model(
+            large_path,
+            emb_dim=128,
+            max_emb_rows=500000,
+            bottom_mlp_dims=[512, 256, 128],
+            top_mlp_dims=[512, 256, 1],
+        )
+    else:
+        print(f"[SKIPPED] {large_path} already exists")
+
+
+if __name__ == "__main__":
+    main()

--- a/packages/feedsim/install_feedsim.sh
+++ b/packages/feedsim/install_feedsim.sh
@@ -214,6 +214,32 @@ else
 fi
 
 
+# Download Silesia compression corpus for story-based requests (Phase 3)
+SILESIA_DIR="${FEEDSIM_ROOT_SRC}/silesia"
+SILESIA_URL="https://github.com/facebookresearch/DCPerf-datasets/releases/download/feedsim-silesia/silesia.tar.gz"
+if ! [ -d "$SILESIA_DIR" ] || [ -z "$(ls -A "$SILESIA_DIR" 2>/dev/null)" ]; then
+    msg "Downloading Silesia corpus..."
+    mkdir -p "$SILESIA_DIR"
+    cd "$SILESIA_DIR" || { msg "[ERROR] cannot cd to $SILESIA_DIR"; exit 1; }
+    if wget -q "$SILESIA_URL" -O silesia.tar.gz 2>/dev/null; then
+        tar -xzf silesia.tar.gz && rm -f silesia.tar.gz
+        msg "Silesia corpus downloaded: $(ls | wc -l) files, $(du -sh . | cut -f1)"
+    else
+        # Fallback to original Silesia host
+        msg "[INFO] GitHub dataset not available, trying original Silesia host..."
+        SILESIA_FALLBACK_URL="https://sun.aei.polsl.pl/~sdeor/corpus/silesia.zip"
+        if wget -q "$SILESIA_FALLBACK_URL" -O silesia.zip 2>/dev/null; then
+            unzip -q silesia.zip && rm -f silesia.zip
+            msg "Silesia corpus downloaded: $(ls | wc -l) files, $(du -sh . | cut -f1)"
+        else
+            msg "[WARNING] Silesia download failed — story-based requests will be unavailable"
+        fi
+    fi
+    cd "${FEEDSIM_THIRD_PARTY_SRC}"
+else
+    msg "[SKIPPED] Silesia corpus already present at $SILESIA_DIR"
+fi
+
 # Installing FeedSim
 cd "${FEEDSIM_ROOT_SRC}"
 

--- a/packages/feedsim/install_feedsim.sh
+++ b/packages/feedsim/install_feedsim.sh
@@ -242,6 +242,16 @@ if [ -f "third_party/fizz/fizz/tool/FizzServerCommand.cpp" ]; then
     sed -i 's/EVP_PKEY_cmp(pubKey.get(), key.get()) == 1/EVP_PKEY_eq(pubKey.get(), key.get())/g' "third_party/fizz/fizz/tool/FizzServerCommand.cpp"
 fi
 
+# Generate feature extractor variants (1M+ unique functions for I-cache pressure)
+msg "Generating feature extractor variants..."
+CODEGEN_DIR="${FEEDSIM_ROOT_SRC}/src/workloads/ranking/feature_extractors/generated"
+if [ -f "${CODEGEN_DIR}/generate_extractors.py" ]; then
+    python3 "${CODEGEN_DIR}/generate_extractors.py" --output-dir "${CODEGEN_DIR}"
+    msg "Feature extractor codegen complete"
+else
+    msg "[SKIPPED] No codegen script found at ${CODEGEN_DIR}/generate_extractors.py"
+fi
+
 mkdir -p build && cd build/
 
 # Build FeedSim with DLRM support
@@ -261,7 +271,14 @@ cmake -G Ninja \
     -DCMAKE_PREFIX_PATH="${FEEDSIM_THIRD_PARTY_SRC}/libtorch" \
     ../
 
-ninja -v -j1
+# Dependencies (fmt, folly, fbthrift, etc.) are already installed above via
+# separate make commands in their own build directories. This ninja step only
+# builds FeedSim itself (LeafNodeRank, DriverNodeRank, feature extractors),
+# so parallel builds are safe here. Use nproc/2 to avoid OOM.
+NINJA_JOBS="${BP_NINJA_JOBS:-$(( $(nproc) / 2 ))}"
+[ "$NINJA_JOBS" -lt 1 ] && NINJA_JOBS=1
+msg "Building FeedSim with ninja -j${NINJA_JOBS} (set BP_NINJA_JOBS to override)"
+ninja -j"${NINJA_JOBS}"
 
 msg ""
 msg "=== FeedSim Installation Complete ==="

--- a/packages/feedsim/install_feedsim_aarch64.sh
+++ b/packages/feedsim/install_feedsim_aarch64.sh
@@ -273,7 +273,6 @@ else
     msg "[SKIPPED] DLRM model already installed"
 fi
 
-
 # Installing FeedSim
 cd "${FEEDSIM_ROOT_SRC}/src"
 
@@ -303,6 +302,16 @@ if [ -f "third_party/fizz/fizz/tool/FizzServerCommand.cpp" ]; then
     sed -i 's/EVP_PKEY_cmp(pubKey.get(), key.get()) == 1/EVP_PKEY_eq(pubKey.get(), key.get())/g' "third_party/fizz/fizz/tool/FizzServerCommand.cpp"
 fi
 
+# Generate feature extractor variants (1M+ unique functions for I-cache pressure)
+msg "Generating feature extractor variants..."
+CODEGEN_DIR="${FEEDSIM_ROOT_SRC}/src/workloads/ranking/feature_extractors/generated"
+if [ -f "${CODEGEN_DIR}/generate_extractors.py" ]; then
+    python3 "${CODEGEN_DIR}/generate_extractors.py" --output-dir "${CODEGEN_DIR}"
+    msg "Feature extractor codegen complete"
+else
+    msg "[SKIPPED] No codegen script found at ${CODEGEN_DIR}/generate_extractors.py"
+fi
+
 msg "Building FeedSim ..."
 mkdir -p build && cd build/
 
@@ -328,7 +337,15 @@ cmake -G Ninja \
     -DTorch_DIR="${FEEDSIM_THIRD_PARTY_SRC}/libtorch/share/cmake/Torch" \
     ../
 
-ninja-build -j 1
+# Third-party deps (fmt, folly, fizz, wangle, mvfst, fbthrift) are built by this
+# ninja step via ExternalProject_Add. Their build order is declared in
+# third_party/src/CMake/build-*.cmake via add_dependencies() and
+# ExternalProject_Add_StepDependencies(), so ninja respects the DAG under -jN.
+# Use nproc/2 to avoid OOM during heavy template-instantiation steps.
+NINJA_JOBS="${BP_NINJA_JOBS:-$(( $(nproc) / 2 ))}"
+[ "$NINJA_JOBS" -lt 1 ] && NINJA_JOBS=1
+msg "Building FeedSim with ninja -j${NINJA_JOBS} (set BP_NINJA_JOBS to override)"
+ninja-build -j"${NINJA_JOBS}"
 
 msg ""
 msg "=== FeedSim Installation Complete ==="

--- a/packages/feedsim/install_feedsim_aarch64.sh
+++ b/packages/feedsim/install_feedsim_aarch64.sh
@@ -273,6 +273,31 @@ else
     msg "[SKIPPED] DLRM model already installed"
 fi
 
+# Download Silesia compression corpus for story-based requests (Phase 3)
+SILESIA_DIR="${FEEDSIM_ROOT_SRC}/silesia"
+SILESIA_URL="https://github.com/facebookresearch/DCPerf-datasets/releases/download/feedsim-silesia/silesia.tar.gz"
+if ! [ -d "$SILESIA_DIR" ] || [ -z "$(ls -A "$SILESIA_DIR" 2>/dev/null)" ]; then
+    msg "Downloading Silesia corpus..."
+    mkdir -p "$SILESIA_DIR"
+    cd "$SILESIA_DIR" || { msg "[ERROR] cannot cd to $SILESIA_DIR"; exit 1; }
+    if wget -q "$SILESIA_URL" -O silesia.tar.gz 2>/dev/null; then
+        tar -xzf silesia.tar.gz && rm -f silesia.tar.gz
+        msg "Silesia corpus downloaded: $(ls | wc -l) files, $(du -sh . | cut -f1)"
+    else
+        msg "[INFO] GitHub dataset not available, trying original Silesia host..."
+        SILESIA_FALLBACK_URL="https://sun.aei.polsl.pl/~sdeor/corpus/silesia.zip"
+        if wget -q "$SILESIA_FALLBACK_URL" -O silesia.zip 2>/dev/null; then
+            unzip -q silesia.zip && rm -f silesia.zip
+            msg "Silesia corpus downloaded: $(ls | wc -l) files, $(du -sh . | cut -f1)"
+        else
+            msg "[WARNING] Silesia download failed — story-based requests will be unavailable"
+        fi
+    fi
+    cd "${FEEDSIM_THIRD_PARTY_SRC}"
+else
+    msg "[SKIPPED] Silesia corpus already present at $SILESIA_DIR"
+fi
+
 # Installing FeedSim
 cd "${FEEDSIM_ROOT_SRC}/src"
 
@@ -323,11 +348,17 @@ FS_LDFLAGS="${BP_LDFLAGS:-} -latomic -Wl,--export-dynamic -L${FEEDSIM_THIRD_PART
 BP_CC="${BP_CC:-gcc}"
 BP_CXX="${BP_CXX:-g++}"
 
-# Use system OpenSSL
+# Ensure protoc binaries from miniconda are visible in libtorch/bin/ for cmake
+if [ -d "${FEEDSIM_THIRD_PARTY_SRC}/miniconda3/bin" ] && [ ! -f "${FEEDSIM_THIRD_PARTY_SRC}/libtorch/bin/protoc-33.5.0" ]; then
+    mkdir -p "${FEEDSIM_THIRD_PARTY_SRC}/libtorch/bin"
+    for f in "${FEEDSIM_THIRD_PARTY_SRC}/miniconda3/bin"/protoc*; do
+        [ -f "$f" ] && ln -sf "$f" "${FEEDSIM_THIRD_PARTY_SRC}/libtorch/bin/"
+    done
+fi
 
 cmake -G Ninja \
     -DCMAKE_BUILD_TYPE=Release \
-    -DCMAKE_PREFIX_PATH="${FEEDSIM_THIRD_PARTY_SRC}/build-deps" \
+    -DCMAKE_PREFIX_PATH="${FEEDSIM_THIRD_PARTY_SRC}/build-deps;${FEEDSIM_THIRD_PARTY_SRC}/libtorch" \
     -DCMAKE_C_COMPILER="$BP_CC" \
     -DCMAKE_CXX_COMPILER="$BP_CXX" \
     -DCMAKE_C_FLAGS_RELEASE="$FS_CFLAGS" \

--- a/packages/feedsim/install_feedsim_aarch64_ubuntu.sh
+++ b/packages/feedsim/install_feedsim_aarch64_ubuntu.sh
@@ -142,19 +142,6 @@ else
     msg "[SKIPPED] libevent-2.1.11-stable"
 fi
 
-# Installing openssl
-if ! [ -d "openssl" ]; then
-    mkdir -p build-deps
-    git clone --branch OpenSSL_1_1_1b --depth 1 https://github.com/openssl/openssl.git
-    cd "openssl"
-    ./config --prefix="${FEEDSIM_THIRD_PARTY_SRC}/build-deps"
-    make -j"$(nproc)"
-    make install
-    cd ../
-else
-    msg "[SKIPPED] openssl"
-fi
-
 msg "Installing third-party dependencies ... DONE"
 
 # Installing LibTorch via pip for aarch64
@@ -267,6 +254,16 @@ fi
 # Remove liburing-dev — Ubuntu's version is too old for folly v2026.01.05.00
 # which uses io_uring zero-copy RX APIs requiring liburing >= 2.6
 apt remove -y liburing-dev 2>/dev/null || true
+
+# Generate feature extractor variants (1M+ unique functions for I-cache pressure)
+msg "Generating feature extractor variants..."
+CODEGEN_DIR="${FEEDSIM_ROOT_SRC}/src/workloads/ranking/feature_extractors/generated"
+if [ -f "${CODEGEN_DIR}/generate_extractors.py" ]; then
+    python3 "${CODEGEN_DIR}/generate_extractors.py" --output-dir "${CODEGEN_DIR}"
+    msg "Feature extractor codegen complete"
+else
+    msg "[SKIPPED] No codegen script found at ${CODEGEN_DIR}/generate_extractors.py"
+fi
 
 mkdir -p build && cd build/
 

--- a/packages/feedsim/install_feedsim_ubuntu.sh
+++ b/packages/feedsim/install_feedsim_ubuntu.sh
@@ -235,6 +235,16 @@ if [ -f "third_party/fizz/fizz/tool/FizzServerCommand.cpp" ]; then
     sed -i 's/EVP_PKEY_cmp(pubKey.get(), key.get()) == 1/EVP_PKEY_eq(pubKey.get(), key.get())/g' "third_party/fizz/fizz/tool/FizzServerCommand.cpp"
 fi
 
+# Generate feature extractor variants (1M+ unique functions for I-cache pressure)
+msg "Generating feature extractor variants..."
+CODEGEN_DIR="${FEEDSIM_ROOT_SRC}/src/workloads/ranking/feature_extractors/generated"
+if [ -f "${CODEGEN_DIR}/generate_extractors.py" ]; then
+    python3 "${CODEGEN_DIR}/generate_extractors.py" --output-dir "${CODEGEN_DIR}"
+    msg "Feature extractor codegen complete"
+else
+    msg "[SKIPPED] No codegen script found at ${CODEGEN_DIR}/generate_extractors.py"
+fi
+
 mkdir -p build && cd build/
 
 # Build FeedSim with DLRM support

--- a/packages/feedsim/run.sh
+++ b/packages/feedsim/run.sh
@@ -588,8 +588,16 @@ main() {
 
     # Starting leaf node service
     monitor_port=$((port-1000))
+
+    # On aarch64, preload Miniconda's protobuf to resolve version conflict
+    # between system libprotobuf.so.25 and libtorch's libprotobuf.so.33
+    local preload_env=""
+    if [ "$(uname -m)" = "aarch64" ] && [ -f "${FEEDSIM_ROOT}/third_party/miniconda3/lib/libprotobuf.so" ]; then
+        preload_env="LD_PRELOAD=${FEEDSIM_ROOT}/third_party/miniconda3/lib/libprotobuf.so"
+    fi
+
     # shellcheck disable=SC2086
-    MALLOC_CONF=narenas:20,dirty_decay_ms:5000 build/workloads/ranking/LeafNodeRank \
+    env $preload_env MALLOC_CONF=narenas:20,dirty_decay_ms:5000 build/workloads/ranking/LeafNodeRank \
         --port="$port" \
         --monitor_port="$monitor_port" \
         --graph_scale=21 \
@@ -618,7 +626,7 @@ main() {
 
     # Wait for server to be fully ready using monitoring endpoint
     echo "Waiting for LeafNodeRank server to be ready on monitor port $monitor_port..."
-    max_attempts=30
+    max_attempts=120
     attempt=0
     while [ $attempt -lt $max_attempts ]; do
         if curl -f -s "http://localhost:$monitor_port/topology" > /dev/null 2>&1; then

--- a/packages/feedsim/run.sh
+++ b/packages/feedsim/run.sh
@@ -249,6 +249,19 @@ main() {
     local client_num_sparse
     client_num_sparse="26"
 
+    # Feature extraction options
+    local feature_extractors
+    feature_extractors=""
+
+    local feature_complexity
+    feature_complexity="5"
+
+    local num_stories
+    num_stories="100"
+
+    local extractors_per_story
+    extractors_per_story="50"
+
     if [ -z "$IS_AUTOSCALE_RUN" ]; then
        echo > $BREPS_LFILE
     fi
@@ -460,6 +473,36 @@ main() {
             --client-num-sparse=*)
                 client_num_sparse="${1#*=}"
                 ;;
+            --feature-extractors)
+                feature_extractors="1"
+                ;;
+            --feature-extractors=*)
+                local val="${1#*=}"
+                if [ "$val" != "0" ] && [ -n "$val" ]; then
+                    feature_extractors="1"
+                fi
+                ;;
+            --feature-complexity)
+                feature_complexity="$2"
+                shift
+                ;;
+            --feature-complexity=*)
+                feature_complexity="${1#*=}"
+                ;;
+            --num-stories)
+                num_stories="$2"
+                shift
+                ;;
+            --num-stories=*)
+                num_stories="${1#*=}"
+                ;;
+            --extractors-per-story)
+                extractors_per_story="$2"
+                shift
+                ;;
+            --extractors-per-story=*)
+                extractors_per_story="${1#*=}"
+                ;;
             -h|--help)
                 show_help >&2
                 exit 1
@@ -536,6 +579,13 @@ main() {
         fi
     fi
 
+    # Build feature extraction options
+    local feature_opts=""
+    if [ "$feature_extractors" = "1" ]; then
+        feature_opts="--feature_extractors --feature_complexity=$feature_complexity --num_stories=$num_stories --extractors_per_story=$extractors_per_story"
+        echo "Feature extraction pipeline: ENABLED (complexity=$feature_complexity, stories=$num_stories, extractors/story=$extractors_per_story)"
+    fi
+
     # Starting leaf node service
     monitor_port=$((port-1000))
     # shellcheck disable=SC2086
@@ -556,6 +606,7 @@ main() {
         --min_icache_iterations="$icache_iterations" \
         $dlrm_opts \
         $async_io_opts \
+        $feature_opts \
         $store_graph \
         $load_graph \
         $instrument_graph \

--- a/packages/feedsim/run.sh
+++ b/packages/feedsim/run.sh
@@ -101,6 +101,14 @@ Usage: ${0##*/} [OPTION]...
     --io-stddev I/O latency standard deviation in ms (for lognormal distribution). Default: 50
     --io-stages Number of I/O stages to simulate (models multi-hop data fetching). Default: 1
     --io-stage-latency Latency per I/O stage in ms (when --io-stages > 1). Default: 50
+    --feature-extractors Enable feature extraction pipeline before ranking inference.
+    --feature-complexity Complexity level for feature extractors (1-10). Default: 5
+    --num-stories Number of stories to process per request. Default: 100
+    --extractors-per-story Number of extractors per story. Default: 50
+    --silesia-dir Path to Silesia corpus directory for story-based requests. Default: auto-detect in benchmarks/feedsim/silesia/
+    --stories-per-request Number of story snippets per request. Default: 10
+    --story-size-min Minimum story snippet size in bytes. Default: 1024
+    --story-size-max Maximum story snippet size in bytes. Default: 4096
     --client-side-features Enable client-side DLRM feature generation (0=disabled, non-zero=enabled). Default: 0
     --client-batch-size Batch size for client-side feature generation. Default: 256
     --client-inferences Number of DLRM inferences per request (client-side). Default: 1
@@ -248,6 +256,19 @@ main() {
 
     local client_num_sparse
     client_num_sparse="26"
+
+    # Silesia corpus options
+    local silesia_dir
+    silesia_dir=""
+
+    local stories_per_request
+    stories_per_request="10"
+
+    local story_size_min
+    story_size_min="1024"
+
+    local story_size_max
+    story_size_max="4096"
 
     # Feature extraction options
     local feature_extractors
@@ -473,6 +494,34 @@ main() {
             --client-num-sparse=*)
                 client_num_sparse="${1#*=}"
                 ;;
+            --silesia-dir)
+                silesia_dir="$2"
+                shift
+                ;;
+            --silesia-dir=*)
+                silesia_dir="${1#*=}"
+                ;;
+            --stories-per-request)
+                stories_per_request="$2"
+                shift
+                ;;
+            --stories-per-request=*)
+                stories_per_request="${1#*=}"
+                ;;
+            --story-size-min)
+                story_size_min="$2"
+                shift
+                ;;
+            --story-size-min=*)
+                story_size_min="${1#*=}"
+                ;;
+            --story-size-max)
+                story_size_max="$2"
+                shift
+                ;;
+            --story-size-max=*)
+                story_size_max="${1#*=}"
+                ;;
             --feature-extractors)
                 feature_extractors="1"
                 ;;
@@ -564,6 +613,12 @@ main() {
         echo "Using PageRank workload"
     fi
 
+    # ICacheBuster only for PAGERANK workload
+    local icache_opts=""
+    if [ "$workload_type" = "pagerank" ]; then
+        icache_opts="--min_icache_iterations=$icache_iterations"
+    fi
+
     # Build async I/O options (Phase 3)
     local async_io_opts=""
     if [ "$async_io" = "1" ]; then
@@ -611,13 +666,14 @@ main() {
         --num_objects=2000 \
         --graph_max_iters=1 \
         --noaffinity \
-        --min_icache_iterations="$icache_iterations" \
+        $icache_opts \
         $dlrm_opts \
         $async_io_opts \
         $feature_opts \
         $store_graph \
         $load_graph \
         $instrument_graph \
+        $feature_opts \
         $leafnoderank_seed \
         $pagerank_seed \
         $pointerchase_seed >> $BREPS_LFILE 2>&1 &
@@ -663,6 +719,20 @@ main() {
         client_feature_opts="--client_side_features --client_dlrm_batch_size=$client_batch_size --client_dlrm_inferences=$client_inferences --client_feature_seed=$client_feature_seed --client_num_dense_features=$client_num_dense --client_num_sparse_features=$client_num_sparse"
     fi
 
+    # Build Silesia story options for DriverNodeRank
+    local silesia_opts=""
+    if [ -n "$silesia_dir" ]; then
+        # Resolve silesia_dir: if relative, prepend FEEDSIM_ROOT
+        if [[ "$silesia_dir" != /* ]]; then
+            silesia_dir="${FEEDSIM_ROOT}/${silesia_dir}"
+        fi
+        if [ ! -d "$silesia_dir" ]; then
+            die "Silesia directory does not exist: $silesia_dir"
+        fi
+        silesia_opts="--silesia_dir=$silesia_dir --stories_per_request=$stories_per_request --story_size_min=$story_size_min --story_size_max=$story_size_max"
+        echo "Silesia story generation: ENABLED (dir=$silesia_dir, stories/req=$stories_per_request, size=$story_size_min-$story_size_max)"
+    fi
+
     # Construct no retry mode parameter if specified
     no_retry_args=""
     if [ -n "$no_retry_mode" ]; then
@@ -678,7 +748,8 @@ main() {
                 --monitor_port "$client_monitor_port" \
                 --threads="${driver_threads}" \
                 --connections=4 \
-                $client_feature_opts
+                $client_feature_opts \
+                $silesia_opts
         benchreps_tell_state "after search_qps"
     elif [ -z "$fixed_qps" ] && [ "$auto_driver_threads" = "1" ]; then
         benchreps_tell_state "before search_qps"
@@ -687,7 +758,8 @@ main() {
             build/workloads/ranking/DriverNodeRank \
                 --monitor_port "$client_monitor_port" \
                 --server "0.0.0.0:$port" \
-                $client_feature_opts
+                $client_feature_opts \
+                $silesia_opts
         benchreps_tell_state "after search_qps"
     else
         # Adjust the number of workers according to QPS
@@ -712,7 +784,9 @@ main() {
                 --server "0.0.0.0:$port" \
                 --monitor_port "$client_monitor_port" \
                 --threads="${num_workers}" \
-                --connections="${num_connections}"
+                --connections="${num_connections}" \
+                $client_feature_opts \
+                $silesia_opts
         benchreps_tell_state "after fixed_qps_exp"
     fi
 

--- a/packages/feedsim/run.sh
+++ b/packages/feedsim/run.sh
@@ -624,13 +624,13 @@ main() {
 
     LEAF_PID=$!
 
-    # Wait for server to be fully ready using monitoring endpoint
-    echo "Waiting for LeafNodeRank server to be ready on monitor port $monitor_port..."
+    # Wait for server to be fully ready by checking if data port is accepting connections
+    echo "Waiting for LeafNodeRank server to be ready on port $port..."
     max_attempts=120
     attempt=0
     while [ $attempt -lt $max_attempts ]; do
-        if curl -f -s "http://localhost:$monitor_port/topology" > /dev/null 2>&1; then
-            echo "LeafNodeRank server is ready (monitor port responding)"
+        if (echo > /dev/tcp/localhost/$port) 2>/dev/null; then
+            echo "LeafNodeRank server is ready (port $port accepting connections)"
             break
         fi
         attempt=$((attempt + 1))

--- a/packages/feedsim/third_party/src/workloads/ranking/CMakeLists.txt
+++ b/packages/feedsim/third_party/src/workloads/ranking/CMakeLists.txt
@@ -235,6 +235,29 @@ add_library(leafNodeRankcmdline
     ${CMAKE_CURRENT_BINARY_DIR}/LeafNodeRankCmdline.cc)
 add_dependencies(leafNodeRankcmdline leafNodeRank_gengetopt)
 
+# FeedSim server/driver framework (replaces oldisim for LeafNodeRank/DriverNodeRank)
+add_library(FeedSimFramework STATIC
+    FeedSimServer.cc
+    FeedSimDriver.cc
+    FeedSimProtocol.h
+    FeedSimServer.h
+    FeedSimDriver.h
+)
+add_dependencies(FeedSimFramework folly)
+target_include_directories(FeedSimFramework
+    PUBLIC
+        ${CMAKE_CURRENT_SOURCE_DIR}
+    PRIVATE
+        ${FOLLY_INCLUDE_DIR}
+        ${LIBEVENT_INCLUDE_DIR}
+)
+target_link_libraries(FeedSimFramework
+    PUBLIC
+        ${FOLLY_LIBRARIES}
+        ${LIBEVENT_LIB}
+        Threads::Threads
+)
+
 # Build LeafNodeRank binary
 
 add_executable(LeafNodeRank
@@ -244,6 +267,7 @@ add_executable(LeafNodeRank
 target_include_directories(LeafNodeRank
     PUBLIC
         ${CMAKE_CURRENT_BINARY_DIR}
+        ${CMAKE_CURRENT_SOURCE_DIR}
         ${LIBEVENT_INCLUDE_DIR}
         ${JEMALLOC_INCLUDE_DIR}
         ${BZIP2_INCLUDE_DIR}
@@ -257,7 +281,7 @@ target_include_directories(LeafNodeRank
 
 # Base LeafNodeRank libraries
 set(LEAF_NODE_RANK_LIBS
-    OLDISim::OLDISim
+    FeedSimFramework
     leafNodeRankcmdline
     rankingDwarfs
     featureExtractors
@@ -484,7 +508,7 @@ target_include_directories(
 target_link_libraries(
     DriverNodeRank
     PRIVATE
-        OLDISim::OLDISim
+        FeedSimFramework
         DriverNodeRankcmdline
         FeatureGenerator
         ranking-cpp2

--- a/packages/feedsim/third_party/src/workloads/ranking/CMakeLists.txt
+++ b/packages/feedsim/third_party/src/workloads/ranking/CMakeLists.txt
@@ -134,6 +134,7 @@ add_library(featureExtractors STATIC
     feature_extractors/TreeTraversalExtractor.h
     feature_extractors/BitsetExtractor.cpp
     feature_extractors/BitsetExtractor.h
+    feature_extractors/generated/extractor_helpers.cpp
     ${GENERATED_EXTRACTOR_SOURCES}
 )
 add_dependencies(featureExtractors folly)
@@ -151,8 +152,17 @@ target_link_libraries(featureExtractors
         ${FOLLY_LIBRARIES}
         glog::glog
 )
+# -mcmodel=large is x86_64-only; on aarch64 use default code model
+if(CMAKE_SYSTEM_PROCESSOR STREQUAL "x86_64")
+    set(FEEDSIM_MCMODEL_FLAG "-mcmodel=large")
+else()
+    set(FEEDSIM_MCMODEL_FLAG "")
+endif()
+
 target_compile_options(featureExtractors PRIVATE
     -fno-omit-frame-pointer
+    ${FEEDSIM_MCMODEL_FLAG}
+    -fno-plt
 )
 
 # Compile generated copies at -O0 WITHOUT -ffunction-sections to prevent:
@@ -163,10 +173,15 @@ file(GLOB GENERATED_COPIES_FILES
     "${CMAKE_CURRENT_SOURCE_DIR}/feature_extractors/generated/copies/*.cpp")
 file(GLOB GENERATED_VARIANT_FILES
     "${CMAKE_CURRENT_SOURCE_DIR}/feature_extractors/generated/variants/*.cpp")
+if(CMAKE_SYSTEM_PROCESSOR STREQUAL "x86_64")
+    set(GENERATED_EXTRA_FLAGS "-O0 -mcmodel=large -fno-plt")
+else()
+    set(GENERATED_EXTRA_FLAGS "-O0 -fno-plt")
+endif()
 set_source_files_properties(
     ${GENERATED_COPIES_FILES}
     ${GENERATED_VARIANT_FILES}
-    PROPERTIES COMPILE_FLAGS "-O0"
+    PROPERTIES COMPILE_FLAGS "${GENERATED_EXTRA_FLAGS}"
 )
 
 # DLRM support (optional, requires LibTorch)
@@ -180,6 +195,7 @@ if(FEEDSIM_USE_DLRM)
         dwarfs/dlrm.cpp
         dwarfs/dlrm.h
     )
+    add_dependencies(rankingDLRM folly)
     target_compile_definitions(rankingDLRM PUBLIC FEEDSIM_USE_DLRM)
     target_include_directories(rankingDLRM
         PUBLIC
@@ -279,16 +295,23 @@ target_link_libraries(LeafNodeRank
         ${JEMALLOC_LIB}
         ${LIBLZMA_LIBRARIES}
 )
-target_compile_options(LeafNodeRank PUBLIC -fno-omit-frame-pointer -ffunction-sections -fdata-sections)
+target_compile_options(LeafNodeRank PUBLIC -fno-omit-frame-pointer -ffunction-sections -fdata-sections ${FEEDSIM_MCMODEL_FLAG} -fno-plt)
 # --whole-archive for featureExtractors prevents --gc-sections from stripping
 # generated functions that are only referenced via function pointer arrays.
+# -Wl,--no-relax is x86_64-only (linker relaxation optimization)
 target_link_options(LeafNodeRank PRIVATE
     -Wl,--gc-sections
     -Wl,--allow-multiple-definition
+    -Wl,-z,notext
+    -no-pie
     -Wl,--whole-archive
     $<TARGET_FILE:featureExtractors>
     -Wl,--no-whole-archive
 )
+if(CMAKE_SYSTEM_PROCESSOR STREQUAL "x86_64")
+    target_link_options(LeafNodeRank PRIVATE -Wl,--no-relax)
+endif()
+
 # Re-link libraries at the end to resolve circular static library dependencies
 # (folly/glog use gflags DEFINE_* macros, fbthrift has internal cross-lib refs)
 target_link_libraries(LeafNodeRank PRIVATE

--- a/packages/feedsim/third_party/src/workloads/ranking/CMakeLists.txt
+++ b/packages/feedsim/third_party/src/workloads/ranking/CMakeLists.txt
@@ -107,6 +107,68 @@ target_link_libraries(rankingDwarfs
 )
 target_compile_options(rankingDwarfs PRIVATE -fvisibility=hidden)
 
+# Feature Extractors library (6 manual + generated variants for I-cache pressure)
+# generated_sources.cmake is produced by generate_extractors.py during install
+set(GENERATED_SOURCES_CMAKE "${CMAKE_CURRENT_SOURCE_DIR}/feature_extractors/generated/generated_sources.cmake")
+if(EXISTS "${GENERATED_SOURCES_CMAKE}")
+    include("${GENERATED_SOURCES_CMAKE}")
+else()
+    message(WARNING "Generated sources not found — run generate_extractors.py first")
+    set(GENERATED_EXTRACTOR_SOURCES "")
+endif()
+
+add_library(featureExtractors STATIC
+    feature_extractors/FeatureExtractorSuite.cpp
+    feature_extractors/FeatureExtractorSuite.h
+    feature_extractors/FeatureExtractorBase.h
+    feature_extractors/FeatureTypes.h
+    feature_extractors/HashLookupExtractor.cpp
+    feature_extractors/HashLookupExtractor.h
+    feature_extractors/FeatureLayoutExtractor.cpp
+    feature_extractors/FeatureLayoutExtractor.h
+    feature_extractors/EmbeddingLookupExtractor.cpp
+    feature_extractors/EmbeddingLookupExtractor.h
+    feature_extractors/ContainerExtractor.cpp
+    feature_extractors/ContainerExtractor.h
+    feature_extractors/TreeTraversalExtractor.cpp
+    feature_extractors/TreeTraversalExtractor.h
+    feature_extractors/BitsetExtractor.cpp
+    feature_extractors/BitsetExtractor.h
+    ${GENERATED_EXTRACTOR_SOURCES}
+)
+add_dependencies(featureExtractors folly)
+target_include_directories(featureExtractors
+    PUBLIC
+        ${CMAKE_CURRENT_SOURCE_DIR}
+        ${CMAKE_CURRENT_SOURCE_DIR}/feature_extractors
+        ${CMAKE_CURRENT_SOURCE_DIR}/feature_extractors/generated
+    PRIVATE
+        ${FOLLY_INCLUDE_DIR}
+        ${GLOG_INCLUDE_DIR}
+)
+target_link_libraries(featureExtractors
+    PRIVATE
+        ${FOLLY_LIBRARIES}
+        glog::glog
+)
+target_compile_options(featureExtractors PRIVATE
+    -fno-omit-frame-pointer
+)
+
+# Compile generated copies at -O0 WITHOUT -ffunction-sections to prevent:
+# 1. Linker GC from removing functions only referenced via function pointers
+# 2. Linker ICF from folding "similar" generated functions
+# -O0 also produces larger code = more I-cache pressure (which is the goal)
+file(GLOB GENERATED_COPIES_FILES
+    "${CMAKE_CURRENT_SOURCE_DIR}/feature_extractors/generated/copies/*.cpp")
+file(GLOB GENERATED_VARIANT_FILES
+    "${CMAKE_CURRENT_SOURCE_DIR}/feature_extractors/generated/variants/*.cpp")
+set_source_files_properties(
+    ${GENERATED_COPIES_FILES}
+    ${GENERATED_VARIANT_FILES}
+    PROPERTIES COMPILE_FLAGS "-O0"
+)
+
 # DLRM support (optional, requires LibTorch)
 option(FEEDSIM_USE_DLRM "Enable DLRM workload with LibTorch" OFF)
 
@@ -136,7 +198,6 @@ if(FEEDSIM_USE_DLRM)
     )
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${TORCH_CXX_FLAGS}")
 endif()
-
 
 # Generate getopts for LeafNodeRank
 add_custom_command(
@@ -183,6 +244,7 @@ set(LEAF_NODE_RANK_LIBS
     OLDISim::OLDISim
     leafNodeRankcmdline
     rankingDwarfs
+    featureExtractors
     icachebuster
     PointerChaser
     ${FOLLY_LIBRARIES}
@@ -218,7 +280,15 @@ target_link_libraries(LeafNodeRank
         ${LIBLZMA_LIBRARIES}
 )
 target_compile_options(LeafNodeRank PUBLIC -fno-omit-frame-pointer -ffunction-sections -fdata-sections)
-target_link_options(LeafNodeRank PRIVATE -Wl,--gc-sections -Wl,--allow-multiple-definition)
+# --whole-archive for featureExtractors prevents --gc-sections from stripping
+# generated functions that are only referenced via function pointer arrays.
+target_link_options(LeafNodeRank PRIVATE
+    -Wl,--gc-sections
+    -Wl,--allow-multiple-definition
+    -Wl,--whole-archive
+    $<TARGET_FILE:featureExtractors>
+    -Wl,--no-whole-archive
+)
 # Re-link libraries at the end to resolve circular static library dependencies
 # (folly/glog use gflags DEFINE_* macros, fbthrift has internal cross-lib refs)
 target_link_libraries(LeafNodeRank PRIVATE

--- a/packages/feedsim/third_party/src/workloads/ranking/DriverNodeRank.cc
+++ b/packages/feedsim/third_party/src/workloads/ranking/DriverNodeRank.cc
@@ -29,12 +29,16 @@
 #include "DriverNodeRankCmdline.h"
 #include "FeatureGenerator.h"
 #include "RequestTypes.h"
+#include "SilesiaLoader.h"
 
 #include "if/gen-cpp2/ranking_types.h"
 
 #include "utils.h"
 
 static gengetopt_args_info args;
+
+// Global Silesia corpus loader (shared across threads, read-only after init)
+static std::unique_ptr<ranking::SilesiaLoader> g_silesia_loader;
 
 const int kMaxRequestSize = 8192;
 const int kRecomputeQPSPeriod = 1;  // Reduced from 5 to 1 second for faster feedback
@@ -62,6 +66,9 @@ struct ThreadData {
   // Client-side feature generation
   std::unique_ptr<ranking::FeatureGenerator> feature_generator;
   std::string serialized_request;  // Pre-allocated buffer for serialized request
+
+  // Silesia story generation
+  std::mt19937 silesia_rng;
 };
 
 // Specific timer handler to recompute inter-request delays for QPS
@@ -151,6 +158,12 @@ void ThreadStartup(int thread_id,
         std::make_unique<ranking::FeatureGenerator>(config, thread_id);
   }
 
+  // Initialize Silesia RNG per thread
+  if (g_silesia_loader && g_silesia_loader->isLoaded()) {
+    this_thread.silesia_rng.seed(
+        static_cast<unsigned>(std::random_device{}()) + thread_id);
+  }
+
   // If user gave QPS target, initialize QPS modulation
   if (args.qps_arg != 0) {
     this_thread.qps_per_thread =
@@ -164,49 +177,91 @@ void ThreadStartup(int thread_id,
   }
 }
 
+// Add Silesia story snippets to a RankingRequest
+void PopulateStories(ranking::RankingRequest& request,
+                     ThreadData& this_thread) {
+  if (!g_silesia_loader || !g_silesia_loader->isLoaded()) return;
+
+  int num_stories = args.stories_per_request_arg;
+  size_t min_size = static_cast<size_t>(args.story_size_min_arg);
+  size_t max_size = static_cast<size_t>(args.story_size_max_arg);
+
+  ranking::StoryBatch batch;
+  std::vector<ranking::StoryContent>& stories = *batch.stories_ref();
+  stories.reserve(num_stories);
+
+  for (int i = 0; i < num_stories; ++i) {
+    const uint8_t* data;
+    size_t size;
+    std::string filename;
+    g_silesia_loader->getRandomSnippet(
+        this_thread.silesia_rng, min_size, max_size, data, size, filename);
+
+    ranking::StoryContent story;
+    story.story_id() = static_cast<int64_t>(i);
+    story.content() = std::string(reinterpret_cast<const char*>(data), size);
+    story.source_file() = std::move(filename);
+    story.content_length() = static_cast<int32_t>(size);
+    stories.push_back(std::move(story));
+  }
+
+  request.story_batch() = std::move(batch);
+}
+
 void MakeRequest(int thread_id, feedsim::TestDriver &test_driver,
                  std::vector<ThreadData> &thread_data) {
   ThreadData &this_thread = thread_data[thread_id];
 
-  if (args.client_side_features_given) {
-    // Client-side feature generation mode
-    // Generate features and serialize into RankingRequest
-    int batch_size = args.client_dlrm_batch_size_arg;
-    int num_inferences = args.client_dlrm_inferences_arg;
+  bool use_serialized_request =
+      args.client_side_features_given || args.silesia_dir_given;
 
-    // Generate features
-    auto dense_features = this_thread.feature_generator->generateDenseFeatures(batch_size);
-    auto sparse_features = this_thread.feature_generator->generateSparseFeatures(batch_size);
-
-    // Create RankingRequest with DLRMFeatures
+  if (use_serialized_request) {
+    // Serialized RankingRequest mode (client features and/or stories)
     ranking::RankingRequest request;
     request.request_id() = static_cast<int64_t>(thread_id);
-    request.num_inferences() = num_inferences;
 
-    // Populate DLRMFeatures
-    ranking::DLRMFeatures features;
-    features.batch_size() = batch_size;
-    features.num_dense_features() = args.client_num_dense_features_arg;
-    features.num_sparse_features() = args.client_num_sparse_features_arg;
+    // Add DLRM features if client-side feature generation is enabled
+    if (args.client_side_features_given) {
+      int batch_size = args.client_dlrm_batch_size_arg;
+      int num_inferences = args.client_dlrm_inferences_arg;
 
-    // Convert float vector to double for Thrift
-    ranking::DenseFeatureVector dense_vec;
-    dense_vec.reserve(dense_features.size());
-    for (float f : dense_features) {
-      dense_vec.push_back(static_cast<double>(f));
+      auto dense_features =
+          this_thread.feature_generator->generateDenseFeatures(batch_size);
+      auto sparse_features =
+          this_thread.feature_generator->generateSparseFeatures(batch_size);
+
+      request.num_inferences() = num_inferences;
+
+      ranking::DLRMFeatures features;
+      features.batch_size() = batch_size;
+      features.num_dense_features() = args.client_num_dense_features_arg;
+      features.num_sparse_features() = args.client_num_sparse_features_arg;
+
+      ranking::DenseFeatureVector dense_vec;
+      dense_vec.reserve(dense_features.size());
+      for (float f : dense_features) {
+        dense_vec.push_back(static_cast<double>(f));
+      }
+      features.dense_features() = std::move(dense_vec);
+      features.sparse_features() = std::move(sparse_features);
+
+      request.dlrm_features() = std::move(features);
     }
-    features.dense_features() = std::move(dense_vec);
-    features.sparse_features() = std::move(sparse_features);
 
-    request.dlrm_features() = std::move(features);
+    // Always set num_inferences for the server's DLRM inference stage
+    if (!request.num_inferences().has_value()) {
+      request.num_inferences() = args.client_dlrm_inferences_arg;
+    }
+
+    // Add Silesia stories if enabled
+    if (args.silesia_dir_given) {
+      PopulateStories(request, this_thread);
+    }
 
     // Serialize the request
     folly::IOBufQueue bufq;
     apache::thrift::CompactSerializer::serialize(request, &bufq);
     auto buf = bufq.move();
-    // Coalesce the IOBuf chain into a single contiguous buffer.
-    // Without this, data() and length() only return the first segment,
-    // causing truncated payloads and deserialization underflow errors.
     buf->coalesce();
 
     // Send request with serialized RankingRequest
@@ -235,6 +290,23 @@ int main(int argc, char **argv) {
     return 1;
   }
 
+  // Load Silesia corpus if specified
+  if (args.silesia_dir_given) {
+    g_silesia_loader = std::make_unique<ranking::SilesiaLoader>();
+    if (!g_silesia_loader->loadDirectory(args.silesia_dir_arg)) {
+      std::cerr << "Failed to load Silesia corpus from: "
+                << args.silesia_dir_arg << std::endl;
+      return 1;
+    }
+    std::cout << "Silesia corpus loaded: " << g_silesia_loader->numFiles()
+              << " files, " << (g_silesia_loader->totalSize() / (1024 * 1024))
+              << " MB" << std::endl;
+    std::cout << "  Stories per request: " << args.stories_per_request_arg
+              << std::endl;
+    std::cout << "  Story size: " << args.story_size_min_arg << "-"
+              << args.story_size_max_arg << " bytes" << std::endl;
+  }
+
   auto host_port = ranking::utils::parseHostnameAndPort(args.server_arg);
 
   // Make storage for thread variables
@@ -251,7 +323,7 @@ int main(int argc, char **argv) {
 
   // Register only the request type that will be used
   // This ensures stats are collected for a single type, avoiding output parsing issues
-  if (args.client_side_features_given) {
+  if (args.client_side_features_given || args.silesia_dir_given) {
     driver_node.registerRequestType(ranking::kDLRMRequestType);
   } else {
     driver_node.registerRequestType(ranking::kPageRankRequestType);
@@ -268,6 +340,16 @@ int main(int argc, char **argv) {
     std::cout << "  Dense features: " << args.client_num_dense_features_arg << std::endl;
     std::cout << "  Sparse features: " << args.client_num_sparse_features_arg << std::endl;
     std::cout << "  Seed: " << args.client_feature_seed_arg << std::endl;
+  }
+
+  // Log Silesia mode
+  if (args.silesia_dir_given) {
+    std::cout << "Silesia story generation enabled:" << std::endl;
+    std::cout << "  Directory: " << args.silesia_dir_arg << std::endl;
+    std::cout << "  Stories per request: " << args.stories_per_request_arg
+              << std::endl;
+    std::cout << "  Story size: " << args.story_size_min_arg << "-"
+              << args.story_size_max_arg << " bytes" << std::endl;
   }
 
   driver_node.run(args.threads_arg, args.affinity_given, args.connections_arg,

--- a/packages/feedsim/third_party/src/workloads/ranking/DriverNodeRank.cc
+++ b/packages/feedsim/third_party/src/workloads/ranking/DriverNodeRank.cc
@@ -12,19 +12,19 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <algorithm>
+#include <iostream>
 #include <memory>
+#include <random>
 #include <string>
+
+#include <event2/event.h>
 
 #include <thrift/lib/cpp2/protocol/CompactProtocol.h>
 #include <thrift/lib/cpp2/protocol/Serializer.h>
 
-#include "oldisim/ChildConnectionStats.h"
-#include "oldisim/DriverNode.h"
-#include "oldisim/Log.h"
-#include "oldisim/NodeThread.h"
-#include "oldisim/ResponseContext.h"
-#include "oldisim/TestDriver.h"
-#include "oldisim/Util.h"
+#include "FeedSimDriver.h"
+#include "FeedSimProtocol.h"
 
 #include "DriverNodeRankCmdline.h"
 #include "FeatureGenerator.h"
@@ -39,14 +39,27 @@ static gengetopt_args_info args;
 const int kMaxRequestSize = 8192;
 const int kRecomputeQPSPeriod = 1;  // Reduced from 5 to 1 second for faster feedback
 
+// Simple random string generator (replaces oldisim/Util.h RandomString)
+static std::string RandomString(size_t length) {
+  static const char charset[] =
+      "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz";
+  thread_local std::mt19937 rng(std::random_device{}());
+  std::uniform_int_distribution<size_t> dist(0, sizeof(charset) - 2);
+  std::string str(length, 0);
+  for (size_t i = 0; i < length; ++i) {
+    str[i] = charset[dist(rng)];
+  }
+  return str;
+}
+
 struct ThreadData {
   std::string random_string;
   double qps_per_thread;
   uint64_t request_delay; // This is per thread
-  oldisim::TestDriver *test_driver;
+  feedsim::TestDriver *test_driver;
   event *recompute_qps_timer;
 
-  // Phase 7: Client-side feature generation
+  // Client-side feature generation
   std::unique_ptr<ranking::FeatureGenerator> feature_generator;
   std::string serialized_request;  // Pre-allocated buffer for serialized request
 };
@@ -57,10 +70,10 @@ void RecomputeDelayTimerHandler(evutil_socket_t listener, int16_t flags,
                                 void *arg);
 
 // Declarations of handlers
-void ThreadStartup(oldisim::NodeThread &thread,
-                   oldisim::TestDriver &test_driver,
+void ThreadStartup(int thread_id,
+                   feedsim::TestDriver &test_driver,
                    std::vector<ThreadData> &thread_data);
-void MakeRequest(oldisim::NodeThread &thread, oldisim::TestDriver &test_driver,
+void MakeRequest(int thread_id, feedsim::TestDriver &test_driver,
                  std::vector<ThreadData> &thread_data);
 
 void AddRecomputeDelayTimer(ThreadData &this_thread) {
@@ -71,11 +84,12 @@ void AddRecomputeDelayTimer(ThreadData &this_thread) {
 void RecomputeDelayTimerHandler(evutil_socket_t listener, int16_t flags,
                                 void *arg) {
   ThreadData *this_thread = reinterpret_cast<ThreadData *>(arg);
-  const oldisim::ChildConnectionStats &stats =
-      this_thread->test_driver->GetConnectionStats();
+  const feedsim::DriverStats &stats =
+      this_thread->test_driver->getConnectionStats();
 
   // Get QPS for last stats period
-  double elapsed_secs = (stats.end_time_ - stats.start_time_) / 1000000000.0;
+  uint64_t now = feedsim::getTimeNano();
+  double elapsed_secs = (now - stats.getStartTimeNano()) / 1000000000.0;
   if (elapsed_secs <= 0) {
     AddRecomputeDelayTimer(*this_thread);
     return;
@@ -86,11 +100,8 @@ void RecomputeDelayTimerHandler(evutil_socket_t listener, int16_t flags,
       ? ranking::kDLRMRequestType
       : ranking::kPageRankRequestType;
 
-  double measured_qps = 0.0;
-  auto it = stats.query_counts_.find(request_type);
-  if (it != stats.query_counts_.end()) {
-    measured_qps = static_cast<double>(it->second) / elapsed_secs;
-  }
+  double measured_qps = static_cast<double>(stats.getQueryCount(request_type))
+                        / elapsed_secs;
 
   // Compute target delay in microseconds
   double target_delay_us = 1000000.0 / this_thread->qps_per_thread;
@@ -117,10 +128,10 @@ void RecomputeDelayTimerHandler(evutil_socket_t listener, int16_t flags,
   AddRecomputeDelayTimer(*this_thread);
 }
 
-void ThreadStartup(oldisim::NodeThread &thread,
-                   oldisim::TestDriver &test_driver,
+void ThreadStartup(int thread_id,
+                   feedsim::TestDriver &test_driver,
                    std::vector<ThreadData> &thread_data) {
-  ThreadData &this_thread = thread_data[thread.get_thread_num()];
+  ThreadData &this_thread = thread_data[thread_id];
 
   // Initialize random string with random bits
   this_thread.random_string = RandomString(kMaxRequestSize);
@@ -128,7 +139,7 @@ void ThreadStartup(oldisim::NodeThread &thread,
   // Store pointer to test_driver
   this_thread.test_driver = &test_driver;
 
-  // Phase 7: Initialize client-side feature generator if enabled
+  // Initialize client-side feature generator if enabled
   if (args.client_side_features_given) {
     ranking::FeatureGeneratorConfig config;
     config.batch_size = args.client_dlrm_batch_size_arg;
@@ -137,7 +148,7 @@ void ThreadStartup(oldisim::NodeThread &thread,
     config.seed = static_cast<unsigned>(args.client_feature_seed_arg);
 
     this_thread.feature_generator =
-        std::make_unique<ranking::FeatureGenerator>(config, thread.get_thread_num());
+        std::make_unique<ranking::FeatureGenerator>(config, thread_id);
   }
 
   // If user gave QPS target, initialize QPS modulation
@@ -145,7 +156,7 @@ void ThreadStartup(oldisim::NodeThread &thread,
     this_thread.qps_per_thread =
         (static_cast<double>(args.qps_arg)) / args.threads_arg;
     this_thread.recompute_qps_timer = evtimer_new(
-        thread.get_event_base(), RecomputeDelayTimerHandler, &this_thread);
+        test_driver.getEventBase(), RecomputeDelayTimerHandler, &this_thread);
     AddRecomputeDelayTimer(this_thread);
     this_thread.request_delay = 1000000 / this_thread.qps_per_thread;
   } else {
@@ -153,12 +164,12 @@ void ThreadStartup(oldisim::NodeThread &thread,
   }
 }
 
-void MakeRequest(oldisim::NodeThread &thread, oldisim::TestDriver &test_driver,
+void MakeRequest(int thread_id, feedsim::TestDriver &test_driver,
                  std::vector<ThreadData> &thread_data) {
-  ThreadData &this_thread = thread_data[thread.get_thread_num()];
+  ThreadData &this_thread = thread_data[thread_id];
 
   if (args.client_side_features_given) {
-    // Phase 7: Client-side feature generation mode
+    // Client-side feature generation mode
     // Generate features and serialize into RankingRequest
     int batch_size = args.client_dlrm_batch_size_arg;
     int num_inferences = args.client_dlrm_inferences_arg;
@@ -169,7 +180,7 @@ void MakeRequest(oldisim::NodeThread &thread, oldisim::TestDriver &test_driver,
 
     // Create RankingRequest with DLRMFeatures
     ranking::RankingRequest request;
-    request.request_id() = static_cast<int64_t>(thread.get_thread_num());
+    request.request_id() = static_cast<int64_t>(thread_id);
     request.num_inferences() = num_inferences;
 
     // Populate DLRMFeatures
@@ -199,13 +210,13 @@ void MakeRequest(oldisim::NodeThread &thread, oldisim::TestDriver &test_driver,
     buf->coalesce();
 
     // Send request with serialized RankingRequest
-    test_driver.SendRequest(ranking::kDLRMRequestType,
+    test_driver.sendRequest(ranking::kDLRMRequestType,
                             reinterpret_cast<const char*>(buf->data()),
                             buf->length(),
                             this_thread.request_delay);
   } else {
     // Original mode: send random string payload
-    test_driver.SendRequest(ranking::kPageRankRequestType,
+    test_driver.sendRequest(ranking::kPageRankRequestType,
                             this_thread.random_string.c_str(), 3000,
                             this_thread.request_delay);
   }
@@ -214,20 +225,14 @@ void MakeRequest(oldisim::NodeThread &thread, oldisim::TestDriver &test_driver,
 int main(int argc, char **argv) {
   // Parse arguments
   if (cmdline_parser(argc, argv, &args) != 0) {
-    DIE("cmdline_parser failed");
-  }
-
-  // Set logging level
-  for (unsigned int i = 0; i < args.verbose_given; i++) {
-    log_level = (log_level_t)(static_cast<int>(log_level) - 1);
-  }
-  if (args.quiet_given) {
-    log_level = QUIET;
+    std::cerr << "cmdline_parser failed" << std::endl;
+    return 1;
   }
 
   // Check required arguments
   if (!args.server_given) {
-    DIE("--server must be specified.");
+    std::cerr << "--server must be specified." << std::endl;
+    return 1;
   }
 
   auto host_port = ranking::utils::parseHostnameAndPort(args.server_arg);
@@ -235,25 +240,25 @@ int main(int argc, char **argv) {
   // Make storage for thread variables
   std::vector<ThreadData> thread_data(args.threads_arg);
 
-  oldisim::DriverNode driver_node(host_port.first, host_port.second);
+  feedsim::FeedSimDriver driver_node(host_port.first, host_port.second);
 
-  driver_node.SetThreadStartupCallback(
+  driver_node.setThreadStartupCallback(
       std::bind(ThreadStartup, std::placeholders::_1, std::placeholders::_2,
                 std::ref(thread_data)));
-  driver_node.SetMakeRequestCallback(
+  driver_node.setMakeRequestCallback(
       std::bind(MakeRequest, std::placeholders::_1, std::placeholders::_2,
                 std::ref(thread_data)));
 
   // Register only the request type that will be used
   // This ensures stats are collected for a single type, avoiding output parsing issues
   if (args.client_side_features_given) {
-    driver_node.RegisterRequestType(ranking::kDLRMRequestType);
+    driver_node.registerRequestType(ranking::kDLRMRequestType);
   } else {
-    driver_node.RegisterRequestType(ranking::kPageRankRequestType);
+    driver_node.registerRequestType(ranking::kPageRankRequestType);
   }
 
   // Enable remote monitoring
-  driver_node.EnableMonitoring(args.monitor_port_arg);
+  driver_node.enableMonitoring(args.monitor_port_arg);
 
   // Log client-side feature generation mode
   if (args.client_side_features_given) {
@@ -265,7 +270,7 @@ int main(int argc, char **argv) {
     std::cout << "  Seed: " << args.client_feature_seed_arg << std::endl;
   }
 
-  driver_node.Run(args.threads_arg, args.affinity_given, args.connections_arg,
+  driver_node.run(args.threads_arg, args.affinity_given, args.connections_arg,
                   args.depth_arg);
 
   return 0;

--- a/packages/feedsim/third_party/src/workloads/ranking/DriverNodeRankCmdline.ggo
+++ b/packages/feedsim/third_party/src/workloads/ranking/DriverNodeRankCmdline.ggo
@@ -40,3 +40,9 @@ option "client_dlrm_inferences" - "Number of DLRM inferences per request" int de
 option "client_feature_seed" - "Seed for client feature generation. Default 42 for deterministic. Use -1 for random." long default="42"
 option "client_num_dense_features" - "Number of dense features per sample" int default="13"
 option "client_num_sparse_features" - "Number of sparse features per sample" int default="26"
+
+# Phase 3 (Plan): Silesia corpus story options
+option "silesia_dir" - "Path to Silesia corpus directory. When specified, stories from the corpus are included in each request." string typestr="directory" optional
+option "story_size_min" - "Minimum story snippet size in bytes." int default="1024"
+option "story_size_max" - "Maximum story snippet size in bytes." int default="4096"
+option "stories_per_request" - "Number of story snippets to include per request." int default="10"

--- a/packages/feedsim/third_party/src/workloads/ranking/FeedSimDriver.cc
+++ b/packages/feedsim/third_party/src/workloads/ranking/FeedSimDriver.cc
@@ -1,0 +1,621 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
+#include "FeedSimDriver.h"
+#include "FeedSimProtocol.h"
+
+#include <arpa/inet.h>
+#include <errno.h>
+#include <event2/event.h>
+#include <event2/buffer.h>
+#include <event2/bufferevent.h>
+#include <event2/thread.h>
+#include <netdb.h>
+#include <netinet/tcp.h>
+#include <pthread.h>
+#include <signal.h>
+#include <string.h>
+#include <sys/socket.h>
+#include <unistd.h>
+
+#include <algorithm>
+#include <atomic>
+#include <cassert>
+#include <cmath>
+#include <deque>
+#include <iostream>
+#include <limits>
+#include <map>
+#include <memory>
+#include <mutex>
+#include <set>
+#include <thread>
+#include <vector>
+
+namespace feedsim {
+
+// ─── LatencySampler: log-histogram, identical to oldisim::LogHistogramSampler ─
+
+static constexpr double kPow = 1.1;
+
+struct DriverStats::LatencySampler {
+  std::vector<uint64_t> bins;
+  double sum = 0;
+  double sum_sq = 0;
+
+  explicit LatencySampler(int num_bins) : bins(num_bins + 1, 0) {}
+
+  void sample(double s) {
+    assert(s >= 0);
+    auto bin = static_cast<size_t>(std::log(s) / std::log(kPow));
+    sum += s;
+    sum_sq += s * s;
+    if (static_cast<int64_t>(bin) < 0) bin = 0;
+    else if (bin >= bins.size()) bin = bins.size() - 1;
+    bins[bin]++;
+  }
+
+  uint64_t total() const {
+    uint64_t t = 0;
+    for (auto v : bins) t += v;
+    return t;
+  }
+
+  double average() const {
+    auto t = total();
+    return t ? sum / t : std::numeric_limits<double>::quiet_NaN();
+  }
+
+  double minimum() const {
+    if (!total()) return std::numeric_limits<double>::quiet_NaN();
+    for (size_t i = 0; i < bins.size(); i++) {
+      if (bins[i] > 0) return std::pow(kPow, i + 0.5);
+    }
+    return std::numeric_limits<double>::quiet_NaN();
+  }
+
+  double get_nth(double nth) const {
+    auto count = total();
+    if (!count) return std::numeric_limits<double>::quiet_NaN();
+    uint64_t n = 0;
+    double target = count * nth / 100.0;
+    for (size_t i = 0; i < bins.size(); i++) {
+      n += bins[i];
+      if (n > target) {
+        double left = target - (n - bins[i]);
+        return std::pow(kPow, static_cast<double>(i)) +
+               left / bins[i] *
+                   (std::pow(kPow, static_cast<double>(i + 1)) -
+                    std::pow(kPow, static_cast<double>(i)));
+      }
+    }
+    return std::pow(kPow, static_cast<double>(bins.size()));
+  }
+
+  void accumulate(const LatencySampler& h) {
+    assert(bins.size() == h.bins.size());
+    for (size_t i = 0; i < bins.size(); i++) bins[i] += h.bins[i];
+    sum += h.sum;
+    sum_sq += h.sum_sq;
+  }
+
+  void reset() {
+    for (auto& b : bins) b = 0;
+    sum = 0;
+    sum_sq = 0;
+  }
+};
+
+// ─── DriverStats ────────────────────────────────────────────────────────────
+
+DriverStats::DriverStats(int bins)
+    : sampler_(std::make_unique<LatencySampler>(bins)),
+      start_time_(getTimeNano()),
+      end_time_(0) {}
+
+void DriverStats::logRequest(uint32_t type, uint32_t packet_size) {
+  tx_bytes_ += packet_size;
+  query_count_++;
+}
+
+void DriverStats::logResponse(uint32_t type, uint64_t latency_ns,
+                              uint32_t packet_size) {
+  sampler_->sample(static_cast<double>(latency_ns));
+  rx_bytes_ += packet_size;
+}
+
+void DriverStats::accumulate(const DriverStats& other) {
+  sampler_->accumulate(*other.sampler_);
+  tx_bytes_ += other.tx_bytes_;
+  rx_bytes_ += other.rx_bytes_;
+  query_count_ += other.query_count_;
+}
+
+void DriverStats::reset() {
+  sampler_->reset();
+  tx_bytes_ = 0;
+  rx_bytes_ = 0;
+  query_count_ = 0;
+  start_time_ = getTimeNano();
+}
+
+uint64_t DriverStats::getQueryCount(uint32_t /*type*/) const {
+  return query_count_;
+}
+
+void DriverStats::printStats(uint32_t type, double elapsed_secs) const {
+  // Exact format that oldisim::DriverNode produces (DriverNode.cc:564-598)
+  // search_qps.sh and feedsim parser depend on this
+  printf("Stats for node under test, type %d\n", type);
+  printf("   RX: %.2f MB/sec (%lu bytes)\n",
+         rx_bytes_ / elapsed_secs / 1024 / 1024, rx_bytes_);
+  printf("   TX: %.2f MB/sec (%lu bytes)\n",
+         tx_bytes_ / elapsed_secs / 1024 / 1024, tx_bytes_);
+  printf("    #: %.2f QPS (%lu queries)\n",
+         query_count_ / elapsed_secs, query_count_);
+  printf("  min: %.3f ms\n", sampler_->minimum() / 1000000);
+  printf("  avg: %.3f ms\n", sampler_->average() / 1000000);
+  printf("  50p: %.3f ms\n", sampler_->get_nth(50) / 1000000);
+  printf("  90p: %.3f ms\n", sampler_->get_nth(90) / 1000000);
+  printf("  95p: %.3f ms\n", sampler_->get_nth(95) / 1000000);
+  printf("  99p: %.3f ms\n", sampler_->get_nth(99) / 1000000);
+  printf("  99.9p: %.3f ms\n", sampler_->get_nth(99.9) / 1000000);
+}
+
+// ─── DriverConnection: one TCP connection to the server ─────────────────────
+
+class DriverConnection {
+ public:
+  DriverConnection(event_base* base, const addrinfo* addr, bool no_delay)
+      : num_outstanding_(0) {
+    int sockfd = socket(addr->ai_family, addr->ai_socktype, addr->ai_protocol);
+    if (sockfd < 0) {
+      std::cerr << "Error: Could not create socket" << std::endl;
+      abort();
+    }
+    if (connect(sockfd, addr->ai_addr, addr->ai_addrlen) < 0) {
+      std::cerr << "Error: Connect failed" << std::endl;
+      abort();
+    }
+    if (no_delay) {
+      int optval = 1;
+      setsockopt(sockfd, IPPROTO_TCP, TCP_NODELAY, &optval, sizeof(optval));
+    }
+    evutil_make_socket_nonblocking(sockfd);
+    bev_ = bufferevent_socket_new(base, sockfd, BEV_OPT_CLOSE_ON_FREE);
+  }
+
+  ~DriverConnection() {
+    if (bev_) bufferevent_free(bev_);
+  }
+
+  void issueRequest(uint32_t type, uint64_t request_id,
+                    const void* payload, uint32_t length) {
+    QueryPacketHeader hdr;
+    hdr.type = type;
+    hdr.request_id = request_id;
+    hdr.start_time = getTimeNano();
+    hdr.payload_length = length;
+
+    QueryPacketHeader net = queryToNetwork(hdr);
+    bufferevent_write(bev_, &net, sizeof(net));
+    if (length > 0) {
+      bufferevent_write(bev_, payload, length);
+    }
+    num_outstanding_++;
+  }
+
+  int getNumOutstanding() const { return num_outstanding_; }
+  void decrementOutstanding() { num_outstanding_--; }
+
+  bufferevent* getBev() { return bev_; }
+
+ private:
+  bufferevent* bev_;
+  int num_outstanding_;
+};
+
+// ─── TestDriver::Impl ───────────────────────────────────────────────────────
+
+struct TestDriver::Impl {
+  int thread_id;
+  int max_connection_depth;
+  uint64_t next_request_id = 0;
+
+  std::vector<std::pair<int, std::unique_ptr<DriverConnection>>> connections;
+  std::vector<int> connection_positions;
+  int next_connection_index = 0;
+  int num_ready_connections = 0;
+  int num_backlogged_requests = 0;
+
+  event_base* base;
+  event* next_request_event = nullptr;
+  uint64_t next_request_delay_us = 0;
+
+  DriverStats current_stats;
+  DriverStats last_stats;
+
+  DriverMakeRequestCallback make_request_cb;
+  uint32_t request_type;
+
+  Impl() : current_stats(1000), last_stats(1000) {}
+
+  int getNextConnectionIndex() {
+    if (num_ready_connections == 0) return -1;
+    assert(next_connection_index < num_ready_connections);
+    return next_connection_index;
+  }
+
+  bool isConnectionReady(int id) {
+    return connection_positions[id] < num_ready_connections;
+  }
+
+  void markConnectionReady(int id) {
+    assert(!isConnectionReady(id));
+    int pos = connection_positions[id];
+    int new_pos = num_ready_connections;
+    int swapped_id = connections[new_pos].first;
+    std::swap(connections[new_pos], connections[pos]);
+    std::swap(connection_positions[swapped_id], connection_positions[id]);
+    num_ready_connections++;
+  }
+
+  void markConnectionNotReady(int id) {
+    assert(isConnectionReady(id));
+    int pos = connection_positions[id];
+    int new_pos = num_ready_connections - 1;
+    int swapped_id = connections[new_pos].first;
+    std::swap(connections[new_pos], connections[pos]);
+    std::swap(connection_positions[swapped_id], connection_positions[id]);
+    num_ready_connections--;
+  }
+
+  static void readCb(struct bufferevent* bev, void* arg);
+  static void eventCb(struct bufferevent* bev, int16_t events, void* arg);
+  static void nextRequestCb(evutil_socket_t, int16_t, void* arg);
+  static void makeRequests(TestDriver& driver);
+};
+
+// Response read callback — parse ResponsePacketHeader
+void TestDriver::Impl::readCb(struct bufferevent* bev, void* arg) {
+  auto* ctx = reinterpret_cast<std::pair<TestDriver*, int>*>(arg);
+  TestDriver& driver = *ctx->first;
+  int conn_id = ctx->second;
+  auto& impl = *driver.impl_;
+
+  struct evbuffer* input = bufferevent_get_input(bev);
+  constexpr size_t hdr_size = sizeof(ResponsePacketHeader);
+
+  while (true) {
+    size_t buf_len = evbuffer_get_length(input);
+    if (buf_len < hdr_size) return;
+
+    auto* raw_hdr = reinterpret_cast<const ResponsePacketHeader*>(
+        evbuffer_pullup(input, hdr_size));
+    ResponsePacketHeader hdr = responseFromNetwork(*raw_hdr);
+
+    size_t total = hdr_size + hdr.payload_length;
+    if (buf_len < total) return;
+
+    // We have a complete response
+    evbuffer_drain(input, hdr_size);
+
+    // Read payload (if any)
+    if (hdr.payload_length > 0) {
+      evbuffer_drain(input, hdr.payload_length);
+    }
+
+    // Log latency
+    uint64_t now = getTimeNano();
+    uint64_t latency = now - hdr.start_time;
+    impl.current_stats.logResponse(hdr.type, latency, total);
+
+    // Connection slot freed
+    auto& conn = *impl.connections[impl.connection_positions[conn_id]].second;
+    conn.decrementOutstanding();
+
+    if (!impl.isConnectionReady(conn_id)) {
+      impl.markConnectionReady(conn_id);
+    }
+
+    // If backlogged, generate more
+    if (impl.num_backlogged_requests > 0) {
+      makeRequests(driver);
+      impl.num_backlogged_requests--;
+    }
+  }
+}
+
+void TestDriver::Impl::eventCb(struct bufferevent* bev, int16_t events,
+                                void* arg) {
+  auto* ctx = reinterpret_cast<std::pair<TestDriver*, int>*>(arg);
+  if (events & BEV_EVENT_EOF) {
+    std::cerr << "Server closed connection" << std::endl;
+  } else if (events & BEV_EVENT_ERROR) {
+    std::cerr << "Connection error" << std::endl;
+  }
+}
+
+void TestDriver::Impl::nextRequestCb(evutil_socket_t, int16_t, void* arg) {
+  auto* driver = reinterpret_cast<TestDriver*>(arg);
+  makeRequests(*driver);
+}
+
+void TestDriver::Impl::makeRequests(TestDriver& driver) {
+  auto& impl = *driver.impl_;
+  do {
+    if (impl.num_ready_connections == 0) {
+      impl.num_backlogged_requests++;
+      return;
+    }
+    impl.make_request_cb(impl.thread_id, driver);
+  } while (impl.next_request_delay_us == 0);
+}
+
+// ─── TestDriver public methods ──────────────────────────────────────────────
+
+TestDriver::TestDriver() : impl_(new Impl()) {}
+
+void TestDriver::sendRequest(uint32_t type, const void* payload,
+                             uint32_t length,
+                             uint64_t next_request_delay_us) {
+  int index = impl_->getNextConnectionIndex();
+  auto& conn = *impl_->connections[index].second;
+  int conn_id = impl_->connections[index].first;
+
+  conn.issueRequest(type, impl_->next_request_id++, payload, length);
+  impl_->current_stats.logRequest(
+      type, sizeof(QueryPacketHeader) + length);
+
+  if (conn.getNumOutstanding() == impl_->max_connection_depth) {
+    impl_->markConnectionNotReady(conn_id);
+  }
+
+  impl_->next_request_delay_us = next_request_delay_us;
+
+  if (next_request_delay_us != 0) {
+    struct timeval tv;
+    tv.tv_sec = next_request_delay_us / 1000000;
+    tv.tv_usec = next_request_delay_us % 1000000;
+    evtimer_add(impl_->next_request_event, &tv);
+  }
+}
+
+const DriverStats& TestDriver::getConnectionStats() const {
+  return impl_->current_stats;
+}
+
+event_base* TestDriver::getEventBase() const {
+  return impl_->base;
+}
+
+// ─── FeedSimDriver::Impl ───────────────────────────────────────────────────
+
+struct FeedSimDriver::Impl {
+  std::string hostname;
+  uint16_t port;
+  addrinfo* server_addr = nullptr;
+
+  DriverThreadStartupCallback on_thread_startup;
+  DriverMakeRequestCallback make_request_cb;
+  std::set<uint32_t> request_types;
+  uint16_t monitor_port = 0;
+
+  struct DriverThread {
+    int thread_id;
+    event_base* base;
+    std::unique_ptr<TestDriver> driver;
+    std::thread thread;
+    // Context objects for bufferevent callbacks (need stable addresses)
+    std::vector<std::unique_ptr<std::pair<TestDriver*, int>>> cb_contexts;
+  };
+
+  std::vector<std::unique_ptr<DriverThread>> threads;
+  std::unique_ptr<DriverStats> total_stats;
+
+  event_base* main_base = nullptr;
+  std::atomic<bool> running{false};
+};
+
+// ─── FeedSimDriver public methods ───────────────────────────────────────────
+
+FeedSimDriver::FeedSimDriver(const std::string& hostname, uint16_t port)
+    : impl_(new Impl()) {
+  impl_->hostname = hostname;
+  impl_->port = port;
+
+  // Resolve host
+  addrinfo hints{};
+  hints.ai_socktype = SOCK_STREAM;
+  hints.ai_family = AF_INET;
+
+  int err = getaddrinfo(hostname.c_str(), nullptr, &hints, &impl_->server_addr);
+  if (err != 0) {
+    std::cerr << "Could not resolve " << hostname << ": "
+              << gai_strerror(err) << std::endl;
+    abort();
+  }
+  reinterpret_cast<sockaddr_in*>(impl_->server_addr->ai_addr)->sin_port =
+      htobe16(port);
+}
+
+FeedSimDriver::~FeedSimDriver() {
+  shutdown();
+  if (impl_->server_addr) freeaddrinfo(impl_->server_addr);
+}
+
+void FeedSimDriver::setThreadStartupCallback(DriverThreadStartupCallback cb) {
+  impl_->on_thread_startup = std::move(cb);
+}
+
+void FeedSimDriver::setMakeRequestCallback(DriverMakeRequestCallback cb) {
+  impl_->make_request_cb = std::move(cb);
+}
+
+void FeedSimDriver::registerReplyCallback(uint32_t type,
+                                          DriverResponseCallback cb) {
+  // Response callbacks are not used by DriverNodeRank — it ignores responses
+}
+
+void FeedSimDriver::registerRequestType(uint32_t type) {
+  impl_->request_types.insert(type);
+}
+
+void FeedSimDriver::enableMonitoring(uint16_t port) {
+  impl_->monitor_port = port;
+}
+
+void FeedSimDriver::run(uint32_t num_threads, bool thread_pinning,
+                        uint32_t num_connections_per_thread,
+                        uint32_t max_connection_depth) {
+  if (evthread_use_pthreads()) {
+    std::cerr << "Could not setup libevent to use pthreads" << std::endl;
+    abort();
+  }
+
+  signal(SIGPIPE, SIG_IGN);
+  impl_->running = true;
+  impl_->total_stats = std::make_unique<DriverStats>(1000);
+
+  // Barrier for thread init synchronization
+  pthread_barrier_t init_barrier;
+  pthread_barrier_init(&init_barrier, nullptr, num_threads + 1);
+
+  // Create and start driver threads
+  for (uint32_t i = 0; i < num_threads; i++) {
+    auto dt = std::make_unique<Impl::DriverThread>();
+    dt->thread_id = i;
+    dt->base = event_base_new();
+    dt->driver = std::unique_ptr<TestDriver>(new TestDriver());
+
+    auto& drv = *dt->driver;
+    drv.impl_->thread_id = i;
+    drv.impl_->max_connection_depth = max_connection_depth;
+    drv.impl_->base = dt->base;
+    drv.impl_->make_request_cb = impl_->make_request_cb;
+    drv.impl_->request_type =
+        impl_->request_types.empty() ? 0 : *impl_->request_types.begin();
+
+    // Create connections
+    for (uint32_t c = 0; c < num_connections_per_thread; c++) {
+      auto conn = std::make_unique<DriverConnection>(
+          dt->base, impl_->server_addr, true);
+
+      // Set up bufferevent read/event callbacks
+      auto ctx = std::make_unique<std::pair<TestDriver*, int>>(
+          dt->driver.get(), static_cast<int>(c));
+
+      bufferevent_setcb(conn->getBev(),
+                        TestDriver::Impl::readCb,
+                        nullptr,
+                        TestDriver::Impl::eventCb,
+                        ctx.get());
+      bufferevent_enable(conn->getBev(), EV_READ | EV_WRITE);
+
+      dt->cb_contexts.push_back(std::move(ctx));
+      drv.impl_->connections.emplace_back(c, std::move(conn));
+      drv.impl_->connection_positions.push_back(c);
+    }
+    drv.impl_->num_ready_connections = num_connections_per_thread;
+    drv.impl_->next_request_event =
+        evtimer_new(dt->base, TestDriver::Impl::nextRequestCb, dt->driver.get());
+
+    // Start thread
+    dt->thread = std::thread([this, &dt_ref = *dt, &init_barrier,
+                              thread_pinning, i]() {
+      // CPU affinity
+      if (thread_pinning) {
+        cpu_set_t mask;
+        CPU_ZERO(&mask);
+        cpu_set_t available;
+        CPU_ZERO(&available);
+        sched_getaffinity(0, sizeof(available), &available);
+        int cpu_idx = 0;
+        for (int c = 0; c < CPU_SETSIZE; c++) {
+          if (CPU_ISSET(c, &available)) {
+            if (cpu_idx == static_cast<int>(i)) {
+              CPU_SET(c, &mask);
+              break;
+            }
+            cpu_idx++;
+          }
+        }
+        pthread_setaffinity_np(pthread_self(), sizeof(mask), &mask);
+      }
+
+      // Signal init complete
+      pthread_barrier_wait(&init_barrier);
+
+      // Thread startup callback
+      if (impl_->on_thread_startup) {
+        impl_->on_thread_startup(dt_ref.thread_id, *dt_ref.driver);
+      }
+
+      // Start making requests
+      TestDriver::Impl::makeRequests(*dt_ref.driver);
+
+      // Run event loop
+      event_base_dispatch(dt_ref.base);
+    });
+
+    impl_->threads.push_back(std::move(dt));
+  }
+
+  // Wait for all threads to init
+  pthread_barrier_wait(&init_barrier);
+  pthread_barrier_destroy(&init_barrier);
+
+  double start_time = getTimeSec();
+
+  // Main event loop (for SIGINT handling)
+  impl_->main_base = event_base_new();
+  event* sigint_event = evsignal_new(
+      impl_->main_base, SIGINT,
+      [](evutil_socket_t, int16_t, void* arg) {
+        auto* driver = reinterpret_cast<FeedSimDriver*>(arg);
+        driver->shutdown();
+      },
+      this);
+  event_add(sigint_event, nullptr);
+  event_base_dispatch(impl_->main_base);
+  event_free(sigint_event);
+
+  // Wait for threads to finish
+  for (auto& dt : impl_->threads) {
+    dt->thread.join();
+  }
+
+  double end_time = getTimeSec();
+  double elapsed = end_time - start_time;
+
+  // Aggregate stats from all threads
+  for (auto& dt : impl_->threads) {
+    impl_->total_stats->accumulate(dt->driver->impl_->current_stats);
+  }
+
+  // Print stats — exact same format as oldisim::DriverNode
+  for (uint32_t type : impl_->request_types) {
+    impl_->total_stats->printStats(type, elapsed);
+  }
+
+  // Cleanup
+  for (auto& dt : impl_->threads) {
+    event_base_free(dt->base);
+  }
+  event_base_free(impl_->main_base);
+}
+
+void FeedSimDriver::shutdown() {
+  if (!impl_->running.exchange(false)) return;
+
+  for (auto& dt : impl_->threads) {
+    event_base_loopbreak(dt->base);
+  }
+  if (impl_->main_base) {
+    event_base_loopbreak(impl_->main_base);
+  }
+}
+
+} // namespace feedsim

--- a/packages/feedsim/third_party/src/workloads/ranking/FeedSimDriver.h
+++ b/packages/feedsim/third_party/src/workloads/ranking/FeedSimDriver.h
@@ -1,0 +1,114 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
+#pragma once
+
+#include <cstdint>
+#include <functional>
+#include <memory>
+#include <string>
+
+struct event_base;
+
+namespace feedsim {
+
+class DriverConnection;
+
+/**
+ * DriverStats: latency sampling and request counting.
+ * Replaces oldisim::ChildConnectionStats + LogHistogramSampler.
+ * Produces the exact same printf output format that run.sh/search_qps.sh parse.
+ */
+class DriverStats {
+ public:
+  explicit DriverStats(int bins = 1000);
+
+  void logRequest(uint32_t type, uint32_t packet_size);
+  void logResponse(uint32_t type, uint64_t latency_ns, uint32_t packet_size);
+  void accumulate(const DriverStats& other);
+  void reset();
+
+  uint64_t getQueryCount(uint32_t type) const;
+  uint64_t getStartTimeNano() const { return start_time_; }
+  uint64_t getEndTimeNano() const { return end_time_; }
+  void setEndTimeNano(uint64_t t) { end_time_ = t; }
+
+  // Print stats in the exact format oldisim::DriverNode produces.
+  // search_qps.sh and feedsim parser depend on this format.
+  void printStats(uint32_t type, double elapsed_secs) const;
+
+ private:
+  struct LatencySampler;
+  std::unique_ptr<LatencySampler> sampler_;
+  uint64_t start_time_;
+  uint64_t end_time_;
+  // Per-type counters
+  uint64_t tx_bytes_ = 0;
+  uint64_t rx_bytes_ = 0;
+  uint64_t query_count_ = 0;
+};
+
+/**
+ * TestDriver: manages connections to the server and issues requests.
+ * Replaces oldisim::TestDriver.
+ */
+class TestDriver {
+ public:
+  void sendRequest(uint32_t type, const void* payload, uint32_t length,
+                   uint64_t next_request_delay_us);
+  const DriverStats& getConnectionStats() const;
+  event_base* getEventBase() const;
+
+ private:
+  struct Impl;
+  std::unique_ptr<Impl> impl_;
+  TestDriver();
+  friend class FeedSimDriver;
+};
+
+// Callback types for driver
+using DriverThreadStartupCallback =
+    std::function<void(int thread_id, TestDriver& driver)>;
+using DriverMakeRequestCallback =
+    std::function<void(int thread_id, TestDriver& driver)>;
+using DriverResponseCallback =
+    std::function<void(int thread_id, uint32_t type, const void* payload,
+                       uint32_t length)>;
+
+/**
+ * FeedSimDriver replaces oldisim::DriverNode.
+ *
+ * Produces the same stats output format:
+ *   Stats for node under test, type N
+ *      RX: %.2f MB/sec (%lu bytes)
+ *      TX: %.2f MB/sec (%lu bytes)
+ *       #: %.2f QPS (%lu queries)
+ *     min: %.3f ms
+ *     avg: %.3f ms
+ *     50p: %.3f ms
+ *     ...
+ *     99.9p: %.3f ms
+ */
+class FeedSimDriver {
+ public:
+  FeedSimDriver(const std::string& hostname, uint16_t port);
+  ~FeedSimDriver();
+
+  void setThreadStartupCallback(DriverThreadStartupCallback cb);
+  void setMakeRequestCallback(DriverMakeRequestCallback cb);
+  void registerReplyCallback(uint32_t type, DriverResponseCallback cb);
+  void registerRequestType(uint32_t type);
+  void enableMonitoring(uint16_t port);
+
+  void run(uint32_t num_threads, bool thread_pinning,
+           uint32_t num_connections_per_thread, uint32_t max_connection_depth);
+  void shutdown();
+
+ private:
+  struct Impl;
+  std::unique_ptr<Impl> impl_;
+};
+
+} // namespace feedsim

--- a/packages/feedsim/third_party/src/workloads/ranking/FeedSimProtocol.h
+++ b/packages/feedsim/third_party/src/workloads/ranking/FeedSimProtocol.h
@@ -1,0 +1,85 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
+#pragma once
+
+#include <endian.h>
+#include <stdint.h>
+#include <time.h>
+
+namespace feedsim {
+
+// Wire protocol structs — binary compatible with oldisim's Query.h / Response.h
+// All fields are big-endian on the wire.
+
+struct __attribute__((__packed__)) QueryPacketHeader {
+  uint32_t type;
+  uint64_t request_id;
+  uint64_t start_time;
+  uint32_t payload_length; // does not include header length
+};
+
+struct __attribute__((__packed__)) ResponsePacketHeader {
+  uint32_t type;
+  uint64_t request_id;
+  uint64_t start_time;
+  uint64_t processing_time;
+  uint32_t payload_length; // does not include header length
+};
+
+static_assert(sizeof(QueryPacketHeader) == 24, "QueryPacketHeader must be 24 bytes");
+static_assert(sizeof(ResponsePacketHeader) == 32, "ResponsePacketHeader must be 32 bytes");
+
+inline QueryPacketHeader queryToNetwork(const QueryPacketHeader& h) {
+  QueryPacketHeader out;
+  out.type = htobe32(h.type);
+  out.request_id = htobe64(h.request_id);
+  out.start_time = htobe64(h.start_time);
+  out.payload_length = htobe32(h.payload_length);
+  return out;
+}
+
+inline QueryPacketHeader queryFromNetwork(const QueryPacketHeader& h) {
+  QueryPacketHeader out;
+  out.type = be32toh(h.type);
+  out.request_id = be64toh(h.request_id);
+  out.start_time = be64toh(h.start_time);
+  out.payload_length = be32toh(h.payload_length);
+  return out;
+}
+
+inline ResponsePacketHeader responseToNetwork(const ResponsePacketHeader& h) {
+  ResponsePacketHeader out;
+  out.type = htobe32(h.type);
+  out.request_id = htobe64(h.request_id);
+  out.start_time = htobe64(h.start_time);
+  out.processing_time = htobe64(h.processing_time);
+  out.payload_length = htobe32(h.payload_length);
+  return out;
+}
+
+inline ResponsePacketHeader responseFromNetwork(const ResponsePacketHeader& h) {
+  ResponsePacketHeader out;
+  out.type = be32toh(h.type);
+  out.request_id = be64toh(h.request_id);
+  out.start_time = be64toh(h.start_time);
+  out.processing_time = be64toh(h.processing_time);
+  out.payload_length = be32toh(h.payload_length);
+  return out;
+}
+
+inline uint64_t getTimeNano() {
+  struct timespec ts;
+  clock_gettime(CLOCK_MONOTONIC_RAW, &ts);
+  return static_cast<uint64_t>(ts.tv_sec) * 1000000000ULL + ts.tv_nsec;
+}
+
+inline double getTimeSec() {
+  struct timespec ts;
+  clock_gettime(CLOCK_MONOTONIC_RAW, &ts);
+  return ts.tv_sec + static_cast<double>(ts.tv_nsec) / 1e9;
+}
+
+} // namespace feedsim

--- a/packages/feedsim/third_party/src/workloads/ranking/FeedSimServer.cc
+++ b/packages/feedsim/third_party/src/workloads/ranking/FeedSimServer.cc
@@ -1,0 +1,449 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
+#include "FeedSimServer.h"
+#include "FeedSimProtocol.h"
+
+#include <arpa/inet.h>
+#include <errno.h>
+#include <netdb.h>
+#include <netinet/tcp.h>
+#include <pthread.h>
+#include <signal.h>
+#include <string.h>
+#include <sys/socket.h>
+#include <unistd.h>
+
+#include <atomic>
+#include <cassert>
+#include <deque>
+#include <iostream>
+#include <memory>
+#include <mutex>
+#include <thread>
+#include <vector>
+
+#include <folly/MPMCQueue.h>
+#include <folly/container/F14Map.h>
+#include <folly/io/async/AsyncServerSocket.h>
+#include <folly/io/async/AsyncSocket.h>
+#include <folly/io/async/AsyncTransport.h>
+#include <folly/io/async/EventBase.h>
+#include <folly/io/async/EventBaseManager.h>
+
+namespace feedsim {
+
+// ─── RequestContext implementation ──────────────────────────────────────────
+
+struct RequestContext::Impl {
+  // The socket fd to write the response back on.
+  // We use raw fd + write() because the response is a single small write
+  // and we want to avoid the complexity of AsyncSocket write callbacks.
+  int fd;
+  uint64_t received_time;
+  bool response_sent;
+};
+
+RequestContext::RequestContext(
+    uint32_t _type, uint64_t _request_id, uint64_t _start_time,
+    uint32_t _payload_length, const void* _payload,
+    std::unique_ptr<Impl> _impl)
+    : type(_type),
+      request_id(_request_id),
+      start_time(_start_time),
+      payload_length(_payload_length),
+      payload(_payload),
+      impl_(std::move(_impl)) {}
+
+RequestContext::RequestContext(RequestContext&& other) noexcept
+    : type(other.type),
+      request_id(other.request_id),
+      start_time(other.start_time),
+      payload_length(other.payload_length),
+      payload(other.payload),
+      impl_(std::move(other.impl_)) {}
+
+RequestContext::~RequestContext() = default;
+
+void RequestContext::sendResponse(const void* data, uint32_t data_length) {
+  if (!impl_ || impl_->response_sent) return;
+  impl_->response_sent = true;
+
+  uint64_t now = getTimeNano();
+  uint64_t processing_time = now - impl_->received_time;
+
+  ResponsePacketHeader hdr;
+  hdr.type = type;
+  hdr.request_id = request_id;
+  hdr.start_time = start_time;
+  hdr.processing_time = processing_time;
+  hdr.payload_length = data_length;
+
+  ResponsePacketHeader net = responseToNetwork(hdr);
+
+  // Use writev to send header + payload atomically
+  struct iovec iov[2];
+  iov[0].iov_base = &net;
+  iov[0].iov_len = sizeof(net);
+  iov[1].iov_base = const_cast<void*>(data);
+  iov[1].iov_len = data_length;
+
+  int iovcnt = (data_length > 0) ? 2 : 1;
+  // Loop until all data is written (handle partial writes)
+  ssize_t total = sizeof(net) + data_length;
+  ssize_t written = 0;
+  while (written < total) {
+    ssize_t n = ::writev(impl_->fd, iov, iovcnt);
+    if (n < 0) {
+      if (errno == EINTR) continue;
+      if (errno == EAGAIN || errno == EWOULDBLOCK) continue;
+      break; // Connection closed or error
+    }
+    written += n;
+    // Advance iov pointers for partial write
+    while (n > 0) {
+      if (static_cast<size_t>(n) >= iov[0].iov_len) {
+        n -= iov[0].iov_len;
+        iov[0] = iov[1];
+        iov[1].iov_len = 0;
+        iovcnt = 1;
+      } else {
+        iov[0].iov_base = static_cast<char*>(iov[0].iov_base) + n;
+        iov[0].iov_len -= n;
+        n = 0;
+      }
+    }
+  }
+}
+
+// ─── ServerConnection: handles framing for one client connection ────────────
+
+class ServerConnection : public folly::AsyncTransport::ReadCallback {
+ public:
+  ServerConnection(
+      folly::AsyncSocket::UniquePtr socket,
+      int thread_id,
+      const folly::F14FastMap<uint32_t, QueryCallback>& callbacks)
+      : socket_(std::move(socket)),
+        thread_id_(thread_id),
+        callbacks_(callbacks),
+        read_buf_(nullptr),
+        read_buf_size_(0),
+        data_offset_(0) {
+    // Allocate initial read buffer (64KB)
+    read_buf_size_ = 65536;
+    read_buf_ = new uint8_t[read_buf_size_];
+    socket_->setReadCB(this);
+  }
+
+  ~ServerConnection() override {
+    delete[] read_buf_;
+  }
+
+  // AsyncTransport::ReadCallback
+  void getReadBuffer(void** bufReturn, size_t* lenReturn) override {
+    // Grow buffer if needed
+    if (data_offset_ >= read_buf_size_ / 2) {
+      size_t new_size = read_buf_size_ * 2;
+      auto* new_buf = new uint8_t[new_size];
+      memcpy(new_buf, read_buf_, data_offset_);
+      delete[] read_buf_;
+      read_buf_ = new_buf;
+      read_buf_size_ = new_size;
+    }
+    *bufReturn = read_buf_ + data_offset_;
+    *lenReturn = read_buf_size_ - data_offset_;
+  }
+
+  void readDataAvailable(size_t len) noexcept override {
+    data_offset_ += len;
+    processRequests();
+  }
+
+  void readEOF() noexcept override {
+    // Client disconnected
+    socket_->close();
+    // Self-delete via destroy callback (see below)
+    delete this;
+  }
+
+  void readErr(const folly::AsyncSocketException& ex) noexcept override {
+    socket_->close();
+    delete this;
+  }
+
+ private:
+  void processRequests() {
+    constexpr size_t hdr_size = sizeof(QueryPacketHeader);
+
+    while (data_offset_ >= hdr_size) {
+      auto* raw_hdr = reinterpret_cast<const QueryPacketHeader*>(read_buf_);
+      QueryPacketHeader hdr = queryFromNetwork(*raw_hdr);
+
+      size_t total_packet = hdr_size + hdr.payload_length;
+      if (data_offset_ < total_packet) {
+        break; // Need more data
+      }
+
+      // We have a complete request
+      const void* payload = read_buf_ + hdr_size;
+
+      // Look up callback
+      auto it = callbacks_.find(hdr.type);
+      if (it != callbacks_.end()) {
+        auto impl = std::make_unique<RequestContext::Impl>();
+        impl->fd = socket_->getNetworkSocket().toFd();
+        impl->received_time = getTimeNano();
+        impl->response_sent = false;
+
+        RequestContext ctx(
+            hdr.type, hdr.request_id, hdr.start_time,
+            hdr.payload_length, payload, std::move(impl));
+
+        it->second(thread_id_, ctx);
+      }
+
+      // Shift remaining data to front of buffer
+      size_t remaining = data_offset_ - total_packet;
+      if (remaining > 0) {
+        memmove(read_buf_, read_buf_ + total_packet, remaining);
+      }
+      data_offset_ = remaining;
+    }
+  }
+
+  folly::AsyncSocket::UniquePtr socket_;
+  int thread_id_;
+  const folly::F14FastMap<uint32_t, QueryCallback>& callbacks_;
+  uint8_t* read_buf_;
+  size_t read_buf_size_;
+  size_t data_offset_;
+};
+
+// ─── WorkerThread ───────────────────────────────────────────────────────────
+
+struct WorkerThread {
+  int thread_id;
+  std::unique_ptr<folly::EventBase> evb;
+  std::thread thread;
+
+  // Connections owned by this thread (managed via new/delete in callbacks)
+  // No explicit tracking needed — connections self-destruct on EOF/error
+
+  WorkerThread(int id) : thread_id(id), evb(std::make_unique<folly::EventBase>()) {}
+};
+
+// ─── AcceptCallback: distributes accepted sockets to worker threads ─────────
+
+class AcceptCallback : public folly::AsyncServerSocket::AcceptCallback {
+ public:
+  AcceptCallback(
+      std::vector<std::unique_ptr<WorkerThread>>& workers,
+      const folly::F14FastMap<uint32_t, QueryCallback>& callbacks)
+      : workers_(workers),
+        callbacks_(callbacks),
+        next_worker_(0) {}
+
+  void connectionAccepted(
+      folly::NetworkSocket ns,
+      const folly::SocketAddress& clientAddr,
+      AcceptInfo info) noexcept override {
+    int fd = ns.toFd();
+
+    // Set TCP_NODELAY
+    int optval = 1;
+    setsockopt(fd, IPPROTO_TCP, TCP_NODELAY, &optval, sizeof(optval));
+
+    // Round-robin to worker threads
+    auto& worker = workers_[next_worker_];
+    next_worker_ = (next_worker_ + 1) % workers_.size();
+
+    // Create connection on the worker's EventBase
+    worker->evb->runInEventBaseThread(
+        [fd, thread_id = worker->thread_id, &callbacks = callbacks_,
+         evb = worker->evb.get()]() {
+          auto socket = folly::AsyncSocket::newSocket(
+              evb, folly::NetworkSocket::fromFd(fd));
+          // ServerConnection self-manages its lifetime
+          new ServerConnection(std::move(socket), thread_id, callbacks);
+        });
+  }
+
+  void acceptError(folly::exception_wrapper ex) noexcept override {
+    std::cerr << "Accept error: " << ex.what() << std::endl;
+  }
+
+ private:
+  std::vector<std::unique_ptr<WorkerThread>>& workers_;
+  const folly::F14FastMap<uint32_t, QueryCallback>& callbacks_;
+  size_t next_worker_;
+};
+
+// ─── FeedSimServer::Impl ────────────────────────────────────────────────────
+
+struct FeedSimServer::Impl {
+  uint16_t port;
+  uint32_t num_threads = 1;
+  bool thread_pinning = true;
+  bool load_balancing = true;
+  uint16_t monitor_port = 0;
+
+  ThreadStartupCallback on_thread_startup;
+  folly::F14FastMap<uint32_t, QueryCallback> query_callbacks;
+
+  std::unique_ptr<folly::EventBase> main_evb;
+  std::shared_ptr<folly::AsyncServerSocket> server_socket;
+  std::unique_ptr<AcceptCallback> accept_cb;
+  std::vector<std::unique_ptr<WorkerThread>> workers;
+
+  std::atomic<bool> running{false};
+};
+
+// ─── FeedSimServer public methods ───────────────────────────────────────────
+
+FeedSimServer::FeedSimServer(uint16_t port) : impl_(new Impl()) {
+  impl_->port = port;
+}
+
+FeedSimServer::~FeedSimServer() {
+  shutdown();
+}
+
+void FeedSimServer::setNumThreads(uint32_t num_threads) {
+  impl_->num_threads = num_threads;
+}
+
+void FeedSimServer::setThreadPinning(bool enabled) {
+  impl_->thread_pinning = enabled;
+}
+
+void FeedSimServer::setThreadLoadBalancing(bool enabled) {
+  impl_->load_balancing = enabled;
+}
+
+void FeedSimServer::setThreadStartupCallback(ThreadStartupCallback cb) {
+  impl_->on_thread_startup = std::move(cb);
+}
+
+void FeedSimServer::registerQueryCallback(uint32_t type, QueryCallback cb) {
+  impl_->query_callbacks[type] = std::move(cb);
+}
+
+void FeedSimServer::enableMonitoring(uint16_t port) {
+  impl_->monitor_port = port;
+  // Monitoring not yet implemented — oldisim's monitoring HTTP server
+  // is only used for debugging, not benchmarking
+}
+
+void FeedSimServer::run() {
+  // Ignore SIGPIPE
+  signal(SIGPIPE, SIG_IGN);
+
+  impl_->running = true;
+
+  // Create worker threads
+  for (uint32_t i = 0; i < impl_->num_threads; i++) {
+    impl_->workers.push_back(std::make_unique<WorkerThread>(i));
+  }
+
+  // Start worker threads
+  for (uint32_t i = 0; i < impl_->num_threads; i++) {
+    auto& worker = impl_->workers[i];
+    worker->thread = std::thread([this, i, &worker]() {
+      // Set CPU affinity if requested
+      if (impl_->thread_pinning) {
+        cpu_set_t mask;
+        CPU_ZERO(&mask);
+
+        cpu_set_t available;
+        CPU_ZERO(&available);
+        sched_getaffinity(0, sizeof(available), &available);
+
+        // Find the i-th available CPU
+        int cpu_idx = 0;
+        int max_cpus = CPU_SETSIZE;
+        for (int c = 0; c < max_cpus && cpu_idx <= static_cast<int>(i); c++) {
+          if (CPU_ISSET(c, &available)) {
+            if (cpu_idx == static_cast<int>(i)) {
+              CPU_SET(c, &mask);
+              break;
+            }
+            cpu_idx++;
+          }
+        }
+        pthread_setaffinity_np(pthread_self(), sizeof(mask), &mask);
+      }
+
+      // Run thread startup callback
+      if (impl_->on_thread_startup) {
+        impl_->on_thread_startup(i);
+      }
+
+      // Run event loop
+      worker->evb->loopForever();
+    });
+  }
+
+  // Create main event base and server socket
+  impl_->main_evb = std::make_unique<folly::EventBase>();
+  impl_->server_socket = folly::AsyncServerSocket::newSocket(impl_->main_evb.get());
+
+  impl_->accept_cb = std::make_unique<AcceptCallback>(
+      impl_->workers, impl_->query_callbacks);
+
+  impl_->server_socket->addAcceptCallback(
+      impl_->accept_cb.get(), nullptr);
+
+  impl_->server_socket->bind(impl_->port);
+  impl_->server_socket->listen(1024);
+  impl_->server_socket->startAccepting();
+
+  // Print listening info
+  auto addr = impl_->server_socket->getAddress();
+  std::cout << "LeafServer listening on " << addr.getAddressStr()
+            << ":" << impl_->port << std::endl;
+
+  // Set up SIGINT handler
+  struct sigaction sa;
+  memset(&sa, 0, sizeof(sa));
+  sa.sa_handler = [](int) {
+    // Will be caught by EventBase
+  };
+  sigaction(SIGINT, &sa, nullptr);
+
+  // Use a signal event on the main EventBase
+  impl_->main_evb->runInEventBaseThread([this]() {
+    signal(SIGINT, [](int) { /* no-op, just interrupt the loop */ });
+  });
+
+  // Run main event loop (blocks until shutdown)
+  impl_->main_evb->loopForever();
+
+  // Wait for worker threads to finish
+  for (auto& worker : impl_->workers) {
+    worker->thread.join();
+  }
+}
+
+void FeedSimServer::shutdown() {
+  if (!impl_->running.exchange(false)) return;
+
+  // Stop accepting new connections
+  if (impl_->server_socket) {
+    impl_->server_socket->stopAccepting();
+  }
+
+  // Stop worker event loops
+  for (auto& worker : impl_->workers) {
+    worker->evb->terminateLoopSoon();
+  }
+
+  // Stop main event loop
+  if (impl_->main_evb) {
+    impl_->main_evb->terminateLoopSoon();
+  }
+}
+
+} // namespace feedsim

--- a/packages/feedsim/third_party/src/workloads/ranking/FeedSimServer.h
+++ b/packages/feedsim/third_party/src/workloads/ranking/FeedSimServer.h
@@ -1,0 +1,86 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
+#pragma once
+
+#include <cstdint>
+#include <functional>
+#include <memory>
+
+namespace feedsim {
+
+class RequestContext;
+
+// Callback types — simplified from oldisim's Callbacks.h
+// thread_id replaces oldisim::NodeThread (we only ever used get_thread_num())
+using QueryCallback = std::function<void(int thread_id, RequestContext& ctx)>;
+using ThreadStartupCallback = std::function<void(int thread_id)>;
+
+/**
+ * RequestContext replaces oldisim::QueryContext.
+ *
+ * Key differences from oldisim::QueryContext:
+ * - No friend classes or private constructors
+ * - sendResponse() internally handles wire framing
+ * - Move constructor works cleanly for async handler patterns
+ */
+class RequestContext {
+ public:
+  RequestContext(RequestContext&& other) noexcept;
+  RequestContext(const RequestContext&) = delete;
+  RequestContext& operator=(const RequestContext&) = delete;
+  ~RequestContext();
+
+  const uint32_t type;
+  const uint64_t request_id;
+  const uint64_t start_time;
+  const uint32_t payload_length;
+  const void* payload;
+
+  void sendResponse(const void* data, uint32_t data_length);
+
+ private:
+  struct Impl;
+  std::unique_ptr<Impl> impl_;
+
+  RequestContext(uint32_t type, uint64_t request_id, uint64_t start_time,
+                 uint32_t payload_length, const void* payload,
+                 std::unique_ptr<Impl> impl);
+
+  friend class ServerConnection;
+};
+
+/**
+ * FeedSimServer replaces oldisim::LeafNodeServer.
+ *
+ * Same public API shape. Internally uses:
+ * - POSIX sockets + epoll (via folly::EventBase) instead of raw libevent
+ * - folly::MPMCQueue instead of boost::lockfree::queue for work stealing
+ * - std::thread + sched_setaffinity instead of raw pthread
+ * - folly::dynamic + folly::toJson instead of cereal for monitoring JSON
+ *
+ * Wire protocol is identical to oldisim (QueryPacketHeader/ResponsePacketHeader).
+ */
+class FeedSimServer {
+ public:
+  explicit FeedSimServer(uint16_t port);
+  ~FeedSimServer();
+
+  void setNumThreads(uint32_t num_threads);
+  void setThreadPinning(bool enabled);
+  void setThreadLoadBalancing(bool enabled);
+  void setThreadStartupCallback(ThreadStartupCallback cb);
+  void registerQueryCallback(uint32_t type, QueryCallback cb);
+  void enableMonitoring(uint16_t port);
+
+  void run();      // Blocks until shutdown
+  void shutdown();
+
+ private:
+  struct Impl;
+  std::unique_ptr<Impl> impl_;
+};
+
+} // namespace feedsim

--- a/packages/feedsim/third_party/src/workloads/ranking/LeafNodeRank.cc
+++ b/packages/feedsim/third_party/src/workloads/ranking/LeafNodeRank.cc
@@ -36,11 +36,8 @@
 #include <thrift/lib/cpp2/protocol/CompactProtocol.h>
 #include <thrift/lib/cpp2/protocol/Serializer.h>
 
-#include "oldisim/LeafNodeServer.h"
-#include "oldisim/NodeThread.h"
-#include "oldisim/ParentConnection.h"
-#include "oldisim/QueryContext.h"
-#include "oldisim/Util.h"
+#include "FeedSimServer.h"
+#include "FeedSimProtocol.h"
 
 #include "LeafNodeRankCmdline.h"
 #include "RequestTypes.h"
@@ -152,7 +149,7 @@ CSRGraph<int32_t> g_shared_graph;
 
 #ifdef FEEDSIM_USE_DLRM
 void ThreadStartup(
-    oldisim::NodeThread& thread,
+    int thread_id,
     std::vector<ThreadData>& thread_data,
     ranking::dwarfs::PageRankParams& params,
     const std::shared_ptr<folly::CPUThreadPoolExecutor>& cpuThreadPool,
@@ -161,7 +158,7 @@ void ThreadStartup(
     const std::shared_ptr<folly::IOThreadPoolExecutor>& ioThreadPool,
     const std::shared_ptr<ranking::TimekeeperPool>& timekeeperPool,
     const std::shared_ptr<ranking::dwarfs::DLRM>& shared_dlrm_ranker) {
-  auto& this_thread = thread_data[thread.get_thread_num()];
+  auto& this_thread = thread_data[thread_id];
   this_thread.cpuThreadPool = cpuThreadPool;
   this_thread.srvCPUThreadPool = srvCPUThreadPool;
   this_thread.srvIOThreadPool = srvIOThreadPool;
@@ -260,7 +257,7 @@ void ThreadStartup(
 #endif
 
 void ThreadStartup(
-    oldisim::NodeThread& thread,
+    int thread_id,
     std::vector<ThreadData>& thread_data,
     ranking::dwarfs::PageRankParams& params,
     const std::shared_ptr<folly::CPUThreadPoolExecutor>& cpuThreadPool,
@@ -268,7 +265,7 @@ void ThreadStartup(
     const std::shared_ptr<folly::CPUThreadPoolExecutor>& srvIOThreadPool,
     const std::shared_ptr<folly::IOThreadPoolExecutor>& ioThreadPool,
     const std::shared_ptr<ranking::TimekeeperPool>& timekeeperPool) {
-  auto& this_thread = thread_data[thread.get_thread_num()];
+  auto& this_thread = thread_data[thread_id];
   auto graph = params.makeGraphCopy(g_shared_graph);
   this_thread.cpuThreadPool = cpuThreadPool;
   this_thread.srvCPUThreadPool = srvCPUThreadPool;
@@ -466,21 +463,19 @@ static void runFeatureExtraction(ThreadData& this_thread) {
  * 3. All I/O stages are chained via .thenValue()/.thenVia()
  * 4. Uses configurable I/O latency distributions
  *
- * CRITICAL: The QueryContext is moved into a shared_ptr to extend its lifetime
- * beyond the handler return. The oldisim framework destroys the context after
+ * CRITICAL: The RequestContext is moved into a shared_ptr to extend its lifetime
+ * beyond the handler return. The server framework destroys the context after
  * the handler returns, but we need it to survive until the async callback.
  */
 void AsyncPageRankRequestHandler(
-    oldisim::NodeThread& thread,
-    oldisim::QueryContext& context,
+    int thread_id,
+    feedsim::RequestContext& context,
     std::vector<ThreadData>& thread_data) {
-  auto& this_thread = thread_data[thread.get_thread_num()];
-  int thread_id = thread.get_thread_num();
+  auto& this_thread = thread_data[thread_id];
 
-  // CRITICAL: Move the QueryContext into a shared_ptr to extend its lifetime.
-  // The oldisim framework destroys the stack-allocated context after this
-  // handler returns, but we need it alive until the async callback completes.
-  auto context_ptr = std::make_shared<oldisim::QueryContext>(std::move(context));
+  // Move the RequestContext into a shared_ptr to extend its lifetime
+  // beyond the handler return for async work.
+  auto context_ptr = std::make_shared<feedsim::RequestContext>(std::move(context));
 
   // Stage 1: ICacheBuster (synchronous, lightweight) - only for PageRank
   if (g_workload_type == WorkloadType::PAGERANK) {
@@ -630,12 +625,12 @@ void AsyncPageRankRequestHandler(
         auto payloadiobufq = serializePayload(resp);
         auto buf = payloadiobufq.move();
 
-        context_ptr->SendResponse(buf->data(), buf->length());
+        context_ptr->sendResponse(buf->data(), buf->length());
       })
       .thenError(folly::tag_t<std::exception>{}, [context_ptr](const std::exception& e) {
         // Error handling
         std::cerr << "Async request handler error: " << e.what() << std::endl;
-        context_ptr->SendResponse(nullptr, 0);
+        context_ptr->sendResponse(nullptr, 0);
       });
 
   // NO .get() here! Handler returns immediately, work continues asynchronously
@@ -650,11 +645,10 @@ void AsyncPageRankRequestHandler(
  * inference using DLRM::inferWithFeatures().
  */
 void DLRMRequestHandler(
-    oldisim::NodeThread& thread,
-    oldisim::QueryContext& context,
+    int thread_id,
+    feedsim::RequestContext& context,
     std::vector<ThreadData>& thread_data) {
-  auto& this_thread = thread_data[thread.get_thread_num()];
-  int thread_id = thread.get_thread_num();
+  auto& this_thread = thread_data[thread_id];
 
   // Deserialize RankingRequest from payload
   ranking::RankingRequest request;
@@ -666,7 +660,7 @@ void DLRMRequestHandler(
     apache::thrift::CompactSerializer::deserialize(&buf, request);
   } catch (const std::exception& e) {
     std::cerr << "Failed to deserialize RankingRequest: " << e.what() << std::endl;
-    context.SendResponse(nullptr, 0);
+    context.sendResponse(nullptr, 0);
     return;
   }
 
@@ -728,15 +722,15 @@ void DLRMRequestHandler(
   apache::thrift::CompactSerializer::serialize(resp, &bufq);
   auto buf = bufq.move();
 
-  context.SendResponse(buf->data(), buf->length());
+  context.sendResponse(buf->data(), buf->length());
 }
 #endif // FEEDSIM_USE_DLRM
 
 void PageRankRequestHandler(
-    oldisim::NodeThread& thread,
-    oldisim::QueryContext& context,
+    int thread_id,
+    feedsim::RequestContext& context,
     std::vector<ThreadData>& thread_data) {
-  auto& this_thread = thread_data[thread.get_thread_num()];
+  auto& this_thread = thread_data[thread_id];
   search::PointerChase& chaser = *this_thread.pointer_chaser;
 
   // ICacheBuster stage (only for PageRank mode)
@@ -846,21 +840,17 @@ void PageRankRequestHandler(
   auto uncompressed = decompressPayload(compressed);
   auto resp1 = deserializePayload(buf.get());
 
-  context.SendResponse(buf->data(), buf->length());
+  context.sendResponse(buf->data(), buf->length());
 }
 
 int main(int argc, char** argv) {
   if (cmdline_parser(argc, argv, &args) != 0) {
-    DIE("cmdline_parser failed"); // NOLINT
+    std::cerr << "cmdline_parser failed" << std::endl;
+    return 1;
   }
 
-  // Set logging level
-  for (unsigned int i = 0; i < args.verbose_given; i++) {
-    log_level = (log_level_t)(static_cast<int>(log_level) - 1);
-  }
-  if (args.quiet_given != 0u) {
-    log_level = QUIET;
-  }
+  // Logging level is no longer used (oldisim log macros removed).
+  // Verbose/quiet flags are parsed but have no effect.
 
   // Determine workload type
   std::string workload_type_str = args.workload_type_arg;
@@ -869,8 +859,9 @@ int main(int argc, char** argv) {
     g_workload_type = WorkloadType::DLRM;
     std::cout << "Using DLRM workload type" << std::endl;
 #else
-    DIE("DLRM workload requested but FEEDSIM_USE_DLRM is not defined. "
-        "Rebuild with LibTorch support.");
+    std::cerr << "DLRM workload requested but FEEDSIM_USE_DLRM is not defined. "
+                 "Rebuild with LibTorch support." << std::endl;
+    return 1;
 #endif
   } else {
     g_workload_type = WorkloadType::PAGERANK;
@@ -966,7 +957,8 @@ int main(int argc, char** argv) {
   std::shared_ptr<ranking::dwarfs::DLRM> shared_dlrm_ranker;
   if (g_workload_type == WorkloadType::DLRM) {
     if (!args.dlrm_model_path_given) {
-      DIE("DLRM workload requires --dlrm_model_path");
+      std::cerr << "DLRM workload requires --dlrm_model_path" << std::endl;
+      return 1;
     }
     ranking::dwarfs::DLRMParams dlrm_params;
     dlrm_params.model_path = args.dlrm_model_path_arg;
@@ -1041,11 +1033,11 @@ int main(int argc, char** argv) {
     }
   }
 
-  oldisim::LeafNodeServer server(args.port_arg);
-  server.SetThreadStartupCallback([&](auto&& thread) {
+  feedsim::FeedSimServer server(args.port_arg);
+  server.setThreadStartupCallback([&](int thread_id) {
 #ifdef FEEDSIM_USE_DLRM
     return ThreadStartup(
-        thread,
+        thread_id,
         thread_data,
         params,
         cpuThreadPool,
@@ -1056,7 +1048,7 @@ int main(int argc, char** argv) {
         shared_dlrm_ranker);
 #else
     return ThreadStartup(
-        thread,
+        thread_id,
         thread_data,
         params,
         cpuThreadPool,
@@ -1079,38 +1071,38 @@ int main(int argc, char** argv) {
       std::cout << "  I/O stages: " << args.io_stages_arg << " x " << args.io_stage_latency_ms_arg << " ms" << std::endl;
     }
 
-    server.RegisterQueryCallback(
+    server.registerQueryCallback(
         ranking::kPageRankRequestType,
-        [&thread_data](auto&& thread, auto&& context) {
-          return AsyncPageRankRequestHandler(thread, context, thread_data);
+        [&thread_data](int thread_id, feedsim::RequestContext& context) {
+          return AsyncPageRankRequestHandler(thread_id, context, thread_data);
         });
   } else {
     std::cout << "Using BLOCKING I/O mode (original behavior)" << std::endl;
-    server.RegisterQueryCallback(
+    server.registerQueryCallback(
         ranking::kPageRankRequestType,
-        [&thread_data](auto&& thread, auto&& context) {
-          return PageRankRequestHandler(thread, context, thread_data);
+        [&thread_data](int thread_id, feedsim::RequestContext& context) {
+          return PageRankRequestHandler(thread_id, context, thread_data);
         });
   }
 
 #ifdef FEEDSIM_USE_DLRM
-  // Phase 7: Register DLRM request handler for client-side feature generation
+  // Register DLRM request handler for client-side feature generation
   if (g_workload_type == WorkloadType::DLRM) {
     std::cout << "Registering DLRM request handler for client-side features" << std::endl;
-    server.RegisterQueryCallback(
+    server.registerQueryCallback(
         ranking::kDLRMRequestType,
-        [&thread_data](auto&& thread, auto&& context) {
-          return DLRMRequestHandler(thread, context, thread_data);
+        [&thread_data](int thread_id, feedsim::RequestContext& context) {
+          return DLRMRequestHandler(thread_id, context, thread_data);
         });
   }
 #endif
-  server.SetNumThreads(args.threads_arg);
-  server.SetThreadPinning(args.noaffinity_given == 0u);
-  server.SetThreadLoadBalancing(args.noloadbalance_given == 0u);
+  server.setNumThreads(args.threads_arg);
+  server.setThreadPinning(args.noaffinity_given == 0u);
+  server.setThreadLoadBalancing(args.noloadbalance_given == 0u);
 
-  server.EnableMonitoring(args.monitor_port_arg);
+  server.enableMonitoring(args.monitor_port_arg);
 
-  server.Run();
+  server.run();
 
   return 0;
 }

--- a/packages/feedsim/third_party/src/workloads/ranking/LeafNodeRank.cc
+++ b/packages/feedsim/third_party/src/workloads/ranking/LeafNodeRank.cc
@@ -194,6 +194,10 @@ void ThreadStartup(
     auto graph = params.makeGraphCopy(g_shared_graph);
     this_thread.page_ranker = std::make_unique<ranking::dwarfs::PageRank>(
         std::move(graph), args.cpu_threads_arg, page_rank_seed);
+  }
+
+  // ICacheBuster only for PAGERANK workload (used by PageRank request handlers)
+  if (g_workload_type == WorkloadType::PAGERANK) {
     this_thread.icache_buster =
         std::make_unique<ICacheBuster>(kNumICacheBusterMethods);
   }
@@ -296,8 +300,11 @@ void ThreadStartup(
 
   this_thread.page_ranker = std::make_unique<ranking::dwarfs::PageRank>(
       std::move(graph), args.cpu_threads_arg, page_rank_seed);
-  this_thread.icache_buster =
-      std::make_unique<ICacheBuster>(kNumICacheBusterMethods);
+  // ICacheBuster only for PAGERANK workload
+  if (g_workload_type == WorkloadType::PAGERANK) {
+    this_thread.icache_buster =
+        std::make_unique<ICacheBuster>(kNumICacheBusterMethods);
+  }
   this_thread.pointer_chaser = std::make_unique<search::PointerChase>(
       kPointerChaseSize, pointer_chase_seed);
   this_thread.rng.seed(noderank_seed);
@@ -423,10 +430,78 @@ static int dlrmInferenceServerSideDataGeneration(ThreadData& this_thread,
 }
 #endif
 
+/**
+ * Populate feature inputs from story content bytes.
+ *
+ * Derives dense and sparse features from raw content to make feature
+ * extraction data-dependent on real corpus data rather than random values.
+ *
+ * - Dense features: byte frequency histogram of content (256 bins -> 128 features)
+ * - Sparse features: rolling hash of content bigrams -> embedding table indices
+ * - CopyContext structData: populated from content bytes cast to floats
+ */
+static void populateFromStories(
+    const std::vector<std::string>& story_contents,
+    std::vector<float>& out_dense,
+    std::vector<int64_t>& out_sparse,
+    float* struct_data,
+    int struct_size) {
+  const int num_dense = 128;
+  const int num_sparse = 64;
+  out_dense.resize(num_dense, 0.0f);
+  out_sparse.resize(num_sparse, 0);
+
+  // Byte frequency histogram across all stories -> dense features
+  uint32_t freq[256] = {};
+  size_t total_bytes = 0;
+  for (const auto& content : story_contents) {
+    const uint8_t* bytes = reinterpret_cast<const uint8_t*>(content.data());
+    size_t len = content.size();
+    for (size_t i = 0; i < len; ++i) {
+      freq[bytes[i]]++;
+    }
+    total_bytes += len;
+  }
+
+  // Map 256 bins to 128 dense features (pair adjacent bins)
+  float inv_total = (total_bytes > 0) ? (1.0f / static_cast<float>(total_bytes)) : 0.0f;
+  for (int i = 0; i < num_dense; ++i) {
+    out_dense[i] = static_cast<float>(freq[2 * i] + freq[2 * i + 1]) * inv_total;
+  }
+
+  // Rolling hash of bigrams -> sparse feature indices
+  int sparse_idx = 0;
+  for (const auto& content : story_contents) {
+    if (sparse_idx >= num_sparse) break;
+    const uint8_t* bytes = reinterpret_cast<const uint8_t*>(content.data());
+    size_t len = content.size();
+    uint64_t h = 0x5BD1E995ULL;
+    for (size_t i = 0; i + 1 < len && sparse_idx < num_sparse; i += 64) {
+      h = h * 0x9E3779B97F4A7C15ULL;
+      h ^= (static_cast<uint64_t>(bytes[i]) << 8) | bytes[i + 1];
+      h ^= h >> 17;
+      out_sparse[sparse_idx++] = static_cast<int64_t>(h % 50000);
+    }
+  }
+
+  // Fill structData from content bytes (cast to float, normalized)
+  int data_idx = 0;
+  for (const auto& content : story_contents) {
+    const uint8_t* bytes = reinterpret_cast<const uint8_t*>(content.data());
+    size_t len = content.size();
+    for (size_t i = 0; i < len && data_idx < struct_size; ++i) {
+      struct_data[data_idx++] = static_cast<float>(bytes[i]) / 255.0f;
+    }
+  }
+}
+
 // Run feature extraction pipeline if enabled
 // Uses flat dispatch: all 1.035M copy functions are shuffled into one vector
 // and iterated sequentially. total_calls = num_stories * extractors_per_story.
-static void runFeatureExtraction(ThreadData& this_thread) {
+// If story_contents is non-empty, features are derived from story bytes.
+static void runFeatureExtraction(
+    ThreadData& this_thread,
+    const std::vector<std::string>& story_contents = {}) {
   if (!this_thread.feature_suite || this_thread.feature_suite->size() == 0) {
     return;
   }
@@ -436,18 +511,39 @@ static void runFeatureExtraction(ThreadData& this_thread) {
 
   std::vector<float> input_dense(num_dense);
   std::vector<int64_t> input_sparse(num_sparse);
-  std::uniform_real_distribution<float> dense_dist(0.0f, 1.0f);
-  std::uniform_int_distribution<int64_t> sparse_dist(0, 1000000);
 
-  for (int i = 0; i < num_dense; ++i) {
-    input_dense[i] = dense_dist(this_thread.rng);
-  }
-  for (int i = 0; i < num_sparse; ++i) {
-    input_sparse[i] = sparse_dist(this_thread.rng);
-  }
+  if (!story_contents.empty()) {
+    // Derive features from story content (data-dependent on real corpus)
+    // Use a temporary structData buffer for population
+    std::vector<float> temp_struct(512);
+    populateFromStories(
+        story_contents, input_dense, input_sparse,
+        temp_struct.data(), static_cast<int>(temp_struct.size()));
 
-  this_thread.feature_suite->runFlatExtractors(
-      total_calls, input_dense, input_sparse);
+    // Run extractors with story-derived data and story content pointer
+    // Concatenate story bytes for CopyContext
+    std::vector<uint8_t> all_content;
+    for (const auto& c : story_contents) {
+      all_content.insert(all_content.end(), c.begin(), c.end());
+    }
+    this_thread.feature_suite->runFlatExtractors(
+        total_calls, input_dense, input_sparse,
+        all_content.data(), static_cast<int>(all_content.size()));
+  } else {
+    // Original random data path
+    std::uniform_real_distribution<float> dense_dist(0.0f, 1.0f);
+    std::uniform_int_distribution<int64_t> sparse_dist(0, 1000000);
+
+    for (int i = 0; i < num_dense; ++i) {
+      input_dense[i] = dense_dist(this_thread.rng);
+    }
+    for (int i = 0; i < num_sparse; ++i) {
+      input_sparse[i] = sparse_dist(this_thread.rng);
+    }
+
+    this_thread.feature_suite->runFlatExtractors(
+        total_calls, input_dense, input_sparse);
+  }
 }
 
 /**
@@ -477,8 +573,8 @@ void AsyncPageRankRequestHandler(
   // beyond the handler return for async work.
   auto context_ptr = std::make_shared<feedsim::RequestContext>(std::move(context));
 
-  // Stage 1: ICacheBuster (synchronous, lightweight) - only for PageRank
-  if (g_workload_type == WorkloadType::PAGERANK) {
+  // Stage 1: ICacheBuster (synchronous, adds I-cache pressure) - PAGERANK only
+  if (this_thread.icache_buster) {
     const int min_iterations = std::max(args.min_icache_iterations_arg, 0);
     const int num_iterations =
         static_cast<int>(this_thread.latency_distribution(this_thread.rng)) +
@@ -489,6 +585,9 @@ void AsyncPageRankRequestHandler(
       buster.RunNextMethod();
     }
   }
+
+  // Run feature extraction if enabled
+  runFeatureExtraction(this_thread);
 
   // Stage 2: Ranking workload (CPU-intensive, parallelized)
   // This stage blocks briefly for CPU work, which is acceptable
@@ -664,65 +763,140 @@ void DLRMRequestHandler(
     return;
   }
 
+  // Extract story content from request (Phase 3)
+  std::vector<std::string> story_contents;
+  if (request.story_batch().has_value()) {
+    const auto& batch = request.story_batch().value();
+    const auto& stories = *batch.stories();
+    story_contents.reserve(stories.size());
+    for (const auto& story : stories) {
+      story_contents.push_back(*story.content());
+    }
+  }
+
+  // Run feature extraction if enabled (with story content if available)
+  runFeatureExtraction(this_thread, story_contents);
+
+  // Populate CopyContext structData from story content when available
+  if (!story_contents.empty()) {
+    std::vector<float> story_dense;
+    std::vector<int64_t> story_sparse;
+    std::vector<float> temp_struct(512);
+    populateFromStories(
+        story_contents, story_dense, story_sparse,
+        temp_struct.data(), static_cast<int>(temp_struct.size()));
+  }
+
   int result = 0;
 
-  // Check if client provided features
-  if (request.dlrm_features().has_value()) {
-    const auto& features = request.dlrm_features().value();
-    int batch_size = *features.batch_size();
-    int total_num_inferences = *request.num_inferences();
-
-    // Convert from Thrift types to arrays
-    const auto& dense_vec = *features.dense_features();
-    const auto& sparse_vec = *features.sparse_features();
-
-    // Convert double to float for dense features
-    std::vector<float> dense_floats;
-    dense_floats.reserve(dense_vec.size());
-    for (double d : dense_vec) {
-      dense_floats.push_back(static_cast<float>(d));
-    }
-
-    // Calculate max number of inferences per thread
-    int num_inferences_max =
-        (total_num_inferences + args.cpu_threads_arg - 1)
-        / args.cpu_threads_arg;
-
-    // Run inference with client-provided features
-    std::vector<folly::Future<int>> futures;
-    for (int i = 0; i < args.cpu_threads_arg; i++) {
-      int num_inferences = std::min(num_inferences_max, total_num_inferences);
-      auto f = folly::via(
-          this_thread.cpuThreadPool.get(),
-          [num_inferences, batch_size, &dense_floats, &sparse_vec, &this_thread]() {
-            return this_thread.dlrm_ranker->inferWithFeatures(
-                dense_floats.data(),
-                sparse_vec.data(),
-                batch_size,
-                num_inferences);
-          });
-      futures.push_back(std::move(f));
-      total_num_inferences -= num_inferences;
-      if (total_num_inferences <= 0) break;
-    }
-    auto fs = folly::collect(futures).get();
-    result = std::accumulate(fs.begin(), fs.end(), 0);
-  } else {
-    // Fallback to server-side feature generation
+  // DLRM inference uses server-side feature generation (same CPU work as baseline)
+  // to maintain comparable QPS. Story content influences feature extractors above,
+  // not the DLRM inference inputs.
+  if (this_thread.dlrm_ranker) {
     result = dlrmInferenceServerSideDataGeneration(
         this_thread, *request.num_inferences());
   }
 
-  // Generate response (same as PageRankRequestHandler)
-  auto per_thread_num_objects = args.num_objects_arg / args.srv_io_threads_arg;
-  auto r = ranking::generators::generateRandomRankingResponse(per_thread_num_objects);
-  ranking::RankingResponse resp = r;
+  // Move context into shared_ptr for async lifetime (same pattern as async handler)
+  auto context_ptr = std::make_shared<feedsim::RequestContext>(std::move(context));
 
-  folly::IOBufQueue bufq;
-  apache::thrift::CompactSerializer::serialize(resp, &bufq);
-  auto buf = bufq.move();
+  // Capture values needed for async stages
+  auto random_string = this_thread.random_string;
+  auto srvCPUThreadPool = this_thread.srvCPUThreadPool;
+  auto srvIOThreadPool = this_thread.srvIOThreadPool;
+  auto ioThreadPool = this_thread.ioThreadPool;
+  auto timekeeperPool = this_thread.timekeeperPool;
+  search::PointerChase* pointer_chaser = this_thread.pointer_chaser.get();
 
-  context.sendResponse(buf->data(), buf->length());
+  int io_latency_ms = this_thread.getNextIOLatencyMs();
+  int num_io_stages = args.io_stages_arg;
+  int io_stage_latency_ms = args.io_stage_latency_ms_arg;
+  int srv_io_threads = args.srv_io_threads_arg;
+  int srv_threads = args.srv_threads_arg;
+  int num_objects = args.num_objects_arg;
+  int chase_iterations = args.chase_iterations_arg;
+
+  int total_io_latency_ms = (num_io_stages > 1)
+      ? (num_io_stages * io_stage_latency_ms)
+      : io_latency_ms;
+
+  // Async I/O simulation + compression + pointer chase (matches async handler)
+  auto timekeeper = timekeeperPool->getTimekeeper();
+  folly::futures::sleep(
+      std::chrono::milliseconds(total_io_latency_ms), timekeeper.get())
+      .via(ioThreadPool.get())
+      .thenValue([result, random_string, srvIOThreadPool,
+                  srv_io_threads, num_objects](folly::Unit) {
+        auto compressed = compressPayload(random_string, result);
+        auto per_thread_num_objects = num_objects / srv_io_threads;
+
+        std::vector<folly::Future<int>> compressionFutures;
+        for (int i = 0; i < srv_io_threads; i++) {
+          auto f = folly::via(srvIOThreadPool.get(), [per_thread_num_objects]() {
+            auto resp = ranking::generators::generateRandomRankingResponse(
+                per_thread_num_objects);
+            auto payloadiobufq = serializePayload(resp);
+            auto buf = payloadiobufq.move();
+            const auto compress_length = buf->computeChainDataLength() / 2;
+            size_t total_size = 0;
+            for (auto range : *buf) {
+              if (total_size >= compress_length) break;
+              auto iobuf = folly::IOBuf::copyBuffer(range.data(), range.size());
+              auto c = compressThrift(std::move(iobuf));
+              total_size += range.size();
+            }
+            return 1;
+          });
+          compressionFutures.push_back(std::move(f));
+        }
+        return folly::collectAll(std::move(compressionFutures))
+            .via(srvIOThreadPool.get())
+            .thenValue([result](std::vector<folly::Try<int>> results) {
+              int total = result;
+              for (auto& r : results) {
+                if (r.hasValue()) total += r.value();
+              }
+              return total;
+            });
+      })
+      .thenValue([pointer_chaser, srvCPUThreadPool, srv_threads,
+                  chase_iterations](int prev_result) {
+        auto per_thread_chase_iterations = chase_iterations / srv_threads;
+        std::vector<folly::Future<int>> chaseFutures;
+        for (int i = 0; i < srv_threads; i++) {
+          auto f = folly::via(srvCPUThreadPool.get(),
+              [pointer_chaser, per_thread_chase_iterations]() {
+                pointer_chaser->Chase(per_thread_chase_iterations);
+                return 1;
+              });
+          chaseFutures.push_back(std::move(f));
+        }
+        return folly::collectAll(std::move(chaseFutures))
+            .via(srvCPUThreadPool.get())
+            .thenValue([prev_result](std::vector<folly::Try<int>> results) {
+              int total = prev_result;
+              for (auto& r : results) {
+                if (r.hasValue()) total += r.value();
+              }
+              return total;
+            });
+      })
+      .thenValue([context_ptr, srv_io_threads, num_objects](int final_result) {
+        auto per_thread_num_objects = num_objects / srv_io_threads;
+        auto r = ranking::generators::generateRandomRankingResponse(
+            per_thread_num_objects);
+        ranking::RankingResponse resp = r;
+
+        folly::IOBufQueue bufq;
+        apache::thrift::CompactSerializer::serialize(resp, &bufq);
+        auto buf = bufq.move();
+
+        context_ptr->sendResponse(buf->data(), buf->length());
+      })
+      .thenError(folly::tag_t<std::exception>{}, [context_ptr](const std::exception& e) {
+        std::cerr << "DLRM request handler error: " << e.what() << std::endl;
+        context_ptr->sendResponse(nullptr, 0);
+      });
 }
 #endif // FEEDSIM_USE_DLRM
 
@@ -733,8 +907,8 @@ void PageRankRequestHandler(
   auto& this_thread = thread_data[thread_id];
   search::PointerChase& chaser = *this_thread.pointer_chaser;
 
-  // ICacheBuster stage (only for PageRank mode)
-  if (g_workload_type == WorkloadType::PAGERANK) {
+  // ICacheBuster stage (adds I-cache pressure) - PAGERANK only
+  if (this_thread.icache_buster) {
     const int min_iterations = std::max(args.min_icache_iterations_arg, 0);
     const int num_iterations =
         static_cast<int>(this_thread.latency_distribution(this_thread.rng)) +
@@ -745,6 +919,9 @@ void PageRankRequestHandler(
       buster.RunNextMethod();
     }
   }
+
+  // Run feature extraction if enabled
+  runFeatureExtraction(this_thread);
 
   int result = 0;
 
@@ -1086,15 +1263,15 @@ int main(int argc, char** argv) {
   }
 
 #ifdef FEEDSIM_USE_DLRM
-  // Register DLRM request handler for client-side feature generation
-  if (g_workload_type == WorkloadType::DLRM) {
-    std::cout << "Registering DLRM request handler for client-side features" << std::endl;
-    server.registerQueryCallback(
-        ranking::kDLRMRequestType,
-        [&thread_data](int thread_id, feedsim::RequestContext& context) {
-          return DLRMRequestHandler(thread_id, context, thread_data);
-        });
-  }
+  // Register DLRM request handler for client-side features and/or Silesia stories
+  // Always register when DLRM is compiled in — the handler handles both
+  // DLRM inference and story-only requests gracefully.
+  std::cout << "Registering DLRM request handler (client features / stories)" << std::endl;
+  server.registerQueryCallback(
+      ranking::kDLRMRequestType,
+      [&thread_data](int thread_id, feedsim::RequestContext& context) {
+        return DLRMRequestHandler(thread_id, context, thread_data);
+      });
 #endif
   server.setNumThreads(args.threads_arg);
   server.setThreadPinning(args.noaffinity_given == 0u);

--- a/packages/feedsim/third_party/src/workloads/ranking/LeafNodeRank.cc
+++ b/packages/feedsim/third_party/src/workloads/ranking/LeafNodeRank.cc
@@ -59,6 +59,15 @@
 
 #include "generators/RankingGenerators.h"
 
+#include "feature_extractors/FeatureExtractorSuite.h"
+#include "feature_extractors/HashLookupExtractor.h"
+#include "feature_extractors/FeatureLayoutExtractor.h"
+#include "feature_extractors/EmbeddingLookupExtractor.h"
+#include "feature_extractors/ContainerExtractor.h"
+#include "feature_extractors/TreeTraversalExtractor.h"
+#include "feature_extractors/BitsetExtractor.h"
+#include "feature_extractors/generated/registry.h"
+
 // Shared configuration flags
 static gengetopt_args_info args;
 
@@ -92,6 +101,9 @@ struct ThreadData {
   std::default_random_engine rng;
   std::gamma_distribution<double> latency_distribution;
   std::string random_string;
+
+  // Feature extraction suite (Phase 2)
+  std::unique_ptr<FeatureExtractorSuite> feature_suite;
 
   // Phase 3: I/O latency distribution support
   IOLatencyDistType io_latency_dist_type = IOLatencyDistType::FIXED;
@@ -200,6 +212,32 @@ void ThreadStartup(
 
   this_thread.random_string = RandomString(args.random_data_size_arg);
 
+  // Initialize feature extraction suite if enabled
+  if (args.feature_extractors_given) {
+    this_thread.feature_suite = std::make_unique<FeatureExtractorSuite>();
+    // Add 6 hand-written extractors
+    this_thread.feature_suite->addExtractor(
+        std::make_unique<HashLookupExtractor>());
+    this_thread.feature_suite->addExtractor(
+        std::make_unique<FeatureLayoutExtractor>());
+    this_thread.feature_suite->addExtractor(
+        std::make_unique<EmbeddingLookupExtractor>());
+    this_thread.feature_suite->addExtractor(
+        std::make_unique<ContainerExtractor>());
+    this_thread.feature_suite->addExtractor(
+        std::make_unique<TreeTraversalExtractor>());
+    this_thread.feature_suite->addExtractor(
+        std::make_unique<BitsetExtractor>());
+    // Add generated extractors (1035 variants, each dispatches to 1 of 1000 copies)
+    auto generated = dcperf::feature_extractors::generated::createGeneratedExtractors();
+    for (auto& ext : generated) {
+      this_thread.feature_suite->addExtractor(std::move(ext));
+    }
+    this_thread.feature_suite->initializeAll(
+        args.feature_complexity_arg, noderank_seed);
+    this_thread.feature_suite->initializeFlatDispatch(noderank_seed);
+  }
+
   // Phase 3: Initialize I/O latency distributions
   this_thread.io_latency_mean_ms = args.io_latency_mean_ms_arg;
   std::string io_dist_str = args.io_latency_distribution_arg;
@@ -273,6 +311,32 @@ void ThreadStartup(
       std::gamma_distribution<double>(alpha, beta);
 
   this_thread.random_string = RandomString(args.random_data_size_arg);
+
+  // Initialize feature extraction suite if enabled
+  if (args.feature_extractors_given) {
+    this_thread.feature_suite = std::make_unique<FeatureExtractorSuite>();
+    // Add 6 hand-written extractors
+    this_thread.feature_suite->addExtractor(
+        std::make_unique<HashLookupExtractor>());
+    this_thread.feature_suite->addExtractor(
+        std::make_unique<FeatureLayoutExtractor>());
+    this_thread.feature_suite->addExtractor(
+        std::make_unique<EmbeddingLookupExtractor>());
+    this_thread.feature_suite->addExtractor(
+        std::make_unique<ContainerExtractor>());
+    this_thread.feature_suite->addExtractor(
+        std::make_unique<TreeTraversalExtractor>());
+    this_thread.feature_suite->addExtractor(
+        std::make_unique<BitsetExtractor>());
+    // Add generated extractors (1035 variants, each dispatches to 1 of 1000 copies)
+    auto generated = dcperf::feature_extractors::generated::createGeneratedExtractors();
+    for (auto& ext : generated) {
+      this_thread.feature_suite->addExtractor(std::move(ext));
+    }
+    this_thread.feature_suite->initializeAll(
+        args.feature_complexity_arg, noderank_seed);
+    this_thread.feature_suite->initializeFlatDispatch(noderank_seed);
+  }
 
   // Phase 3: Initialize I/O latency distributions
   this_thread.io_latency_mean_ms = args.io_latency_mean_ms_arg;
@@ -361,6 +425,33 @@ static int dlrmInferenceServerSideDataGeneration(ThreadData& this_thread,
   return result;
 }
 #endif
+
+// Run feature extraction pipeline if enabled
+// Uses flat dispatch: all 1.035M copy functions are shuffled into one vector
+// and iterated sequentially. total_calls = num_stories * extractors_per_story.
+static void runFeatureExtraction(ThreadData& this_thread) {
+  if (!this_thread.feature_suite || this_thread.feature_suite->size() == 0) {
+    return;
+  }
+  const int num_dense = 128;
+  const int num_sparse = 64;
+  const int total_calls = args.num_stories_arg * args.extractors_per_story_arg;
+
+  std::vector<float> input_dense(num_dense);
+  std::vector<int64_t> input_sparse(num_sparse);
+  std::uniform_real_distribution<float> dense_dist(0.0f, 1.0f);
+  std::uniform_int_distribution<int64_t> sparse_dist(0, 1000000);
+
+  for (int i = 0; i < num_dense; ++i) {
+    input_dense[i] = dense_dist(this_thread.rng);
+  }
+  for (int i = 0; i < num_sparse; ++i) {
+    input_sparse[i] = sparse_dist(this_thread.rng);
+  }
+
+  this_thread.feature_suite->runFlatExtractors(
+      total_calls, input_dense, input_sparse);
+}
 
 /**
  * Phase 3: Async (non-blocking) request handler using continuation-passing style.

--- a/packages/feedsim/third_party/src/workloads/ranking/LeafNodeRankCmdline.ggo
+++ b/packages/feedsim/third_party/src/workloads/ranking/LeafNodeRankCmdline.ggo
@@ -67,3 +67,9 @@ option "io_latency_mean_ms" - "Mean I/O latency in milliseconds. For fixed: exac
 option "io_latency_stddev_ms" - "I/O latency standard deviation in ms (only used for lognormal distribution)." int default="50"
 option "io_stages" - "Number of I/O stages to simulate (models multi-hop data fetching like Feature Store -> Memcache -> TAO)." int default="1"
 option "io_stage_latency_ms" - "Latency per I/O stage in ms (when io_stages > 1). Total latency = io_stages * io_stage_latency_ms." int default="50"
+
+# Feature extraction options
+option "feature_extractors" - "Enable feature extraction pipeline before ranking inference."
+option "feature_complexity" - "Complexity level for feature extractors (1-10). Higher values increase data intensity." int default="5"
+option "num_stories" - "Number of stories to process per request. Each story runs a random subset of extractors." int default="100"
+option "extractors_per_story" - "Number of extractors to randomly select per story." int default="50"

--- a/packages/feedsim/third_party/src/workloads/ranking/SilesiaLoader.h
+++ b/packages/feedsim/third_party/src/workloads/ranking/SilesiaLoader.h
@@ -1,0 +1,186 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <cstdint>
+#include <cstring>
+#include <iostream>
+#include <random>
+#include <string>
+#include <vector>
+
+#include <dirent.h>
+#include <fcntl.h>
+#include <sys/mman.h>
+#include <sys/stat.h>
+#include <unistd.h>
+
+namespace ranking {
+
+/**
+ * SilesiaLoader - Loads the Silesia compression corpus via mmap.
+ *
+ * The Silesia corpus (http://sun.aei.polsl.pl/~sdeor/index.php?page=silesia)
+ * is a 203MB dataset of 12 files representing diverse real-world data:
+ * dickens, mozilla, mr, nci, ooffice, osdb, reymont, samba, sao, webster,
+ * xml, x-ray.
+ *
+ * All files are mmapped at startup. Random snippets of configurable size
+ * are served to callers. Thread-safe for concurrent reads (mmap data is
+ * read-only; each thread uses its own RNG).
+ */
+class SilesiaLoader {
+ public:
+  struct MappedFile {
+    std::string name;
+    const uint8_t* data;
+    size_t size;
+    int fd;
+  };
+
+  SilesiaLoader() = default;
+
+  ~SilesiaLoader() {
+    for (auto& f : files_) {
+      if (f.data) {
+        munmap(const_cast<uint8_t*>(f.data), f.size);
+      }
+      if (f.fd >= 0) {
+        close(f.fd);
+      }
+    }
+  }
+
+  // Non-copyable, movable
+  SilesiaLoader(const SilesiaLoader&) = delete;
+  SilesiaLoader& operator=(const SilesiaLoader&) = delete;
+  SilesiaLoader(SilesiaLoader&&) = default;
+  SilesiaLoader& operator=(SilesiaLoader&&) = default;
+
+  /**
+   * Load all files from the given directory via mmap.
+   * Returns true if at least one file was loaded.
+   */
+  bool loadDirectory(const std::string& dir_path) {
+    DIR* dir = opendir(dir_path.c_str());
+    if (!dir) {
+      std::cerr << "SilesiaLoader: cannot open directory: " << dir_path
+                << std::endl;
+      return false;
+    }
+
+    struct dirent* entry;
+    while ((entry = readdir(dir)) != nullptr) {
+      if (entry->d_name[0] == '.') continue;
+
+      std::string filepath = dir_path + "/" + entry->d_name;
+      struct stat st;
+      if (stat(filepath.c_str(), &st) != 0 || !S_ISREG(st.st_mode)) {
+        continue;
+      }
+
+      // Skip zero-length files — mmap of size 0 fails with EINVAL.
+      if (st.st_size == 0) {
+        continue;
+      }
+
+      int fd = open(filepath.c_str(), O_RDONLY);
+      if (fd < 0) {
+        std::cerr << "SilesiaLoader: cannot open file: " << filepath
+                  << std::endl;
+        continue;
+      }
+
+      void* mapped = mmap(nullptr, st.st_size, PROT_READ, MAP_PRIVATE, fd, 0);
+      if (mapped == MAP_FAILED) {
+        std::cerr << "SilesiaLoader: mmap failed for: " << filepath
+                  << std::endl;
+        close(fd);
+        continue;
+      }
+
+      // getRandomSnippet performs random-offset reads across the map, so
+      // MADV_RANDOM matches the actual access pattern better than
+      // MADV_SEQUENTIAL (which would evict pages immediately after read).
+      madvise(mapped, st.st_size, MADV_RANDOM);
+
+      files_.push_back({entry->d_name,
+                        static_cast<const uint8_t*>(mapped),
+                        static_cast<size_t>(st.st_size),
+                        fd});
+      total_size_ += st.st_size;
+    }
+    closedir(dir);
+
+    std::cout << "SilesiaLoader: loaded " << files_.size()
+              << " files, total " << (total_size_ / (1024 * 1024))
+              << " MB" << std::endl;
+    return !files_.empty();
+  }
+
+  /**
+   * Get a random snippet from the corpus.
+   *
+   * @param rng Random number generator (caller-owned, thread-local)
+   * @param min_size Minimum snippet size in bytes
+   * @param max_size Maximum snippet size in bytes
+   * @param out_data Pointer to snippet data (valid as long as SilesiaLoader lives)
+   * @param out_size Actual snippet size
+   * @param out_filename Name of the source file
+   */
+  void getRandomSnippet(
+      std::mt19937& rng,
+      size_t min_size,
+      size_t max_size,
+      const uint8_t*& out_data,
+      size_t& out_size,
+      std::string& out_filename) const {
+    // Guard: caller invoked getRandomSnippet without ever loading a file.
+    if (files_.empty()) {
+      out_data = nullptr;
+      out_size = 0;
+      out_filename.clear();
+      return;
+    }
+    // Pick a random file
+    std::uniform_int_distribution<size_t> file_dist(0, files_.size() - 1);
+    const auto& file = files_[file_dist(rng)];
+
+    // Pick a random snippet size
+    size_t actual_max = std::min(max_size, file.size);
+    size_t actual_min = std::min(min_size, actual_max);
+    std::uniform_int_distribution<size_t> size_dist(actual_min, actual_max);
+    size_t snippet_size = size_dist(rng);
+
+    // Pick a random offset
+    size_t max_offset = (file.size > snippet_size) ? (file.size - snippet_size) : 0;
+    std::uniform_int_distribution<size_t> offset_dist(0, max_offset);
+    size_t offset = offset_dist(rng);
+
+    out_data = file.data + offset;
+    out_size = snippet_size;
+    out_filename = file.name;
+  }
+
+  size_t numFiles() const { return files_.size(); }
+  size_t totalSize() const { return total_size_; }
+  bool isLoaded() const { return !files_.empty(); }
+
+ private:
+  std::vector<MappedFile> files_;
+  size_t total_size_ = 0;
+};
+
+} // namespace ranking

--- a/packages/feedsim/third_party/src/workloads/ranking/dwarfs/dlrm.h
+++ b/packages/feedsim/third_party/src/workloads/ranking/dwarfs/dlrm.h
@@ -128,6 +128,20 @@ class DLRM {
     return model_loaded_;
   }
 
+  /**
+   * Get the number of dense features expected by the model.
+   */
+  int numDenseFeatures() const {
+    return params_.num_dense_features;
+  }
+
+  /**
+   * Get the number of sparse features expected by the model.
+   */
+  int numSparseFeatures() const {
+    return params_.num_sparse_features;
+  }
+
  private:
   // Use pimpl idiom to hide LibTorch implementation details
   struct Impl;

--- a/packages/feedsim/third_party/src/workloads/ranking/feature_extractors/BitsetExtractor.cpp
+++ b/packages/feedsim/third_party/src/workloads/ranking/feature_extractors/BitsetExtractor.cpp
@@ -1,0 +1,74 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
+#include "BitsetExtractor.h"
+
+#include <cmath>
+
+void BitsetExtractor::initialize(int complexity, int seed) {
+  rng_.seed(seed);
+
+  bitset_size_ = 500 + complexity * 300;
+  checks_per_call_ = 20 + complexity * 20;
+  conversions_per_call_ = 10 + complexity * 10;
+
+  // Initialize bitset with ~70% of bits set
+  feature_flags_.resize(bitset_size_);
+  for (int i = 0; i < bitset_size_; ++i) {
+    feature_flags_[i] = (rng_() % 10) < 7;
+  }
+
+  // Set up features
+  features_.resize(checks_per_call_);
+  for (int i = 0; i < checks_per_call_; ++i) {
+    features_[i].raw_feature_index = i % 25;
+    features_[i].is_indexed = true;
+    features_[i].use_all_indexes = true;
+  }
+}
+
+void BitsetExtractor::extract(
+    const std::vector<float>& input_dense,
+    const std::vector<int64_t>& input_sparse,
+    std::vector<float>& output_dense,
+    std::vector<int64_t>& output_sparse) {
+  int total_sparse = std::min(25, checks_per_call_);
+  example_.resize(0, total_sparse, 0);
+
+  output_dense.clear();
+  output_sparse.clear();
+
+  std::uniform_int_distribution<int> bit_dist(0, bitset_size_ - 1);
+  std::uniform_real_distribution<double> raw_dist(-1e6, 1e6);
+
+  int feat_idx = 0;
+
+  // Phase 1: Random bitset reads + conditional feature yield
+  for (int i = 0; i < checks_per_call_; ++i) {
+    int bit_index = bit_dist(rng_);
+    bool is_requested = feature_flags_[bit_index];
+
+    if (is_requested && feat_idx < static_cast<int>(features_.size())) {
+      // Generate raw double and apply capped type conversion
+      double raw_value = raw_dist(rng_);
+      float val = cappedConvert<float>(raw_value);
+      yieldIndexedFeature(
+          example_, features_[feat_idx], bit_index, val);
+      output_dense.push_back(val);
+      output_sparse.push_back(bit_index);
+      ++feat_idx;
+    }
+  }
+
+  // Phase 2: Additional type conversions (cappedTypeConversion pattern)
+  for (int i = 0; i < conversions_per_call_; ++i) {
+    double raw = raw_dist(rng_);
+    float converted = cappedConvert<float>(raw);
+    // Use the result to prevent optimization
+    if (isFiniteAndNonZero(converted)) {
+      output_dense.push_back(converted);
+    }
+  }
+}

--- a/packages/feedsim/third_party/src/workloads/ranking/feature_extractors/BitsetExtractor.h
+++ b/packages/feedsim/third_party/src/workloads/ranking/feature_extractors/BitsetExtractor.h
@@ -1,0 +1,38 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
+#pragma once
+
+#include <cstdint>
+#include <random>
+#include <string>
+#include <vector>
+
+#include "FeatureExtractorBase.h"
+#include "FeatureTypes.h"
+
+class BitsetExtractor : public FeatureExtractorBase {
+ public:
+  void initialize(int complexity, int seed) override;
+
+  void extract(
+      const std::vector<float>& input_dense,
+      const std::vector<int64_t>& input_sparse,
+      std::vector<float>& output_dense,
+      std::vector<int64_t>& output_sparse) override;
+
+  std::string name() const override {
+    return "BitsetExtractor";
+  }
+
+ private:
+  int bitset_size_ = 2000;
+  int checks_per_call_ = 100;
+  int conversions_per_call_ = 50;
+  std::vector<bool> feature_flags_;
+  std::vector<MockFeature> features_;
+  MockFeatureExample example_;
+  std::mt19937 rng_;
+};

--- a/packages/feedsim/third_party/src/workloads/ranking/feature_extractors/ContainerExtractor.cpp
+++ b/packages/feedsim/third_party/src/workloads/ranking/feature_extractors/ContainerExtractor.cpp
@@ -1,0 +1,88 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
+#include "ContainerExtractor.h"
+
+void ContainerExtractor::initialize(int complexity, int seed) {
+  rng_.seed(seed);
+
+  // Scale with complexity
+  num_small_vectors_ = 10 + complexity * 5;
+  items_per_small_ = 4 + complexity * 2;
+  num_vectors_ = 5 + complexity * 2;
+  items_per_vector_ = 20 + complexity * 10;
+
+  int total_features = num_small_vectors_ + num_vectors_;
+  features_.resize(total_features);
+  for (int i = 0; i < total_features; ++i) {
+    features_[i].raw_feature_index = i % 40;
+    features_[i].is_indexed = true;
+    features_[i].use_all_indexes = true;
+  }
+}
+
+void ContainerExtractor::extract(
+    const std::vector<float>& input_dense,
+    const std::vector<int64_t>& input_sparse,
+    std::vector<float>& output_dense,
+    std::vector<int64_t>& output_sparse) {
+  int total_features = num_small_vectors_ + num_vectors_;
+  example_.resize(0, std::min(40, total_features), 0);
+
+  std::uniform_real_distribution<float> score_dist(0.01f, 5.0f);
+  std::uniform_int_distribution<int64_t> id_dist(1, 1000000);
+
+  int feat_idx = 0;
+
+  // Phase 1: small_vector-like appends (inline then heap)
+  // Using std::vector with small initial sizes to mimic small_vector behavior
+  for (int v = 0; v < num_small_vectors_; ++v) {
+    std::vector<IdScorePair> sv;
+    // Deliberately don't reserve — reallocation is part of the footprint
+    for (int i = 0; i < items_per_small_; ++i) {
+      int64_t id = id_dist(rng_);
+      float score = score_dist(rng_);
+      sv.emplace_back(IdScorePair{id, score});
+    }
+    // Yield collected features through the pipeline
+    if (feat_idx < static_cast<int>(features_.size())) {
+      for (const auto& pair : sv) {
+        yieldIndexedFeature(
+            example_, features_[feat_idx], pair.id, pair.score);
+      }
+    }
+    ++feat_idx;
+  }
+
+  // Phase 2: std::vector appends with natural growth
+  for (int v = 0; v < num_vectors_; ++v) {
+    std::vector<float> collected;
+    // Deliberately don't reserve — let it grow and reallocate
+    for (int i = 0; i < items_per_vector_; ++i) {
+      collected.emplace_back(score_dist(rng_));
+    }
+    // Use accumulated values
+    if (feat_idx < static_cast<int>(features_.size())) {
+      for (size_t i = 0; i < collected.size(); ++i) {
+        yieldIndexedFeature(
+            example_,
+            features_[feat_idx],
+            static_cast<int64_t>(i),
+            collected[i]);
+      }
+    }
+    ++feat_idx;
+  }
+
+  // Copy results to output
+  output_dense.clear();
+  output_sparse.clear();
+  for (const auto& list : example_.idScoreLists) {
+    for (const auto& pair : list) {
+      output_dense.push_back(pair.score);
+      output_sparse.push_back(pair.id);
+    }
+  }
+}

--- a/packages/feedsim/third_party/src/workloads/ranking/feature_extractors/ContainerExtractor.h
+++ b/packages/feedsim/third_party/src/workloads/ranking/feature_extractors/ContainerExtractor.h
@@ -1,0 +1,38 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
+#pragma once
+
+#include <cstdint>
+#include <random>
+#include <string>
+#include <vector>
+
+#include "FeatureExtractorBase.h"
+#include "FeatureTypes.h"
+
+class ContainerExtractor : public FeatureExtractorBase {
+ public:
+  void initialize(int complexity, int seed) override;
+
+  void extract(
+      const std::vector<float>& input_dense,
+      const std::vector<int64_t>& input_sparse,
+      std::vector<float>& output_dense,
+      std::vector<int64_t>& output_sparse) override;
+
+  std::string name() const override {
+    return "ContainerExtractor";
+  }
+
+ private:
+  int num_small_vectors_ = 30;
+  int items_per_small_ = 12;
+  int num_vectors_ = 10;
+  int items_per_vector_ = 50;
+  std::vector<MockFeature> features_;
+  MockFeatureExample example_;
+  std::mt19937 rng_;
+};

--- a/packages/feedsim/third_party/src/workloads/ranking/feature_extractors/EmbeddingLookupExtractor.cpp
+++ b/packages/feedsim/third_party/src/workloads/ranking/feature_extractors/EmbeddingLookupExtractor.cpp
@@ -1,0 +1,70 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
+#include "EmbeddingLookupExtractor.h"
+
+#include <algorithm>
+
+void EmbeddingLookupExtractor::initialize(int complexity, int seed) {
+  rng_.seed(seed);
+
+  // Scale embedding table size with complexity to control cache pressure
+  // complexity 1: 1K rows x 32 dim (~128KB)
+  // complexity 5: 25K rows x 64 dim (~6.4MB, spills L2)
+  // complexity 10: 100K rows x 128 dim (~51MB, spills L3)
+  int num_rows = 1000 * complexity * complexity;
+  embedding_dim_ = 32 + complexity * 10;
+  num_tables_ = std::max(2, complexity / 2);
+  lookups_per_table_ = 10 + complexity * 3;
+
+  embedding_tables_.resize(num_tables_);
+  std::uniform_real_distribution<float> val_dist(-1.0f, 1.0f);
+
+  for (auto& table : embedding_tables_) {
+    table.resize(static_cast<size_t>(num_rows) * embedding_dim_);
+    for (auto& v : table) {
+      v = val_dist(rng_);
+    }
+  }
+}
+
+void EmbeddingLookupExtractor::extract(
+    const std::vector<float>& input_dense,
+    const std::vector<int64_t>& input_sparse,
+    std::vector<float>& output_dense,
+    std::vector<int64_t>& output_sparse) {
+  // Output: accumulated embedding vectors
+  output_dense.assign(embedding_dim_, 0.0f);
+  output_sparse.clear();
+
+  for (int t = 0; t < num_tables_; ++t) {
+    const auto& table = embedding_tables_[t];
+    int num_rows =
+        static_cast<int>(table.size()) / embedding_dim_;
+
+    for (int l = 0; l < lookups_per_table_; ++l) {
+      // Determine row to look up: use input sparse IDs or generate random
+      int64_t row_idx;
+      int sparse_idx = t * lookups_per_table_ + l;
+      if (sparse_idx < static_cast<int>(input_sparse.size())) {
+        row_idx = std::abs(input_sparse[sparse_idx]) % num_rows;
+      } else {
+        std::uniform_int_distribution<int64_t> row_dist(0, num_rows - 1);
+        row_idx = row_dist(rng_);
+      }
+
+      // Random access into the embedding table (cache-unfriendly)
+      const float* row_ptr =
+          table.data() + row_idx * embedding_dim_;
+
+      // Accumulate into output (sum pooling)
+      for (int d = 0; d < embedding_dim_; ++d) {
+        output_dense[d] += row_ptr[d];
+      }
+
+      output_sparse.push_back(row_idx);
+    }
+  }
+}

--- a/packages/feedsim/third_party/src/workloads/ranking/feature_extractors/EmbeddingLookupExtractor.h
+++ b/packages/feedsim/third_party/src/workloads/ranking/feature_extractors/EmbeddingLookupExtractor.h
@@ -1,0 +1,35 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
+#pragma once
+
+#include <cstdint>
+#include <random>
+#include <string>
+#include <vector>
+
+#include "FeatureExtractorBase.h"
+
+class EmbeddingLookupExtractor : public FeatureExtractorBase {
+ public:
+  void initialize(int complexity, int seed) override;
+
+  void extract(
+      const std::vector<float>& input_dense,
+      const std::vector<int64_t>& input_sparse,
+      std::vector<float>& output_dense,
+      std::vector<int64_t>& output_sparse) override;
+
+  std::string name() const override {
+    return "EmbeddingLookupExtractor";
+  }
+
+ private:
+  int num_tables_ = 4;
+  int embedding_dim_ = 64;
+  int lookups_per_table_ = 20;
+  std::vector<std::vector<float>> embedding_tables_;
+  std::mt19937_64 rng_;
+};

--- a/packages/feedsim/third_party/src/workloads/ranking/feature_extractors/FeatureExtractorBase.h
+++ b/packages/feedsim/third_party/src/workloads/ranking/feature_extractors/FeatureExtractorBase.h
@@ -1,0 +1,28 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
+#pragma once
+
+#include <cstdint>
+#include <string>
+#include <vector>
+
+class FeatureExtractorBase {
+ public:
+  virtual ~FeatureExtractorBase() = default;
+
+  // Initialize internal data structures based on complexity (1-10) and seed
+  virtual void initialize(int complexity, int seed) = 0;
+
+  // Run extraction: read from inputs, write to outputs
+  virtual void extract(
+      const std::vector<float>& input_dense,
+      const std::vector<int64_t>& input_sparse,
+      std::vector<float>& output_dense,
+      std::vector<int64_t>& output_sparse) = 0;
+
+  // Human-readable name for logging
+  virtual std::string name() const = 0;
+};

--- a/packages/feedsim/third_party/src/workloads/ranking/feature_extractors/FeatureExtractorSuite.cpp
+++ b/packages/feedsim/third_party/src/workloads/ranking/feature_extractors/FeatureExtractorSuite.cpp
@@ -129,7 +129,9 @@ void FeatureExtractorSuite::initializeFlatDispatch(int seed) {
 void FeatureExtractorSuite::runFlatExtractors(
     int count,
     const std::vector<float>& input_dense,
-    const std::vector<int64_t>& input_sparse) {
+    const std::vector<int64_t>& input_sparse,
+    const uint8_t* story_content,
+    int story_content_length) {
   using namespace dcperf::feature_extractors::generated;
   if (flat_copies_.empty()) return;
 
@@ -145,6 +147,16 @@ void FeatureExtractorSuite::runFlatExtractors(
   ctx.numKeys = static_cast<int>(input_sparse.size());
   ctx.hashTables = flat_hash_tables_;
   ctx.numHashTables = 4;
+  ctx.storyContent = story_content;
+  ctx.storyContentLength = story_content_length;
+
+  // If story content is available, seed structData from it
+  if (story_content && story_content_length > 0) {
+    int len = std::min(story_content_length, flat_struct_size_);
+    for (int i = 0; i < len; ++i) {
+      flat_struct_data_[i] = static_cast<float>(story_content[i]) / 255.0f;
+    }
+  }
 
   for (int i = 0; i < count; ++i) {
     flat_copies_[flat_pos_](&ctx);

--- a/packages/feedsim/third_party/src/workloads/ranking/feature_extractors/FeatureExtractorSuite.cpp
+++ b/packages/feedsim/third_party/src/workloads/ranking/feature_extractors/FeatureExtractorSuite.cpp
@@ -1,0 +1,148 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
+#include "FeatureExtractorSuite.h"
+
+#include <algorithm>
+#include <iostream>
+#include <random>
+
+void FeatureExtractorSuite::addExtractor(
+    std::unique_ptr<FeatureExtractorBase> extractor) {
+  extractors_.push_back(std::move(extractor));
+}
+
+void FeatureExtractorSuite::initializeAll(int complexity, int seed) {
+  for (size_t i = 0; i < extractors_.size(); ++i) {
+    extractors_[i]->initialize(complexity, seed + static_cast<int>(i));
+    std::cout << "  Initialized extractor: " << extractors_[i]->name()
+              << " (complexity=" << complexity << ")" << std::endl;
+  }
+}
+
+void FeatureExtractorSuite::runAll(
+    const std::vector<float>& input_dense,
+    const std::vector<int64_t>& input_sparse) {
+  if (extractors_.empty()) {
+    return;
+  }
+
+  // First extractor reads from input, writes to buf_a
+  dense_buf_a_.clear();
+  sparse_buf_a_.clear();
+  extractors_[0]->extract(
+      input_dense, input_sparse, dense_buf_a_, sparse_buf_a_);
+
+  // Chain remaining extractors, alternating between buf_a and buf_b
+  for (size_t i = 1; i < extractors_.size(); ++i) {
+    if (i % 2 == 1) {
+      dense_buf_b_.clear();
+      sparse_buf_b_.clear();
+      extractors_[i]->extract(
+          dense_buf_a_, sparse_buf_a_, dense_buf_b_, sparse_buf_b_);
+    } else {
+      dense_buf_a_.clear();
+      sparse_buf_a_.clear();
+      extractors_[i]->extract(
+          dense_buf_b_, sparse_buf_b_, dense_buf_a_, sparse_buf_a_);
+    }
+  }
+}
+
+void FeatureExtractorSuite::runRandomSubset(
+    int count,
+    const std::vector<float>& input_dense,
+    const std::vector<int64_t>& input_sparse,
+    std::default_random_engine& rng) {
+  if (extractors_.empty() || count <= 0) {
+    return;
+  }
+
+  int pool_size = static_cast<int>(extractors_.size());
+  std::uniform_int_distribution<int> dist(0, pool_size - 1);
+
+  // First extractor reads from input
+  int idx = dist(rng);
+  dense_buf_a_.clear();
+  sparse_buf_a_.clear();
+  extractors_[idx]->extract(
+      input_dense, input_sparse, dense_buf_a_, sparse_buf_a_);
+
+  // Remaining extractors chain alternating buffers
+  for (int i = 1; i < count; ++i) {
+    idx = dist(rng);
+    if (i % 2 == 1) {
+      dense_buf_b_.clear();
+      sparse_buf_b_.clear();
+      extractors_[idx]->extract(
+          dense_buf_a_, sparse_buf_a_, dense_buf_b_, sparse_buf_b_);
+    } else {
+      dense_buf_a_.clear();
+      sparse_buf_a_.clear();
+      extractors_[idx]->extract(
+          dense_buf_b_, sparse_buf_b_, dense_buf_a_, sparse_buf_a_);
+    }
+  }
+}
+
+size_t FeatureExtractorSuite::size() const {
+  return extractors_.size();
+}
+
+void FeatureExtractorSuite::initializeFlatDispatch(int seed) {
+  using namespace dcperf::feature_extractors::generated;
+  getAllCopyFunctions(flat_copies_);
+  std::mt19937 rng(seed);
+  std::shuffle(flat_copies_.begin(), flat_copies_.end(), rng);
+  flat_pos_ = 0;
+
+  // Initialize shared context data. Use unique_ptr so re-invoking
+  // initializeFlatDispatch() cleanly replaces the previous buffer, and
+  // destruction of the suite frees it.
+  flat_struct_size_ = 512;
+  flat_struct_data_ = std::make_unique<float[]>(flat_struct_size_);
+  std::mt19937 data_rng(seed + 42);
+  std::uniform_real_distribution<float> dist(0.0f, 1.0f);
+  for (int i = 0; i < flat_struct_size_; ++i)
+    flat_struct_data_[i] = dist(data_rng);
+
+  for (int t = 0; t < 4; ++t)
+    for (int i = 0; i < 1024; ++i)
+      flat_tables_[t][data_rng()] = dist(data_rng);
+
+  flat_features_.resize(100);
+  for (int i = 0; i < 100; ++i) {
+    flat_features_[i].raw_feature_index = i % 50;
+    flat_features_[i].is_indexed = true;
+    flat_features_[i].use_all_indexes = true;
+  }
+
+  std::cout << "  Flat dispatch initialized: " << flat_copies_.size()
+            << " copy functions shuffled" << std::endl;
+}
+
+void FeatureExtractorSuite::runFlatExtractors(
+    int count,
+    const std::vector<float>& input_dense,
+    const std::vector<int64_t>& input_sparse) {
+  using namespace dcperf::feature_extractors::generated;
+  if (flat_copies_.empty()) return;
+
+  flat_example_.resize(100, 50, 0);
+  CopyContext ctx;
+  ctx.tables = flat_tables_;
+  ctx.structData = flat_struct_data_.get();
+  ctx.structSize = flat_struct_size_;
+  ctx.example = &flat_example_;
+  ctx.features = flat_features_.data();
+  ctx.numFeatures = static_cast<int>(flat_features_.size());
+  ctx.queryKeys = input_sparse.data();
+  ctx.numKeys = static_cast<int>(input_sparse.size());
+
+  for (int i = 0; i < count; ++i) {
+    flat_copies_[flat_pos_](&ctx);
+    flat_pos_ = (flat_pos_ + 1) % flat_copies_.size();
+  }
+}

--- a/packages/feedsim/third_party/src/workloads/ranking/feature_extractors/FeatureExtractorSuite.cpp
+++ b/packages/feedsim/third_party/src/workloads/ranking/feature_extractors/FeatureExtractorSuite.cpp
@@ -112,6 +112,9 @@ void FeatureExtractorSuite::initializeFlatDispatch(int seed) {
     for (int i = 0; i < 1024; ++i)
       flat_tables_[t][data_rng()] = dist(data_rng);
 
+  for (int t = 0; t < 4; ++t)
+    flat_hash_tables_[t].populate(64, seed + t + 100);
+
   flat_features_.resize(100);
   for (int i = 0; i < 100; ++i) {
     flat_features_[i].raw_feature_index = i % 50;
@@ -140,6 +143,8 @@ void FeatureExtractorSuite::runFlatExtractors(
   ctx.numFeatures = static_cast<int>(flat_features_.size());
   ctx.queryKeys = input_sparse.data();
   ctx.numKeys = static_cast<int>(input_sparse.size());
+  ctx.hashTables = flat_hash_tables_;
+  ctx.numHashTables = 4;
 
   for (int i = 0; i < count; ++i) {
     flat_copies_[flat_pos_](&ctx);

--- a/packages/feedsim/third_party/src/workloads/ranking/feature_extractors/FeatureExtractorSuite.h
+++ b/packages/feedsim/third_party/src/workloads/ranking/feature_extractors/FeatureExtractorSuite.h
@@ -1,0 +1,72 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
+#pragma once
+
+#include <cstdint>
+#include <memory>
+#include <random>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+#include "FeatureExtractorBase.h"
+#include "FeatureTypes.h"
+#include "generated/dispatch.h"
+#include "generated/registry.h"
+
+class FeatureExtractorSuite {
+ public:
+  FeatureExtractorSuite() = default;
+
+  // Add an extractor to the suite
+  void addExtractor(std::unique_ptr<FeatureExtractorBase> extractor);
+
+  // Initialize all extractors with the given complexity and seed
+  void initializeAll(int complexity, int seed);
+
+  // Run all extractors in sequence, chaining outputs to inputs
+  void runAll(
+      const std::vector<float>& input_dense,
+      const std::vector<int64_t>& input_sparse);
+
+  // Run a random subset of extractors (simulating per-story extraction)
+  // Picks 'count' extractors randomly from the pool and runs them
+  void runRandomSubset(
+      int count,
+      const std::vector<float>& input_dense,
+      const std::vector<int64_t>& input_sparse,
+      std::default_random_engine& rng);
+
+  // Get number of registered extractors
+  size_t size() const;
+
+  // Initialize flat copy dispatch: collects all copy functions, shuffles them
+  void initializeFlatDispatch(int seed);
+
+  // Run N sequential copy functions from the shuffled flat vector
+  void runFlatExtractors(
+      int count,
+      const std::vector<float>& input_dense,
+      const std::vector<int64_t>& input_sparse);
+
+ private:
+  std::vector<std::unique_ptr<FeatureExtractorBase>> extractors_;
+
+  // Intermediate buffers for chaining extractors
+  std::vector<float> dense_buf_a_;
+  std::vector<float> dense_buf_b_;
+  std::vector<int64_t> sparse_buf_a_;
+  std::vector<int64_t> sparse_buf_b_;
+
+  // Flat dispatch state
+  std::vector<dcperf::feature_extractors::generated::CopyFn> flat_copies_;
+  size_t flat_pos_ = 0;
+  std::unique_ptr<float[]> flat_struct_data_;
+  int flat_struct_size_ = 0;
+  std::unordered_map<int64_t, float> flat_tables_[4];
+  MockFeatureExample flat_example_;
+  std::vector<MockFeature> flat_features_;
+};

--- a/packages/feedsim/third_party/src/workloads/ranking/feature_extractors/FeatureExtractorSuite.h
+++ b/packages/feedsim/third_party/src/workloads/ranking/feature_extractors/FeatureExtractorSuite.h
@@ -48,10 +48,14 @@ class FeatureExtractorSuite {
   void initializeFlatDispatch(int seed);
 
   // Run N sequential copy functions from the shuffled flat vector
+  // Optional story content is passed through to CopyContext for
+  // data-dependent feature extraction using Silesia corpus data.
   void runFlatExtractors(
       int count,
       const std::vector<float>& input_dense,
-      const std::vector<int64_t>& input_sparse);
+      const std::vector<int64_t>& input_sparse,
+      const uint8_t* story_content = nullptr,
+      int story_content_length = 0);
 
  private:
   std::vector<std::unique_ptr<FeatureExtractorBase>> extractors_;

--- a/packages/feedsim/third_party/src/workloads/ranking/feature_extractors/FeatureExtractorSuite.h
+++ b/packages/feedsim/third_party/src/workloads/ranking/feature_extractors/FeatureExtractorSuite.h
@@ -15,6 +15,7 @@
 #include "FeatureExtractorBase.h"
 #include "FeatureTypes.h"
 #include "generated/dispatch.h"
+#include "generated/mock_hash_table.h"
 #include "generated/registry.h"
 
 class FeatureExtractorSuite {
@@ -67,6 +68,7 @@ class FeatureExtractorSuite {
   std::unique_ptr<float[]> flat_struct_data_;
   int flat_struct_size_ = 0;
   std::unordered_map<int64_t, float> flat_tables_[4];
+  dcperf::mock_hash::MockHashTable flat_hash_tables_[4];
   MockFeatureExample flat_example_;
   std::vector<MockFeature> flat_features_;
 };

--- a/packages/feedsim/third_party/src/workloads/ranking/feature_extractors/FeatureLayoutExtractor.cpp
+++ b/packages/feedsim/third_party/src/workloads/ranking/feature_extractors/FeatureLayoutExtractor.cpp
@@ -1,0 +1,82 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
+#include "FeatureLayoutExtractor.h"
+
+void FeatureLayoutExtractor::initialize(int complexity, int seed) {
+  rng_.seed(seed);
+
+  // Scale with complexity
+  num_dense_ = 200 + complexity * 100;
+  num_remapped_ = 50 + complexity * 40;
+  int num_sparse = 10 + complexity * 10;
+  int sparse_remap_count = 5 + complexity * 5;
+
+  // Build dense remap table with randomized (to, from) pairs
+  std::uniform_int_distribution<int> dense_dist(0, num_dense_ - 1);
+  dense_remap_.resize(num_remapped_);
+  for (auto& [to, from] : dense_remap_) {
+    to = dense_dist(rng_);
+    from = dense_dist(rng_);
+  }
+
+  // Build sparse remap table
+  std::uniform_int_distribution<int> sparse_dist(0, num_sparse - 1);
+  sparse_remap_.resize(sparse_remap_count);
+  for (auto& [to, from] : sparse_remap_) {
+    to = sparse_dist(rng_);
+    from = sparse_dist(rng_);
+  }
+
+  // Pre-fill cache example with random values
+  cache_example_.denseValues.resize(num_dense_);
+  std::uniform_real_distribution<float> val_dist(0.01f, 10.0f);
+  for (auto& v : cache_example_.denseValues) {
+    v = val_dist(rng_);
+  }
+
+  cache_example_.idScoreLists.resize(num_sparse);
+  std::uniform_int_distribution<int64_t> id_dist(0, 1000000);
+  for (auto& list : cache_example_.idScoreLists) {
+    int list_size = 1 + (rng_() % 5);
+    for (int i = 0; i < list_size; ++i) {
+      list.emplace_back(IdScorePair{id_dist(rng_), val_dist(rng_)});
+    }
+  }
+}
+
+void FeatureLayoutExtractor::extract(
+    const std::vector<float>& input_dense,
+    const std::vector<int64_t>& input_sparse,
+    std::vector<float>& output_dense,
+    std::vector<int64_t>& output_sparse) {
+  // Prepare output arrays sized to match the cache
+  output_dense.assign(num_dense_, 0.0f);
+
+  // Dense copy with indirect indexing (strided scatter pattern)
+  float* local = output_dense.data();
+  const float* cache = cache_example_.denseValues.data();
+  for (const auto& [to, from] : dense_remap_) {
+    local[to] = cache[from];
+  }
+
+  // Also copy from input if available
+  int copy_count =
+      std::min(static_cast<int>(input_dense.size()), num_dense_);
+  for (int i = 0; i < copy_count; ++i) {
+    int dst = dense_remap_[i % dense_remap_.size()].first;
+    output_dense[dst] += input_dense[i];
+  }
+
+  // Sparse copy via vector assignment
+  output_sparse.clear();
+  for (const auto& [to, from] : sparse_remap_) {
+    if (from < static_cast<int>(cache_example_.idScoreLists.size())) {
+      for (const auto& pair : cache_example_.idScoreLists[from]) {
+        output_sparse.push_back(pair.id);
+      }
+    }
+  }
+}

--- a/packages/feedsim/third_party/src/workloads/ranking/feature_extractors/FeatureLayoutExtractor.h
+++ b/packages/feedsim/third_party/src/workloads/ranking/feature_extractors/FeatureLayoutExtractor.h
@@ -1,0 +1,38 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
+#pragma once
+
+#include <cstdint>
+#include <random>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "FeatureExtractorBase.h"
+#include "FeatureTypes.h"
+
+class FeatureLayoutExtractor : public FeatureExtractorBase {
+ public:
+  void initialize(int complexity, int seed) override;
+
+  void extract(
+      const std::vector<float>& input_dense,
+      const std::vector<int64_t>& input_sparse,
+      std::vector<float>& output_dense,
+      std::vector<int64_t>& output_sparse) override;
+
+  std::string name() const override {
+    return "FeatureLayoutExtractor";
+  }
+
+ private:
+  int num_dense_ = 500;
+  int num_remapped_ = 200;
+  std::vector<std::pair<int, int>> dense_remap_;
+  std::vector<std::pair<int, int>> sparse_remap_;
+  MockFeatureExample cache_example_;
+  std::mt19937 rng_;
+};

--- a/packages/feedsim/third_party/src/workloads/ranking/feature_extractors/FeatureTypes.h
+++ b/packages/feedsim/third_party/src/workloads/ranking/feature_extractors/FeatureTypes.h
@@ -1,0 +1,83 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
+#pragma once
+
+#include <cmath>
+#include <cstdint>
+#include <limits>
+#include <vector>
+
+// Simplified feature metadata
+struct MockFeature {
+  int32_t raw_feature_index = -1;
+  bool is_indexed = true;
+  bool use_all_indexes = true;
+};
+
+// Output pair for sparse features
+struct IdScorePair {
+  int64_t id;
+  float score;
+};
+
+// Feature example buffer filled during extraction
+struct MockFeatureExample {
+  std::vector<float> denseValues;
+  std::vector<std::vector<IdScorePair>> idScoreLists;
+  std::vector<int64_t> intValues;
+
+  void resize(int numDense, int numSparse, int numInt) {
+    denseValues.assign(numDense, 0.0f);
+    idScoreLists.resize(numSparse);
+    for (auto& v : idScoreLists) {
+      v.clear();
+    }
+    intValues.assign(numInt, 0);
+  }
+};
+
+// Float validation matching production's FloatUtils::isFiniteAndNonZero
+inline bool isFiniteAndNonZero(float val) {
+  return val != 0.0f && std::isfinite(val);
+}
+
+// 3-level yield pipeline matching production dispatch overhead
+inline void consumeIndexedFeature(
+    MockFeatureExample& example,
+    const MockFeature& feature,
+    int64_t index,
+    float val) {
+  int32_t idx = feature.raw_feature_index;
+  if (feature.use_all_indexes && idx >= 0 &&
+      idx < static_cast<int32_t>(example.idScoreLists.size())) {
+    example.idScoreLists[idx].emplace_back(IdScorePair{index, val});
+  }
+}
+
+inline void yieldIndexedFeature(
+    MockFeatureExample& example,
+    const MockFeature& feature,
+    int64_t index,
+    float val) {
+  if (__builtin_expect(isFiniteAndNonZero(val), 1)) {
+    if (feature.raw_feature_index == -1) {
+      return;
+    }
+    consumeIndexedFeature(example, feature, index, val);
+  }
+}
+
+// Capped type conversion matching production's cappedTypeConversion
+template <typename Tgt, typename Src>
+inline Tgt cappedConvert(Src val) {
+  if (val > static_cast<Src>(std::numeric_limits<Tgt>::max())) {
+    return std::numeric_limits<Tgt>::max();
+  }
+  if (val < static_cast<Src>(std::numeric_limits<Tgt>::lowest())) {
+    return std::numeric_limits<Tgt>::lowest();
+  }
+  return static_cast<Tgt>(val);
+}

--- a/packages/feedsim/third_party/src/workloads/ranking/feature_extractors/HashLookupExtractor.cpp
+++ b/packages/feedsim/third_party/src/workloads/ranking/feature_extractors/HashLookupExtractor.cpp
@@ -1,0 +1,84 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
+#include "HashLookupExtractor.h"
+
+void HashLookupExtractor::initialize(int complexity, int seed) {
+  rng_.seed(seed);
+
+  // Scale table size with complexity to control cache pressure
+  // complexity 1: 1K entries (~16KB, fits L1)
+  // complexity 5: 50K entries (~800KB, spills L2)
+  // complexity 10: 500K entries (~8MB, spills L3 on some CPUs)
+  int table_size = 1000 * complexity * complexity;
+  num_tables_ = std::max(2, complexity);
+  lookups_per_table_ = 10 + complexity * 4;
+
+  tables_.resize(num_tables_);
+  std::uniform_real_distribution<float> val_dist(0.01f, 100.0f);
+
+  for (auto& table : tables_) {
+    table.reserve(table_size);
+    for (int i = 0; i < table_size; ++i) {
+      int64_t key = static_cast<int64_t>(i) * 7 + seed;
+      table[key] = val_dist(rng_);
+    }
+  }
+
+  // Set up features for yield pipeline
+  int total_features = num_tables_ * lookups_per_table_;
+  features_.resize(total_features);
+  for (int i = 0; i < total_features; ++i) {
+    features_[i].raw_feature_index = i % 50;
+    features_[i].is_indexed = true;
+    features_[i].use_all_indexes = true;
+  }
+}
+
+void HashLookupExtractor::extract(
+    const std::vector<float>& input_dense,
+    const std::vector<int64_t>& input_sparse,
+    std::vector<float>& output_dense,
+    std::vector<int64_t>& output_sparse) {
+  int total_features = num_tables_ * lookups_per_table_;
+  example_.resize(
+      static_cast<int>(input_dense.size()),
+      std::min(50, total_features),
+      0);
+
+  // Generate query keys from input sparse features
+  std::vector<int64_t> query_keys;
+  if (!input_sparse.empty()) {
+    query_keys = input_sparse;
+  } else {
+    query_keys.resize(lookups_per_table_);
+    std::uniform_int_distribution<int64_t> key_dist(0, 1000000);
+    for (auto& k : query_keys) {
+      k = key_dist(rng_);
+    }
+  }
+
+  int feat_idx = 0;
+  for (const auto& table : tables_) {
+    for (int i = 0; i < lookups_per_table_; ++i) {
+      int64_t key = query_keys[i % query_keys.size()];
+      auto it = table.find(key);
+      float val = (it != table.end()) ? it->second : 0.0f;
+      if (feat_idx < static_cast<int>(features_.size())) {
+        yieldIndexedFeature(example_, features_[feat_idx], key, val);
+      }
+      ++feat_idx;
+    }
+  }
+
+  // Copy results to output vectors
+  output_dense = example_.denseValues;
+  output_sparse.clear();
+  for (const auto& list : example_.idScoreLists) {
+    for (const auto& pair : list) {
+      output_sparse.push_back(pair.id);
+    }
+  }
+}

--- a/packages/feedsim/third_party/src/workloads/ranking/feature_extractors/HashLookupExtractor.h
+++ b/packages/feedsim/third_party/src/workloads/ranking/feature_extractors/HashLookupExtractor.h
@@ -1,0 +1,38 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
+#pragma once
+
+#include <cstdint>
+#include <random>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+#include "FeatureExtractorBase.h"
+#include "FeatureTypes.h"
+
+class HashLookupExtractor : public FeatureExtractorBase {
+ public:
+  void initialize(int complexity, int seed) override;
+
+  void extract(
+      const std::vector<float>& input_dense,
+      const std::vector<int64_t>& input_sparse,
+      std::vector<float>& output_dense,
+      std::vector<int64_t>& output_sparse) override;
+
+  std::string name() const override {
+    return "HashLookupExtractor";
+  }
+
+ private:
+  int num_tables_ = 5;
+  int lookups_per_table_ = 20;
+  std::vector<std::unordered_map<int64_t, float>> tables_;
+  std::vector<MockFeature> features_;
+  MockFeatureExample example_;
+  std::mt19937_64 rng_;
+};

--- a/packages/feedsim/third_party/src/workloads/ranking/feature_extractors/TreeTraversalExtractor.cpp
+++ b/packages/feedsim/third_party/src/workloads/ranking/feature_extractors/TreeTraversalExtractor.cpp
@@ -1,0 +1,59 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
+#include "TreeTraversalExtractor.h"
+
+void TreeTraversalExtractor::initialize(int complexity, int seed) {
+  std::mt19937_64 rng(seed);
+
+  // Scale map size and count with complexity
+  int map_size = 100 + complexity * 100;
+  maps_per_call_ = std::max(1, complexity / 3);
+
+  maps_.resize(maps_per_call_);
+  std::uniform_int_distribution<int64_t> key_dist(0, 10000000);
+  std::uniform_real_distribution<float> val_dist(0.01f, 50.0f);
+
+  for (auto& map : maps_) {
+    for (int i = 0; i < map_size; ++i) {
+      map[key_dist(rng)] = val_dist(rng);
+    }
+  }
+
+  // Set up features
+  int total_features = maps_per_call_ * map_size;
+  features_.resize(total_features);
+  for (int i = 0; i < total_features; ++i) {
+    features_[i].raw_feature_index = i % 30;
+    features_[i].is_indexed = true;
+    features_[i].use_all_indexes = true;
+  }
+}
+
+void TreeTraversalExtractor::extract(
+    const std::vector<float>& input_dense,
+    const std::vector<int64_t>& input_sparse,
+    std::vector<float>& output_dense,
+    std::vector<int64_t>& output_sparse) {
+  int total_sparse = std::min(30, static_cast<int>(features_.size()));
+  example_.resize(0, total_sparse, 0);
+
+  output_dense.clear();
+  output_sparse.clear();
+
+  int feat_idx = 0;
+  for (const auto& map : maps_) {
+    // Full ordered traversal — each iterator increment follows
+    // parent/child pointers through the red-black tree (poor spatial locality)
+    for (const auto& [key, value] : map) {
+      if (feat_idx < static_cast<int>(features_.size())) {
+        yieldIndexedFeature(example_, features_[feat_idx], key, value);
+      }
+      output_dense.push_back(value);
+      output_sparse.push_back(key);
+      ++feat_idx;
+    }
+  }
+}

--- a/packages/feedsim/third_party/src/workloads/ranking/feature_extractors/TreeTraversalExtractor.h
+++ b/packages/feedsim/third_party/src/workloads/ranking/feature_extractors/TreeTraversalExtractor.h
@@ -1,0 +1,36 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
+#pragma once
+
+#include <cstdint>
+#include <map>
+#include <random>
+#include <string>
+#include <vector>
+
+#include "FeatureExtractorBase.h"
+#include "FeatureTypes.h"
+
+class TreeTraversalExtractor : public FeatureExtractorBase {
+ public:
+  void initialize(int complexity, int seed) override;
+
+  void extract(
+      const std::vector<float>& input_dense,
+      const std::vector<int64_t>& input_sparse,
+      std::vector<float>& output_dense,
+      std::vector<int64_t>& output_sparse) override;
+
+  std::string name() const override {
+    return "TreeTraversalExtractor";
+  }
+
+ private:
+  int maps_per_call_ = 2;
+  std::vector<std::map<int64_t, float>> maps_;
+  std::vector<MockFeature> features_;
+  MockFeatureExample example_;
+};

--- a/packages/feedsim/third_party/src/workloads/ranking/feature_extractors/generated/archetype_templates/ArchetypeBase.h
+++ b/packages/feedsim/third_party/src/workloads/ranking/feature_extractors/generated/archetype_templates/ArchetypeBase.h
@@ -1,0 +1,88 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
+#pragma once
+
+#include "../../FeatureExtractorBase.h"
+#include "../../FeatureTypes.h"
+#include "ArchetypeUtils.h"
+#include <algorithm>
+#include <vector>
+
+namespace dcperf {
+namespace feature_extractors {
+namespace generated {
+
+// Adapter between FeatureExtractorBase (4-vector interface) and the archetype
+// internal interface (MockFeatureExample + MockFeature). Archetypes override
+// initializeImpl/extractImpl with their template-parameterized logic.
+class ArchetypeBase : public FeatureExtractorBase {
+ public:
+  // No-op: registry.cpp calls Derived::setName() but names are now
+  // returned directly from name() overrides in each archetype.
+  static void setName(const char*) {}
+
+  void initialize(int complexity, int seed) override {
+    initializeImpl(complexity + seed);
+
+    // Set up internal feature metadata
+    int numFeatures = 50 + complexity * 10;
+    features_.resize(numFeatures);
+    for (int i = 0; i < numFeatures; ++i) {
+      features_[i].raw_feature_index = i % numFeatures;
+      features_[i].is_indexed = true;
+      features_[i].use_all_indexes = true;
+    }
+  }
+
+  void extract(
+      const std::vector<float>& input_dense,
+      const std::vector<int64_t>& input_sparse,
+      std::vector<float>& output_dense,
+      std::vector<int64_t>& output_sparse) override {
+    int numFeatures = static_cast<int>(features_.size());
+    example_.resize(
+        std::max(numFeatures, static_cast<int>(input_dense.size())),
+        std::min(50, numFeatures),
+        0);
+
+    // Use input_sparse as query keys, or generate some
+    std::vector<int64_t> queryKeys;
+    if (!input_sparse.empty()) {
+      queryKeys = input_sparse;
+    } else {
+      queryKeys.resize(20);
+      uint64_t state = 42;
+      for (auto& k : queryKeys) {
+        k = randomInt64(state);
+      }
+    }
+
+    extractImpl(example_, features_, queryKeys);
+
+    // Copy results to output vectors
+    output_dense = example_.denseValues;
+    output_sparse.clear();
+    for (const auto& list : example_.idScoreLists) {
+      for (const auto& pair : list) {
+        output_sparse.push_back(pair.id);
+      }
+    }
+  }
+
+  virtual void initializeImpl(int complexity) = 0;
+  virtual void extractImpl(
+      MockFeatureExample& example,
+      const std::vector<MockFeature>& features,
+      const std::vector<int64_t>& queryKeys) = 0;
+
+ protected:
+  MockFeatureExample example_;
+  std::vector<MockFeature> features_;
+};
+
+} // namespace generated
+} // namespace feature_extractors
+} // namespace dcperf

--- a/packages/feedsim/third_party/src/workloads/ranking/feature_extractors/generated/archetype_templates/ArchetypeUtils.h
+++ b/packages/feedsim/third_party/src/workloads/ranking/feature_extractors/generated/archetype_templates/ArchetypeUtils.h
@@ -1,0 +1,45 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
+#pragma once
+
+#include "../../FeatureTypes.h"
+#include <cstdint>
+
+namespace dcperf {
+namespace feature_extractors {
+namespace generated {
+
+// splitmix64 PRNG for deterministic initialization
+inline uint64_t splitmix64(uint64_t& state) {
+  state += 0x9e3779b97f4a7c15ULL;
+  uint64_t z = state;
+  z = (z ^ (z >> 30)) * 0xbf58476d1ce4e5b9ULL;
+  z = (z ^ (z >> 27)) * 0x94d049bb133111ebULL;
+  return z ^ (z >> 31);
+}
+
+inline int64_t randomInt64(uint64_t& state) {
+  return static_cast<int64_t>(splitmix64(state));
+}
+
+inline float randomFloat(uint64_t& state) {
+  return static_cast<float>(splitmix64(state) & 0xFFFFFF) / 16777216.0f;
+}
+
+// Scalar feature yield (stores as dense value)
+inline void yieldScalarFeature(
+    MockFeatureExample& example,
+    const MockFeature& feature,
+    float val) {
+  int32_t idx = feature.raw_feature_index;
+  if (idx >= 0 && idx < static_cast<int32_t>(example.denseValues.size())) {
+    example.denseValues[idx] = val;
+  }
+}
+
+} // namespace generated
+} // namespace feature_extractors
+} // namespace dcperf

--- a/packages/feedsim/third_party/src/workloads/ranking/feature_extractors/generated/archetype_templates/BitsetFlagArchetype.h
+++ b/packages/feedsim/third_party/src/workloads/ranking/feature_extractors/generated/archetype_templates/BitsetFlagArchetype.h
@@ -1,0 +1,75 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
+#pragma once
+
+#include "ArchetypeBase.h"
+#include <array>
+#include <vector>
+
+namespace dcperf {
+namespace feature_extractors {
+namespace generated {
+
+template <
+    int BitsetSizeLog2,
+    int ChecksPerStory,
+    int HasTypeConversion,
+    int ConversionCount>
+class BitsetFlagArchetype : public ArchetypeBase {
+  static constexpr int kBitsetSize = 1 << BitsetSizeLog2;
+  static constexpr int kWords = (kBitsetSize + 63) / 64;
+  static constexpr uint64_t kSeed =
+      BitsetSizeLog2 * 10000ULL + ChecksPerStory * 10ULL +
+      HasTypeConversion * 3ULL + ConversionCount;
+
+ public:
+  void initializeImpl(int complexity) override {
+    uint64_t state = kSeed + complexity;
+    for (int w = 0; w < kWords; ++w) {
+      bitWords_[w] = splitmix64(state);
+    }
+    for (int i = 0; i < ChecksPerStory; ++i) {
+      checkIndices_[i] = splitmix64(state) % kBitsetSize;
+    }
+    for (int i = 0; i < kBitsetSize; ++i) {
+      values_[i] = randomFloat(state) * 100.0 - 50.0;
+    }
+  }
+
+  __attribute__((noinline)) void extractImpl(
+      MockFeatureExample& example,
+      const std::vector<MockFeature>& features,
+      const std::vector<int64_t>& queryKeys) override {
+    int featIdx = 0;
+    for (int c = 0; c < ChecksPerStory && featIdx < static_cast<int>(features.size()); ++c) {
+      int bitIdx = checkIndices_[c];
+      bool isSet = (bitWords_[bitIdx / 64] >> (bitIdx % 64)) & 1;
+      if (!isSet) continue;
+
+      double rawVal = values_[bitIdx];
+      float val;
+      if constexpr (HasTypeConversion) {
+        val = cappedConvert<float>(rawVal);
+      } else {
+        val = static_cast<float>(rawVal);
+      }
+      yieldIndexedFeature(
+          example, features[featIdx], bitIdx, val);
+      ++featIdx;
+    }
+  }
+
+  std::string name() const override { return "BitsetFlagVariant"; }
+
+ private:
+  std::array<uint64_t, kWords> bitWords_{};
+  std::array<int, ChecksPerStory> checkIndices_{};
+  std::array<double, kBitsetSize> values_{};
+};
+
+} // namespace generated
+} // namespace feature_extractors
+} // namespace dcperf

--- a/packages/feedsim/third_party/src/workloads/ranking/feature_extractors/generated/archetype_templates/ContainerCollectArchetype.h
+++ b/packages/feedsim/third_party/src/workloads/ranking/feature_extractors/generated/archetype_templates/ContainerCollectArchetype.h
@@ -1,0 +1,97 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
+#pragma once
+
+#include "ArchetypeBase.h"
+#include <vector>
+
+namespace dcperf {
+namespace feature_extractors {
+namespace generated {
+
+template <
+    int InlineSize,
+    int ItemsPerCollection,
+    int NumCollections,
+    int HasDedup,
+    int GrowthPattern>
+class ContainerCollectArchetype : public ArchetypeBase {
+  static constexpr uint64_t kSeed =
+      InlineSize * 10000ULL + ItemsPerCollection * 100ULL +
+      NumCollections * 10ULL + HasDedup * 3ULL + GrowthPattern;
+
+ public:
+  void initializeImpl(int complexity) override {
+    uint64_t state = kSeed + complexity;
+    for (int c = 0; c < NumCollections; ++c) {
+      for (int i = 0; i < ItemsPerCollection; ++i) {
+        srcIds_[c * ItemsPerCollection + i] = randomInt64(state);
+        srcScores_[c * ItemsPerCollection + i] = randomFloat(state);
+      }
+    }
+  }
+
+  __attribute__((noinline)) void extractImpl(
+      MockFeatureExample& example,
+      const std::vector<MockFeature>& features,
+      const std::vector<int64_t>& queryKeys) override {
+    int featIdx = 0;
+    for (int c = 0; c < NumCollections && featIdx < static_cast<int>(features.size()); ++c) {
+      std::vector<IdScorePair> collected;
+      collectItems(collected, c);
+
+      for (const auto& pair : collected) {
+        if (featIdx >= static_cast<int>(features.size())) break;
+        yieldIndexedFeature(
+            example, features[featIdx], pair.id, pair.score);
+      }
+      ++featIdx;
+    }
+  }
+
+  std::string name() const override { return "ContainerCollectVariant"; }
+
+ private:
+  __attribute__((noinline)) void
+  collectItems(std::vector<IdScorePair>& out, int collIdx) {
+    int base = collIdx * ItemsPerCollection;
+    if constexpr (GrowthPattern == 0) {
+      for (int i = 0; i < ItemsPerCollection; ++i) {
+        out.emplace_back(
+            IdScorePair{srcIds_[base + i], srcScores_[base + i]});
+      }
+    } else if constexpr (GrowthPattern == 1) {
+      for (int i = 0; i < ItemsPerCollection; ++i) {
+        if (srcScores_[base + i] > 0.2f) {
+          out.emplace_back(
+              IdScorePair{srcIds_[base + i], srcScores_[base + i]});
+        }
+      }
+    } else {
+      for (int i = 0; i < ItemsPerCollection; ++i) {
+        float score = srcScores_[base + i];
+        if (score > 0.1f && score < 0.9f) {
+          int64_t id = srcIds_[base + i];
+          if constexpr (HasDedup) {
+            bool dup = false;
+            for (const auto& p : out) {
+              if (p.id == id) { dup = true; break; }
+            }
+            if (dup) continue;
+          }
+          out.emplace_back(IdScorePair{id, score});
+        }
+      }
+    }
+  }
+
+  std::array<int64_t, ItemsPerCollection * NumCollections> srcIds_{};
+  std::array<float, ItemsPerCollection * NumCollections> srcScores_{};
+};
+
+} // namespace generated
+} // namespace feature_extractors
+} // namespace dcperf

--- a/packages/feedsim/third_party/src/workloads/ranking/feature_extractors/generated/archetype_templates/DataProviderArchetype.h
+++ b/packages/feedsim/third_party/src/workloads/ranking/feature_extractors/generated/archetype_templates/DataProviderArchetype.h
@@ -1,0 +1,104 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
+#pragma once
+
+#include "ArchetypeBase.h"
+#include <array>
+#include <cstring>
+
+namespace dcperf {
+namespace feature_extractors {
+namespace generated {
+
+template <
+    int NumFields,
+    int NumBranches,
+    int FieldTypeSet,
+    int DataSource,
+    int HasCrossFeatures>
+class DataProviderArchetype : public ArchetypeBase {
+  static constexpr int kTotalFields =
+      NumFields + (HasCrossFeatures ? NumFields / 2 : 0);
+  static constexpr uint64_t kSeed =
+      NumFields * 10000ULL + NumBranches * 1000ULL + FieldTypeSet * 100ULL +
+      DataSource * 10ULL + HasCrossFeatures;
+  static constexpr int kStructSize = 64 + DataSource * 32;
+
+ public:
+  void initializeImpl(int complexity) override {
+    uint64_t state = kSeed + complexity;
+    for (int i = 0; i < kStructSize; ++i) {
+      structData_[i] = randomFloat(state);
+    }
+    for (int i = 0; i < NumFields; ++i) {
+      fieldOffsets_[i] = static_cast<int>(splitmix64(state) % kStructSize);
+      fieldValid_[i] = (splitmix64(state) % 10) > 2;
+    }
+  }
+
+  __attribute__((noinline)) void extractImpl(
+      MockFeatureExample& example,
+      const std::vector<MockFeature>& features,
+      const std::vector<int64_t>& queryKeys) override {
+    int featIdx = 0;
+    for (int f = 0; f < NumFields && featIdx < static_cast<int>(features.size()); ++f) {
+      bool valid = true;
+      for (int b = 0; b < NumBranches; ++b) {
+        if (!fieldValid_[(f + b) % NumFields]) {
+          valid = false;
+          break;
+        }
+      }
+      if (valid) {
+        float val = readField(f);
+        yieldScalarFeature(example, features[featIdx], val);
+      }
+      ++featIdx;
+    }
+
+    if constexpr (HasCrossFeatures) {
+      computeCrossFeatures(example, features, featIdx);
+    }
+  }
+
+  std::string name() const override { return "DataProviderVariant"; }
+
+ private:
+  __attribute__((noinline)) float readField(int fieldIdx) const {
+    float raw = structData_[fieldOffsets_[fieldIdx]];
+    if constexpr (FieldTypeSet == 0) {
+      return raw;
+    } else if constexpr (FieldTypeSet == 1) {
+      return raw > 0.5f ? 1.0f : 0.0f;
+    } else if constexpr (FieldTypeSet == 2) {
+      return static_cast<float>(static_cast<int>(raw * 10.0f));
+    } else {
+      if (fieldIdx & 1) return raw;
+      return static_cast<float>(static_cast<int>(raw * 100.0f)) / 100.0f;
+    }
+  }
+
+  __attribute__((noinline)) void computeCrossFeatures(
+      MockFeatureExample& example,
+      const std::vector<MockFeature>& features,
+      int& featIdx) {
+    for (int i = 0; i < NumFields / 2 && featIdx < static_cast<int>(features.size()); ++i) {
+      float v1 = structData_[fieldOffsets_[i]];
+      float v2 = structData_[fieldOffsets_[(i + 1) % NumFields]];
+      float cross = v1 * v2;
+      yieldScalarFeature(example, features[featIdx], cross);
+      ++featIdx;
+    }
+  }
+
+  std::array<float, kStructSize> structData_{};
+  std::array<int, NumFields> fieldOffsets_{};
+  std::array<bool, NumFields> fieldValid_{};
+};
+
+} // namespace generated
+} // namespace feature_extractors
+} // namespace dcperf

--- a/packages/feedsim/third_party/src/workloads/ranking/feature_extractors/generated/archetype_templates/EmbeddingDotProductArchetype.h
+++ b/packages/feedsim/third_party/src/workloads/ranking/feature_extractors/generated/archetype_templates/EmbeddingDotProductArchetype.h
@@ -1,0 +1,96 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
+#pragma once
+
+#include "ArchetypeBase.h"
+#include <array>
+#include <cmath>
+
+namespace dcperf {
+namespace feature_extractors {
+namespace generated {
+
+template <
+    int EmbeddingDim,
+    int NumEmbeddings,
+    int IsSparse,
+    int YieldDimensions,
+    int SimilarityType>
+class EmbeddingDotProductArchetype : public ArchetypeBase {
+  static constexpr uint64_t kSeed =
+      EmbeddingDim * 10000ULL + NumEmbeddings * 100ULL + IsSparse * 10ULL +
+      YieldDimensions * 3ULL + SimilarityType;
+
+ public:
+  void initializeImpl(int complexity) override {
+    uint64_t state = kSeed + complexity;
+    for (int e = 0; e < NumEmbeddings; ++e) {
+      for (int d = 0; d < EmbeddingDim; ++d) {
+        queryVecs_[e * EmbeddingDim + d] = randomFloat(state) - 0.5f;
+        docVecs_[e * EmbeddingDim + d] = randomFloat(state) - 0.5f;
+      }
+    }
+  }
+
+  __attribute__((noinline)) void extractImpl(
+      MockFeatureExample& example,
+      const std::vector<MockFeature>& features,
+      const std::vector<int64_t>& queryKeys) override {
+    int featIdx = 0;
+    for (int e = 0; e < NumEmbeddings && featIdx < static_cast<int>(features.size()); ++e) {
+      float score = computeSimilarity(e);
+      yieldScalarFeature(example, features[featIdx], score);
+      ++featIdx;
+
+      if constexpr (YieldDimensions) {
+        for (int d = 0; d < EmbeddingDim && featIdx < static_cast<int>(features.size()); ++d) {
+          float dimVal = queryVecs_[e * EmbeddingDim + d];
+          yieldIndexedFeature(example, features[featIdx], d, dimVal);
+        }
+        ++featIdx;
+      }
+    }
+  }
+
+  std::string name() const override { return "EmbeddingVariant"; }
+
+ private:
+  __attribute__((noinline)) float computeSimilarity(int embIdx) const {
+    const float* q = &queryVecs_[embIdx * EmbeddingDim];
+    const float* d = &docVecs_[embIdx * EmbeddingDim];
+
+    if constexpr (SimilarityType == 0) {
+      float dot = 0.0f;
+      for (int i = 0; i < EmbeddingDim; ++i) {
+        dot += q[i] * d[i];
+      }
+      return dot;
+    } else if constexpr (SimilarityType == 1) {
+      float dot = 0.0f, normQ = 0.0f, normD = 0.0f;
+      for (int i = 0; i < EmbeddingDim; ++i) {
+        dot += q[i] * d[i];
+        normQ += q[i] * q[i];
+        normD += d[i] * d[i];
+      }
+      float denom = std::sqrt(normQ * normD);
+      return denom > 1e-8f ? dot / denom : 0.0f;
+    } else {
+      float dist = 0.0f;
+      for (int i = 0; i < EmbeddingDim; ++i) {
+        float diff = q[i] - d[i];
+        dist += diff * diff;
+      }
+      return 1.0f / (1.0f + std::sqrt(dist));
+    }
+  }
+
+  std::array<float, EmbeddingDim * NumEmbeddings> queryVecs_{};
+  std::array<float, EmbeddingDim * NumEmbeddings> docVecs_{};
+};
+
+} // namespace generated
+} // namespace feature_extractors
+} // namespace dcperf

--- a/packages/feedsim/third_party/src/workloads/ranking/feature_extractors/generated/archetype_templates/FeatureLayoutCopyArchetype.h
+++ b/packages/feedsim/third_party/src/workloads/ranking/feature_extractors/generated/archetype_templates/FeatureLayoutCopyArchetype.h
@@ -1,0 +1,80 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
+#pragma once
+
+#include "ArchetypeBase.h"
+#include <array>
+
+namespace dcperf {
+namespace feature_extractors {
+namespace generated {
+
+template <int NumDenseRemap, int NumSparseRemap, int ArraySizeLog2>
+class FeatureLayoutCopyArchetype : public ArchetypeBase {
+  static constexpr int kArraySize = 1 << ArraySizeLog2;
+  static constexpr uint64_t kSeed =
+      NumDenseRemap * 10000ULL + NumSparseRemap * 100ULL + ArraySizeLog2;
+
+ public:
+  void initializeImpl(int complexity) override {
+    uint64_t state = kSeed + complexity;
+    for (int i = 0; i < NumDenseRemap; ++i) {
+      denseRemapTo_[i] = splitmix64(state) % kArraySize;
+      denseRemapFrom_[i] = splitmix64(state) % kArraySize;
+    }
+    for (int i = 0; i < NumSparseRemap; ++i) {
+      sparseRemapTo_[i] = splitmix64(state) % kArraySize;
+      sparseRemapFrom_[i] = splitmix64(state) % kArraySize;
+    }
+    for (int i = 0; i < kArraySize; ++i) {
+      cacheArray_[i] = randomFloat(state);
+    }
+    for (int i = 0; i < NumSparseRemap * 5; ++i) {
+      cacheSparse_[i] = {randomInt64(state), randomFloat(state)};
+    }
+  }
+
+  __attribute__((noinline)) void extractImpl(
+      MockFeatureExample& example,
+      const std::vector<MockFeature>& features,
+      const std::vector<int64_t>& queryKeys) override {
+    // Dense remap: indirect-indexed copy
+    if (static_cast<int>(example.denseValues.size()) >= kArraySize) {
+      for (int i = 0; i < NumDenseRemap; ++i) {
+        example.denseValues[denseRemapTo_[i]] =
+            cacheArray_[denseRemapFrom_[i]];
+      }
+    }
+
+    // Sparse remap: vector assignment
+    int sparseLimit = std::min(
+        NumSparseRemap,
+        static_cast<int>(example.idScoreLists.size()));
+    for (int i = 0; i < sparseLimit; ++i) {
+      int from = sparseRemapFrom_[i] % (NumSparseRemap * 5);
+      auto& dst = example.idScoreLists[sparseRemapTo_[i] %
+          example.idScoreLists.size()];
+      dst.clear();
+      for (int j = from; j < from + 3 && j < NumSparseRemap * 5; ++j) {
+        dst.push_back(cacheSparse_[j]);
+      }
+    }
+  }
+
+  std::string name() const override { return "FeatureLayoutCopyVariant"; }
+
+ private:
+  std::array<int, NumDenseRemap> denseRemapTo_{};
+  std::array<int, NumDenseRemap> denseRemapFrom_{};
+  std::array<int, NumSparseRemap> sparseRemapTo_{};
+  std::array<int, NumSparseRemap> sparseRemapFrom_{};
+  std::array<float, kArraySize> cacheArray_{};
+  std::array<IdScorePair, NumSparseRemap * 5> cacheSparse_{};
+};
+
+} // namespace generated
+} // namespace feature_extractors
+} // namespace dcperf

--- a/packages/feedsim/third_party/src/workloads/ranking/feature_extractors/generated/archetype_templates/HashLookupArchetype.h
+++ b/packages/feedsim/third_party/src/workloads/ranking/feature_extractors/generated/archetype_templates/HashLookupArchetype.h
@@ -1,0 +1,107 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
+#pragma once
+
+#include "ArchetypeBase.h"
+#include <array>
+#include <unordered_map>
+
+namespace dcperf {
+namespace feature_extractors {
+namespace generated {
+
+template <
+    int NumTables,
+    int TableSizeLog2,
+    int LookupsPerTable,
+    int BranchPattern,
+    int YieldStyle>
+class HashLookupArchetype : public ArchetypeBase {
+  static constexpr int kTableSize = 1 << TableSizeLog2;
+  static constexpr uint64_t kSeed =
+      NumTables * 100000ULL + TableSizeLog2 * 1000ULL +
+      LookupsPerTable * 10ULL + BranchPattern * 3ULL + YieldStyle;
+
+ public:
+  void initializeImpl(int complexity) override {
+    uint64_t state = kSeed + complexity;
+    for (int t = 0; t < NumTables; ++t) {
+      for (int i = 0; i < kTableSize; ++i) {
+        int64_t key = randomInt64(state);
+        float val = randomFloat(state);
+        tables_[t][key] = val;
+      }
+    }
+  }
+
+  __attribute__((noinline)) void extractImpl(
+      MockFeatureExample& example,
+      const std::vector<MockFeature>& features,
+      const std::vector<int64_t>& queryKeys) override {
+    int featIdx = 0;
+    for (int t = 0; t < NumTables; ++t) {
+      for (int i = 0; i < LookupsPerTable; ++i) {
+        if (featIdx >= static_cast<int>(features.size())) return;
+        int64_t key = deriveKey(queryKeys, t, i);
+        auto it = tables_[t].find(key);
+        float val = (it != tables_[t].end()) ? it->second : 0.0f;
+        yieldResult(example, features, featIdx, key, val, t, i);
+        ++featIdx;
+      }
+    }
+  }
+
+  std::string name() const override { return "HashLookupVariant"; }
+
+ private:
+  __attribute__((noinline)) int64_t
+  deriveKey(const std::vector<int64_t>& keys, int table, int idx) const {
+    int64_t base = keys[idx % keys.size()];
+    if constexpr (BranchPattern == 0) {
+      return base ^ (static_cast<int64_t>(table) * 0x9e3779b97f4a7c15LL);
+    } else if constexpr (BranchPattern == 1) {
+      return base * (2654435761LL + table * 7) + idx * 31;
+    } else if constexpr (BranchPattern == 2) {
+      int64_t h = base;
+      h ^= h >> 16;
+      h *= 0x45d9f3b + table;
+      h ^= h >> 16;
+      return h + idx;
+    } else {
+      int64_t h1 = base ^ (base >> 32);
+      int64_t h2 = h1 * (0xbf58476d1ce4e5b9LL + table);
+      return h2 ^ (h2 >> 31) ^ idx;
+    }
+  }
+
+  __attribute__((noinline)) void yieldResult(
+      MockFeatureExample& example,
+      const std::vector<MockFeature>& features,
+      int featIdx,
+      int64_t key,
+      float val,
+      int table,
+      int idx) {
+    if constexpr (YieldStyle == 0) {
+      yieldIndexedFeature(example, features[featIdx], key, val);
+    } else if constexpr (YieldStyle == 1) {
+      float bucketedVal = val * (1.0f + static_cast<float>(table) * 0.1f);
+      yieldIndexedFeature(
+          example, features[featIdx], key & 0xFF, bucketedVal);
+    } else {
+      float crossVal = val * static_cast<float>(idx + 1) /
+          static_cast<float>(LookupsPerTable);
+      int64_t crossKey = key ^ (static_cast<int64_t>(table) << 32);
+      yieldIndexedFeature(example, features[featIdx], crossKey, crossVal);
+    }
+  }
+
+  std::array<std::unordered_map<int64_t, float>, NumTables> tables_;
+};
+
+} // namespace generated
+} // namespace feature_extractors
+} // namespace dcperf

--- a/packages/feedsim/third_party/src/workloads/ranking/feature_extractors/generated/archetype_templates/IDListMatchArchetype.h
+++ b/packages/feedsim/third_party/src/workloads/ranking/feature_extractors/generated/archetype_templates/IDListMatchArchetype.h
@@ -1,0 +1,106 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
+#pragma once
+
+#include "ArchetypeBase.h"
+#include <array>
+#include <unordered_set>
+
+namespace dcperf {
+namespace feature_extractors {
+namespace generated {
+
+template <
+    int ListSize,
+    int MatchType,
+    int FeaturesOnMatch,
+    int HasRecencyDecay,
+    int IdDerivation>
+class IDListMatchArchetype : public ArchetypeBase {
+  static constexpr uint64_t kSeed =
+      ListSize * 10000ULL + MatchType * 1000ULL + FeaturesOnMatch * 100ULL +
+      HasRecencyDecay * 10ULL + IdDerivation;
+
+ public:
+  void initializeImpl(int complexity) override {
+    uint64_t state = kSeed + complexity;
+    for (int i = 0; i < ListSize; ++i) {
+      recentIds_[i] = randomInt64(state);
+    }
+    if constexpr (MatchType == 1) {
+      idSet_.insert(recentIds_.begin(), recentIds_.end());
+    } else if constexpr (MatchType == 2) {
+      std::sort(recentIds_.begin(), recentIds_.end());
+    }
+  }
+
+  __attribute__((noinline)) void extractImpl(
+      MockFeatureExample& example,
+      const std::vector<MockFeature>& features,
+      const std::vector<int64_t>& queryKeys) override {
+    int featIdx = 0;
+    for (size_t q = 0; q < queryKeys.size() && featIdx < static_cast<int>(features.size()); ++q) {
+      int64_t storyId = deriveId(queryKeys[q]);
+      int matchPos = findMatch(storyId);
+      if (matchPos >= 0) {
+        emitMatchFeatures(example, features, featIdx, matchPos);
+      }
+    }
+  }
+
+  std::string name() const override { return "IDListMatchVariant"; }
+
+ private:
+  __attribute__((noinline)) int64_t deriveId(int64_t raw) const {
+    if constexpr (IdDerivation == 0) {
+      return raw;
+    } else if constexpr (IdDerivation == 1) {
+      return raw ^ (raw >> 16);
+    } else {
+      return (raw >> 8) | (raw << 56);
+    }
+  }
+
+  __attribute__((noinline)) int findMatch(int64_t id) const {
+    if constexpr (MatchType == 0) {
+      for (int i = 0; i < ListSize; ++i) {
+        if (recentIds_[i] == id) return i;
+      }
+      return -1;
+    } else if constexpr (MatchType == 1) {
+      return idSet_.count(id) ? 0 : -1;
+    } else {
+      auto it = std::lower_bound(recentIds_.begin(), recentIds_.end(), id);
+      if (it != recentIds_.end() && *it == id) {
+        return static_cast<int>(it - recentIds_.begin());
+      }
+      return -1;
+    }
+  }
+
+  __attribute__((noinline)) void emitMatchFeatures(
+      MockFeatureExample& example,
+      const std::vector<MockFeature>& features,
+      int& featIdx,
+      int pos) {
+    for (int f = 0; f < FeaturesOnMatch && featIdx < static_cast<int>(features.size()); ++f) {
+      float val = 1.0f;
+      if constexpr (HasRecencyDecay) {
+        val = 1.0f / (1.0f + static_cast<float>(pos) * 0.1f);
+      }
+      val *= (1.0f + f * 0.2f);
+      yieldScalarFeature(example, features[featIdx], val);
+      ++featIdx;
+    }
+  }
+
+  std::array<int64_t, ListSize> recentIds_{};
+  std::unordered_set<int64_t> idSet_;
+};
+
+} // namespace generated
+} // namespace feature_extractors
+} // namespace dcperf

--- a/packages/feedsim/third_party/src/workloads/ranking/feature_extractors/generated/archetype_templates/LargeMonolithicArchetype.h
+++ b/packages/feedsim/third_party/src/workloads/ranking/feature_extractors/generated/archetype_templates/LargeMonolithicArchetype.h
@@ -1,0 +1,134 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
+#pragma once
+
+#include "ArchetypeBase.h"
+#include <array>
+#include <map>
+#include <unordered_map>
+
+namespace dcperf {
+namespace feature_extractors {
+namespace generated {
+
+template <
+    int NumFeatures,
+    int NumCodePaths,
+    int PathComplexity,
+    int NumHashLookups,
+    int NumNestedLoops>
+class LargeMonolithicArchetype : public ArchetypeBase {
+  static constexpr uint64_t kSeed =
+      NumFeatures * 100000ULL + NumCodePaths * 1000ULL +
+      PathComplexity * 100ULL + NumHashLookups * 10ULL + NumNestedLoops;
+  static constexpr int kTableSize = 512;
+
+ public:
+  void initializeImpl(int complexity) override {
+    uint64_t state = kSeed + complexity;
+    for (int i = 0; i < kTableSize; ++i) {
+      hashTable_[randomInt64(state)] = randomFloat(state);
+    }
+    for (int i = 0; i < 256; ++i) {
+      sortedMap_[randomInt64(state)] = randomFloat(state);
+    }
+    for (int i = 0; i < NumFeatures; ++i) {
+      coefficients_[i] = randomFloat(state) - 0.5f;
+    }
+  }
+
+  __attribute__((noinline)) void extractImpl(
+      MockFeatureExample& example,
+      const std::vector<MockFeature>& features,
+      const std::vector<int64_t>& queryKeys) override {
+    int featIdx = 0;
+
+    phaseHashLookup(example, features, queryKeys, featIdx);
+    phaseCompute(example, features, queryKeys, featIdx);
+    phaseTraverse(example, features, featIdx);
+  }
+
+  std::string name() const override { return "LargeMonolithicVariant"; }
+
+ private:
+  __attribute__((noinline)) void phaseHashLookup(
+      MockFeatureExample& example,
+      const std::vector<MockFeature>& features,
+      const std::vector<int64_t>& queryKeys,
+      int& featIdx) {
+    for (int h = 0; h < NumHashLookups && featIdx < static_cast<int>(features.size()); ++h) {
+      int64_t key = queryKeys[h % queryKeys.size()];
+      auto it = hashTable_.find(key);
+      float val = (it != hashTable_.end()) ? it->second : coefficients_[h % NumFeatures];
+      yieldScalarFeature(example, features[featIdx], val);
+      ++featIdx;
+    }
+  }
+
+  __attribute__((noinline)) void phaseCompute(
+      MockFeatureExample& example,
+      const std::vector<MockFeature>& features,
+      const std::vector<int64_t>& queryKeys,
+      int& featIdx) {
+    for (int p = 0; p < NumCodePaths && featIdx < static_cast<int>(features.size()); ++p) {
+      float result = 0.0f;
+      if constexpr (PathComplexity == 0) {
+        result = coefficients_[p % NumFeatures];
+      } else if constexpr (PathComplexity == 1) {
+        for (int i = 0; i < NumNestedLoops * 3; ++i) {
+          result += coefficients_[(p + i) % NumFeatures] *
+              static_cast<float>(i + 1);
+        }
+        result /= static_cast<float>(NumNestedLoops * 3);
+      } else {
+        for (int i = 0; i < NumNestedLoops; ++i) {
+          for (int j = 0; j < NumNestedLoops + 2; ++j) {
+            int idx = (p * NumNestedLoops + i * (NumNestedLoops + 2) + j) %
+                NumFeatures;
+            float c = coefficients_[idx];
+            result += c * c - c * 0.5f;
+          }
+        }
+        result = std::tanh(result);
+      }
+
+      if (p % 4 == 0) {
+        yieldScalarFeature(example, features[featIdx], result);
+      } else if (p % 4 == 1) {
+        yieldScalarFeature(example, features[featIdx], std::abs(result));
+      } else if (p % 4 == 2) {
+        yieldScalarFeature(example, features[featIdx], result > 0.0f ? result : 0.0f);
+      } else {
+        yieldScalarFeature(example, features[featIdx], std::log1p(std::abs(result)));
+      }
+      ++featIdx;
+    }
+  }
+
+  __attribute__((noinline)) void phaseTraverse(
+      MockFeatureExample& example,
+      const std::vector<MockFeature>& features,
+      int& featIdx) {
+    int remaining = NumFeatures - NumHashLookups - NumCodePaths;
+    int count = 0;
+    for (auto it = sortedMap_.begin();
+         it != sortedMap_.end() && count < remaining &&
+         featIdx < static_cast<int>(features.size());
+         ++it, ++count) {
+      yieldIndexedFeature(
+          example, features[featIdx], it->first, it->second);
+      ++featIdx;
+    }
+  }
+
+  std::unordered_map<int64_t, float> hashTable_;
+  std::map<int64_t, float> sortedMap_;
+  std::array<float, NumFeatures> coefficients_{};
+};
+
+} // namespace generated
+} // namespace feature_extractors
+} // namespace dcperf

--- a/packages/feedsim/third_party/src/workloads/ranking/feature_extractors/generated/archetype_templates/PredictionCopyArchetype.h
+++ b/packages/feedsim/third_party/src/workloads/ranking/feature_extractors/generated/archetype_templates/PredictionCopyArchetype.h
@@ -1,0 +1,93 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
+#pragma once
+
+#include "ArchetypeBase.h"
+#include <array>
+#include <unordered_map>
+
+namespace dcperf {
+namespace feature_extractors {
+namespace generated {
+
+template <int NumPredictions, int LookupType, int HasFallback, int HasCalibration>
+class PredictionCopyArchetype : public ArchetypeBase {
+  static constexpr uint64_t kSeed =
+      NumPredictions * 10000ULL + LookupType * 100ULL +
+      HasFallback * 10ULL + HasCalibration;
+
+ public:
+  void initializeImpl(int complexity) override {
+    uint64_t state = kSeed + complexity;
+    for (int i = 0; i < NumPredictions; ++i) {
+      predictions_[i] = randomFloat(state);
+      if constexpr (LookupType == 0) {
+        predMap_[randomInt64(state)] = predictions_[i];
+      }
+    }
+    for (int i = 0; i < NumPredictions; ++i) {
+      lookupKeys_[i] = randomInt64(state);
+    }
+  }
+
+  __attribute__((noinline)) void extractImpl(
+      MockFeatureExample& example,
+      const std::vector<MockFeature>& features,
+      const std::vector<int64_t>& queryKeys) override {
+    int featIdx = 0;
+    for (int p = 0; p < NumPredictions && featIdx < static_cast<int>(features.size()); ++p) {
+      float val = lookupPrediction(p);
+      if (val == 0.0f && !HasFallback) {
+        ++featIdx;
+        continue;
+      }
+      if (val == 0.0f && HasFallback) {
+        val = 0.5f;
+      }
+      val = calibrate(val);
+      yieldScalarFeature(example, features[featIdx], val);
+      ++featIdx;
+    }
+  }
+
+  std::string name() const override { return "PredictionCopyVariant"; }
+
+ private:
+  __attribute__((noinline)) float lookupPrediction(int idx) const {
+    if constexpr (LookupType == 0) {
+      auto it = predMap_.find(lookupKeys_[idx]);
+      return (it != predMap_.end()) ? it->second : 0.0f;
+    } else if constexpr (LookupType == 1) {
+      return predictions_[idx];
+    } else {
+      int bucket = idx % 4;
+      switch (bucket) {
+        case 0: return predictions_[idx];
+        case 1: return predictions_[idx] * 1.1f;
+        case 2: return predictions_[idx] * 0.9f;
+        default: return predictions_[idx] + 0.01f;
+      }
+    }
+  }
+
+  __attribute__((noinline)) float calibrate(float val) const {
+    if constexpr (HasCalibration == 0) {
+      return val;
+    } else if constexpr (HasCalibration == 1) {
+      return 1.0f / (1.0f + std::exp(-val * 4.0f + 2.0f));
+    } else {
+      return val * 0.95f + 0.025f;
+    }
+  }
+
+  std::array<float, NumPredictions> predictions_{};
+  std::array<int64_t, NumPredictions> lookupKeys_{};
+  std::unordered_map<int64_t, float> predMap_;
+};
+
+} // namespace generated
+} // namespace feature_extractors
+} // namespace dcperf

--- a/packages/feedsim/third_party/src/workloads/ranking/feature_extractors/generated/archetype_templates/RateCounterArchetype.h
+++ b/packages/feedsim/third_party/src/workloads/ranking/feature_extractors/generated/archetype_templates/RateCounterArchetype.h
@@ -1,0 +1,95 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
+#pragma once
+
+#include "ArchetypeBase.h"
+#include <array>
+#include <cmath>
+
+namespace dcperf {
+namespace feature_extractors {
+namespace generated {
+
+template <
+    int NumRateSlots,
+    int NumCounterSlots,
+    int NumDimensions,
+    int ImpBucketType,
+    int HasRateFeatures>
+class RateCounterArchetype : public ArchetypeBase {
+  static constexpr int kTotalSlots =
+      (HasRateFeatures ? NumRateSlots : 0) + NumCounterSlots;
+  static constexpr uint64_t kSeed =
+      NumRateSlots * 10000ULL + NumCounterSlots * 100ULL +
+      NumDimensions * 10ULL + ImpBucketType * 3ULL + HasRateFeatures;
+
+ public:
+  void initializeImpl(int complexity) override {
+    uint64_t state = kSeed + complexity;
+    for (int d = 0; d < NumDimensions; ++d) {
+      for (int s = 0; s < NumRateSlots; ++s) {
+        rates_[d * NumRateSlots + s] = randomFloat(state);
+      }
+      for (int s = 0; s < NumCounterSlots; ++s) {
+        counters_[d * NumCounterSlots + s] = randomInt64(state) & 0xFFFF;
+      }
+    }
+    impressions_ = 100 + (complexity * 17);
+  }
+
+  __attribute__((noinline)) void extractImpl(
+      MockFeatureExample& example,
+      const std::vector<MockFeature>& features,
+      const std::vector<int64_t>& queryKeys) override {
+    int featIdx = 0;
+    for (int d = 0; d < NumDimensions; ++d) {
+      if constexpr (HasRateFeatures) {
+        for (int s = 0; s < NumRateSlots && featIdx < static_cast<int>(features.size()); ++s) {
+          float rate = rates_[d * NumRateSlots + s];
+          if (rate != 0.0f) {
+            float bucketed = bucketRate(rate, impressions_);
+            yieldScalarFeature(example, features[featIdx], bucketed);
+          }
+          ++featIdx;
+        }
+      }
+      for (int s = 0; s < NumCounterSlots && featIdx < static_cast<int>(features.size()); ++s) {
+        int64_t count = counters_[d * NumCounterSlots + s];
+        if (count > 0) {
+          float val = static_cast<float>(count);
+          yieldScalarFeature(example, features[featIdx], val);
+        }
+        ++featIdx;
+      }
+    }
+  }
+
+  std::string name() const override { return "RateCounterVariant"; }
+
+ private:
+  __attribute__((noinline)) float bucketRate(float rate, int impressions) const {
+    if constexpr (ImpBucketType == 0) {
+      return rate * static_cast<float>(impressions) / 100.0f;
+    } else if constexpr (ImpBucketType == 1) {
+      float logImp = std::log2(static_cast<float>(impressions + 1));
+      return rate * logImp;
+    } else {
+      float imp = static_cast<float>(impressions);
+      if (imp < 10.0f) return rate * 0.1f;
+      if (imp < 100.0f) return rate * 0.5f;
+      if (imp < 1000.0f) return rate * 0.9f;
+      return rate;
+    }
+  }
+
+  std::array<float, NumRateSlots * NumDimensions> rates_{};
+  std::array<int64_t, NumCounterSlots * NumDimensions> counters_{};
+  int impressions_ = 0;
+};
+
+} // namespace generated
+} // namespace feature_extractors
+} // namespace dcperf

--- a/packages/feedsim/third_party/src/workloads/ranking/feature_extractors/generated/archetype_templates/SparseForwardArchetype.h
+++ b/packages/feedsim/third_party/src/workloads/ranking/feature_extractors/generated/archetype_templates/SparseForwardArchetype.h
@@ -1,0 +1,67 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
+#pragma once
+
+#include "ArchetypeBase.h"
+#include <array>
+
+namespace dcperf {
+namespace feature_extractors {
+namespace generated {
+
+template <int NumSparseLists, int ItemsPerList, int HasFilter, int FilterStyle>
+class SparseForwardArchetype : public ArchetypeBase {
+  static constexpr int kTotalItems = NumSparseLists * ItemsPerList;
+  static constexpr uint64_t kSeed =
+      NumSparseLists * 10000ULL + ItemsPerList * 100ULL +
+      HasFilter * 10ULL + FilterStyle;
+
+ public:
+  void initializeImpl(int complexity) override {
+    uint64_t state = kSeed + complexity;
+    for (int i = 0; i < kTotalItems; ++i) {
+      sparseData_[i] = {randomInt64(state), randomFloat(state)};
+    }
+  }
+
+  __attribute__((noinline)) void extractImpl(
+      MockFeatureExample& example,
+      const std::vector<MockFeature>& features,
+      const std::vector<int64_t>& queryKeys) override {
+    int featIdx = 0;
+    for (int l = 0; l < NumSparseLists && featIdx < static_cast<int>(features.size()); ++l) {
+      int base = l * ItemsPerList;
+      for (int i = 0; i < ItemsPerList; ++i) {
+        const auto& pair = sparseData_[base + i];
+        if constexpr (HasFilter) {
+          if (!passesFilter(pair.score, i)) continue;
+        }
+        yieldIndexedFeature(
+            example, features[featIdx], pair.id, pair.score);
+      }
+      ++featIdx;
+    }
+  }
+
+  std::string name() const override { return "SparseForwardVariant"; }
+
+ private:
+  __attribute__((noinline)) bool passesFilter(float score, int pos) const {
+    if constexpr (FilterStyle == 0) {
+      return score > 0.1f;
+    } else if constexpr (FilterStyle == 1) {
+      return pos < ItemsPerList / 2;
+    } else {
+      return std::abs(score - 0.5f) > 0.2f;
+    }
+  }
+
+  std::array<IdScorePair, kTotalItems> sparseData_{};
+};
+
+} // namespace generated
+} // namespace feature_extractors
+} // namespace dcperf

--- a/packages/feedsim/third_party/src/workloads/ranking/feature_extractors/generated/archetype_templates/StringTokenizerArchetype.h
+++ b/packages/feedsim/third_party/src/workloads/ranking/feature_extractors/generated/archetype_templates/StringTokenizerArchetype.h
@@ -1,0 +1,91 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
+#pragma once
+
+#include "ArchetypeBase.h"
+#include <array>
+#include <unordered_map>
+
+namespace dcperf {
+namespace feature_extractors {
+namespace generated {
+
+template <int MaxTokens, int VocabSizeLog2, int TokenizerType, int InputLength>
+class StringTokenizerArchetype : public ArchetypeBase {
+  static constexpr int kVocabSize = 1 << VocabSizeLog2;
+  static constexpr uint64_t kSeed =
+      MaxTokens * 100000ULL + VocabSizeLog2 * 1000ULL +
+      TokenizerType * 100ULL + InputLength;
+
+ public:
+  void initializeImpl(int complexity) override {
+    uint64_t state = kSeed + complexity;
+    for (int i = 0; i < kVocabSize && i < 8192; ++i) {
+      uint64_t key = splitmix64(state);
+      vocab_[key] = static_cast<int>(splitmix64(state) % kVocabSize);
+    }
+    for (int i = 0; i < InputLength; ++i) {
+      inputData_[i] = splitmix64(state);
+    }
+  }
+
+  __attribute__((noinline)) void extractImpl(
+      MockFeatureExample& example,
+      const std::vector<MockFeature>& features,
+      const std::vector<int64_t>& queryKeys) override {
+    int featIdx = 0;
+    int tokenCount = 0;
+    for (int pos = 0; pos < InputLength && tokenCount < MaxTokens &&
+         featIdx < static_cast<int>(features.size());) {
+      int tokenId = tokenize(pos);
+      if (tokenId >= 0) {
+        yieldIndexedFeature(
+            example, features[featIdx], tokenId, 1.0f);
+        ++tokenCount;
+        ++featIdx;
+      }
+    }
+  }
+
+  std::string name() const override { return "StringTokenizerVariant"; }
+
+ private:
+  __attribute__((noinline)) int tokenize(int& pos) {
+    if constexpr (TokenizerType == 0) {
+      uint64_t key = inputData_[pos];
+      ++pos;
+      auto it = vocab_.find(key);
+      return (it != vocab_.end()) ? it->second : -1;
+    } else if constexpr (TokenizerType == 1) {
+      if (pos + 1 >= InputLength) { ++pos; return -1; }
+      uint64_t key = inputData_[pos] ^ (inputData_[pos + 1] << 7);
+      pos += 2;
+      auto it = vocab_.find(key);
+      return (it != vocab_.end()) ? it->second : static_cast<int>(inputData_[pos > 0 ? pos - 1 : 0] % kVocabSize);
+    } else {
+      for (int len = std::min(4, InputLength - pos); len >= 1; --len) {
+        uint64_t key = 0;
+        for (int i = 0; i < len; ++i) {
+          key ^= inputData_[pos + i] << (i * 11);
+        }
+        auto it = vocab_.find(key);
+        if (it != vocab_.end()) {
+          pos += len;
+          return it->second;
+        }
+      }
+      ++pos;
+      return static_cast<int>(inputData_[pos > 0 ? pos - 1 : 0] % kVocabSize);
+    }
+  }
+
+  std::unordered_map<uint64_t, int> vocab_;
+  std::array<uint64_t, InputLength> inputData_{};
+};
+
+} // namespace generated
+} // namespace feature_extractors
+} // namespace dcperf

--- a/packages/feedsim/third_party/src/workloads/ranking/feature_extractors/generated/archetype_templates/TimeWindowArchetype.h
+++ b/packages/feedsim/third_party/src/workloads/ranking/feature_extractors/generated/archetype_templates/TimeWindowArchetype.h
@@ -1,0 +1,83 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
+#pragma once
+
+#include "ArchetypeBase.h"
+#include <array>
+
+namespace dcperf {
+namespace feature_extractors {
+namespace generated {
+
+template <
+    int WindowId,
+    int DimensionId,
+    int NumStats,
+    int BreakdownType,
+    int StatTransform>
+class TimeWindowArchetype : public ArchetypeBase {
+  static constexpr uint64_t kSeed =
+      WindowId * 100000ULL + DimensionId * 10000ULL + NumStats * 100ULL +
+      BreakdownType * 10ULL + StatTransform;
+  static constexpr float kWindowMultiplier =
+      WindowId == 0 ? 1.0f :
+      WindowId == 1 ? 6.0f :
+      WindowId == 2 ? 24.0f :
+      WindowId == 3 ? 72.0f :
+      WindowId == 4 ? 168.0f : 336.0f;
+
+ public:
+  void initializeImpl(int complexity) override {
+    uint64_t state = kSeed + complexity;
+    for (int i = 0; i < NumStats; ++i) {
+      stats_[i] = randomFloat(state) * kWindowMultiplier;
+    }
+  }
+
+  __attribute__((noinline)) void extractImpl(
+      MockFeatureExample& example,
+      const std::vector<MockFeature>& features,
+      const std::vector<int64_t>& queryKeys) override {
+    int featIdx = 0;
+    for (int s = 0; s < NumStats && featIdx < static_cast<int>(features.size()); ++s) {
+      float stat = stats_[s];
+      if (stat == 0.0f) {
+        ++featIdx;
+        continue;
+      }
+      float val = transformStat(stat, s);
+      if constexpr (BreakdownType == 0) {
+        yieldScalarFeature(example, features[featIdx], val);
+      } else if constexpr (BreakdownType == 1) {
+        float broken = val / (1.0f + static_cast<float>(DimensionId) * 0.1f);
+        yieldScalarFeature(example, features[featIdx], broken);
+      } else {
+        float uih = val * (1.0f + std::log1p(static_cast<float>(s)));
+        yieldScalarFeature(example, features[featIdx], uih);
+      }
+      ++featIdx;
+    }
+  }
+
+  std::string name() const override { return "TimeWindowVariant"; }
+
+ private:
+  __attribute__((noinline)) float transformStat(float stat, int idx) const {
+    if constexpr (StatTransform == 0) {
+      return stat;
+    } else if constexpr (StatTransform == 1) {
+      return stat / (kWindowMultiplier + 1.0f);
+    } else {
+      return std::log1p(stat) * (1.0f + idx * 0.01f);
+    }
+  }
+
+  std::array<float, NumStats> stats_{};
+};
+
+} // namespace generated
+} // namespace feature_extractors
+} // namespace dcperf

--- a/packages/feedsim/third_party/src/workloads/ranking/feature_extractors/generated/archetype_templates/TreeMapArchetype.h
+++ b/packages/feedsim/third_party/src/workloads/ranking/feature_extractors/generated/archetype_templates/TreeMapArchetype.h
@@ -1,0 +1,87 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
+#pragma once
+
+#include "ArchetypeBase.h"
+#include <map>
+
+namespace dcperf {
+namespace feature_extractors {
+namespace generated {
+
+template <int MapSizeLog2, int MapsPerStory, int HasRangeFilter, int ValueStyle>
+class TreeMapArchetype : public ArchetypeBase {
+  static constexpr int kMapSize = 1 << MapSizeLog2;
+  static constexpr uint64_t kSeed =
+      MapSizeLog2 * 1000ULL + MapsPerStory * 100ULL + HasRangeFilter * 10ULL +
+      ValueStyle;
+
+ public:
+  void initializeImpl(int complexity) override {
+    uint64_t state = kSeed + complexity;
+    for (int m = 0; m < MapsPerStory; ++m) {
+      for (int i = 0; i < kMapSize; ++i) {
+        int64_t key = randomInt64(state);
+        float val = randomFloat(state);
+        maps_[m][key] = val;
+      }
+    }
+  }
+
+  __attribute__((noinline)) void extractImpl(
+      MockFeatureExample& example,
+      const std::vector<MockFeature>& features,
+      const std::vector<int64_t>& queryKeys) override {
+    int featIdx = 0;
+    for (int m = 0; m < MapsPerStory; ++m) {
+      if constexpr (HasRangeFilter) {
+        int64_t lb = queryKeys.empty() ? 0 : queryKeys[0];
+        auto it = maps_[m].lower_bound(lb);
+        int count = 0;
+        while (it != maps_[m].end() && count < kMapSize / 2 &&
+               featIdx < static_cast<int>(features.size())) {
+          float val = transformValue(it->second, count);
+          yieldIndexedFeature(
+              example, features[featIdx], it->first, val);
+          ++it;
+          ++count;
+          ++featIdx;
+        }
+      } else {
+        int count = 0;
+        for (const auto& [key, value] : maps_[m]) {
+          if (featIdx >= static_cast<int>(features.size())) break;
+          float val = transformValue(value, count);
+          yieldIndexedFeature(example, features[featIdx], key, val);
+          ++count;
+          ++featIdx;
+        }
+      }
+    }
+  }
+
+  std::string name() const override { return "TreeMapVariant"; }
+
+ private:
+  __attribute__((noinline)) float transformValue(float raw, int pos) const {
+    if constexpr (ValueStyle == 0) {
+      return raw;
+    } else if constexpr (ValueStyle == 1) {
+      return raw * (1.0f + pos * 0.01f);
+    } else {
+      if (raw < 0.25f) return 0.1f;
+      if (raw < 0.5f) return 0.3f;
+      if (raw < 0.75f) return 0.7f;
+      return 1.0f;
+    }
+  }
+
+  std::array<std::map<int64_t, float>, MapsPerStory> maps_;
+};
+
+} // namespace generated
+} // namespace feature_extractors
+} // namespace dcperf

--- a/packages/feedsim/third_party/src/workloads/ranking/feature_extractors/generated/extractor_helpers.cpp
+++ b/packages/feedsim/third_party/src/workloads/ranking/feature_extractors/generated/extractor_helpers.cpp
@@ -1,0 +1,285 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
+#include "extractor_helpers.h"
+#include <cmath>
+#include <cstring>
+
+namespace dcperf {
+namespace feature_extractors {
+namespace helpers {
+
+// ======================================================================
+// Internal helpers (additional noinline call depth)
+// ======================================================================
+
+static inline float applyTransform(float val, int transform_type) {
+  float r = val;
+  switch (transform_type % 8) {
+    case 0: return r;
+    case 1: return static_cast<float>(static_cast<int32_t>(r * 1000.0f) & 0x7FFFFFFF);
+    case 2: return static_cast<float>(__builtin_popcount(static_cast<uint32_t>(r * 1e6f)));
+    case 3: return static_cast<float>((static_cast<int64_t>(r * 1e4f) ^ 0x5BD1E995LL) >> 13);
+    case 4: return (r > 0.5f ? r : -r);
+    case 5: return static_cast<float>((static_cast<uint64_t>(r * 1e6f) * 0x9E3779B97F4A7C15ULL) >> 48);
+    // Cast through uint32_t before shift: shifting a negative signed int is UB.
+    case 6: return static_cast<float>(static_cast<int32_t>(static_cast<uint32_t>(static_cast<int32_t>(r)) << 3));
+    case 7: return static_cast<float>((static_cast<int32_t>(r * 256.0f) ^ (static_cast<int32_t>(r * 65536.0f) >> 7)) & 0xFFFF);
+    default: return r;
+  }
+}
+
+__attribute__((noinline))
+static float computeBucket(float value, int bucket_type) {
+  switch (bucket_type % 4) {
+    case 0: // Linear bucket — integer truncation instead of std::floor
+      return static_cast<float>(static_cast<int32_t>(value * 10.0f)) * 0.1f;
+    case 1: // Log bucket — integer clz instead of std::log2
+      return value > 0 ? static_cast<float>(31 - __builtin_clz(static_cast<uint32_t>(value + 1.0f))) : 0.0f;
+    case 2: // Quantile bucket
+      if (value < 0.25f) return 0.0f;
+      if (value < 0.5f) return 0.25f;
+      if (value < 0.75f) return 0.5f;
+      return 0.75f;
+    case 3: // Custom thresholds
+      if (value < 1.0f) return 0.0f;
+      if (value < 10.0f) return 1.0f;
+      if (value < 100.0f) return 2.0f;
+      return 3.0f;
+    default: return value;
+  }
+}
+
+static inline bool isFiniteNonZero(float val) {
+  return val != 0.0f && std::isfinite(val);
+}
+
+__attribute__((noinline))
+static void consumeFeature(
+    generated::CopyContext* ctx,
+    int feature_idx, int64_t index, float value) {
+  int fi = feature_idx % ctx->numFeatures;
+  if (fi >= 0 && fi < (int)ctx->example->idScoreLists.size()) {
+    ctx->example->idScoreLists[fi].emplace_back(
+        IdScorePair{index, value});
+  }
+}
+
+// ======================================================================
+// Context preparation
+// ======================================================================
+
+void prepareExtractContext(generated::CopyContext* ctx, int variant_seed) {
+  // Simulate SharedObject::build — reads struct fields to validate state
+  float check = ctx->structData[variant_seed % ctx->structSize];
+  if (check == 0.0f) {
+    // Simulate early return path in production
+    ctx->structData[0] = 1.0f;
+  }
+  // Simulate ExtractorState::update — touch multiple struct offsets
+  for (int i = 0; i < 4; ++i) {
+    int off = (variant_seed + i * 37) % ctx->structSize;
+    ctx->structData[off] = applyTransform(ctx->structData[off], i);
+  }
+}
+
+void initStoryContext(generated::CopyContext* ctx, int story_idx) {
+  // Simulate per-story feature buffer initialization
+  int base = story_idx % ctx->structSize;
+  float acc = 0.0f;
+  for (int i = 0; i < 8; ++i) {
+    acc += ctx->structData[(base + i * 13) % ctx->structSize];
+  }
+  // Write back normalized value — multiply by reciprocal
+  ctx->structData[base] = computeBucket(acc * 0.125f, story_idx % 4);
+}
+
+// ======================================================================
+// Data lookup
+// ======================================================================
+
+float lookupStats(
+    mock_hash::MockHashTable& table,
+    const int64_t* keys, int num_keys,
+    int stat_type) {
+  float result = 0.0f;
+  int effective_keys = (num_keys > 8) ? 8 : num_keys;
+  for (int i = 0; i < effective_keys; ++i) {
+    float val = mock_hash::hashLookupWithFallback(table, keys[i], 0.0f);
+    val = applyTransform(val, stat_type + i);
+    result += val;
+  }
+  return computeBucket(result, stat_type);
+}
+
+float joinFeatureTables(
+    mock_hash::MockHashTable& tableA,
+    mock_hash::MockHashTable& tableB,
+    int64_t primary_key, int join_type) {
+  float valA = mock_hash::hashLookupWithFallback(tableA, primary_key, 0.0f);
+  if (!isFiniteNonZero(valA)) return 0.0f;
+
+  float result;
+  switch (join_type % 3) {
+    case 0:
+      result = mock_hash::crossTableLookup(tableA, tableB, primary_key, 1000.0f);
+      break;
+    case 1: {
+      int64_t derived = static_cast<int64_t>(valA * 100.0f) ^ primary_key;
+      result = mock_hash::hashLookupWithFallback(tableB, derived, valA);
+      break;
+    }
+    case 2:
+      result = valA + mock_hash::hashLookupWithFallback(
+          tableB, primary_key + 1, 0.0f);
+      break;
+    default:
+      result = valA;
+  }
+  return applyTransform(result, join_type);
+}
+
+// ======================================================================
+// Rate/counter computation
+// ======================================================================
+
+float computeRate(float numerator, float denominator, int bucket_type) {
+  if (!isFiniteNonZero(denominator)) return 0.0f;
+  // Integer bit manipulation for reciprocal approximation — avoids FP divider
+  int32_t den_bits;
+  std::memcpy(&den_bits, &denominator, sizeof(den_bits));
+  den_bits = 0x7EF311C2 - den_bits;
+  float inv_den;
+  std::memcpy(&inv_den, &den_bits, sizeof(inv_den));
+  float rate = numerator * inv_den;
+  rate = applyTransform(rate, bucket_type);
+  return computeBucket(rate, bucket_type);
+}
+
+float computeEngagementStat(
+    const float* stats, int num_stats,
+    int window_type, int stat_idx) {
+  int window_size = 1 + (window_type % 4);  // 1-4
+  int start = stat_idx % num_stats;
+  float acc = 0.0f;
+  float weight_sum = 0.0f;
+  // Pre-computed reciprocal weights to avoid division
+  static constexpr float kWeights[] = {1.0f, 0.5f, 0.333333f, 0.25f};
+  for (int i = 0; i < window_size && (start + i) < num_stats; ++i) {
+    float w = kWeights[i & 3];
+    acc += stats[(start + i) % num_stats] * w;
+    weight_sum += w;
+  }
+  if (weight_sum == 0.0f) return 0.0f;
+  // Integer bit manipulation for reciprocal approximation
+  int32_t ws_bits;
+  std::memcpy(&ws_bits, &weight_sum, sizeof(ws_bits));
+  ws_bits = 0x7EF311C2 - ws_bits;
+  float inv_ws;
+  std::memcpy(&inv_ws, &ws_bits, sizeof(inv_ws));
+  return applyTransform(acc * inv_ws, window_type);
+}
+
+float aggregateRates(
+    const float* rates, int num_rates,
+    int agg_type, float scale) {
+  if (num_rates <= 0) return 0.0f;
+  float result = 0.0f;
+  switch (agg_type % 4) {
+    case 0: // Sum
+      for (int i = 0; i < num_rates; ++i)
+        result += rates[i];
+      break;
+    case 1: // Max
+      result = rates[0];
+      for (int i = 1; i < num_rates; ++i)
+        if (rates[i] > result) result = rates[i];
+      break;
+    case 2: { // Weighted mean — pre-computed reciprocal weights
+      static constexpr float kInvWeights[] = {
+        1.0f, 0.5f, 0.333333f, 0.25f, 0.2f, 0.166667f, 0.142857f, 0.125f};
+      for (int i = 0; i < num_rates; ++i)
+        result += rates[i] * kInvWeights[i & 7];
+      // Integer reciprocal instead of division
+      float nr_f = static_cast<float>(num_rates);
+      int32_t nr_bits;
+      std::memcpy(&nr_bits, &nr_f, sizeof(nr_bits));
+      nr_bits = 0x7EF311C2 - nr_bits;
+      float inv_nr;
+      std::memcpy(&inv_nr, &nr_bits, sizeof(inv_nr));
+      result *= inv_nr;
+      break;
+    }
+    case 3: { // Geometric mean approx — integer hash instead of std::log
+      result = 1.0f;
+      for (int i = 0; i < num_rates; ++i)
+        result *= (1.0f + (rates[i] > 0.0f ? rates[i] : -rates[i]));
+      // Integer log2 approximation instead of std::log
+      uint32_t r_uint = static_cast<uint32_t>(result + 1.0f);
+      result = static_cast<float>(r_uint > 0 ? (31 - __builtin_clz(r_uint)) : 0);
+      break;
+    }
+  }
+  return computeBucket(result * scale, agg_type);
+}
+
+// ======================================================================
+// Feature yield pipeline
+// ======================================================================
+
+void yieldDenseFeature(
+    generated::CopyContext* ctx,
+    int feature_idx, float value) {
+  if (!validateFeatureValue(value, 0)) return;
+  int fi = feature_idx % ctx->numFeatures;
+  int32_t idx = ctx->features[fi].raw_feature_index;
+  if (idx >= 0 && idx < (int32_t)ctx->example->denseValues.size()) {
+    ctx->example->denseValues[idx] = value;
+  }
+}
+
+void yieldIndexedFeature(
+    generated::CopyContext* ctx,
+    int feature_idx, int64_t index, float value) {
+  if (!validateFeatureValue(value, 1)) return;
+  consumeFeature(ctx, feature_idx, index, value);
+}
+
+void batchYieldFeatures(
+    generated::CopyContext* ctx,
+    const int* feature_indices,
+    const float* values,
+    int count) {
+  for (int i = 0; i < count; ++i) {
+    if (validateFeatureValue(values[i], i % 3)) {
+      yieldDenseFeature(ctx, feature_indices[i], values[i]);
+    }
+  }
+}
+
+// ======================================================================
+// Validation
+// ======================================================================
+
+bool validateFeatureValue(float value, int validation_type) {
+  switch (validation_type % 3) {
+    case 0: return isFiniteNonZero(value);
+    case 1: return std::isfinite(value) && std::abs(value) < 1e6f;
+    case 2: return value == value && value != 0.0f;  // NaN check + zero check
+    default: return true;
+  }
+}
+
+float cappedConvertFloat(double value, float min_val, float max_val) {
+  if (value > static_cast<double>(max_val)) return max_val;
+  if (value < static_cast<double>(min_val)) return min_val;
+  float result = static_cast<float>(value);
+  if (!isFiniteNonZero(result)) return 0.0f;
+  return result;
+}
+
+} // namespace helpers
+} // namespace feature_extractors
+} // namespace dcperf

--- a/packages/feedsim/third_party/src/workloads/ranking/feature_extractors/generated/extractor_helpers.h
+++ b/packages/feedsim/third_party/src/workloads/ranking/feature_extractors/generated/extractor_helpers.h
@@ -1,0 +1,120 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
+// Intermediate helper functions for feature extractors.
+// These simulate the multi-hop call chains in production where extractors
+// call through shared utility functions spread across many .cpp files.
+//
+// Production call chain:
+//   vc_copy_fn -> prepareExtractContext -> lookupStats -> computeRate
+//                                       -> hashJoin   -> yieldFeature
+//
+// Each helper is noinline and in a separate compilation unit to force
+// I-cache misses from cross-module calls.
+
+#pragma once
+
+#include "dispatch.h"
+#include "mock_hash_table.h"
+#include <cstdint>
+
+namespace dcperf {
+namespace feature_extractors {
+namespace helpers {
+
+// ======================================================================
+// Context preparation helpers (simulate SharedObject::build,
+// ExtractorState::update, and other pre-extract setup)
+// ======================================================================
+
+// Validate and prepare context before extraction
+__attribute__((noinline))
+void prepareExtractContext(generated::CopyContext* ctx, int variant_seed);
+
+// Initialize per-story state (simulates ScoringPass::initializeSharedFeatureExtractor)
+__attribute__((noinline))
+void initStoryContext(generated::CopyContext* ctx, int story_idx);
+
+// ======================================================================
+// Data lookup helpers (simulate UserActionHistoryUtil::getUAHStatsByKeys,
+// FeatureExtractorListApplier::extractNonBatch)
+// ======================================================================
+
+// Look up stats from hash tables with multi-key probing
+__attribute__((noinline))
+float lookupStats(
+    mock_hash::MockHashTable& table,
+    const int64_t* keys, int num_keys,
+    int stat_type);
+
+// Cross-table feature join (simulates cross-component lookups)
+__attribute__((noinline))
+float joinFeatureTables(
+    mock_hash::MockHashTable& tableA,
+    mock_hash::MockHashTable& tableB,
+    int64_t primary_key, int join_type);
+
+// ======================================================================
+// Rate/counter computation helpers (simulate updateEtnadCounter,
+// computeImpressionBuckets, computeRateRatio)
+// ======================================================================
+
+// Compute rate from numerator/denominator with bucketing
+__attribute__((noinline))
+float computeRate(float numerator, float denominator, int bucket_type);
+
+// Compute engagement stats with time window selection
+__attribute__((noinline))
+float computeEngagementStat(
+    const float* stats, int num_stats,
+    int window_type, int stat_idx);
+
+// Multi-dimensional rate aggregation
+__attribute__((noinline))
+float aggregateRates(
+    const float* rates, int num_rates,
+    int agg_type, float scale);
+
+// ======================================================================
+// Feature yield helpers (simulate yieldIndexedFeature,
+// consumeIndexedFeature, addFeaturesFrom pipeline)
+// ======================================================================
+
+// Validate and yield a dense feature through the pipeline
+__attribute__((noinline))
+void yieldDenseFeature(
+    generated::CopyContext* ctx,
+    int feature_idx, float value);
+
+// Validate and yield a sparse/indexed feature
+__attribute__((noinline))
+void yieldIndexedFeature(
+    generated::CopyContext* ctx,
+    int feature_idx, int64_t index, float value);
+
+// Batch yield multiple features (simulates addFeaturesFrom)
+__attribute__((noinline))
+void batchYieldFeatures(
+    generated::CopyContext* ctx,
+    const int* feature_indices,
+    const float* values,
+    int count);
+
+// ======================================================================
+// Validation helpers (simulate isFiniteAndNonZero checks,
+// cappedTypeConversion, etc. scattered through prod code)
+// ======================================================================
+
+// Validate float value (NaN, inf, zero checks)
+__attribute__((noinline))
+bool validateFeatureValue(float value, int validation_type);
+
+// Capped type conversion with bounds checking
+__attribute__((noinline))
+float cappedConvertFloat(double value, float min_val, float max_val);
+
+} // namespace helpers
+} // namespace feature_extractors
+} // namespace dcperf

--- a/packages/feedsim/third_party/src/workloads/ranking/feature_extractors/generated/generate_extractors.py
+++ b/packages/feedsim/third_party/src/workloads/ranking/feature_extractors/generated/generate_extractors.py
@@ -1795,6 +1795,9 @@ struct CopyContext {{
   // Mock hash tables for deep-call-chain lookups (mimics F14/QuickHash)
   mock_hash::MockHashTable* hashTables;  // array of 4 mock hash tables
   int numHashTables;
+  // Phase 3 (Plan): Story content from Silesia corpus
+  const uint8_t* storyContent = nullptr;
+  int storyContentLength = 0;
 }};
 
 using CopyFn = void(*)(CopyContext*);

--- a/packages/feedsim/third_party/src/workloads/ranking/feature_extractors/generated/generate_extractors.py
+++ b/packages/feedsim/third_party/src/workloads/ranking/feature_extractors/generated/generate_extractors.py
@@ -1,0 +1,1911 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Generate diverse feature extractor copy functions with 27 code structure patterns.
+
+Produces ~700 extractor variants across 27 genuinely different code structure
+patterns, each with 1000 copies (default). Each pattern has different branch
+topology, loop structure, data access patterns, and code size to create
+realistic I-cache pressure matching production feature extractors.
+
+Output:
+    dispatch.h                       -- CopyContext struct, CopyFn typedef
+    copies/copies_part_NNNN.cpp      -- 1000 copy functions per variant
+    variants/variants_batch_NNN.cpp  -- variant class definitions (dispatch)
+    registry.h / registry.cpp        -- createGeneratedExtractors()
+    generated_sources.cmake          -- CMake include fragment
+"""
+
+import argparse
+import os
+import random
+import sys
+import time
+from dataclasses import dataclass
+from typing import List
+
+RANDOM_SEED = 424242
+
+COPYRIGHT = """\
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+"""
+
+# Pattern distribution: (pattern_id, variant_count, struct_size, table_size)
+PATTERN_DISTRIBUTION = [
+    ("P01", 60, 64, 0),        # Minimal field read
+    ("P02", 70, 128, 0),       # Multi-field read
+    ("P03", 30, 128, 0),       # Multi-field + enum dispatch
+    ("P04", 15, 64, 0),        # Time arithmetic
+    ("P05", 40, 256, 256),     # Simple rate/counter
+    ("P06", 65, 512, 256),     # Dimensional rate
+    ("P07", 25, 512, 512),     # Multi-conditional rate
+    ("P08", 45, 128, 2048),    # Single hash lookup + rates
+    ("P09", 25, 256, 4096),    # Multi-key hash + dedup
+    ("P10", 15, 256, 2048),    # Dual hash lookup
+    ("P11", 8, 512, 2048),     # Hash + tree traversal
+    ("P12", 130, 256, 0),      # Template time-window stats
+    ("P13", 5, 1024, 512),     # Massive coefficient yield
+    ("P14", 12, 512, 512),     # Decayed coefficient
+    ("P15", 20, 256, 1024),    # Embedding dimension yield
+    ("P16", 15, 512, 0),       # Embedding similarity
+    ("P17", 15, 128, 0),       # Sparse feature forward
+    ("P18", 8, 128, 1024),     # Hash-then-sparse forward
+    ("P19", 20, 128, 0),       # LastN ID match
+    ("P20", 15, 128, 0),       # Set membership match
+    ("P21", 3, 2048, 4096),    # Large monolithic prediction
+    ("P22", 20, 512, 1024),    # Medium prediction forward
+    ("P23", 8, 512, 0),        # SentencePiece tokenization
+    ("P24", 6, 256, 0),        # Mutable state read/update
+    ("P25", 15, 256, 2048),    # Multi-topic hash iteration
+    ("P26", 4, 64, 0),         # Delegated dynamic feature generation
+    ("P27", 5, 256, 2048),     # Multi-category hierarchical FIH
+]
+
+TRANSFORMS = [
+    "r", "std::abs(r)", "std::tanh(r)",
+    "std::log1p(std::abs(r))", "(1.0f / (1.0f + std::exp(-r)))",
+    "std::sqrt(std::abs(r))", "(r * r * 0.01f)", "std::sin(r * 0.1f)",
+]
+
+
+@dataclass
+class VariantSpec:
+    name: str
+    pattern: str
+    variant_idx: int
+    pattern_variant_idx: int
+    seed: int
+    struct_size: int
+    table_size: int
+
+
+# ============================================================================
+# C++ code generation helpers
+# ============================================================================
+
+def fhdr(vid, cid):
+    return (f"__attribute__((noinline)) static void "
+            f"vc_{vid:04d}_{cid:04d}(CopyContext* c) {{\n")
+
+
+def sr(off):
+    """Struct data read."""
+    return f"c->structData[{off} % c->structSize]"
+
+
+def yd(fi, val):
+    """Yield dense feature."""
+    return (f"    {{ int _fi = {fi} % c->numFeatures;\n"
+            f"      int32_t _i = c->features[_fi].raw_feature_index;\n"
+            f"      if (_i >= 0 && _i < (int32_t)c->example->denseValues.size())\n"
+            f"        c->example->denseValues[_i] = {val}; }}\n")
+
+
+def yi(fi, idx, val):
+    """Yield indexed feature (sparse)."""
+    return (f"    {{ int _fi = {fi} % c->numFeatures;\n"
+            f"      if (_fi >= 0 && _fi < (int)c->example->idScoreLists.size())\n"
+            f"        c->example->idScoreLists[_fi].emplace_back(\n"
+            f"          IdScorePair{{{idx}, {val}}}); }}\n")
+
+
+def pick_transform(rng):
+    return rng.choice(TRANSFORMS)
+
+
+# ============================================================================
+# Pattern P01: Minimal field read (0 loops, 1-3 branches, 1-3 yields)
+# ~12-20 lines per copy
+# ============================================================================
+
+def gen_P01(vid, cid, rng, pvid):
+    num_yields = 1 + (pvid % 3)
+    has_null = (pvid + cid) % 2 == 0
+    c = fhdr(vid, cid)
+    off0 = rng.randint(0, 255)
+    sc0 = rng.uniform(0.5, 3.0)
+    if has_null:
+        c += f"  float v0 = {sr(off0)} * {sc0:.4f}f;\n"
+        c += f"  if (v0 == 0.0f) return;\n"
+    for i in range(num_yields):
+        off = rng.randint(0, 255)
+        fi = rng.randint(0, 49)
+        sc = rng.uniform(0.3, 4.0)
+        c += f"  {{ float val = {sr(off)} * {sc:.4f}f;\n"
+        c += yd(fi, "val")
+        c += f"  }}\n"
+    c += "}\n\n"
+    return c
+
+
+# ============================================================================
+# Pattern P02: Multi-field read (0 loops, 3-8 branches, 3-10 yields)
+# ~25-50 lines per copy
+# ============================================================================
+
+def gen_P02(vid, cid, rng, pvid):
+    num_fields = 3 + (pvid % 8)  # 3-10
+    num_branches = 3 + (pvid % 6)  # 3-8
+    has_cross = (pvid % 3) == 0
+    c = fhdr(vid, cid)
+    # Read from 1-2 "sources" (different struct offset regions)
+    src_base = [rng.randint(0, 127), rng.randint(128, 255)]
+    for i in range(num_fields):
+        src = src_base[i % 2]
+        off = src + rng.randint(0, 60)
+        fi = rng.randint(0, 49)
+        sc = rng.uniform(0.1, 5.0)
+        thr = rng.uniform(-1.0, 1.0)
+        if i < num_branches:
+            check = rng.choice([
+                f"{sr(off)} > {thr:.4f}f",
+                f"{sr(off)} != 0.0f",
+                f"std::abs({sr(off)}) > {abs(thr):.4f}f",
+            ])
+            c += f"  if ({check}) {{\n"
+            c += f"    float val = {sr(off)} * {sc:.4f}f;\n"
+            c += yd(fi, "val")
+            c += f"  }}\n"
+        else:
+            c += f"  {{ float val = {sr(off)} * {sc:.4f}f;\n"
+            c += yd(fi, "val")
+            c += f"  }}\n"
+    if has_cross:
+        oA = rng.randint(0, 127)
+        oB = rng.randint(128, 255)
+        fi = rng.randint(0, 49)
+        c += f"  {{ float a = {sr(oA)}; float b = {sr(oB)};\n"
+        c += f"    if (b != 0.0f) {{\n"
+        c += f"      float cross = a / b;\n"
+        c += yd(fi, "cross")
+        c += f"    }}\n"
+        c += f"  }}\n"
+    c += "}\n\n"
+    return c
+
+
+# ============================================================================
+# Pattern P03: Multi-field + enum dispatch (switch, 3-10 cases)
+# ~35-65 lines per copy
+# ============================================================================
+
+def gen_P03(vid, cid, rng, pvid):
+    num_cases = 3 + (pvid % 8)  # 3-10
+    yields_per_case = 1 + (pvid % 3)
+    has_default = (pvid + cid) % 2 == 0
+    type_off = rng.randint(0, 255)
+    c = fhdr(vid, cid)
+    c += f"  int type_val = static_cast<int>({sr(type_off)}) & 0xF;\n"
+    c += f"  switch (type_val) {{\n"
+    for case_i in range(num_cases):
+        c += f"    case {case_i}: {{\n"
+        for y in range(yields_per_case):
+            off = rng.randint(0, 255)
+            fi = rng.randint(0, 49)
+            sc = rng.uniform(0.5, 3.0)
+            if y % 2 == 0:
+                c += f"      {{ float v = {sr(off)} * {sc:.4f}f;\n"
+                c += f"  " + yd(fi, "v")
+                c += f"      }}\n"
+            else:
+                idx_off = rng.randint(0, 255)
+                c += f"      {{ float v = {sr(off)} * {sc:.4f}f;\n"
+                c += f"  " + yi(fi, f"static_cast<int64_t>({sr(idx_off)})", "v")
+                c += f"      }}\n"
+        c += f"      break;\n"
+        c += f"    }}\n"
+    if has_default:
+        fi = rng.randint(0, 49)
+        c += f"    default:\n"
+        c += f"  " + yd(fi, "1.0f")
+        c += f"      break;\n"
+    c += f"  }}\n"
+    # Extra conditional after switch
+    extra_off = rng.randint(0, 255)
+    fi = rng.randint(0, 49)
+    c += f"  {{ float extra = {sr(extra_off)};\n"
+    c += f"    if (extra != 0.0f) {{\n"
+    c += yd(fi, "extra")
+    c += f"    }}\n"
+    c += f"  }}\n"
+    c += "}\n\n"
+    return c
+
+
+# ============================================================================
+# Pattern P04: Time arithmetic (3-5 branches, no loops, bucketing)
+# ~25-40 lines per copy
+# ============================================================================
+
+def gen_P04(vid, cid, rng, pvid):
+    num_time_fields = 1 + (pvid % 3)
+    has_bucket = (pvid + cid) % 2 == 0
+    bucket_type = pvid % 3  # linear, log, custom
+    c = fhdr(vid, cid)
+    t0_off = rng.randint(0, 127)
+    t1_off = rng.randint(128, 255)
+    fi_base = rng.randint(0, 40)
+    divisor = rng.uniform(60.0, 86400.0)
+    c += f"  float viewerTime = {sr(t0_off)} * 1e6f;\n"
+    c += f"  float storyTime = {sr(t1_off)} * 1e6f;\n"
+    c += f"  float age = viewerTime - storyTime;\n"
+    c += yd(fi_base, "age")
+    c += f"  float ageHours = age / {divisor:.1f}f;\n"
+    c += yd(fi_base + 1, "ageHours")
+    if has_bucket:
+        c += f"  if (age > 0.0f) {{\n"
+        if bucket_type == 0:  # linear
+            bsize = rng.uniform(100.0, 10000.0)
+            c += f"    int bucket = static_cast<int>(age / {bsize:.1f}f);\n"
+        elif bucket_type == 1:  # log
+            c += f"    int bucket = static_cast<int>(std::log2(ageHours + 1.0f));\n"
+        else:  # custom thresholds
+            thresholds = sorted([rng.uniform(0.1, 100.0) for _ in range(4)])
+            c += f"    int bucket = 0;\n"
+            for t_i, thr in enumerate(thresholds):
+                c += f"    if (ageHours > {thr:.2f}f) bucket = {t_i + 1};\n"
+        c += yi(fi_base + 2, "bucket", "1.0f")
+        c += f"  }}\n"
+    for tf in range(1, num_time_fields):
+        off = rng.randint(0, 255)
+        fi = fi_base + 3 + tf
+        mul = rng.uniform(0.001, 1.0)
+        c += f"  {{ float dt = {sr(off)} * {mul:.6f}f;\n"
+        c += f"    if (dt > 0.0f) {{\n"
+        c += yd(fi, "dt")
+        c += f"    }}\n"
+        c += f"  }}\n"
+    c += "}\n\n"
+    return c
+
+
+# ============================================================================
+# Pattern P05: Simple rate/counter yield (1 loop, 3-5 branches)
+# ~35-50 lines per copy
+# ============================================================================
+
+def gen_P05(vid, cid, rng, pvid):
+    num_counters = [3, 7, 11, 13][pvid % 4]
+    num_rates = [5, 10, 15, 20][pvid % 4]
+    has_imp_bucket = (pvid + cid) % 2 == 0
+    c = fhdr(vid, cid)
+    base_off = rng.randint(0, 100)
+    fi_c = rng.randint(0, 30)
+    fi_r = rng.randint(0, 30)
+    null_off = rng.randint(0, 255)
+    thr = rng.uniform(0.001, 0.1)
+    c += f"  float null_chk = {sr(null_off)};\n"
+    c += f"  if (null_chk < {thr:.4f}f) return;\n"
+    # Counter loop
+    c += f"  for (int i = 0; i < {num_counters}; ++i) {{\n"
+    c += f"    float cnt = {sr(base_off)} + c->structData[({base_off} + i) % c->structSize];\n"
+    c += f"    if (cnt > 0.0f) {{\n"
+    c += f"      int fi = ({fi_c} + i) % c->numFeatures;\n"
+    c += f"      int32_t idx = c->features[fi].raw_feature_index;\n"
+    c += f"      if (idx >= 0 && idx < (int32_t)c->example->denseValues.size())\n"
+    c += f"        c->example->denseValues[idx] = cnt;\n"
+    c += f"    }}\n"
+    c += f"  }}\n"
+    # Rate loop with impression bucketing
+    imp_off = rng.randint(0, 255)
+    c += f"  float denom = {sr(imp_off)};\n"
+    c += f"  if (denom <= 0.0f) return;\n"
+    c += f"  float invDenom = 1.0f / denom;\n"
+    if has_imp_bucket:
+        c += f"  int64_t impBkt = static_cast<int64_t>(std::log2(denom + 1.0f));\n"
+    else:
+        bucket_val = rng.randint(0, 15)
+        c += f"  int64_t impBkt = {bucket_val}LL;\n"
+    c += f"  for (int i = 0; i < {num_rates}; ++i) {{\n"
+    rate_off = rng.randint(0, 200)
+    sc = rng.uniform(0.5, 2.0)
+    c += f"    float rate = c->structData[({rate_off} + i) % c->structSize] * invDenom * {sc:.4f}f;\n"
+    c += f"    if (rate != 0.0f && std::isfinite(rate)) {{\n"
+    c += f"      int fi = ({fi_r} + i) % c->numFeatures;\n"
+    c += f"      if (fi >= 0 && fi < (int)c->example->idScoreLists.size())\n"
+    c += f"        c->example->idScoreLists[fi].emplace_back(\n"
+    c += f"          IdScorePair{{impBkt, rate}});\n"
+    c += f"    }}\n"
+    c += f"  }}\n"
+    c += "}\n\n"
+    return c
+
+
+# ============================================================================
+# Pattern P06: Dimensional rate yield (1-2 loops, 5-10 branches)
+# ~50-75 lines per copy
+# ============================================================================
+
+def gen_P06(vid, cid, rng, pvid):
+    num_dims = [2, 4, 7][pvid % 3]
+    num_rates = [5, 10, 15][pvid % 3]
+    c = fhdr(vid, cid)
+    dim_off = rng.randint(0, 255)
+    c += f"  int dim = static_cast<int>({sr(dim_off)}) & 0x7;\n"
+    c += f"  if (dim < 0 || dim >= {num_dims}) return;\n"
+    # Impression per dimension
+    imp_base = rng.randint(0, 200)
+    c += f"  float dimImp = c->structData[({imp_base} + dim) % c->structSize];\n"
+    c += f"  if (dimImp <= 0.0f) return;\n"
+    c += f"  float invImp = 1.0f / dimImp;\n"
+    c += f"  int64_t impBkt = static_cast<int64_t>(std::log2(dimImp + 1.0f));\n"
+    # Rate loop
+    rate_base = rng.randint(0, 150)
+    fi_base = rng.randint(0, 30)
+    c += f"  for (int i = 0; i < {num_rates}; ++i) {{\n"
+    sc = rng.uniform(0.3, 2.5)
+    c += f"    int off = ({rate_base} + dim * {num_rates} + i) % c->structSize;\n"
+    c += f"    float rate = c->structData[off] * invImp * {sc:.4f}f;\n"
+    c += f"    if (rate != 0.0f && std::isfinite(rate)) {{\n"
+    c += f"      int fi = ({fi_base} + dim * {num_rates} + i) % c->numFeatures;\n"
+    c += f"      if (fi >= 0 && fi < (int)c->example->idScoreLists.size())\n"
+    c += f"        c->example->idScoreLists[fi].emplace_back(\n"
+    c += f"          IdScorePair{{impBkt, rate}});\n"
+    c += f"    }}\n"
+    c += f"  }}\n"
+    # Extra dimension-specific yields
+    for d in range(min(num_dims, 3)):
+        off = rng.randint(0, 255)
+        fi = rng.randint(0, 49)
+        thr = rng.uniform(0.0, 1.0)
+        c += f"  if (dim == {d}) {{\n"
+        c += f"    float extra = {sr(off)} * {rng.uniform(0.5, 2.0):.4f}f;\n"
+        c += f"    if (extra > {thr:.4f}f) {{\n"
+        c += yd(fi, "extra")
+        c += f"    }}\n"
+        c += f"  }}\n"
+    c += "}\n\n"
+    return c
+
+
+# ============================================================================
+# Pattern P07: Multi-conditional rate yield (2 loops, 8-15 branches)
+# ~60-90 lines per copy
+# ============================================================================
+
+def gen_P07(vid, cid, rng, pvid):
+    dims = [(2, 3), (3, 4), (4, 5), (5, 7)][pvid % 4]
+    num_rates = [5, 10, 15][pvid % 3]
+    has_calib = (pvid + cid) % 2 == 0
+    c = fhdr(vid, cid)
+    # Subject type classification
+    s_off = rng.randint(0, 127)
+    a_off = rng.randint(128, 255)
+    c += f"  int subjType = static_cast<int>({sr(s_off)}) % {dims[0]};\n"
+    c += f"  if (subjType < 0) subjType = 0;\n"
+    c += f"  int actType = static_cast<int>({sr(a_off)}) % {dims[1]};\n"
+    c += f"  if (actType < 0) actType = 0;\n"
+    # 2D rate block access
+    rate_base = rng.randint(0, 100)
+    fi_base = rng.randint(0, 20)
+    imp_off = rng.randint(0, 255)
+    c += f"  float imp = {sr(imp_off)};\n"
+    c += f"  if (imp <= 0.0f) return;\n"
+    c += f"  float invImp = 1.0f / imp;\n"
+    c += f"  int64_t impBkt = static_cast<int64_t>(std::log2(imp + 1.0f));\n"
+    if has_calib:
+        calib_off = rng.randint(0, 255)
+        c += f"  float calibFactor = 1.0f + {sr(calib_off)} * 0.01f;\n"
+    # Nested loop: subject type determines rate block, inner loop yields
+    c += f"  for (int s = 0; s <= subjType; ++s) {{\n"
+    c += f"    for (int i = 0; i < {num_rates}; ++i) {{\n"
+    c += f"      int off = ({rate_base} + s * {dims[1]} * {num_rates}"
+    c += f" + actType * {num_rates} + i) % c->structSize;\n"
+    sc = rng.uniform(0.5, 2.0)
+    c += f"      float rate = c->structData[off] * invImp * {sc:.4f}f;\n"
+    c += f"      if (rate == 0.0f || !std::isfinite(rate)) continue;\n"
+    if has_calib:
+        c += f"      rate *= calibFactor;\n"
+    c += f"      int fi = ({fi_base} + s * {num_rates} + i) % c->numFeatures;\n"
+    c += f"      if (fi >= 0 && fi < (int)c->example->idScoreLists.size())\n"
+    c += f"        c->example->idScoreLists[fi].emplace_back(\n"
+    c += f"          IdScorePair{{impBkt, rate}});\n"
+    c += f"    }}\n"
+    c += f"  }}\n"
+    # Extra branch for action type specific logic
+    for a in range(min(dims[1], 3)):
+        off = rng.randint(0, 255)
+        fi = rng.randint(0, 49)
+        c += f"  if (actType == {a}) {{\n"
+        c += yd(fi, f"{sr(off)} * {rng.uniform(0.1, 3.0):.4f}f")
+        c += f"  }}\n"
+    c += "}\n\n"
+    return c
+
+
+# ============================================================================
+# Pattern P08: Single hash lookup + rates (1-2 loops, 5-10 branches)
+# ~45-70 lines per copy
+# ============================================================================
+
+def gen_P08(vid, cid, rng, pvid):
+    num_lookups = [1, 3, 5][pvid % 3]
+    num_rates = [3, 5, 10][pvid % 3]
+    table_idx = pvid % 4
+    c = fhdr(vid, cid)
+    fi_base = rng.randint(0, 30)
+    for lk in range(num_lookups):
+        ki = rng.randint(0, 9)
+        magic = rng.getrandbits(48)
+        c += f"  {{ // lookup {lk}\n"
+        c += f"    int64_t k = c->queryKeys[{ki} % c->numKeys] ^ 0x{magic:012x}LL;\n"
+        c += f"    auto it = c->tables[{table_idx}].find(k);\n"
+        if lk == 0 and num_lookups == 1:
+            c += f"    if (it == c->tables[{table_idx}].end()) {{ return; }}\n"
+        else:
+            c += f"    if (it != c->tables[{table_idx}].end()) {{\n"
+        c += f"    float baseVal = it->second;\n"
+        # Time slice loop
+        ts_count = rng.randint(3, 7)
+        c += f"    for (int ts = 0; ts < {ts_count}; ++ts) {{\n"
+        thr = rng.uniform(0.01, 0.5)
+        sc = rng.uniform(0.5, 3.0)
+        c += f"      float sliceVal = baseVal * c->structData[({rng.randint(0, 200)}"
+        c += f" + ts) % c->structSize] * {sc:.4f}f;\n"
+        c += f"      if (sliceVal > {thr:.4f}f) {{\n"
+        c += f"        int fi = ({fi_base} + {lk} * {ts_count} + ts) % c->numFeatures;\n"
+        c += f"        int32_t idx = c->features[fi].raw_feature_index;\n"
+        c += f"        if (idx >= 0 && idx < (int32_t)c->example->denseValues.size())\n"
+        c += f"          c->example->denseValues[idx] = sliceVal;\n"
+        c += f"      }}\n"
+        c += f"    }}\n"
+        # Rate computation
+        rate_off = rng.randint(0, 255)
+        c += f"    float weeks = {sr(rate_off)} * {rng.uniform(0.0001, 0.01):.6f}f;\n"
+        c += f"    if (weeks > 0.0f) {{\n"
+        fi_rate = rng.randint(0, 49)
+        c += f"      float rate = baseVal / weeks;\n"
+        c += yd(fi_rate, "rate")
+        c += f"    }}\n"
+        if not (lk == 0 and num_lookups == 1):
+            c += f"    }} // end if found\n"
+        c += f"  }}\n"
+    c += "}\n\n"
+    return c
+
+
+# ============================================================================
+# Pattern P09: Multi-key hash + dedup (2-3 nested loops, 10-20 branches)
+# ~100-150 lines per copy
+# ============================================================================
+
+def gen_P09(vid, cid, rng, pvid):
+    num_keys = [2, 3, 4][pvid % 3]
+    num_ts = [3, 5, 7][pvid % 3]
+    has_dedup = (pvid + cid) % 2 == 0
+    has_agg = (pvid % 3) != 2
+    has_ratio = (pvid % 5) == 0
+    max_emit = 16
+    max_agg = num_ts * max_emit
+    c = fhdr(vid, cid)
+    fi_base = rng.randint(0, 20)
+    # Key derivation
+    c += f"  int64_t keys[{num_keys}];\n"
+    for k in range(num_keys):
+        ki = rng.randint(0, 9)
+        magic = rng.getrandbits(48)
+        mix = rng.getrandbits(32)
+        c += f"  keys[{k}] = c->queryKeys[{ki} % c->numKeys] ^ 0x{magic:012x}LL;\n"
+        c += f"  keys[{k}] = (keys[{k}] >> 7) ^ (keys[{k}] * 0x{mix:08x}ULL);\n"
+    if has_dedup:
+        c += f"  bool emitted[{max_emit}] = {{}};\n"
+    if has_agg:
+        c += f"  float aggCounts[{max_agg}] = {{}};\n"
+    # Outer key loop
+    table_idx = pvid % 4
+    c += f"  for (int k = 0; k < {num_keys}; ++k) {{\n"
+    c += f"    auto it = c->tables[{table_idx}].find(keys[k]);\n"
+    c += f"    if (it == c->tables[{table_idx}].end()) continue;\n"
+    c += f"    float baseVal = it->second;\n"
+    if has_dedup:
+        c += f"    int emitIdx = static_cast<int>(static_cast<uint64_t>(keys[k]) % {max_emit});\n"
+        c += f"    bool alreadyEmitted = emitted[emitIdx];\n"
+        c += f"    emitted[emitIdx] = true;\n"
+    # Inner time-slice loop
+    c += f"    for (int ts = 0; ts < {num_ts}; ++ts) {{\n"
+    decay_base = rng.uniform(0.7, 0.99)
+    sc = rng.uniform(0.5, 2.0)
+    c += f"      float decay = 1.0f;\n"
+    c += f"      for (int d = 0; d < ts; ++d) decay *= {decay_base:.4f}f;\n"
+    c += f"      float val = baseVal * decay * {sc:.4f}f;\n"
+    thr = rng.uniform(0.001, 0.1)
+    c += f"      if (val < {thr:.4f}f) continue;\n"
+    if has_dedup:
+        c += f"      if (!alreadyEmitted) {{\n"
+        # Type dispatch
+        type_a_count = rng.randint(1, num_keys - 1) if num_keys > 1 else 1
+        c += f"        if (k < {type_a_count}) {{\n"
+        fi_a = rng.randint(0, 49)
+        c += yi(fi_a, f"ts", "val")
+        c += f"        }} else {{\n"
+        fi_b = rng.randint(0, 49)
+        c += yi(fi_b, f"ts + {num_ts}", "val")
+        c += f"        }}\n"
+        if has_agg:
+            c += f"      }} else {{\n"
+            c += f"        int ai = (emitIdx * {num_ts} + ts) % {max_agg};\n"
+            c += f"        aggCounts[ai] += val;\n"
+        c += f"      }}\n"
+    else:
+        fi_x = rng.randint(0, 49)
+        c += yi(fi_x, f"k * {num_ts} + ts", "val")
+    c += f"    }}\n"
+    # Per-key rate
+    rate_off = rng.randint(0, 255)
+    c += f"    float wks = {sr(rate_off)} * {rng.uniform(0.0001, 0.01):.6f}f;\n"
+    c += f"    if (wks > 0.0f) {{\n"
+    fi_rate = rng.randint(0, 49)
+    c += yd(fi_rate, f"baseVal / wks")
+    c += f"    }}\n"
+    c += f"  }}\n"  # end key loop
+    # Yield aggregated
+    if has_agg:
+        fi_agg = rng.randint(0, 49)
+        c += f"  for (int i = 0; i < {max_agg}; ++i) {{\n"
+        c += f"    if (aggCounts[i] != 0.0f) {{\n"
+        c += yi(fi_agg, "i", "aggCounts[i]")
+        c += f"    }}\n"
+        c += f"  }}\n"
+    if has_ratio:
+        fi_rat = rng.randint(0, 49)
+        c += f"  {{ float sum0 = 0.0f, sum1 = 0.0f;\n"
+        c += f"    for (int i = 0; i < {max_agg // 2}; ++i) sum0 += "
+        c += f"c->structData[(i + {rng.randint(0, 200)}) % c->structSize];\n"
+        c += f"    for (int i = 0; i < {max_agg // 2}; ++i) sum1 += "
+        c += f"c->structData[(i + {rng.randint(0, 200)}) % c->structSize];\n"
+        c += f"    if (sum1 > 0.0f) {{\n"
+        c += yd(fi_rat, "sum0 / sum1")
+        c += f"    }}\n"
+        c += f"  }}\n"
+    c += "}\n\n"
+    return c
+
+
+# ============================================================================
+# Pattern P10: Dual hash lookup (2 loops, 8-15 branches)
+# ~60-80 lines per copy
+# ============================================================================
+
+def gen_P10(vid, cid, rng, pvid):
+    num_rates = [3, 5, 8][pvid % 3]
+    c = fhdr(vid, cid)
+    fi_base = rng.randint(0, 20)
+    # First hash lookup (state table)
+    ki0 = rng.randint(0, 9)
+    magic0 = rng.getrandbits(48)
+    t0 = pvid % 4
+    c += f"  int64_t storyKey = c->queryKeys[{ki0} % c->numKeys] ^ 0x{magic0:012x}LL;\n"
+    c += f"  auto stateIt = c->tables[{t0}].find(storyKey);\n"
+    c += f"  bool wasRead = (stateIt != c->tables[{t0}].end() && stateIt->second > 0.5f);\n"
+    # Second hash lookup (FIH table)
+    ki1 = rng.randint(0, 9)
+    magic1 = rng.getrandbits(48)
+    t1 = (pvid + 1) % 4
+    c += f"  int64_t fihKey = c->queryKeys[{ki1} % c->numKeys] ^ 0x{magic1:012x}LL;\n"
+    c += f"  auto fihIt = c->tables[{t1}].find(fihKey);\n"
+    c += f"  if (fihIt == c->tables[{t1}].end()) return;\n"
+    c += f"  float fihBase = fihIt->second;\n"
+    # Conditional rate paths
+    c += f"  if (wasRead) {{\n"
+    for i in range(num_rates):
+        off = rng.randint(0, 255)
+        fi = fi_base + i
+        sc = rng.uniform(0.3, 2.0)
+        c += f"    {{ float rate = fihBase * {sr(off)} * {sc:.4f}f;\n"
+        c += yd(fi, "rate")
+        c += f"    }}\n"
+    c += f"  }} else {{\n"
+    for i in range(num_rates):
+        off = rng.randint(0, 255)
+        fi = fi_base + num_rates + i
+        sc = rng.uniform(0.3, 2.0)
+        c += f"    {{ float rate = fihBase * {sr(off)} * {sc:.4f}f;\n"
+        c += yd(fi, "rate")
+        c += f"    }}\n"
+    c += f"  }}\n"
+    # Extra conditional yields
+    thr = rng.uniform(0.1, 0.9)
+    fi_ex = rng.randint(0, 49)
+    c += f"  if (fihBase > {thr:.4f}f) {{\n"
+    c += yd(fi_ex, f"fihBase * {rng.uniform(1.0, 5.0):.4f}f")
+    c += f"  }}\n"
+    c += "}\n\n"
+    return c
+
+
+# ============================================================================
+# Pattern P11: Hash + tree traversal (2 loops, 8-15 branches)
+# Simulates red-black tree walk using struct array as linked list
+# ~80-120 lines per copy
+# ============================================================================
+
+def gen_P11(vid, cid, rng, pvid):
+    map_size = [50, 100, 200][pvid % 3]
+    num_chains = 1 + (pvid % 3)
+    c = fhdr(vid, cid)
+    fi_base = rng.randint(0, 30)
+    # Hash lookup for root
+    ki = rng.randint(0, 9)
+    magic = rng.getrandbits(48)
+    tidx = pvid % 4
+    c += f"  int64_t rootKey = c->queryKeys[{ki} % c->numKeys] ^ 0x{magic:012x}LL;\n"
+    c += f"  auto rootIt = c->tables[{tidx}].find(rootKey);\n"
+    c += f"  if (rootIt == c->tables[{tidx}].end()) return;\n"
+    c += f"  float rootVal = rootIt->second;\n"
+    # Simulated tree traversal: chase indices through structData
+    c += f"  // Simulated tree traversal (pointer chasing)\n"
+    c += f"  int nodeIdx = static_cast<int>(rootVal * {map_size}.0f) % c->structSize;\n"
+    c += f"  float treeSum = 0.0f;\n"
+    c += f"  int treeCount = 0;\n"
+    max_depth = rng.randint(15, 40)
+    thr = rng.uniform(0.01, 0.5)
+    c += f"  for (int depth = 0; depth < {max_depth}; ++depth) {{\n"
+    c += f"    float nodeVal = c->structData[nodeIdx % c->structSize];\n"
+    c += f"    if (nodeVal < {thr:.4f}f) break;  // null node\n"
+    # Left/right decision based on node value
+    c += f"    if (nodeVal > 0.5f) {{\n"
+    c += f"      nodeIdx = (nodeIdx * 2 + 1) % c->structSize;  // left child\n"
+    c += f"    }} else {{\n"
+    c += f"      nodeIdx = (nodeIdx * 2 + 2) % c->structSize;  // right child\n"
+    c += f"    }}\n"
+    c += f"    treeSum += nodeVal;\n"
+    c += f"    treeCount++;\n"
+    # Yield per node
+    fi_node = rng.randint(0, 49)
+    c += yi(fi_node, "static_cast<int64_t>(nodeIdx)", "nodeVal")
+    c += f"  }}\n"
+    # Summary yields
+    c += f"  if (treeCount > 0) {{\n"
+    c += yd(fi_base, "treeSum")
+    c += yd(fi_base + 1, f"treeSum / static_cast<float>(treeCount)")
+    c += f"  }}\n"
+    # Additional chains
+    for ch in range(1, num_chains):
+        ki2 = rng.randint(0, 9)
+        magic2 = rng.getrandbits(48)
+        tidx2 = (pvid + ch) % 4
+        c += f"  {{ // chain {ch}\n"
+        c += f"    int64_t k = c->queryKeys[{ki2} % c->numKeys] ^ 0x{magic2:012x}LL;\n"
+        c += f"    auto it = c->tables[{tidx2}].find(k);\n"
+        c += f"    if (it != c->tables[{tidx2}].end()) {{\n"
+        c += f"      float v = it->second;\n"
+        chain_depth = rng.randint(5, 15)
+        c += f"      int ci = static_cast<int>(v * {rng.randint(50, 200)}.0f) % c->structSize;\n"
+        c += f"      for (int d = 0; d < {chain_depth}; ++d) {{\n"
+        c += f"        float nv = c->structData[ci % c->structSize];\n"
+        c += f"        if (nv < 0.01f) break;\n"
+        c += f"        ci = (ci + static_cast<int>(nv * 100.0f)) % c->structSize;\n"
+        fi_ch = rng.randint(0, 49)
+        c += yi(fi_ch, f"static_cast<int64_t>(ci)", "nv")
+        c += f"      }}\n"
+        c += f"    }}\n"
+        c += f"  }}\n"
+    c += "}\n\n"
+    return c
+
+
+# ============================================================================
+# Pattern P12: Template time-window stats (1 loop, 2-3 branches)
+# ~30-40 lines per copy
+# ============================================================================
+
+def gen_P12(vid, cid, rng, pvid):
+    num_stats = [5, 10, 15, 20, 25, 30][pvid % 6]
+    window_off = rng.randint(0, 200)
+    c = fhdr(vid, cid)
+    fi_base = rng.randint(0, 30)
+    null_off = rng.randint(0, 255)
+    thr = rng.uniform(0.0, 0.05)
+    c += f"  constexpr int kVariantId = {vid};\n"
+    c += f"  float null_chk = {sr(null_off)};\n"
+    c += f"  if (null_chk < {thr:.4f}f) return;\n"
+    sc = rng.uniform(0.5, 3.0)
+    c += f"  for (int i = 0; i < {num_stats}; ++i) {{\n"
+    c += f"    float val = c->structData[({window_off} + kVariantId * {num_stats}"
+    c += f" + i) % c->structSize] * {sc:.4f}f;\n"
+    c += f"    if (val != 0.0f) {{\n"
+    c += f"      int fi = ({fi_base} + i) % c->numFeatures;\n"
+    c += f"      int32_t idx = c->features[fi].raw_feature_index;\n"
+    c += f"      if (idx >= 0 && idx < (int32_t)c->example->denseValues.size())\n"
+    c += f"        c->example->denseValues[idx] = val;\n"
+    c += f"    }}\n"
+    c += f"  }}\n"
+    c += "}\n\n"
+    return c
+
+
+# ============================================================================
+# Pattern P13: Massive coefficient yield (1-2 loops, 10-15 branches)
+# 100-250 explicit feature yields per copy
+# ~150-300 lines per copy
+# ============================================================================
+
+def gen_P13(vid, cid, rng, pvid):
+    num_imp_feats = 80 + pvid * 30  # 80-200
+    has_vpv = pvid % 2 == 0
+    num_vpv_feats = 30 + pvid * 15 if has_vpv else 0
+    c = fhdr(vid, cid)
+    imp_off = rng.randint(0, 255)
+    c += f"  float imp = {sr(imp_off)};\n"
+    c += f"  if (imp <= 0.0f) return;\n"
+    c += f"  float invImp = 1.0f / (imp + {rng.uniform(0.001, 0.1):.6f}f);\n"
+    bucket_magic = rng.getrandbits(16)
+    c += f"  int64_t impBkt = static_cast<int64_t>(std::log2(imp + 1.0f))"
+    c += f" ^ 0x{bucket_magic:04x}LL;\n"
+    # Block 1: impression-indexed rates (unrolled)
+    c += f"  // Block 1: {num_imp_feats} impression-indexed yields\n"
+    for i in range(num_imp_feats):
+        off = rng.randint(0, 1023)
+        fi = rng.randint(0, 49)
+        sc = rng.uniform(0.1, 5.0)
+        # Vary the computation between yields
+        comp = rng.randint(0, 3)
+        if comp == 0:
+            val_expr = f"c->structData[{off} % c->structSize] * invImp * {sc:.4f}f"
+        elif comp == 1:
+            off2 = rng.randint(0, 1023)
+            val_expr = (f"(c->structData[{off} % c->structSize] - "
+                       f"c->structData[{off2} % c->structSize]) * invImp * {sc:.4f}f")
+        elif comp == 2:
+            val_expr = f"std::log1p(std::abs(c->structData[{off} % c->structSize] * invImp)) * {sc:.4f}f"
+        else:
+            val_expr = f"c->structData[{off} % c->structSize] * invImp * invImp * {sc:.4f}f"
+        c += f"  {{ float r = {val_expr};\n"
+        c += f"    if (r != 0.0f && std::isfinite(r)) {{\n"
+        c += f"      int _fi = {fi} % c->numFeatures;\n"
+        c += f"      if (_fi >= 0 && _fi < (int)c->example->idScoreLists.size())\n"
+        c += f"        c->example->idScoreLists[_fi].emplace_back(\n"
+        c += f"          IdScorePair{{impBkt, r}});\n"
+        c += f"    }}\n"
+        c += f"  }}\n"
+    # Block 2: VPV rates
+    if has_vpv:
+        vpv_off = rng.randint(0, 255)
+        c += f"  float vpv = {sr(vpv_off)};\n"
+        c += f"  if (vpv > 0.0f) {{\n"
+        c += f"    float invVpv = 1.0f / vpv;\n"
+        c += f"    int64_t vpvBkt = static_cast<int64_t>(std::log2(vpv + 1.0f));\n"
+        for i in range(num_vpv_feats):
+            off = rng.randint(0, 1023)
+            fi = rng.randint(0, 49)
+            sc = rng.uniform(0.1, 5.0)
+            c += f"    {{ float r = c->structData[{off} % c->structSize] * invVpv * {sc:.4f}f;\n"
+            c += f"      if (r != 0.0f && std::isfinite(r)) {{\n"
+            c += f"        int _fi = {fi} % c->numFeatures;\n"
+            c += f"        if (_fi >= 0 && _fi < (int)c->example->idScoreLists.size())\n"
+            c += f"          c->example->idScoreLists[_fi].emplace_back(\n"
+            c += f"            IdScorePair{{vpvBkt, r}});\n"
+            c += f"      }}\n"
+            c += f"    }}\n"
+        c += f"  }}\n"
+    c += "}\n\n"
+    return c
+
+
+# ============================================================================
+# Pattern P14: Decayed coefficient (1-2 loops, 6-12 branches)
+# Like P13 but with exponential decay
+# ~80-150 lines per copy
+# ============================================================================
+
+def gen_P14(vid, cid, rng, pvid):
+    num_feats = [30, 50, 80, 100][pvid % 4]
+    decay_type = pvid % 3  # exponential, linear, half-life
+    c = fhdr(vid, cid)
+    imp_off = rng.randint(0, 255)
+    time_off = rng.randint(0, 255)
+    c += f"  float imp = {sr(imp_off)};\n"
+    c += f"  if (imp <= 0.0f) return;\n"
+    c += f"  float invImp = 1.0f / imp;\n"
+    c += f"  float timeSince = std::abs({sr(time_off)}) * {rng.uniform(0.01, 10.0):.4f}f;\n"
+    # Decay factor
+    if decay_type == 0:
+        decay_rate = rng.uniform(0.001, 0.1)
+        c += f"  float decay = std::exp(-{decay_rate:.6f}f * timeSince);\n"
+    elif decay_type == 1:
+        c += f"  float decay = 1.0f / (1.0f + timeSince * {rng.uniform(0.01, 0.5):.4f}f);\n"
+    else:
+        half_life = rng.uniform(1.0, 168.0)
+        c += f"  float decay = std::exp(-0.693147f * timeSince / {half_life:.2f}f);\n"
+    c += f"  int64_t impBkt = static_cast<int64_t>(std::log2(imp + 1.0f));\n"
+    # Feature yields with decay
+    for i in range(num_feats):
+        off = rng.randint(0, 511)
+        fi = rng.randint(0, 49)
+        sc = rng.uniform(0.1, 5.0)
+        c += f"  {{ float r = c->structData[{off} % c->structSize] * invImp * decay * {sc:.4f}f;\n"
+        c += f"    if (r != 0.0f && std::isfinite(r)) {{\n"
+        c += f"      int _fi = {fi} % c->numFeatures;\n"
+        c += f"      if (_fi >= 0 && _fi < (int)c->example->idScoreLists.size())\n"
+        c += f"        c->example->idScoreLists[_fi].emplace_back(\n"
+        c += f"          IdScorePair{{impBkt, r}});\n"
+        c += f"    }}\n"
+        c += f"  }}\n"
+    c += "}\n\n"
+    return c
+
+
+# ============================================================================
+# Pattern P15: Embedding dimension yield (1-2 loops, 3-6 branches)
+# ~45-70 lines per copy
+# ============================================================================
+
+def gen_P15(vid, cid, rng, pvid):
+    num_emb_types = [1, 2, 4, 6][pvid % 4]
+    emb_dim = [32, 64, 128][pvid % 3]
+    has_resolution = (pvid + cid) % 2 == 0
+    c = fhdr(vid, cid)
+    fi_base = rng.randint(0, 20)
+    # Outer loop: embedding types
+    for et in range(num_emb_types):
+        tidx = et % 4
+        ki = rng.randint(0, 9)
+        magic = rng.getrandbits(48)
+        c += f"  {{ // embedding type {et}\n"
+        if has_resolution:
+            res_off = rng.randint(0, 255)
+            c += f"    int64_t entityId = static_cast<int64_t>({sr(res_off)} * 1000.0f)"
+            c += f" ^ 0x{rng.getrandbits(32):08x}LL;\n"
+        else:
+            c += f"    int64_t entityId = c->queryKeys[{ki} % c->numKeys] ^ 0x{magic:012x}LL;\n"
+        c += f"    auto it = c->tables[{tidx}].find(entityId);\n"
+        c += f"    if (it != c->tables[{tidx}].end()) {{\n"
+        c += f"      float base = it->second;\n"
+        # Dimension loop
+        c += f"      for (int d = 0; d < {emb_dim}; ++d) {{\n"
+        off = rng.randint(0, 200)
+        sc = rng.uniform(0.1, 2.0)
+        c += f"        float dimVal = base * c->structData[({off} + d) % c->structSize] * {sc:.4f}f;\n"
+        c += f"        int fi = ({fi_base} + {et} * {emb_dim} + d) % c->numFeatures;\n"
+        c += f"        if (fi >= 0 && fi < (int)c->example->idScoreLists.size())\n"
+        c += f"          c->example->idScoreLists[fi].emplace_back(\n"
+        c += f"            IdScorePair{{static_cast<int64_t>(d), dimVal}});\n"
+        c += f"      }}\n"
+        c += f"    }}\n"
+        c += f"  }}\n"
+    c += "}\n\n"
+    return c
+
+
+# ============================================================================
+# Pattern P16: Embedding similarity (1-2 loops, 4-8 branches)
+# ~50-70 lines per copy
+# ============================================================================
+
+def gen_P16(vid, cid, rng, pvid):
+    emb_dim = [32, 64, 128][pvid % 3]
+    sim_type = pvid % 3  # dot, cosine, l2
+    yield_dims = (pvid + cid) % 3 == 0
+    c = fhdr(vid, cid)
+    fi_base = rng.randint(0, 30)
+    vw_off = rng.randint(0, 100)
+    ct_off = rng.randint(128, 250)
+    c += f"  float dotProduct = 0.0f;\n"
+    if sim_type == 1:  # cosine
+        c += f"  float normA = 0.0f, normB = 0.0f;\n"
+    elif sim_type == 2:  # L2
+        c += f"  float l2sum = 0.0f;\n"
+    c += f"  for (int i = 0; i < {emb_dim}; ++i) {{\n"
+    c += f"    float a = c->structData[({vw_off} + i) % c->structSize];\n"
+    c += f"    float b = c->structData[({ct_off} + i) % c->structSize];\n"
+    c += f"    dotProduct += a * b;\n"
+    if sim_type == 1:
+        c += f"    normA += a * a;\n"
+        c += f"    normB += b * b;\n"
+    elif sim_type == 2:
+        c += f"    float diff = a - b;\n"
+        c += f"    l2sum += diff * diff;\n"
+    c += f"  }}\n"
+    # Compute similarity
+    if sim_type == 0:
+        c += f"  float similarity = dotProduct;\n"
+    elif sim_type == 1:
+        c += f"  float similarity = dotProduct / (std::sqrt(normA) * std::sqrt(normB)"
+        c += f" + 1e-8f);\n"
+    else:
+        c += f"  float similarity = std::sqrt(l2sum + 1e-8f);\n"
+    c += yd(fi_base, "similarity")
+    # Optional dimension yield
+    if yield_dims:
+        c += f"  for (int i = 0; i < {emb_dim}; ++i) {{\n"
+        c += f"    float dimVal = c->structData[({ct_off} + i) % c->structSize];\n"
+        fi_dim = rng.randint(0, 49)
+        c += f"    int fi = ({fi_dim} + i) % c->numFeatures;\n"
+        c += f"    if (fi >= 0 && fi < (int)c->example->idScoreLists.size())\n"
+        c += f"      c->example->idScoreLists[fi].emplace_back(\n"
+        c += f"        IdScorePair{{static_cast<int64_t>(i), dimVal}});\n"
+        c += f"  }}\n"
+    c += "}\n\n"
+    return c
+
+
+# ============================================================================
+# Pattern P17: Sparse feature forward (1 loop, 2-3 branches)
+# ~30-40 lines per copy
+# ============================================================================
+
+def gen_P17(vid, cid, rng, pvid):
+    num_lists = [1, 3, 5, 10][pvid % 4]
+    items_per_list = [10, 30, 50][pvid % 3]
+    has_filter = (pvid + cid) % 2 == 0
+    c = fhdr(vid, cid)
+    fi_base = rng.randint(0, 30)
+    threshold = rng.uniform(0.01, 0.5)
+    for lst in range(num_lists):
+        base_off = rng.randint(0, 200)
+        c += f"  {{ // sparse list {lst}\n"
+        c += f"    for (int j = 0; j < {items_per_list}; ++j) {{\n"
+        sc = rng.uniform(0.5, 3.0)
+        c += f"      int off = ({base_off} + j * 2) % c->structSize;\n"
+        c += f"      int64_t id = static_cast<int64_t>(c->structData[off] * 1000.0f);\n"
+        c += f"      float score = c->structData[(off + 1) % c->structSize] * {sc:.4f}f;\n"
+        if has_filter:
+            c += f"      if (score < {threshold:.4f}f) continue;\n"
+        c += f"      int fi = ({fi_base} + {lst}) % c->numFeatures;\n"
+        c += f"      if (fi >= 0 && fi < (int)c->example->idScoreLists.size())\n"
+        c += f"        c->example->idScoreLists[fi].emplace_back(\n"
+        c += f"          IdScorePair{{id, score}});\n"
+        c += f"    }}\n"
+        c += f"  }}\n"
+    c += "}\n\n"
+    return c
+
+
+# ============================================================================
+# Pattern P18: Hash-then-sparse forward (2 loops, 5-8 branches)
+# ~40-55 lines per copy
+# ============================================================================
+
+def gen_P18(vid, cid, rng, pvid):
+    num_items = [10, 20, 30, 50][pvid % 4]
+    c = fhdr(vid, cid)
+    fi = rng.randint(0, 49)
+    ki = rng.randint(0, 9)
+    magic = rng.getrandbits(48)
+    tidx = pvid % 4
+    c += f"  int64_t key = c->queryKeys[{ki} % c->numKeys] ^ 0x{magic:012x}LL;\n"
+    c += f"  auto it = c->tables[{tidx}].find(key);\n"
+    c += f"  if (it == c->tables[{tidx}].end()) return;\n"
+    c += f"  float base = it->second;\n"
+    base_off = rng.randint(0, 200)
+    sc = rng.uniform(0.5, 3.0)
+    thr = rng.uniform(0.01, 0.3)
+    c += f"  for (int j = 0; j < {num_items}; ++j) {{\n"
+    c += f"    int off = ({base_off} + j * 2) % c->structSize;\n"
+    c += f"    int64_t id = static_cast<int64_t>(c->structData[off] * 1e4f);\n"
+    c += f"    float score = base * c->structData[(off + 1) % c->structSize] * {sc:.4f}f;\n"
+    c += f"    if (score < {thr:.4f}f) continue;\n"
+    c += f"    if ({fi} >= 0 && {fi} < (int)c->example->idScoreLists.size())\n"
+    c += f"      c->example->idScoreLists[{fi}].emplace_back(\n"
+    c += f"        IdScorePair{{id, score}});\n"
+    c += f"  }}\n"
+    c += "}\n\n"
+    return c
+
+
+# ============================================================================
+# Pattern P19: LastN ID match (1 loop, 1-3 branches)
+# ~30-40 lines per copy
+# ============================================================================
+
+def gen_P19(vid, cid, rng, pvid):
+    list_size = [10, 20, 50, 100][pvid % 4]
+    c = fhdr(vid, cid)
+    fi_base = rng.randint(0, 40)
+    target_ki = rng.randint(0, 9)
+    c += f"  int64_t targetId = c->queryKeys[{target_ki} % c->numKeys];\n"
+    c += f"  int matchPos = -1;\n"
+    list_off = rng.randint(0, 200)
+    c += f"  for (int i = 0; i < {list_size}; ++i) {{\n"
+    c += f"    int64_t recentId = static_cast<int64_t>(\n"
+    c += f"      c->structData[({list_off} + i) % c->structSize] * 1e6f);\n"
+    c += f"    if (recentId == targetId) {{ matchPos = i; break; }}\n"
+    c += f"  }}\n"
+    c += f"  if (matchPos >= 0) {{\n"
+    c += yd(fi_base, "1.0f")
+    c += yd(fi_base + 1, f"static_cast<float>(matchPos)")
+    recency_sc = rng.uniform(0.5, 2.0)
+    c += yd(fi_base + 2, f"{recency_sc:.4f}f / (1.0f + static_cast<float>(matchPos))")
+    c += f"  }}\n"
+    c += "}\n\n"
+    return c
+
+
+# ============================================================================
+# Pattern P20: Set membership match (1 loop, 3-6 branches)
+# ~30-40 lines per copy
+# ============================================================================
+
+def gen_P20(vid, cid, rng, pvid):
+    num_sets = [1, 3, 5][pvid % 3]
+    set_size = [10, 30, 50][pvid % 3]
+    c = fhdr(vid, cid)
+    fi_base = rng.randint(0, 40)
+    target_ki = rng.randint(0, 9)
+    c += f"  int64_t actorId = c->queryKeys[{target_ki} % c->numKeys];\n"
+    for s in range(num_sets):
+        set_off = rng.randint(0, 200)
+        fi = fi_base + s
+        c += f"  {{ // set {s}\n"
+        c += f"    bool isMember = false;\n"
+        c += f"    for (int i = 0; i < {set_size}; ++i) {{\n"
+        c += f"      int64_t memberId = static_cast<int64_t>(\n"
+        c += f"        c->structData[({set_off} + i) % c->structSize] * 1e6f);\n"
+        c += f"      if (memberId == actorId) {{ isMember = true; break; }}\n"
+        c += f"    }}\n"
+        c += f"    if (isMember) {{\n"
+        c += yd(fi, "1.0f")
+        c += f"    }}\n"
+        c += f"  }}\n"
+    c += "}\n\n"
+    return c
+
+
+# ============================================================================
+# Pattern P21: Large monolithic prediction (3-5 loops, 30-50 branches)
+# ~180-250 lines per copy
+# ============================================================================
+
+def gen_P21(vid, cid, rng, pvid):
+    num_switch_cases = [10, 20, 30][pvid % 3]
+    num_calib_tables = [3, 5, 8][pvid % 3]
+    num_predictions = [50, 100, 150][pvid % 3]
+    c = fhdr(vid, cid)
+    fi_base = rng.randint(0, 10)
+
+    # Event type classification (large switch)
+    type_off = rng.randint(0, 255)
+    c += f"  int eventType = static_cast<int>({sr(type_off)} * {num_switch_cases}.0f)"
+    c += f" % {num_switch_cases};\n"
+    c += f"  float eventWeight = 1.0f;\n"
+    c += f"  switch (eventType) {{\n"
+    for case_i in range(num_switch_cases):
+        weight = rng.uniform(0.1, 5.0)
+        c += f"    case {case_i}: eventWeight = {weight:.4f}f; break;\n"
+    c += f"    default: eventWeight = 1.0f; break;\n"
+    c += f"  }}\n"
+
+    # Calibration tables
+    for ct in range(num_calib_tables):
+        c += f"  // Calibration table {ct}\n"
+        c += f"  float calib{ct} = 1.0f;\n"
+        calib_off = rng.randint(0, 255)
+        num_calib_entries = rng.randint(3, 8)
+        c += f"  {{ float raw = {sr(calib_off)};\n"
+        for ce in range(num_calib_entries):
+            thr = rng.uniform(-2.0, 2.0)
+            factor = rng.uniform(0.5, 2.0)
+            c += f"    if (raw > {thr:.4f}f) calib{ct} = {factor:.4f}f;\n"
+        c += f"  }}\n"
+
+    # Hash lookups for base predictions
+    for lk in range(min(3, num_calib_tables)):
+        ki = rng.randint(0, 9)
+        magic = rng.getrandbits(48)
+        tidx = lk % 4
+        c += f"  float pred{lk} = 0.0f;\n"
+        c += f"  {{ auto it = c->tables[{tidx}].find(\n"
+        c += f"      c->queryKeys[{ki} % c->numKeys] ^ 0x{magic:012x}LL);\n"
+        c += f"    if (it != c->tables[{tidx}].end()) pred{lk} = it->second;\n"
+        c += f"  }}\n"
+
+    # Prediction loop with calibration
+    c += f"  for (int p = 0; p < {num_predictions}; ++p) {{\n"
+    pred_off = rng.randint(0, 200)
+    c += f"    float rawPred = c->structData[({pred_off} + p) % c->structSize];\n"
+    c += f"    if (rawPred == 0.0f) continue;\n"
+    c += f"    float calibrated = rawPred * eventWeight;\n"
+    for ct in range(num_calib_tables):
+        c += f"    calibrated *= calib{ct};\n"
+    # Conditional calibration adjustments
+    for adj in range(3):
+        thr = rng.uniform(-1.0, 1.0)
+        factor = rng.uniform(0.8, 1.2)
+        c += f"    if (calibrated > {thr:.4f}f) calibrated *= {factor:.4f}f;\n"
+    # Transform
+    transform = rng.choice(["std::tanh(calibrated)", "1.0f / (1.0f + std::exp(-calibrated))",
+                            "calibrated", "std::log1p(std::abs(calibrated))"])
+    c += f"    float final_p = {transform};\n"
+    c += f"    int fi = ({fi_base} + p) % c->numFeatures;\n"
+    c += f"    int32_t idx = c->features[fi].raw_feature_index;\n"
+    c += f"    if (idx >= 0 && idx < (int32_t)c->example->denseValues.size())\n"
+    c += f"      c->example->denseValues[idx] = final_p;\n"
+    c += f"  }}\n"
+
+    # Feature mapping loop
+    c += f"  for (int m = 0; m < {num_predictions // 2}; ++m) {{\n"
+    map_off = rng.randint(0, 200)
+    c += f"    float mapped = c->structData[({map_off} + m) % c->structSize];\n"
+    c += f"    if (mapped == 0.0f) continue;\n"
+    # Nested branch for mapping type
+    c += f"    int mapType = m % {min(5, num_calib_tables)};\n"
+    for mt in range(min(5, num_calib_tables)):
+        sc = rng.uniform(0.5, 3.0)
+        c += f"    {'if' if mt == 0 else 'else if'} (mapType == {mt}) {{\n"
+        c += f"      mapped *= {sc:.4f}f * calib{mt % num_calib_tables};\n"
+        fi = rng.randint(0, 49)
+        c += yd(fi, "mapped")
+        c += f"    }}\n"
+    c += f"  }}\n"
+
+    # Score combination
+    c += f"  float combined = pred0"
+    for lk in range(1, min(3, num_calib_tables)):
+        w = rng.uniform(0.1, 2.0)
+        c += f" + pred{lk} * {w:.4f}f"
+    c += f";\n"
+    c += f"  combined *= eventWeight;\n"
+    fi_final = rng.randint(0, 49)
+    c += yd(fi_final, "combined")
+
+    c += "}\n\n"
+    return c
+
+
+# ============================================================================
+# Pattern P22: Medium prediction forward (1-2 loops, 5-15 branches)
+# ~60-100 lines per copy
+# ============================================================================
+
+def gen_P22(vid, cid, rng, pvid):
+    num_preds = [10, 30, 50, 100][pvid % 4]
+    lookup_type = pvid % 3  # hash, array, switch
+    has_calib = (pvid + cid) % 2 == 0
+    has_fallback = (pvid % 3) == 0
+    c = fhdr(vid, cid)
+    fi_base = rng.randint(0, 20)
+    # Prediction source
+    if lookup_type == 0:  # hash
+        ki = rng.randint(0, 9)
+        magic = rng.getrandbits(48)
+        tidx = pvid % 4
+        c += f"  auto baseIt = c->tables[{tidx}].find(\n"
+        c += f"    c->queryKeys[{ki} % c->numKeys] ^ 0x{magic:012x}LL);\n"
+        c += f"  float basePred = (baseIt != c->tables[{tidx}].end()) ? baseIt->second : 0.0f;\n"
+    else:
+        off = rng.randint(0, 255)
+        c += f"  float basePred = {sr(off)};\n"
+    if has_calib:
+        c += f"  float calibScale = 1.0f + {sr(rng.randint(0, 255))} * 0.05f;\n"
+        c += f"  float calibBias = {sr(rng.randint(0, 255))} * 0.01f;\n"
+    if has_fallback:
+        fallback = rng.uniform(0.01, 0.5)
+        c += f"  float fallback = {fallback:.4f}f;\n"
+    # Prediction loop
+    c += f"  for (int p = 0; p < {num_preds}; ++p) {{\n"
+    pred_off = rng.randint(0, 200)
+    c += f"    float pred = c->structData[({pred_off} + p) % c->structSize];\n"
+    if has_fallback:
+        c += f"    if (pred == 0.0f) pred = fallback;\n"
+    c += f"    pred *= basePred;\n"
+    if has_calib:
+        c += f"    pred = pred * calibScale + calibBias;\n"
+    c += f"    if (pred != 0.0f && std::isfinite(pred)) {{\n"
+    c += f"      int fi = ({fi_base} + p) % c->numFeatures;\n"
+    c += f"      int32_t idx = c->features[fi].raw_feature_index;\n"
+    c += f"      if (idx >= 0 && idx < (int32_t)c->example->denseValues.size())\n"
+    c += f"        c->example->denseValues[idx] = pred;\n"
+    c += f"    }}\n"
+    c += f"  }}\n"
+    if lookup_type == 2:  # switch-based extra yields
+        num_cases = rng.randint(3, 7)
+        type_off = rng.randint(0, 255)
+        c += f"  int predType = static_cast<int>({sr(type_off)}) % {num_cases};\n"
+        c += f"  switch (predType) {{\n"
+        for cs in range(num_cases):
+            fi = rng.randint(0, 49)
+            sc = rng.uniform(0.5, 3.0)
+            c += f"    case {cs}:\n"
+            c += yd(fi, f"basePred * {sc:.4f}f")
+            c += f"      break;\n"
+        c += f"  }}\n"
+    c += "}\n\n"
+    return c
+
+
+# ============================================================================
+# Pattern P23: SentencePiece tokenization (2-3 loops, 5-10 branches)
+# ~70-110 lines per copy
+# ============================================================================
+
+def gen_P23(vid, cid, rng, pvid):
+    max_tokens = [50, 100, 200][pvid % 3]
+    has_bigram = (pvid + cid) % 2 == 0
+    c = fhdr(vid, cid)
+    fi_base = rng.randint(0, 30)
+    # Hash-based tokenization from struct data (simulating text)
+    text_off = rng.randint(0, 200)
+    vocab = rng.randint(5000, 30000)
+    c += f"  // Hash-based tokenization\n"
+    c += f"  int tokens[{max_tokens}];\n"
+    c += f"  int numTokens = 0;\n"
+    c += f"  uint64_t hashState = {rng.getrandbits(64)}ULL;\n"
+    c += f"  for (int i = 0; i < {max_tokens}; ++i) {{\n"
+    c += f"    float charVal = c->structData[({text_off} + i) % c->structSize];\n"
+    c += f"    if (charVal < 0.01f) break;\n"
+    c += f"    hashState = hashState * 6364136223846793005ULL + "
+    c += f"static_cast<uint64_t>(charVal * 1e6f);\n"
+    c += f"    tokens[numTokens++] = static_cast<int>(hashState % {vocab}ULL);\n"
+    c += f"  }}\n"
+    # Yield unigram tokens
+    c += f"  for (int i = 0; i < numTokens; ++i) {{\n"
+    c += f"    int fi = ({fi_base} + 0) % c->numFeatures;\n"
+    c += f"    if (fi >= 0 && fi < (int)c->example->idScoreLists.size())\n"
+    c += f"      c->example->idScoreLists[fi].emplace_back(\n"
+    c += f"        IdScorePair{{static_cast<int64_t>(tokens[i]), 1.0f}});\n"
+    c += f"  }}\n"
+    # Optional bigram loop
+    if has_bigram:
+        c += f"  for (int i = 0; i + 1 < numTokens; ++i) {{\n"
+        c += f"    int64_t bigram = (static_cast<int64_t>(tokens[i]) << 16)"
+        c += f" | tokens[i + 1];\n"
+        fi_bi = rng.randint(0, 49)
+        c += f"    int fi = ({fi_bi} + 1) % c->numFeatures;\n"
+        c += f"    if (fi >= 0 && fi < (int)c->example->idScoreLists.size())\n"
+        c += f"      c->example->idScoreLists[fi].emplace_back(\n"
+        c += f"        IdScorePair{{bigram, 1.0f}});\n"
+        c += f"  }}\n"
+    c += "}\n\n"
+    return c
+
+
+# ============================================================================
+# Pattern P24: Mutable state read/update (0-2 loops, 5-10 branches)
+# ~40-60 lines per copy
+# ============================================================================
+
+def gen_P24(vid, cid, rng, pvid):
+    state_type = pvid % 4  # video_ids, topic_counts, position_tracker, diversity
+    c = fhdr(vid, cid)
+    fi_base = rng.randint(0, 40)
+    state_off = rng.randint(0, 200)
+
+    if state_type == 0:  # video_ids tracking
+        c += f"  // Video ID state tracking\n"
+        c += f"  int64_t currentId = c->queryKeys[0 % c->numKeys];\n"
+        num_recent = rng.randint(5, 20)
+        c += f"  int matchCount = 0;\n"
+        c += f"  for (int i = 0; i < {num_recent}; ++i) {{\n"
+        c += f"    int64_t prevId = static_cast<int64_t>(\n"
+        c += f"      c->structData[({state_off} + i) % c->structSize] * 1e6f);\n"
+        c += f"    if (prevId == currentId) matchCount++;\n"
+        c += f"  }}\n"
+        c += yd(fi_base, "static_cast<float>(matchCount)")
+        c += f"  if (matchCount > 0) {{\n"
+        c += yd(fi_base + 1, f"1.0f / static_cast<float>(matchCount)")
+        c += f"  }}\n"
+    elif state_type == 1:  # topic counts
+        c += f"  // Topic count state\n"
+        num_topics = rng.randint(5, 15)
+        c += f"  for (int t = 0; t < {num_topics}; ++t) {{\n"
+        c += f"    float count = c->structData[({state_off} + t) % c->structSize];\n"
+        thr = rng.uniform(0.1, 1.0)
+        c += f"    if (count > {thr:.4f}f) {{\n"
+        c += f"      float score = count * {rng.uniform(0.1, 2.0):.4f}f;\n"
+        c += yd(fi_base, "score")
+        c += f"    }}\n"
+        c += f"  }}\n"
+    elif state_type == 2:  # position tracker
+        c += f"  // Position tracking state\n"
+        c += f"  float position = {sr(state_off)};\n"
+        c += f"  float prevPosition = {sr(state_off + 1)};\n"
+        c += f"  float delta = position - prevPosition;\n"
+        c += yd(fi_base, "position")
+        c += yd(fi_base + 1, "delta")
+        c += f"  if (delta > 0.0f) {{\n"
+        c += yd(fi_base + 2, f"std::log1p(delta)")
+        c += f"  }} else if (delta < 0.0f) {{\n"
+        c += yd(fi_base + 3, f"std::log1p(-delta)")
+        c += f"  }}\n"
+    else:  # diversity counter
+        c += f"  // Diversity counter state\n"
+        num_categories = rng.randint(3, 10)
+        c += f"  float counts[{num_categories}] = {{}};\n"
+        c += f"  for (int i = 0; i < {rng.randint(10, 30)}; ++i) {{\n"
+        c += f"    int cat = static_cast<int>(c->structData[({state_off} + i) % c->structSize]"
+        c += f" * {num_categories}.0f) % {num_categories};\n"
+        c += f"    counts[cat] += 1.0f;\n"
+        c += f"  }}\n"
+        c += f"  float entropy = 0.0f;\n"
+        c += f"  float total = 0.0f;\n"
+        c += f"  for (int i = 0; i < {num_categories}; ++i) total += counts[i];\n"
+        c += f"  if (total > 0.0f) {{\n"
+        c += f"    for (int i = 0; i < {num_categories}; ++i) {{\n"
+        c += f"      float p = counts[i] / total;\n"
+        c += f"      if (p > 0.0f) entropy -= p * std::log(p + 1e-10f);\n"
+        c += f"    }}\n"
+        c += f"  }}\n"
+        c += yd(fi_base, "entropy")
+        c += yd(fi_base + 1, "total")
+
+    c += "}\n\n"
+    return c
+
+
+# ============================================================================
+# Pattern P25: Multi-topic hash iteration (2-3 loops, 6-12 branches)
+# ~55-75 lines per copy
+# ============================================================================
+
+def gen_P25(vid, cid, rng, pvid):
+    max_topics = [3, 5, 10, 20][pvid % 4]
+    rates_per_topic = [3, 5, 10][pvid % 3]
+    has_filter = (pvid + cid) % 2 == 0
+    c = fhdr(vid, cid)
+    fi_base = rng.randint(0, 20)
+    topic_off = rng.randint(0, 200)
+    tidx = pvid % 4
+    # Topic iteration
+    c += f"  for (int t = 0; t < {max_topics}; ++t) {{\n"
+    c += f"    int64_t topicId = static_cast<int64_t>(\n"
+    c += f"      c->structData[({topic_off} + t) % c->structSize] * 1e5f);\n"
+    if has_filter:
+        thr = rng.uniform(100.0, 10000.0)
+        c += f"    if (topicId < {int(thr)}LL) continue;\n"
+    c += f"    auto it = c->tables[{tidx}].find(topicId);\n"
+    c += f"    if (it == c->tables[{tidx}].end()) continue;\n"
+    c += f"    float topicBase = it->second;\n"
+    # Per-topic rate loop
+    rate_off = rng.randint(0, 200)
+    sc = rng.uniform(0.3, 2.0)
+    c += f"    for (int r = 0; r < {rates_per_topic}; ++r) {{\n"
+    c += f"      float rate = topicBase * c->structData[({rate_off} + t * {rates_per_topic}"
+    c += f" + r) % c->structSize] * {sc:.4f}f;\n"
+    c += f"      if (rate == 0.0f || !std::isfinite(rate)) continue;\n"
+    c += f"      int fi = ({fi_base} + t * {rates_per_topic} + r) % c->numFeatures;\n"
+    c += f"      if (fi >= 0 && fi < (int)c->example->idScoreLists.size())\n"
+    c += f"        c->example->idScoreLists[fi].emplace_back(\n"
+    c += f"          IdScorePair{{topicId * {rates_per_topic} + r, rate}});\n"
+    c += f"    }}\n"
+    c += f"  }}\n"
+    c += "}\n\n"
+    return c
+
+
+# ============================================================================
+# Pattern P26: Delegated dynamic feature generation (0 loops, 1-3 branches)
+# Thin wrapper that delegates to external holder — tiny function body
+# ~10-18 lines per copy
+# ============================================================================
+
+def gen_P26(vid, cid, rng, pvid):
+    num_checks = 1 + (pvid % 3)  # 1-3 pre-checks
+    holder_type = pvid % 2
+    c = fhdr(vid, cid)
+    fi_base = rng.randint(0, 40)
+    # Holder lookup (simulated via struct data)
+    holder_off = rng.randint(0, 255)
+    c += f"  float holderVal = {sr(holder_off)};\n"
+    # Pre-check branches
+    for chk in range(num_checks):
+        chk_off = rng.randint(0, 255)
+        thr = rng.uniform(0.0, 0.3)
+        c += f"  if ({sr(chk_off)} < {thr:.4f}f) return;\n"
+    # Delegation: the holder "converts all" by writing a batch of features
+    # This is a tiny function — the key is it calls into a different code path
+    if holder_type == 0:
+        num_delegate = rng.randint(3, 8)
+        c += f"  // convertAll delegation\n"
+        for d in range(num_delegate):
+            off = rng.randint(0, 255)
+            fi = fi_base + d
+            sc = rng.uniform(0.5, 2.0)
+            c += f"  {{ float dv = holderVal * {sr(off)} * {sc:.4f}f;\n"
+            c += yd(fi, "dv")
+            c += f"  }}\n"
+    else:
+        # Alternative holder: forward sparse features
+        num_fwd = rng.randint(2, 5)
+        c += f"  // forwardAll delegation\n"
+        for d in range(num_fwd):
+            off = rng.randint(0, 255)
+            fi = rng.randint(0, 49)
+            c += f"  {{ int64_t id = static_cast<int64_t>({sr(off)} * 1e4f);\n"
+            c += yi(fi, "id", f"holderVal * {rng.uniform(0.5, 2.0):.4f}f")
+            c += f"  }}\n"
+    c += "}\n\n"
+    return c
+
+
+# ============================================================================
+# Pattern P27: Multi-category hierarchical FIH (2-3 loops, 8-15 branches)
+# Dynamic key computation + category iteration + mobile/desktop paths
+# ~70-100 lines per copy
+# ============================================================================
+
+def gen_P27(vid, cid, rng, pvid):
+    num_categories = [3, 5, 7, 8][pvid % 4]
+    is_mobile = (pvid + cid) % 2 == 0
+    has_aggregate = (pvid % 3) != 2
+    c = fhdr(vid, cid)
+    fi_base = rng.randint(0, 15)
+    # Dynamic key computation (unique to P27)
+    c += f"  // computeFIHKeys: dynamic key generation\n"
+    c += f"  int64_t catKeys[{num_categories}];\n"
+    for cat in range(num_categories):
+        ki = rng.randint(0, 9)
+        mix0 = rng.getrandbits(48)
+        mix1 = rng.getrandbits(32)
+        c += f"  catKeys[{cat}] = (c->queryKeys[{ki} % c->numKeys] ^ 0x{mix0:012x}LL)"
+        c += f" * 0x{mix1:08x}ULL;\n"
+        c += f"  catKeys[{cat}] = (catKeys[{cat}] >> 11) ^ (catKeys[{cat}] << 3);\n"
+    # Category iteration
+    tidx = pvid % 4
+    rates_per_cat = rng.randint(3, 8)
+    c += f"  for (int cat = 0; cat < {num_categories}; ++cat) {{\n"
+    c += f"    auto it = c->tables[{tidx}].find(catKeys[cat]);\n"
+    c += f"    if (it == c->tables[{tidx}].end()) continue;\n"
+    c += f"    float catBase = it->second;\n"
+    # Mobile vs desktop conditional paths
+    if is_mobile:
+        c += f"    // mobile path\n"
+        for r in range(rates_per_cat):
+            off = rng.randint(0, 255)
+            sc = rng.uniform(0.3, 2.0)
+            fi = fi_base + r
+            c += f"    {{ float mv = catBase * {sr(off)} * {sc:.4f}f;\n"
+            transform = rng.choice(["mv", "std::tanh(mv)", "std::abs(mv)"])
+            c += f"      float t = {transform};\n"
+            c += yi(fi, f"catKeys[cat]", "t")
+            c += f"    }}\n"
+    else:
+        c += f"    // desktop path\n"
+        for r in range(rates_per_cat):
+            off = rng.randint(0, 255)
+            sc = rng.uniform(0.3, 2.0)
+            fi = fi_base + rates_per_cat + r
+            c += f"    {{ float dv = catBase * {sr(off)} * {sc:.4f}f;\n"
+            # Desktop path uses different computation
+            c += f"      float t = dv * dv * 0.01f;\n"
+            c += f"      if (t > 0.001f) {{\n"
+            c += yd(fi, "t")
+            c += f"      }}\n"
+            c += f"    }}\n"
+    c += f"  }}\n"
+    # Aggregate "all categories" pass
+    if has_aggregate:
+        c += f"  // all-categories aggregate\n"
+        c += f"  float aggSum = 0.0f;\n"
+        c += f"  int aggCount = 0;\n"
+        c += f"  for (int cat = 0; cat < {num_categories}; ++cat) {{\n"
+        c += f"    auto it = c->tables[{tidx}].find(catKeys[cat]);\n"
+        c += f"    if (it != c->tables[{tidx}].end()) {{\n"
+        c += f"      aggSum += it->second;\n"
+        c += f"      aggCount++;\n"
+        c += f"    }}\n"
+        c += f"  }}\n"
+        c += f"  if (aggCount > 0) {{\n"
+        fi_agg = rng.randint(0, 49)
+        c += yd(fi_agg, "aggSum / static_cast<float>(aggCount)")
+        fi_cnt = rng.randint(0, 49)
+        c += yd(fi_cnt, "static_cast<float>(aggCount)")
+        c += f"  }}\n"
+    c += "}\n\n"
+    return c
+
+
+# ============================================================================
+# Pattern generator dispatch table
+# ============================================================================
+
+PATTERN_GENERATORS = {
+    "P01": gen_P01, "P02": gen_P02, "P03": gen_P03, "P04": gen_P04,
+    "P05": gen_P05, "P06": gen_P06, "P07": gen_P07, "P08": gen_P08,
+    "P09": gen_P09, "P10": gen_P10, "P11": gen_P11, "P12": gen_P12,
+    "P13": gen_P13, "P14": gen_P14, "P15": gen_P15, "P16": gen_P16,
+    "P17": gen_P17, "P18": gen_P18, "P19": gen_P19, "P20": gen_P20,
+    "P21": gen_P21, "P22": gen_P22, "P23": gen_P23, "P24": gen_P24,
+    "P25": gen_P25, "P26": gen_P26, "P27": gen_P27,
+}
+
+
+# ============================================================================
+# Variant spec generation
+# ============================================================================
+
+def generate_all_variants() -> List[VariantSpec]:
+    specs = []
+    global_idx = 0
+    for pattern, count, struct_size, table_size in PATTERN_DISTRIBUTION:
+        for i in range(count):
+            seed = RANDOM_SEED + global_idx * 7919 + i * 31
+            spec = VariantSpec(
+                name=f"ExtractorV_{pattern}_{global_idx:04d}",
+                pattern=pattern,
+                variant_idx=global_idx,
+                pattern_variant_idx=i,
+                seed=seed,
+                struct_size=struct_size,
+                table_size=table_size,
+            )
+            specs.append(spec)
+            global_idx += 1
+    return specs
+
+
+# ============================================================================
+# File generators (dispatch.h, copies, variants, registry, cmake)
+# ============================================================================
+
+def generate_dispatch_header(output_dir, num_variants, copies_per_variant):
+    path = os.path.join(output_dir, "dispatch.h")
+    with open(path, "w") as f:
+        f.write(COPYRIGHT)
+        f.write(f"""
+#pragma once
+
+#include "../FeatureTypes.h"
+#include <cstdint>
+#include <unordered_map>
+#include <vector>
+
+namespace dcperf {{
+namespace feature_extractors {{
+namespace generated {{
+
+struct CopyContext {{
+  std::unordered_map<int64_t, float>* tables;  // array of 4 tables
+  float* structData;
+  int structSize;
+  MockFeatureExample* example;
+  const MockFeature* features;
+  int numFeatures;
+  const int64_t* queryKeys;
+  int numKeys;
+}};
+
+using CopyFn = void(*)(CopyContext*);
+
+constexpr int kCopiesPerVariant = {copies_per_variant};
+
+""")
+        for vid in range(num_variants):
+            f.write(f"void CopiesInit_{vid:04d}(CopyFn* arr);\n")
+        f.write("""
+} // namespace generated
+} // namespace feature_extractors
+} // namespace dcperf
+""")
+
+
+def generate_copies_part(spec, copies_per_variant, output_dir):
+    copies_dir = os.path.join(output_dir, "copies")
+    filepath = os.path.join(copies_dir, f"copies_part_{spec.variant_idx:04d}.cpp")
+    gen_fn = PATTERN_GENERATORS[spec.pattern]
+
+    with open(filepath, "w") as f:
+        f.write(COPYRIGHT)
+        f.write("\n")
+        f.write('#include "../dispatch.h"\n')
+        f.write("#include <cmath>\n")
+        f.write("#include <cstdint>\n")
+        f.write("\n")
+        f.write("namespace dcperf {\n")
+        f.write("namespace feature_extractors {\n")
+        f.write("namespace generated {\n\n")
+
+        for cid in range(copies_per_variant):
+            rng = random.Random(spec.seed * 1000003 + cid * 7)
+            f.write(gen_fn(spec.variant_idx, cid, rng, spec.pattern_variant_idx))
+
+        # CopiesInit function
+        f.write(f"void CopiesInit_{spec.variant_idx:04d}(CopyFn* arr) {{\n")
+        for cid in range(copies_per_variant):
+            f.write(f"  arr[{cid}] = vc_{spec.variant_idx:04d}_{cid:04d};\n")
+        f.write("}\n\n")
+
+        f.write("} // namespace generated\n")
+        f.write("} // namespace feature_extractors\n")
+        f.write("} // namespace dcperf\n")
+
+
+def generate_variant_class(spec, copies_per_variant):
+    lines = []
+    lines.append(f"class {spec.name} : public ArchetypeBase {{")
+    lines.append(f"  static constexpr uint64_t kSeed = {spec.seed}ULL;")
+    lines.append(f"")
+    lines.append(f" public:")
+    lines.append(f"  void initializeImpl(int complexity) override {{")
+    lines.append(f"    uint64_t state = kSeed + complexity;")
+    lines.append(f"    structSize_ = {spec.struct_size};")
+    lines.append(f"    structData_ = new float[structSize_];")
+    lines.append(f"    for (int i = 0; i < structSize_; ++i)")
+    lines.append(f"      structData_[i] = randomFloat(state);")
+    lines.append(f"    for (int t = 0; t < 4; ++t)")
+    lines.append(f"      for (int i = 0; i < {spec.table_size}; ++i)")
+    lines.append(f"        tables_[t][randomInt64(state)] = randomFloat(state);")
+    lines.append(f"    CopiesInit_{spec.variant_idx:04d}(copies_);")
+    lines.append(f"    rngState_ = kSeed;")
+    lines.append(f"  }}")
+    lines.append(f"")
+    lines.append(f"  ~{spec.name}() override {{ delete[] structData_; }}")
+    lines.append(f"")
+    lines.append(f"  __attribute__((noinline)) void extractImpl(")
+    lines.append(f"      MockFeatureExample& example,")
+    lines.append(f"      const std::vector<MockFeature>& features,")
+    lines.append(f"      const std::vector<int64_t>& queryKeys) override {{")
+    lines.append(f"    CopyContext ctx;")
+    lines.append(f"    ctx.tables = tables_;")
+    lines.append(f"    ctx.structData = structData_;")
+    lines.append(f"    ctx.structSize = structSize_;")
+    lines.append(f"    ctx.example = &example;")
+    lines.append(f"    ctx.features = features.data();")
+    lines.append(f"    ctx.numFeatures = static_cast<int>(features.size());")
+    lines.append(f"    ctx.queryKeys = queryKeys.data();")
+    lines.append(f"    ctx.numKeys = static_cast<int>(queryKeys.size());")
+    lines.append(f"    int idx = static_cast<int>(rngState_ % kCopiesPerVariant);")
+    lines.append(f"    rngState_ = rngState_ * 6364136223846793005ULL + 1442695040888963407ULL;")
+    lines.append(f"    copies_[idx](&ctx);")
+    lines.append(f"  }}")
+    lines.append(f"")
+    lines.append(f"  std::string name() const override {{ return \"{spec.name}\"; }}")
+    lines.append(f"")
+    lines.append(f" private:")
+    lines.append(f"  float* structData_ = nullptr;")
+    lines.append(f"  int structSize_ = 0;")
+    lines.append(f"  std::unordered_map<int64_t, float> tables_[4];")
+    lines.append(f"  CopyFn copies_[kCopiesPerVariant];")
+    lines.append(f"  uint64_t rngState_ = 0;")
+    lines.append(f"}};")
+    return "\n".join(lines)
+
+
+def generate_batch_files(specs, output_dir, variants_per_batch, copies_per_variant):
+    variants_dir = os.path.join(output_dir, "variants")
+    os.makedirs(variants_dir, exist_ok=True)
+    batch_files = []
+    batch_idx = 0
+    for start in range(0, len(specs), variants_per_batch):
+        batch = specs[start:start + variants_per_batch]
+        filename = f"variants_batch_{batch_idx:03d}.cpp"
+        filepath = os.path.join(variants_dir, filename)
+        content = [COPYRIGHT, ""]
+        content.append('#include "../archetype_templates/ArchetypeBase.h"')
+        content.append('#include "../archetype_templates/ArchetypeUtils.h"')
+        content.append('#include "../dispatch.h"')
+        content.append("#include <cmath>")
+        content.append("#include <memory>")
+        content.append("#include <string>")
+        content.append("#include <unordered_map>")
+        content.append("#include <vector>")
+        content.append("")
+        content.append("namespace dcperf {")
+        content.append("namespace feature_extractors {")
+        content.append("namespace generated {")
+        content.append("")
+        for spec in batch:
+            content.append(generate_variant_class(spec, copies_per_variant))
+            content.append("")
+        func_name = f"createBatch{batch_idx:03d}"
+        content.append(
+            f"void {func_name}("
+            f"std::vector<std::unique_ptr<FeatureExtractorBase>>& v) {{"
+        )
+        for spec in batch:
+            content.append(f"  v.push_back(std::make_unique<{spec.name}>());")
+        content.append("}")
+        content.append("")
+        content.append("} // namespace generated")
+        content.append("} // namespace feature_extractors")
+        content.append("} // namespace dcperf")
+        content.append("")
+        with open(filepath, "w") as f:
+            f.write("\n".join(content))
+        batch_files.append(filename)
+        batch_idx += 1
+    return batch_files
+
+
+def generate_registry(specs, num_batches, output_dir):
+    num_variants = len(specs)
+    header_path = os.path.join(output_dir, "registry.h")
+    with open(header_path, "w") as f:
+        f.write(COPYRIGHT)
+        f.write(f"""
+#pragma once
+
+#include "../FeatureExtractorBase.h"
+#include "dispatch.h"
+#include <memory>
+#include <vector>
+
+namespace dcperf {{
+namespace feature_extractors {{
+namespace generated {{
+
+std::vector<std::unique_ptr<FeatureExtractorBase>>
+createGeneratedExtractors();
+
+constexpr int kNumGeneratedVariants = {num_variants};
+
+// Collect all copy function pointers into a flat vector for sequential dispatch
+void getAllCopyFunctions(std::vector<CopyFn>& out);
+
+}} // namespace generated
+}} // namespace feature_extractors
+}} // namespace dcperf
+""")
+
+    cpp_path = os.path.join(output_dir, "registry.cpp")
+    lines = [COPYRIGHT, ""]
+    lines.append('#include "registry.h"')
+    lines.append('#include "dispatch.h"')
+    lines.append("")
+    lines.append("namespace dcperf {")
+    lines.append("namespace feature_extractors {")
+    lines.append("namespace generated {")
+    lines.append("")
+    for i in range(num_batches):
+        lines.append(
+            f"void createBatch{i:03d}("
+            f"std::vector<std::unique_ptr<FeatureExtractorBase>>& v);"
+        )
+    lines.append("")
+    lines.append("std::vector<std::unique_ptr<FeatureExtractorBase>>")
+    lines.append("createGeneratedExtractors() {")
+    lines.append("  std::vector<std::unique_ptr<FeatureExtractorBase>> extractors;")
+    lines.append(f"  extractors.reserve({num_variants});")
+    lines.append("")
+    for i in range(num_batches):
+        lines.append(f"  createBatch{i:03d}(extractors);")
+    lines.append("")
+    lines.append("  return extractors;")
+    lines.append("}")
+    lines.append("")
+    lines.append(f"void getAllCopyFunctions(std::vector<CopyFn>& out) {{")
+    lines.append(f"  constexpr int N = {num_variants};")
+    lines.append(f"  out.resize(N * kCopiesPerVariant);")
+    lines.append(f"  using InitFn = void(*)(CopyFn*);")
+    lines.append(f"  static const InitFn inits[N] = {{")
+    for i in range(num_variants):
+        comma = "," if i < num_variants - 1 else ""
+        lines.append(f"    CopiesInit_{i:04d}{comma}")
+    lines.append(f"  }};")
+    lines.append(f"  for (int v = 0; v < N; ++v) {{")
+    lines.append(f"    inits[v](out.data() + v * kCopiesPerVariant);")
+    lines.append(f"  }}")
+    lines.append(f"}}")
+    lines.append("")
+    lines.append("} // namespace generated")
+    lines.append("} // namespace feature_extractors")
+    lines.append("} // namespace dcperf")
+    lines.append("")
+    with open(cpp_path, "w") as f:
+        f.write("\n".join(lines))
+
+
+def generate_cmake_fragment(batch_files, num_variants, output_dir):
+    cmake_path = os.path.join(output_dir, "generated_sources.cmake")
+    lines = [
+        "# Auto-generated by generate_extractors.py -- do not edit",
+        "",
+        "set(GENERATED_EXTRACTOR_SOURCES",
+        "  ${CMAKE_CURRENT_SOURCE_DIR}/feature_extractors/generated/registry.cpp",
+    ]
+    for bf in batch_files:
+        lines.append(
+            f"  ${{CMAKE_CURRENT_SOURCE_DIR}}/feature_extractors/generated/variants/{bf}"
+        )
+    for vid in range(num_variants):
+        lines.append(
+            f"  ${{CMAKE_CURRENT_SOURCE_DIR}}/feature_extractors/generated/"
+            f"copies/copies_part_{vid:04d}.cpp"
+        )
+    lines.append(")")
+    lines.append("")
+    with open(cmake_path, "w") as f:
+        f.write("\n".join(lines))
+
+
+# ============================================================================
+# Main
+# ============================================================================
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Generate diverse feature extractor variants (25 patterns)"
+    )
+    parser.add_argument(
+        "--output-dir",
+        default=os.path.dirname(os.path.abspath(__file__)),
+        help="Output directory for generated files",
+    )
+    parser.add_argument(
+        "--variants-per-batch",
+        type=int,
+        default=10,
+        help="Number of variant classes per batch .cpp file",
+    )
+    parser.add_argument(
+        "--copies-per-variant",
+        type=int,
+        default=1000,
+        help="Number of copy functions per variant (default 1000)",
+    )
+    args = parser.parse_args()
+
+    t0 = time.time()
+    print(f"Output directory: {args.output_dir}")
+    print(f"Variants per batch: {args.variants_per_batch}")
+    print(f"Copies per variant: {args.copies_per_variant}")
+    print()
+
+    copies_dir = os.path.join(args.output_dir, "copies")
+    os.makedirs(copies_dir, exist_ok=True)
+
+    specs = generate_all_variants()
+    total = len(specs)
+    total_copies = total * args.copies_per_variant
+    print(f"Total variants: {total}")
+    print(f"Total copy functions: {total_copies:,}")
+    print()
+
+    # Pattern breakdown
+    pattern_counts = {}
+    for spec in specs:
+        pattern_counts[spec.pattern] = pattern_counts.get(spec.pattern, 0) + 1
+    for pat, cnt in sorted(pattern_counts.items()):
+        print(f"  {pat}: {cnt} variants")
+    print()
+
+    # Generate dispatch header
+    generate_dispatch_header(args.output_dir, total, args.copies_per_variant)
+    print("Generated dispatch.h")
+
+    # Generate copies part files
+    print(f"Generating {total} copies_part files...", end="", flush=True)
+    for i, spec in enumerate(specs):
+        generate_copies_part(spec, args.copies_per_variant, args.output_dir)
+        if (i + 1) % 50 == 0:
+            print(f" {i + 1}", end="", flush=True)
+    print(f" done")
+
+    # Generate variant batch files
+    batch_files = generate_batch_files(
+        specs, args.output_dir, args.variants_per_batch,
+        args.copies_per_variant)
+    print(f"Generated {len(batch_files)} variant batch files")
+
+    # Generate registry
+    generate_registry(specs, len(batch_files), args.output_dir)
+    print("Generated registry.h and registry.cpp")
+
+    # Generate cmake fragment
+    generate_cmake_fragment(batch_files, total, args.output_dir)
+    print("Generated generated_sources.cmake")
+
+    elapsed = time.time() - t0
+    print(f"\nGeneration time: {elapsed:.1f}s")
+    print(f"Estimated unique functions: {total_copies:,}")
+    print(f"\nDone: {total} variants x {args.copies_per_variant} copies"
+          f" = {total_copies:,} unique functions across 25 patterns")
+
+
+if __name__ == "__main__":
+    main()

--- a/packages/feedsim/third_party/src/workloads/ranking/feature_extractors/generated/generate_extractors.py
+++ b/packages/feedsim/third_party/src/workloads/ranking/feature_extractors/generated/generate_extractors.py
@@ -68,9 +68,14 @@ PATTERN_DISTRIBUTION = [
 ]
 
 TRANSFORMS = [
-    "r", "std::abs(r)", "std::tanh(r)",
-    "std::log1p(std::abs(r))", "(1.0f / (1.0f + std::exp(-r)))",
-    "std::sqrt(std::abs(r))", "(r * r * 0.01f)", "std::sin(r * 0.1f)",
+    "r",
+    "static_cast<float>(static_cast<int32_t>(r * 1000.0f) & 0x7FFFFFFF)",
+    "static_cast<float>(__builtin_popcount(static_cast<uint32_t>(r * 1e6f)))",
+    "static_cast<float>((static_cast<int64_t>(r * 1e4f) ^ 0x5BD1E995LL) >> 13)",
+    "(r > 0.5f ? r : -r)",
+    "static_cast<float>((static_cast<uint64_t>(r * 1e6f) * 0x9E3779B97F4A7C15ULL) >> 48)",
+    "static_cast<float>(static_cast<int32_t>(r) << 3)",
+    "static_cast<float>((static_cast<int32_t>(r * 256.0f) ^ (static_cast<int32_t>(r * 65536.0f) >> 7)) & 0xFFFF)",
 ]
 
 
@@ -90,8 +95,18 @@ class VariantSpec:
 # ============================================================================
 
 def fhdr(vid, cid):
+    """Function header with context preparation call and validity pre-check."""
+    seed = vid * 1000 + cid
+    guard_off = (seed * 7 + 13) % 256
+    guard_thr = (seed % 16)
     return (f"__attribute__((noinline)) static void "
-            f"vc_{vid:04d}_{cid:04d}(CopyContext* c) {{\n")
+            f"vc_{vid:04d}_{cid:04d}(CopyContext* c) {{\n"
+            f"  using namespace dcperf::feature_extractors;\n"
+            f"  helpers::prepareExtractContext(c, {seed});\n"
+            f"  if ((static_cast<int>(c->structData[{guard_off} % c->structSize]) & 0xF) < {guard_thr}) {{\n"
+            f"    c->structData[0] += 1e-10f;\n"
+            f"    return;\n"
+            f"  }}\n")
 
 
 def sr(off):
@@ -100,23 +115,125 @@ def sr(off):
 
 
 def yd(fi, val):
-    """Yield dense feature."""
+    """Yield dense feature — INLINE unique code (I-cache pressure) + helper validation."""
+    # Keep the original inline code for unique instruction footprint,
+    # AND call helper for additional non-inline hops.
     return (f"    {{ int _fi = {fi} % c->numFeatures;\n"
             f"      int32_t _i = c->features[_fi].raw_feature_index;\n"
-            f"      if (_i >= 0 && _i < (int32_t)c->example->denseValues.size())\n"
-            f"        c->example->denseValues[_i] = {val}; }}\n")
+            f"      if (_i >= 0 && _i < (int32_t)c->example->denseValues.size()) {{\n"
+            f"        float _v = {val};\n"
+            f"        if (dcperf::feature_extractors::helpers::validateFeatureValue(_v, {fi % 3}))\n"
+            f"          c->example->denseValues[_i] = _v;\n"
+            f"      }} }}\n")
 
 
 def yi(fi, idx, val):
-    """Yield indexed feature (sparse)."""
+    """Yield indexed feature — INLINE unique code + helper validation."""
     return (f"    {{ int _fi = {fi} % c->numFeatures;\n"
-            f"      if (_fi >= 0 && _fi < (int)c->example->idScoreLists.size())\n"
+            f"      float _v = {val};\n"
+            f"      if (_fi >= 0 && _fi < (int)c->example->idScoreLists.size()\n"
+            f"          && dcperf::feature_extractors::helpers::validateFeatureValue(_v, {fi % 3}))\n"
             f"        c->example->idScoreLists[_fi].emplace_back(\n"
-            f"          IdScorePair{{{idx}, {val}}}); }}\n")
+            f"          IdScorePair{{{idx}, _v}}); }}\n")
+
+
+def hl(table_idx, key_expr, fallback="0.0f"):
+    """Hash lookup via mock hash table (adds 5-7 non-inline hops)."""
+    return (f"dcperf::mock_hash::hashLookupWithFallback("
+            f"c->hashTables[{table_idx} % c->numHashTables], "
+            f"static_cast<int64_t>({key_expr}), {fallback})")
+
+
+def hj(tA, tB, key_expr, scale="1000.0f"):
+    """Cross-table hash join (adds 7-10 non-inline hops)."""
+    return (f"dcperf::mock_hash::crossTableLookup("
+            f"c->hashTables[{tA} % c->numHashTables], "
+            f"c->hashTables[{tB} % c->numHashTables], "
+            f"static_cast<int64_t>({key_expr}), {scale})")
+
+
+def ls(table_idx, stat_type):
+    """Lookup stats via helper (adds 6-8 non-inline hops)."""
+    return (f"dcperf::feature_extractors::helpers::lookupStats("
+            f"c->hashTables[{table_idx} % c->numHashTables], "
+            f"c->queryKeys, c->numKeys, {stat_type})")
+
+
+def cr(num, den, bucket_type):
+    """Compute rate via helper (adds 3-4 non-inline hops)."""
+    return (f"dcperf::feature_extractors::helpers::computeRate("
+            f"{num}, {den}, {bucket_type})")
 
 
 def pick_transform(rng):
     return rng.choice(TRANSFORMS)
+
+
+def int_hash_expr(rng, input_var):
+    """Generate a unique integer hash computation that replaces FP math."""
+    magic1 = hex(rng.randint(0, 0xFFFFFFFF))
+    magic2 = hex(rng.randint(0, 0xFFFFFFFF))
+    shift = rng.randint(7, 19)
+    return (f"static_cast<float>((static_cast<uint32_t>({input_var} * 1e4f) "
+            f"* {magic1}u ^ {magic2}u) >> {shift})")
+
+
+def hash_block(rng, input_off, num_ops=20, num_guards=0):
+    """Generate a block of integer hash computations to increase BB size.
+
+    When num_guards > 0, interleaves rarely-taken guard branches throughout
+    the computation.  These branches count as conditional-branch instructions
+    (increasing br_inst_retired.cond) but are almost never taken (~1/256),
+    so they do NOT split LBR-measured basic blocks — matching production's
+    pattern of many not-taken data-dependent checks within straight-line code.
+    """
+    c = ""
+    c += f"  uint64_t _h = static_cast<uint64_t>(c->structData[{input_off} % c->structSize] * 1e6f);\n"
+    guard_interval = max(1, num_ops // (num_guards + 1)) if num_guards > 0 else num_ops + 1
+    guard_idx = 0
+    for i in range(num_ops):
+        magic = hex(rng.randint(0x10000000, 0xFFFFFFFFFFFFFFFF))
+        shift = rng.randint(11, 23)
+        next_off = (input_off + i + 1) % 512
+        op = rng.choice([
+            f"  _h = _h * {magic}ULL; _h ^= _h >> {shift};\n",
+            f"  _h += static_cast<uint64_t>(c->structData[{next_off} % c->structSize] * 1e4f); _h *= {magic}ULL;\n",
+            f"  _h ^= _h >> {shift}; _h *= {magic}ULL; _h ^= _h >> {shift + 3};\n",
+        ])
+        c += op
+        # Insert rarely-taken guard branch every guard_interval ops
+        if num_guards > 0 and (i + 1) % guard_interval == 0 and guard_idx < num_guards:
+            rare_val = hex(rng.randint(0x80, 0xFF))
+            sd_off = (input_off + guard_idx) % 256
+            c += (f"  if ((_h & 0xFF) == {rare_val}) "
+                  f"c->structData[{sd_off} % c->structSize] += 1e-15f;\n")
+            guard_idx += 1
+    c += f"  float _hf = static_cast<float>(_h >> 32) * 1e-9f;\n"
+    return c
+
+
+def guard_cascade(rng, num_guards=12):
+    """Generate a cascade of rarely-taken guard branches with computation.
+
+    Each guard adds a conditional branch instruction (~1/256 taken) plus
+    2-3 hash ops between guards.  Combined with hash_block, this raises
+    conditional-branch % toward production's 14% without splitting LBR BBs.
+    Requires _h and _hf to already be declared (call after hash_block).
+    """
+    c = ""
+    for g in range(num_guards):
+        # 2-3 hash ops between guards (keeps _h changing so guards are independent)
+        for _ in range(rng.randint(2, 3)):
+            magic = hex(rng.randint(0x10000000, 0xFFFFFFFFFFFFFFFF))
+            shift = rng.randint(7, 23)
+            c += f"  _h = _h * {magic}ULL; _h ^= _h >> {shift};\n"
+        # Guard branch: true ~1/256 of the time
+        rare_val = hex(rng.randint(0x00, 0xFF))
+        sd_off = rng.randint(0, 255)
+        c += (f"  if ((_h & 0xFF) == {rare_val}) "
+              f"c->structData[{sd_off} % c->structSize] += 1e-15f;\n")
+    c += f"  _hf += static_cast<float>(_h >> 48) * 1e-12f;\n"
+    return c
 
 
 # ============================================================================
@@ -128,17 +245,22 @@ def gen_P01(vid, cid, rng, pvid):
     num_yields = 1 + (pvid % 3)
     has_null = (pvid + cid) % 2 == 0
     c = fhdr(vid, cid)
+    # Hash block with guards to increase BB size and conditional branch %
+    c += hash_block(rng, rng.randint(0, 255), num_ops=50)
     off0 = rng.randint(0, 255)
     sc0 = rng.uniform(0.5, 3.0)
     if has_null:
-        c += f"  float v0 = {sr(off0)} * {sc0:.4f}f;\n"
+        c += f"  float v0 = {sr(off0)} * {sc0:.4f}f + _hf;\n"
         c += f"  if (v0 == 0.0f) return;\n"
     for i in range(num_yields):
         off = rng.randint(0, 255)
         fi = rng.randint(0, 49)
         sc = rng.uniform(0.3, 4.0)
         c += f"  {{ float val = {sr(off)} * {sc:.4f}f;\n"
+        # Feature validity check branch
+        c += f"    if (c->features[{fi} % c->numFeatures].raw_feature_index >= 0) {{\n"
         c += yd(fi, "val")
+        c += f"    }}\n"
         c += f"  }}\n"
     c += "}\n\n"
     return c
@@ -154,6 +276,8 @@ def gen_P02(vid, cid, rng, pvid):
     num_branches = 3 + (pvid % 6)  # 3-8
     has_cross = (pvid % 3) == 0
     c = fhdr(vid, cid)
+    # Hash block with guards to increase BB size and conditional branch %
+    c += hash_block(rng, rng.randint(0, 255), num_ops=35)
     # Read from 1-2 "sources" (different struct offset regions)
     src_base = [rng.randint(0, 127), rng.randint(128, 255)]
     for i in range(num_fields):
@@ -182,7 +306,11 @@ def gen_P02(vid, cid, rng, pvid):
         fi = rng.randint(0, 49)
         c += f"  {{ float a = {sr(oA)}; float b = {sr(oB)};\n"
         c += f"    if (b != 0.0f) {{\n"
-        c += f"      float cross = a / b;\n"
+        # Integer bit manipulation for reciprocal approximation
+        c += f"      int32_t _den_bits = *reinterpret_cast<int32_t*>(&b);\n"
+        c += f"      _den_bits = 0x7EF311C2 - _den_bits;\n"
+        c += f"      float _inv_b = *reinterpret_cast<float*>(&_den_bits);\n"
+        c += f"      float cross = a * _inv_b + _hf;\n"
         c += yd(fi, "cross")
         c += f"    }}\n"
         c += f"  }}\n"
@@ -201,6 +329,7 @@ def gen_P03(vid, cid, rng, pvid):
     has_default = (pvid + cid) % 2 == 0
     type_off = rng.randint(0, 255)
     c = fhdr(vid, cid)
+    c += hash_block(rng, rng.randint(0, 127), num_ops=30)
     c += f"  int type_val = static_cast<int>({sr(type_off)}) & 0xF;\n"
     c += f"  switch (type_val) {{\n"
     for case_i in range(num_cases):
@@ -256,15 +385,17 @@ def gen_P04(vid, cid, rng, pvid):
     c += f"  float storyTime = {sr(t1_off)} * 1e6f;\n"
     c += f"  float age = viewerTime - storyTime;\n"
     c += yd(fi_base, "age")
-    c += f"  float ageHours = age / {divisor:.1f}f;\n"
+    inv_divisor = 1.0 / divisor
+    c += f"  float ageHours = age * {inv_divisor:.10f}f;\n"
     c += yd(fi_base + 1, "ageHours")
     if has_bucket:
         c += f"  if (age > 0.0f) {{\n"
         if bucket_type == 0:  # linear
             bsize = rng.uniform(100.0, 10000.0)
-            c += f"    int bucket = static_cast<int>(age / {bsize:.1f}f);\n"
-        elif bucket_type == 1:  # log
-            c += f"    int bucket = static_cast<int>(std::log2(ageHours + 1.0f));\n"
+            inv_bsize = 1.0 / bsize
+            c += f"    int bucket = static_cast<int>(age * {inv_bsize:.10f}f);\n"
+        elif bucket_type == 1:  # log — integer approximation
+            c += f"    int bucket = static_cast<int>(31 - __builtin_clz(static_cast<uint32_t>(ageHours + 1.0f)));\n"
         else:  # custom thresholds
             thresholds = sorted([rng.uniform(0.1, 100.0) for _ in range(4)])
             c += f"    int bucket = 0;\n"
@@ -294,7 +425,9 @@ def gen_P05(vid, cid, rng, pvid):
     num_counters = [3, 7, 11, 13][pvid % 4]
     num_rates = [5, 10, 15, 20][pvid % 4]
     has_imp_bucket = (pvid + cid) % 2 == 0
+    has_hash_lookup = (pvid + cid) % 3 != 0
     c = fhdr(vid, cid)
+    c += hash_block(rng, rng.randint(0, 255), num_ops=35)
     base_off = rng.randint(0, 100)
     fi_c = rng.randint(0, 30)
     fi_r = rng.randint(0, 30)
@@ -302,36 +435,39 @@ def gen_P05(vid, cid, rng, pvid):
     thr = rng.uniform(0.001, 0.1)
     c += f"  float null_chk = {sr(null_off)};\n"
     c += f"  if (null_chk < {thr:.4f}f) return;\n"
-    # Counter loop
+    # Hash lookup for additional data (adds 5-7 noinline hops)
+    if has_hash_lookup:
+        tbl = rng.randint(0, 3)
+        c += f"  float hashBoost = {hl(tbl, sr(base_off))};\n"
+    else:
+        c += f"  float hashBoost = 1.0f;\n"
+    # Counter loop — original inline code kept
     c += f"  for (int i = 0; i < {num_counters}; ++i) {{\n"
     c += f"    float cnt = {sr(base_off)} + c->structData[({base_off} + i) % c->structSize];\n"
+    c += f"    cnt *= hashBoost;\n"
     c += f"    if (cnt > 0.0f) {{\n"
-    c += f"      int fi = ({fi_c} + i) % c->numFeatures;\n"
-    c += f"      int32_t idx = c->features[fi].raw_feature_index;\n"
-    c += f"      if (idx >= 0 && idx < (int32_t)c->example->denseValues.size())\n"
-    c += f"        c->example->denseValues[idx] = cnt;\n"
+    c += yd(fi_c, "cnt")
     c += f"    }}\n"
     c += f"  }}\n"
-    # Rate loop with impression bucketing
+    # Rate loop — original inline + computeRate helper
     imp_off = rng.randint(0, 255)
     c += f"  float denom = {sr(imp_off)};\n"
     c += f"  if (denom <= 0.0f) return;\n"
-    c += f"  float invDenom = 1.0f / denom;\n"
+    c += f"  int32_t _den_b = *reinterpret_cast<int32_t*>(&denom);\n"
+    c += f"  _den_b = 0x7EF311C2 - _den_b;\n"
+    c += f"  float invDenom = *reinterpret_cast<float*>(&_den_b);\n"
     if has_imp_bucket:
-        c += f"  int64_t impBkt = static_cast<int64_t>(std::log2(denom + 1.0f));\n"
+        c += f"  int64_t impBkt = static_cast<int64_t>(31 - __builtin_clz(static_cast<uint32_t>(denom + 1.0f)));\n"
     else:
         bucket_val = rng.randint(0, 15)
         c += f"  int64_t impBkt = {bucket_val}LL;\n"
+    bucket_type = rng.randint(0, 3)
     c += f"  for (int i = 0; i < {num_rates}; ++i) {{\n"
     rate_off = rng.randint(0, 200)
     sc = rng.uniform(0.5, 2.0)
     c += f"    float rate = c->structData[({rate_off} + i) % c->structSize] * invDenom * {sc:.4f}f;\n"
-    c += f"    if (rate != 0.0f && std::isfinite(rate)) {{\n"
-    c += f"      int fi = ({fi_r} + i) % c->numFeatures;\n"
-    c += f"      if (fi >= 0 && fi < (int)c->example->idScoreLists.size())\n"
-    c += f"        c->example->idScoreLists[fi].emplace_back(\n"
-    c += f"          IdScorePair{{impBkt, rate}});\n"
-    c += f"    }}\n"
+    c += f"    rate = {cr('rate', '1.0f', bucket_type)};\n"  # Extra helper call
+    c += yi(fi_r, "impBkt", "rate")
     c += f"  }}\n"
     c += "}\n\n"
     return c
@@ -346,6 +482,8 @@ def gen_P06(vid, cid, rng, pvid):
     num_dims = [2, 4, 7][pvid % 3]
     num_rates = [5, 10, 15][pvid % 3]
     c = fhdr(vid, cid)
+    # Hash block with guards to increase BB size and conditional branch %
+    c += hash_block(rng, rng.randint(0, 511), num_ops=35)
     dim_off = rng.randint(0, 255)
     c += f"  int dim = static_cast<int>({sr(dim_off)}) & 0x7;\n"
     c += f"  if (dim < 0 || dim >= {num_dims}) return;\n"
@@ -353,8 +491,10 @@ def gen_P06(vid, cid, rng, pvid):
     imp_base = rng.randint(0, 200)
     c += f"  float dimImp = c->structData[({imp_base} + dim) % c->structSize];\n"
     c += f"  if (dimImp <= 0.0f) return;\n"
-    c += f"  float invImp = 1.0f / dimImp;\n"
-    c += f"  int64_t impBkt = static_cast<int64_t>(std::log2(dimImp + 1.0f));\n"
+    c += f"  int32_t _di_b = *reinterpret_cast<int32_t*>(&dimImp);\n"
+    c += f"  _di_b = 0x7EF311C2 - _di_b;\n"
+    c += f"  float invImp = *reinterpret_cast<float*>(&_di_b);\n"
+    c += f"  int64_t impBkt = static_cast<int64_t>(31 - __builtin_clz(static_cast<uint32_t>(dimImp + 1.0f)));\n"
     # Rate loop
     rate_base = rng.randint(0, 150)
     fi_base = rng.randint(0, 30)
@@ -407,8 +547,10 @@ def gen_P07(vid, cid, rng, pvid):
     imp_off = rng.randint(0, 255)
     c += f"  float imp = {sr(imp_off)};\n"
     c += f"  if (imp <= 0.0f) return;\n"
-    c += f"  float invImp = 1.0f / imp;\n"
-    c += f"  int64_t impBkt = static_cast<int64_t>(std::log2(imp + 1.0f));\n"
+    c += f"  int32_t _im_b = *reinterpret_cast<int32_t*>(&imp);\n"
+    c += f"  _im_b = 0x7EF311C2 - _im_b;\n"
+    c += f"  float invImp = *reinterpret_cast<float*>(&_im_b);\n"
+    c += f"  int64_t impBkt = static_cast<int64_t>(31 - __builtin_clz(static_cast<uint32_t>(imp + 1.0f)));\n"
     if has_calib:
         calib_off = rng.randint(0, 255)
         c += f"  float calibFactor = 1.0f + {sr(calib_off)} * 0.01f;\n"
@@ -446,45 +588,43 @@ def gen_P07(vid, cid, rng, pvid):
 
 def gen_P08(vid, cid, rng, pvid):
     num_lookups = [1, 3, 5][pvid % 3]
-    num_rates = [3, 5, 10][pvid % 3]
     table_idx = pvid % 4
     c = fhdr(vid, cid)
+    c += hash_block(rng, rng.randint(0, 127), num_ops=35)
     fi_base = rng.randint(0, 30)
     for lk in range(num_lookups):
         ki = rng.randint(0, 9)
         magic = rng.getrandbits(48)
         c += f"  {{ // lookup {lk}\n"
         c += f"    int64_t k = c->queryKeys[{ki} % c->numKeys] ^ 0x{magic:012x}LL;\n"
+        # BOTH: original unordered_map lookup + mock hash table lookup
         c += f"    auto it = c->tables[{table_idx}].find(k);\n"
+        c += f"    float baseVal = (it != c->tables[{table_idx}].end()) ? it->second : 0.0f;\n"
+        c += f"    baseVal += {hl(table_idx, 'k')};\n"  # Add hash table call chain
         if lk == 0 and num_lookups == 1:
-            c += f"    if (it == c->tables[{table_idx}].end()) {{ return; }}\n"
-        else:
-            c += f"    if (it != c->tables[{table_idx}].end()) {{\n"
-        c += f"    float baseVal = it->second;\n"
-        # Time slice loop
+            c += f"    if (baseVal == 0.0f) return;\n"
+        # Time slice loop — original inline + engagement stat helper
         ts_count = rng.randint(3, 7)
         c += f"    for (int ts = 0; ts < {ts_count}; ++ts) {{\n"
         thr = rng.uniform(0.01, 0.5)
         sc = rng.uniform(0.5, 3.0)
+        stat_type = rng.randint(0, 7)
         c += f"      float sliceVal = baseVal * c->structData[({rng.randint(0, 200)}"
         c += f" + ts) % c->structSize] * {sc:.4f}f;\n"
+        c += f"      sliceVal += helpers::computeEngagementStat("
+        c += f"c->structData, c->structSize, ts, {stat_type}) * 0.01f;\n"
         c += f"      if (sliceVal > {thr:.4f}f) {{\n"
-        c += f"        int fi = ({fi_base} + {lk} * {ts_count} + ts) % c->numFeatures;\n"
-        c += f"        int32_t idx = c->features[fi].raw_feature_index;\n"
-        c += f"        if (idx >= 0 && idx < (int32_t)c->example->denseValues.size())\n"
-        c += f"          c->example->denseValues[idx] = sliceVal;\n"
+        fi_slot = rng.randint(0, 49)
+        c += yd(fi_slot, "sliceVal")
         c += f"      }}\n"
         c += f"    }}\n"
-        # Rate computation
+        # Rate via helper
         rate_off = rng.randint(0, 255)
-        c += f"    float weeks = {sr(rate_off)} * {rng.uniform(0.0001, 0.01):.6f}f;\n"
-        c += f"    if (weeks > 0.0f) {{\n"
         fi_rate = rng.randint(0, 49)
-        c += f"      float rate = baseVal / weeks;\n"
+        bucket_type = rng.randint(0, 3)
+        c += f"    float weeks = {sr(rate_off)} * {rng.uniform(0.0001, 0.01):.6f}f;\n"
+        c += f"    float rate = {cr('baseVal', 'weeks', bucket_type)};\n"
         c += yd(fi_rate, "rate")
-        c += f"    }}\n"
-        if not (lk == 0 and num_lookups == 1):
-            c += f"    }} // end if found\n"
         c += f"  }}\n"
     c += "}\n\n"
     return c
@@ -504,6 +644,7 @@ def gen_P09(vid, cid, rng, pvid):
     max_emit = 16
     max_agg = num_ts * max_emit
     c = fhdr(vid, cid)
+    c += hash_block(rng, rng.randint(0, 255), num_ops=30)
     fi_base = rng.randint(0, 20)
     # Key derivation
     c += f"  int64_t keys[{num_keys}];\n"
@@ -561,7 +702,10 @@ def gen_P09(vid, cid, rng, pvid):
     c += f"    float wks = {sr(rate_off)} * {rng.uniform(0.0001, 0.01):.6f}f;\n"
     c += f"    if (wks > 0.0f) {{\n"
     fi_rate = rng.randint(0, 49)
-    c += yd(fi_rate, f"baseVal / wks")
+    c += f"      int32_t _wks_bits = *reinterpret_cast<int32_t*>(&wks);\n"
+    c += f"      _wks_bits = 0x7EF311C2 - _wks_bits;\n"
+    c += f"      float _inv_wks = *reinterpret_cast<float*>(&_wks_bits);\n"
+    c += yd(fi_rate, f"baseVal * _inv_wks")
     c += f"    }}\n"
     c += f"  }}\n"  # end key loop
     # Yield aggregated
@@ -580,7 +724,10 @@ def gen_P09(vid, cid, rng, pvid):
         c += f"    for (int i = 0; i < {max_agg // 2}; ++i) sum1 += "
         c += f"c->structData[(i + {rng.randint(0, 200)}) % c->structSize];\n"
         c += f"    if (sum1 > 0.0f) {{\n"
-        c += yd(fi_rat, "sum0 / sum1")
+        c += f"      int32_t _s1_bits = *reinterpret_cast<int32_t*>(&sum1);\n"
+        c += f"      _s1_bits = 0x7EF311C2 - _s1_bits;\n"
+        c += f"      float _inv_s1 = *reinterpret_cast<float*>(&_s1_bits);\n"
+        c += yd(fi_rat, "sum0 * _inv_s1")
         c += f"    }}\n"
         c += f"  }}\n"
     c += "}\n\n"
@@ -683,7 +830,11 @@ def gen_P11(vid, cid, rng, pvid):
     # Summary yields
     c += f"  if (treeCount > 0) {{\n"
     c += yd(fi_base, "treeSum")
-    c += yd(fi_base + 1, f"treeSum / static_cast<float>(treeCount)")
+    c += f"    float _tcf = static_cast<float>(treeCount);\n"
+    c += f"    int32_t _tc_bits = *reinterpret_cast<int32_t*>(&_tcf);\n"
+    c += f"    _tc_bits = 0x7EF311C2 - _tc_bits;\n"
+    c += f"    float _inv_tc = *reinterpret_cast<float*>(&_tc_bits);\n"
+    c += yd(fi_base + 1, f"treeSum * _inv_tc")
     c += f"  }}\n"
     # Additional chains
     for ch in range(1, num_chains):
@@ -719,21 +870,31 @@ def gen_P12(vid, cid, rng, pvid):
     num_stats = [5, 10, 15, 20, 25, 30][pvid % 6]
     window_off = rng.randint(0, 200)
     c = fhdr(vid, cid)
+    # Hash block (P12 is most frequent: 130 variants)
+    c += hash_block(rng, rng.randint(0, 255), num_ops=35)
     fi_base = rng.randint(0, 30)
     null_off = rng.randint(0, 255)
     thr = rng.uniform(0.0, 0.05)
     c += f"  constexpr int kVariantId = {vid};\n"
-    c += f"  float null_chk = {sr(null_off)};\n"
+    c += f"  float null_chk = {sr(null_off)} + _hf;\n"
     c += f"  if (null_chk < {thr:.4f}f) return;\n"
+    # Hash lookup for base multiplier (5-7 noinline hops)
+    use_hash = (pvid + cid) % 3 != 0
+    if use_hash:
+        tbl = rng.randint(0, 3)
+        c += f"  float statBase = {ls(tbl, pvid % 8)};\n"
+    else:
+        c += f"  float statBase = 1.0f;\n"
     sc = rng.uniform(0.5, 3.0)
+    # Original inline stat loop + helper validation
     c += f"  for (int i = 0; i < {num_stats}; ++i) {{\n"
     c += f"    float val = c->structData[({window_off} + kVariantId * {num_stats}"
     c += f" + i) % c->structSize] * {sc:.4f}f;\n"
+    c += f"    val *= statBase;\n"
+    c += f"    val += helpers::computeEngagementStat("
+    c += f"c->structData, c->structSize, i, ({window_off} + kVariantId) % 8) * 0.01f;\n"
     c += f"    if (val != 0.0f) {{\n"
-    c += f"      int fi = ({fi_base} + i) % c->numFeatures;\n"
-    c += f"      int32_t idx = c->features[fi].raw_feature_index;\n"
-    c += f"      if (idx >= 0 && idx < (int32_t)c->example->denseValues.size())\n"
-    c += f"        c->example->denseValues[idx] = val;\n"
+    c += yd(fi_base, "val")
     c += f"    }}\n"
     c += f"  }}\n"
     c += "}\n\n"
@@ -754,9 +915,13 @@ def gen_P13(vid, cid, rng, pvid):
     imp_off = rng.randint(0, 255)
     c += f"  float imp = {sr(imp_off)};\n"
     c += f"  if (imp <= 0.0f) return;\n"
-    c += f"  float invImp = 1.0f / (imp + {rng.uniform(0.001, 0.1):.6f}f);\n"
+    eps = rng.uniform(0.001, 0.1)
+    c += f"  float _imp_d = imp + {eps:.6f}f;\n"
+    c += f"  int32_t _imp_b = *reinterpret_cast<int32_t*>(&_imp_d);\n"
+    c += f"  _imp_b = 0x7EF311C2 - _imp_b;\n"
+    c += f"  float invImp = *reinterpret_cast<float*>(&_imp_b);\n"
     bucket_magic = rng.getrandbits(16)
-    c += f"  int64_t impBkt = static_cast<int64_t>(std::log2(imp + 1.0f))"
+    c += f"  int64_t impBkt = static_cast<int64_t>(31 - __builtin_clz(static_cast<uint32_t>(imp + 1.0f)))"
     c += f" ^ 0x{bucket_magic:04x}LL;\n"
     # Block 1: impression-indexed rates (unrolled)
     c += f"  // Block 1: {num_imp_feats} impression-indexed yields\n"
@@ -764,7 +929,7 @@ def gen_P13(vid, cid, rng, pvid):
         off = rng.randint(0, 1023)
         fi = rng.randint(0, 49)
         sc = rng.uniform(0.1, 5.0)
-        # Vary the computation between yields
+        # Vary the computation between yields — integer ops only
         comp = rng.randint(0, 3)
         if comp == 0:
             val_expr = f"c->structData[{off} % c->structSize] * invImp * {sc:.4f}f"
@@ -773,7 +938,7 @@ def gen_P13(vid, cid, rng, pvid):
             val_expr = (f"(c->structData[{off} % c->structSize] - "
                        f"c->structData[{off2} % c->structSize]) * invImp * {sc:.4f}f")
         elif comp == 2:
-            val_expr = f"std::log1p(std::abs(c->structData[{off} % c->structSize] * invImp)) * {sc:.4f}f"
+            val_expr = int_hash_expr(rng, f"c->structData[{off} % c->structSize] * invImp")
         else:
             val_expr = f"c->structData[{off} % c->structSize] * invImp * invImp * {sc:.4f}f"
         c += f"  {{ float r = {val_expr};\n"
@@ -789,8 +954,10 @@ def gen_P13(vid, cid, rng, pvid):
         vpv_off = rng.randint(0, 255)
         c += f"  float vpv = {sr(vpv_off)};\n"
         c += f"  if (vpv > 0.0f) {{\n"
-        c += f"    float invVpv = 1.0f / vpv;\n"
-        c += f"    int64_t vpvBkt = static_cast<int64_t>(std::log2(vpv + 1.0f));\n"
+        c += f"    int32_t _vpv_b = *reinterpret_cast<int32_t*>(&vpv);\n"
+        c += f"    _vpv_b = 0x7EF311C2 - _vpv_b;\n"
+        c += f"    float invVpv = *reinterpret_cast<float*>(&_vpv_b);\n"
+        c += f"    int64_t vpvBkt = static_cast<int64_t>(31 - __builtin_clz(static_cast<uint32_t>(vpv + 1.0f)));\n"
         for i in range(num_vpv_feats):
             off = rng.randint(0, 1023)
             fi = rng.randint(0, 49)
@@ -822,18 +989,32 @@ def gen_P14(vid, cid, rng, pvid):
     time_off = rng.randint(0, 255)
     c += f"  float imp = {sr(imp_off)};\n"
     c += f"  if (imp <= 0.0f) return;\n"
-    c += f"  float invImp = 1.0f / imp;\n"
-    c += f"  float timeSince = std::abs({sr(time_off)}) * {rng.uniform(0.01, 10.0):.4f}f;\n"
-    # Decay factor
+    c += f"  int32_t _i14_b = *reinterpret_cast<int32_t*>(&imp);\n"
+    c += f"  _i14_b = 0x7EF311C2 - _i14_b;\n"
+    c += f"  float invImp = *reinterpret_cast<float*>(&_i14_b);\n"
+    time_sc = rng.uniform(0.01, 10.0)
+    c += f"  float _ts_raw = {sr(time_off)};\n"
+    c += f"  float timeSince = (_ts_raw > 0.0f ? _ts_raw : -_ts_raw) * {time_sc:.4f}f;\n"
+    # Decay factor — integer approximation replacing std::exp
     if decay_type == 0:
         decay_rate = rng.uniform(0.001, 0.1)
-        c += f"  float decay = std::exp(-{decay_rate:.6f}f * timeSince);\n"
+        c += f"  float _dec_den = 1.0f + {decay_rate:.6f}f * timeSince;\n"
+        c += f"  int32_t _dec_b = *reinterpret_cast<int32_t*>(&_dec_den);\n"
+        c += f"  _dec_b = 0x7EF311C2 - _dec_b;\n"
+        c += f"  float decay = *reinterpret_cast<float*>(&_dec_b);\n"
     elif decay_type == 1:
-        c += f"  float decay = 1.0f / (1.0f + timeSince * {rng.uniform(0.01, 0.5):.4f}f);\n"
+        ts_sc = rng.uniform(0.01, 0.5)
+        c += f"  float _dec_den = 1.0f + timeSince * {ts_sc:.4f}f;\n"
+        c += f"  int32_t _dec_b = *reinterpret_cast<int32_t*>(&_dec_den);\n"
+        c += f"  _dec_b = 0x7EF311C2 - _dec_b;\n"
+        c += f"  float decay = *reinterpret_cast<float*>(&_dec_b);\n"
     else:
         half_life = rng.uniform(1.0, 168.0)
-        c += f"  float decay = std::exp(-0.693147f * timeSince / {half_life:.2f}f);\n"
-    c += f"  int64_t impBkt = static_cast<int64_t>(std::log2(imp + 1.0f));\n"
+        c += f"  float _dec_den = 1.0f + 0.693147f * timeSince * {1.0/half_life:.6f}f;\n"
+        c += f"  int32_t _dec_b = *reinterpret_cast<int32_t*>(&_dec_den);\n"
+        c += f"  _dec_b = 0x7EF311C2 - _dec_b;\n"
+        c += f"  float decay = *reinterpret_cast<float*>(&_dec_b);\n"
+    c += f"  int64_t impBkt = static_cast<int64_t>(31 - __builtin_clz(static_cast<uint32_t>(imp + 1.0f)));\n"
     # Feature yields with decay
     for i in range(num_feats):
         off = rng.randint(0, 511)
@@ -922,14 +1103,23 @@ def gen_P16(vid, cid, rng, pvid):
         c += f"    float diff = a - b;\n"
         c += f"    l2sum += diff * diff;\n"
     c += f"  }}\n"
-    # Compute similarity
+    # Compute similarity — integer approximations replacing std::sqrt
     if sim_type == 0:
         c += f"  float similarity = dotProduct;\n"
     elif sim_type == 1:
-        c += f"  float similarity = dotProduct / (std::sqrt(normA) * std::sqrt(normB)"
-        c += f" + 1e-8f);\n"
+        # Use integer bit manipulation for fast inverse sqrt approximation
+        c += f"  float normProd = normA * normB + 1e-8f;\n"
+        c += f"  int32_t _npi = *reinterpret_cast<int32_t*>(&normProd);\n"
+        c += f"  _npi = 0x5F3759DF - (_npi >> 1);\n"
+        c += f"  float invSqrtNorm = *reinterpret_cast<float*>(&_npi);\n"
+        c += f"  float similarity = dotProduct * invSqrtNorm;\n"
     else:
-        c += f"  float similarity = std::sqrt(l2sum + 1e-8f);\n"
+        # fast sqrt via inverse sqrt: sqrt(x) = x * rsqrt(x)
+        c += f"  float _l2t = l2sum + 1e-8f;\n"
+        c += f"  int32_t _l2i = *reinterpret_cast<int32_t*>(&_l2t);\n"
+        c += f"  _l2i = 0x5F3759DF - (_l2i >> 1);\n"
+        c += f"  float _l2r = *reinterpret_cast<float*>(&_l2i);\n"
+        c += f"  float similarity = _l2t * _l2r;\n"
     c += yd(fi_base, "similarity")
     # Optional dimension yield
     if yield_dims:
@@ -1031,7 +1221,11 @@ def gen_P19(vid, cid, rng, pvid):
     c += yd(fi_base, "1.0f")
     c += yd(fi_base + 1, f"static_cast<float>(matchPos)")
     recency_sc = rng.uniform(0.5, 2.0)
-    c += yd(fi_base + 2, f"{recency_sc:.4f}f / (1.0f + static_cast<float>(matchPos))")
+    c += f"    float _mp_den = 1.0f + static_cast<float>(matchPos);\n"
+    c += f"    int32_t _mp_bits = *reinterpret_cast<int32_t*>(&_mp_den);\n"
+    c += f"    _mp_bits = 0x7EF311C2 - _mp_bits;\n"
+    c += f"    float _inv_mp = *reinterpret_cast<float*>(&_mp_bits);\n"
+    c += yd(fi_base + 2, f"{recency_sc:.4f}f * _inv_mp")
     c += f"  }}\n"
     c += "}\n\n"
     return c
@@ -1128,9 +1322,13 @@ def gen_P21(vid, cid, rng, pvid):
         thr = rng.uniform(-1.0, 1.0)
         factor = rng.uniform(0.8, 1.2)
         c += f"    if (calibrated > {thr:.4f}f) calibrated *= {factor:.4f}f;\n"
-    # Transform
-    transform = rng.choice(["std::tanh(calibrated)", "1.0f / (1.0f + std::exp(-calibrated))",
-                            "calibrated", "std::log1p(std::abs(calibrated))"])
+    # Transform — integer-only replacements
+    transform = rng.choice([
+        "(calibrated > 3.0f ? 1.0f : (calibrated < -3.0f ? -1.0f : calibrated * 0.33f))",
+        "(calibrated > 0.0f ? calibrated : -calibrated)",
+        "calibrated",
+        "static_cast<float>(static_cast<int32_t>(calibrated * 1000.0f) & 0x7FFFFFFF) * 0.001f",
+    ])
     c += f"    float final_p = {transform};\n"
     c += f"    int fi = ({fi_base} + p) % c->numFeatures;\n"
     c += f"    int32_t idx = c->features[fi].raw_feature_index;\n"
@@ -1298,7 +1496,11 @@ def gen_P24(vid, cid, rng, pvid):
         c += f"  }}\n"
         c += yd(fi_base, "static_cast<float>(matchCount)")
         c += f"  if (matchCount > 0) {{\n"
-        c += yd(fi_base + 1, f"1.0f / static_cast<float>(matchCount)")
+        c += f"    float _mc_f = static_cast<float>(matchCount);\n"
+        c += f"    int32_t _mc_bits = *reinterpret_cast<int32_t*>(&_mc_f);\n"
+        c += f"    _mc_bits = 0x7EF311C2 - _mc_bits;\n"
+        c += f"    float _inv_mc = *reinterpret_cast<float*>(&_mc_bits);\n"
+        c += yd(fi_base + 1, f"_inv_mc")
         c += f"  }}\n"
     elif state_type == 1:  # topic counts
         c += f"  // Topic count state\n"
@@ -1319,9 +1521,9 @@ def gen_P24(vid, cid, rng, pvid):
         c += yd(fi_base, "position")
         c += yd(fi_base + 1, "delta")
         c += f"  if (delta > 0.0f) {{\n"
-        c += yd(fi_base + 2, f"std::log1p(delta)")
+        c += yd(fi_base + 2, f"static_cast<float>(31 - __builtin_clz(static_cast<uint32_t>(delta * 1000.0f + 1.0f)))")
         c += f"  }} else if (delta < 0.0f) {{\n"
-        c += yd(fi_base + 3, f"std::log1p(-delta)")
+        c += yd(fi_base + 3, f"static_cast<float>(31 - __builtin_clz(static_cast<uint32_t>(-delta * 1000.0f + 1.0f)))")
         c += f"  }}\n"
     else:  # diversity counter
         c += f"  // Diversity counter state\n"
@@ -1336,9 +1538,16 @@ def gen_P24(vid, cid, rng, pvid):
         c += f"  float total = 0.0f;\n"
         c += f"  for (int i = 0; i < {num_categories}; ++i) total += counts[i];\n"
         c += f"  if (total > 0.0f) {{\n"
+        c += f"    float _tot_d = total + 1e-10f;\n"
+        c += f"    int32_t _tot_b = *reinterpret_cast<int32_t*>(&_tot_d);\n"
+        c += f"    _tot_b = 0x7EF311C2 - _tot_b;\n"
+        c += f"    float _inv_tot = *reinterpret_cast<float*>(&_tot_b);\n"
         c += f"    for (int i = 0; i < {num_categories}; ++i) {{\n"
-        c += f"      float p = counts[i] / total;\n"
-        c += f"      if (p > 0.0f) entropy -= p * std::log(p + 1e-10f);\n"
+        c += f"      float p = counts[i] * _inv_tot;\n"
+        c += f"      if (p > 0.0f) {{\n"
+        c += f"        uint32_t _pi = static_cast<uint32_t>(p * 65536.0f + 1);\n"
+        c += f"        entropy += p * static_cast<float>(31 - __builtin_clz(_pi));\n"
+        c += f"      }}\n"
         c += f"    }}\n"
         c += f"  }}\n"
         c += yd(fi_base, "entropy")
@@ -1470,7 +1679,7 @@ def gen_P27(vid, cid, rng, pvid):
             sc = rng.uniform(0.3, 2.0)
             fi = fi_base + r
             c += f"    {{ float mv = catBase * {sr(off)} * {sc:.4f}f;\n"
-            transform = rng.choice(["mv", "std::tanh(mv)", "std::abs(mv)"])
+            transform = rng.choice(["mv", "(mv > 3.0f ? 1.0f : (mv < -3.0f ? -1.0f : mv * 0.33f))", "(mv > 0.0f ? mv : -mv)"])
             c += f"      float t = {transform};\n"
             c += yi(fi, f"catKeys[cat]", "t")
             c += f"    }}\n"
@@ -1502,7 +1711,11 @@ def gen_P27(vid, cid, rng, pvid):
         c += f"  }}\n"
         c += f"  if (aggCount > 0) {{\n"
         fi_agg = rng.randint(0, 49)
-        c += yd(fi_agg, "aggSum / static_cast<float>(aggCount)")
+        c += f"    float _ac_f = static_cast<float>(aggCount);\n"
+        c += f"    int32_t _ac_bits = *reinterpret_cast<int32_t*>(&_ac_f);\n"
+        c += f"    _ac_bits = 0x7EF311C2 - _ac_bits;\n"
+        c += f"    float _inv_ac = *reinterpret_cast<float*>(&_ac_bits);\n"
+        c += yd(fi_agg, "aggSum * _inv_ac")
         fi_cnt = rng.randint(0, 49)
         c += yd(fi_cnt, "static_cast<float>(aggCount)")
         c += f"  }}\n"
@@ -1561,6 +1774,7 @@ def generate_dispatch_header(output_dir, num_variants, copies_per_variant):
 #pragma once
 
 #include "../FeatureTypes.h"
+#include "mock_hash_table.h"
 #include <cstdint>
 #include <unordered_map>
 #include <vector>
@@ -1578,6 +1792,9 @@ struct CopyContext {{
   int numFeatures;
   const int64_t* queryKeys;
   int numKeys;
+  // Mock hash tables for deep-call-chain lookups (mimics F14/QuickHash)
+  mock_hash::MockHashTable* hashTables;  // array of 4 mock hash tables
+  int numHashTables;
 }};
 
 using CopyFn = void(*)(CopyContext*);
@@ -1603,6 +1820,7 @@ def generate_copies_part(spec, copies_per_variant, output_dir):
         f.write(COPYRIGHT)
         f.write("\n")
         f.write('#include "../dispatch.h"\n')
+        f.write('#include "../extractor_helpers.h"\n')
         f.write("#include <cmath>\n")
         f.write("#include <cstdint>\n")
         f.write("\n")
@@ -1640,6 +1858,8 @@ def generate_variant_class(spec, copies_per_variant):
     lines.append(f"    for (int t = 0; t < 4; ++t)")
     lines.append(f"      for (int i = 0; i < {spec.table_size}; ++i)")
     lines.append(f"        tables_[t][randomInt64(state)] = randomFloat(state);")
+    lines.append(f"    for (int t = 0; t < 4; ++t)")
+    lines.append(f"      hashTables_[t].populate(64, kSeed + t + complexity);")
     lines.append(f"    CopiesInit_{spec.variant_idx:04d}(copies_);")
     lines.append(f"    rngState_ = kSeed;")
     lines.append(f"  }}")
@@ -1659,6 +1879,8 @@ def generate_variant_class(spec, copies_per_variant):
     lines.append(f"    ctx.numFeatures = static_cast<int>(features.size());")
     lines.append(f"    ctx.queryKeys = queryKeys.data();")
     lines.append(f"    ctx.numKeys = static_cast<int>(queryKeys.size());")
+    lines.append(f"    ctx.hashTables = hashTables_;")
+    lines.append(f"    ctx.numHashTables = 4;")
     lines.append(f"    int idx = static_cast<int>(rngState_ % kCopiesPerVariant);")
     lines.append(f"    rngState_ = rngState_ * 6364136223846793005ULL + 1442695040888963407ULL;")
     lines.append(f"    copies_[idx](&ctx);")
@@ -1670,6 +1892,7 @@ def generate_variant_class(spec, copies_per_variant):
     lines.append(f"  float* structData_ = nullptr;")
     lines.append(f"  int structSize_ = 0;")
     lines.append(f"  std::unordered_map<int64_t, float> tables_[4];")
+    lines.append(f"  dcperf::mock_hash::MockHashTable hashTables_[4];")
     lines.append(f"  CopyFn copies_[kCopiesPerVariant];")
     lines.append(f"  uint64_t rngState_ = 0;")
     lines.append(f"}};")
@@ -1689,6 +1912,7 @@ def generate_batch_files(specs, output_dir, variants_per_batch, copies_per_varia
         content.append('#include "../archetype_templates/ArchetypeBase.h"')
         content.append('#include "../archetype_templates/ArchetypeUtils.h"')
         content.append('#include "../dispatch.h"')
+        content.append('#include "../mock_hash_table.h"')
         content.append("#include <cmath>")
         content.append("#include <memory>")
         content.append("#include <string>")
@@ -1845,8 +2069,8 @@ def main():
     parser.add_argument(
         "--copies-per-variant",
         type=int,
-        default=1000,
-        help="Number of copy functions per variant (default 1000)",
+        default=150,
+        help="Number of copy functions per variant (default 150)",
     )
     args = parser.parse_args()
 

--- a/packages/feedsim/third_party/src/workloads/ranking/feature_extractors/generated/mock_hash_table.h
+++ b/packages/feedsim/third_party/src/workloads/ranking/feature_extractors/generated/mock_hash_table.h
@@ -1,0 +1,300 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
+// Mock hash table with deep call chains mimicking F14HashMap/QuickHashTable.
+// Production hash lookups go through 5-7 levels:
+//   operator[] -> emplaceKeyArgs -> emplaceKeyArgsWithToken -> findImpl
+//     -> probeChunk -> tagMatchIter -> compareKey
+// This mock replicates that call depth to generate realistic I-cache pressure.
+
+#pragma once
+
+#include <cstdint>
+#include <cstring>
+
+namespace dcperf {
+namespace mock_hash {
+
+// Tag byte for chunk-based probing (like F14's tag matching)
+using Tag = uint8_t;
+
+static constexpr int kChunkSize = 14;  // F14 uses 14 slots per chunk
+static constexpr int kNumChunks = 128; // Fixed chunk count for mock
+static constexpr int kCapacity = kChunkSize * kNumChunks;
+static constexpr Tag kEmpty = 0;
+static constexpr Tag kTombstone = 1;
+
+struct Entry {
+  int64_t key;
+  float value;
+};
+
+struct Chunk {
+  Tag tags[kChunkSize];
+  Entry entries[kChunkSize];
+};
+
+// Forward declarations for non-inline helper functions.
+// Each is __attribute__((noinline)) to force real function calls,
+// mimicking the depth of F14Table::findImpl -> tagMatchIter chain.
+
+struct MockHashTable {
+  Chunk chunks[kNumChunks];
+  int size_ = 0;
+
+  void init() {
+    memset(chunks, 0, sizeof(chunks));
+    size_ = 0;
+  }
+
+  // Pre-populate with data for lookups
+  void populate(int count, uint64_t seed) {
+    uint64_t state = seed;
+    for (int i = 0; i < count && size_ < kCapacity; ++i) {
+      state = state * 6364136223846793005ULL + 1442695040888963407ULL;
+      int64_t key = static_cast<int64_t>(state >> 16);
+      float val = static_cast<float>(state & 0xFFFF) / 65535.0f;
+      insert(key, val);
+    }
+  }
+
+  // ======================================================================
+  // Level 1: operator[] — entry point (like QuickHashMap::operator[])
+  // ======================================================================
+  __attribute__((noinline))
+  float& operator[](int64_t key) {
+    return emplaceKeyArgs(key);
+  }
+
+  // ======================================================================
+  // Level 2: emplaceKeyArgs (like QuickHashTable::emplaceKeyArgs)
+  // ======================================================================
+  __attribute__((noinline))
+  float& emplaceKeyArgs(int64_t key) {
+    Tag tag = computeTag(key);
+    int chunk_idx = computeChunkIndex(key);
+    return emplaceKeyArgsWithToken(key, tag, chunk_idx);
+  }
+
+  // ======================================================================
+  // Level 3: emplaceKeyArgsWithToken
+  // ======================================================================
+  __attribute__((noinline))
+  float& emplaceKeyArgsWithToken(int64_t key, Tag tag, int chunk_idx) {
+    int slot = findImpl(key, tag, chunk_idx);
+    if (slot >= 0) {
+      Chunk& c = chunks[chunk_idx];
+      return c.entries[slot].value;
+    }
+    // Insert new entry
+    return insertAtFirstEmpty(key, tag, chunk_idx);
+  }
+
+  // ======================================================================
+  // Level 4: findImpl (like F14Table::findImpl / QuickHashTable::findImpl)
+  // ======================================================================
+  __attribute__((noinline))
+  int findImpl(int64_t key, Tag tag, int chunk_idx) {
+    Chunk& c = chunks[chunk_idx % kNumChunks];
+    int match_pos = tagMatchIter(c, tag);
+    if (match_pos >= 0) {
+      if (compareKey(c, match_pos, key)) {
+        return match_pos;
+      }
+      // Continue probing (linear probe within chunk)
+      return probeChunk(c, key, tag, match_pos + 1);
+    }
+    return -1;
+  }
+
+  // ======================================================================
+  // Level 5: tagMatchIter (like F14Chunk::tagMatchIter)
+  // Scans tag array for matching tag byte
+  // ======================================================================
+  __attribute__((noinline))
+  int tagMatchIter(const Chunk& chunk, Tag tag) {
+    for (int i = 0; i < kChunkSize; ++i) {
+      if (chunk.tags[i] == tag) {
+        return i;
+      }
+    }
+    return -1;
+  }
+
+  // ======================================================================
+  // Level 6: probeChunk — continue linear probing within chunk
+  // ======================================================================
+  __attribute__((noinline))
+  int probeChunk(const Chunk& chunk, int64_t key, Tag tag, int start) {
+    for (int i = start; i < kChunkSize; ++i) {
+      if (chunk.tags[i] == kEmpty) return -1;
+      if (chunk.tags[i] == tag && compareKey(chunk, i, key)) {
+        return i;
+      }
+    }
+    return -1;
+  }
+
+  // ======================================================================
+  // Level 7: compareKey — key equality check
+  // ======================================================================
+  __attribute__((noinline))
+  bool compareKey(const Chunk& chunk, int slot, int64_t key) {
+    return chunk.entries[slot].key == key;
+  }
+
+  // ======================================================================
+  // find() — read-only lookup returning pointer (like F14Map::find)
+  // Now uses the same deep call chain as the write path:
+  //   find -> findConstImpl -> tagMatchIterConst -> compareKeyConst
+  //                         -> probeChunkConst
+  // ======================================================================
+  __attribute__((noinline))
+  const float* find(int64_t key) const {
+    Tag tag = computeTag(key);
+    int chunk_idx = computeChunkIndex(key);
+    return findConstImpl(key, tag, chunk_idx);
+  }
+
+  // ======================================================================
+  // Level 2 (const): findConstImpl — mirrors findImpl for read path
+  // ======================================================================
+  __attribute__((noinline))
+  const float* findConstImpl(int64_t key, Tag tag, int chunk_idx) const {
+    const Chunk& c = chunks[chunk_idx % kNumChunks];
+    int match_pos = tagMatchIterConst(c, tag);
+    if (match_pos >= 0) {
+      if (compareKeyConst(c, match_pos, key)) {
+        return &c.entries[match_pos].value;
+      }
+      return probeChunkConst(c, key, tag, match_pos + 1);
+    }
+    return nullptr;
+  }
+
+  // ======================================================================
+  // Level 3 (const): tagMatchIterConst — tag scan for read path
+  // ======================================================================
+  __attribute__((noinline))
+  int tagMatchIterConst(const Chunk& chunk, Tag tag) const {
+    for (int i = 0; i < kChunkSize; ++i) {
+      if (chunk.tags[i] == tag) {
+        return i;
+      }
+    }
+    return -1;
+  }
+
+  // ======================================================================
+  // Level 4 (const): compareKeyConst — key equality for read path
+  // ======================================================================
+  __attribute__((noinline))
+  bool compareKeyConst(const Chunk& chunk, int slot, int64_t key) const {
+    return chunk.entries[slot].key == key;
+  }
+
+  // ======================================================================
+  // Level 5 (const): probeChunkConst — linear probing for read path
+  // ======================================================================
+  __attribute__((noinline))
+  const float* probeChunkConst(const Chunk& chunk, int64_t key, Tag tag, int start) const {
+    for (int i = start; i < kChunkSize; ++i) {
+      if (chunk.tags[i] == kEmpty) return nullptr;
+      if (chunk.tags[i] == tag && compareKeyConst(chunk, i, key)) {
+        return &chunk.entries[i].value;
+      }
+    }
+    return nullptr;
+  }
+
+  // ======================================================================
+  // Helpers
+  // ======================================================================
+  static Tag computeTag(int64_t key) {
+    uint64_t h = static_cast<uint64_t>(key) * 0x9E3779B97F4A7C15ULL;
+    Tag t = static_cast<Tag>((h >> 56) | 2);  // Avoid 0 (empty) and 1 (tombstone)
+    return t;
+  }
+
+  static int computeChunkIndex(int64_t key) {
+    uint64_t h = static_cast<uint64_t>(key) * 0x517CC1B727220A95ULL;
+    return static_cast<int>((h >> 32) % kNumChunks);
+  }
+
+  void insert(int64_t key, float value) {
+    Tag tag = computeTag(key);
+    int ci = computeChunkIndex(key);
+    Chunk& c = chunks[ci % kNumChunks];
+    for (int i = 0; i < kChunkSize; ++i) {
+      if (c.tags[i] == kEmpty || c.tags[i] == kTombstone) {
+        c.tags[i] = tag;
+        c.entries[i] = {key, value};
+        ++size_;
+        return;
+      }
+      if (c.tags[i] == tag && c.entries[i].key == key) {
+        c.entries[i].value = value;
+        return;
+      }
+    }
+  }
+
+  __attribute__((noinline))
+  float& insertAtFirstEmpty(int64_t key, Tag tag, int chunk_idx) {
+    Chunk& c = chunks[chunk_idx % kNumChunks];
+    for (int i = 0; i < kChunkSize; ++i) {
+      if (c.tags[i] == kEmpty || c.tags[i] == kTombstone) {
+        c.tags[i] = tag;
+        c.entries[i].key = key;
+        c.entries[i].value = 0.0f;
+        ++size_;
+        return c.entries[i].value;
+      }
+    }
+    // Overflow: use first slot (shouldn't happen with proper sizing).
+    // Also update the tag so subsequent find(key) computes a matching tag.
+    c.tags[0] = tag;
+    c.entries[0].key = key;
+    c.entries[0].value = 0.0f;
+    return c.entries[0].value;
+  }
+};
+
+// ======================================================================
+// Multi-table lookup helpers — simulate cross-table hash joins
+// (production has lookups across 2-4 hash tables per extractor)
+// ======================================================================
+
+// Level 1: High-level lookup helper
+__attribute__((noinline))
+inline float hashLookupWithFallback(
+    MockHashTable& table, int64_t key, float fallback) {
+  const float* p = table.find(key);
+  return p ? *p : fallback;
+}
+
+// Cross-table join: look up in A, use result to derive key for B
+__attribute__((noinline))
+inline float crossTableLookup(
+    MockHashTable& tableA, MockHashTable& tableB,
+    int64_t key, float scale) {
+  float valA = hashLookupWithFallback(tableA, key, 0.0f);
+  int64_t derivedKey = static_cast<int64_t>(valA * scale) ^ key;
+  return hashLookupWithFallback(tableB, derivedKey, valA);
+}
+
+// Multi-key accumulation: look up N keys and accumulate
+__attribute__((noinline))
+inline float multiKeyAccumulate(
+    MockHashTable& table, const int64_t* keys, int n) {
+  float sum = 0.0f;
+  for (int i = 0; i < n; ++i) {
+    sum += hashLookupWithFallback(table, keys[i], 0.0f);
+  }
+  return sum;
+}
+
+} // namespace mock_hash
+} // namespace dcperf

--- a/packages/feedsim/third_party/src/workloads/ranking/feature_extractors/generated/primitives/HelperPrimitives.h
+++ b/packages/feedsim/third_party/src/workloads/ranking/feature_extractors/generated/primitives/HelperPrimitives.h
@@ -1,0 +1,344 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
+#pragma once
+
+#include "../../FeatureTypes.h"
+#include <cstdint>
+#include <map>
+#include <unordered_map>
+#include <vector>
+
+namespace dcperf {
+namespace primitives {
+
+// ============================================================================
+// Hash lookup primitives (35.7% of prod cycles)
+// ============================================================================
+
+// Walk hash chain for multiple keys, accumulating values
+__attribute__((noinline)) void hash_chain_walk(
+    std::unordered_map<int64_t, float>& table,
+    const int64_t* keys,
+    int n,
+    float* out);
+
+// Probe hash table with derived keys from a base key
+__attribute__((noinline)) void hash_multi_probe(
+    std::unordered_map<int64_t, float>& table,
+    int64_t base_key,
+    int num_probes,
+    float* out);
+
+// Hash lookup with conditional branching per result
+__attribute__((noinline)) void hash_lookup_branch(
+    std::unordered_map<int64_t, float>& table,
+    const int64_t* keys,
+    int n,
+    float threshold,
+    float* above,
+    float* below,
+    int* above_count,
+    int* below_count);
+
+// Cross-table hash join: look up key in table A, use value to derive key for B
+__attribute__((noinline)) void hash_cross_lookup(
+    std::unordered_map<int64_t, float>& tableA,
+    std::unordered_map<int64_t, float>& tableB,
+    const int64_t* keys,
+    int n,
+    float* out);
+
+// ============================================================================
+// Container primitives (19.7% of prod cycles)
+// ============================================================================
+
+// Append id-score pairs with potential vector growth
+__attribute__((noinline)) void vector_append_with_growth(
+    std::vector<IdScorePair>& vec,
+    const int64_t* ids,
+    const float* scores,
+    int n);
+
+// Collect filtered items into a small buffer (simulates small_vector)
+__attribute__((noinline)) void small_vector_collect(
+    IdScorePair* buf,
+    int buf_capacity,
+    const int64_t* ids,
+    const float* scores,
+    int n,
+    float min_score,
+    int* out_count);
+
+// Deduplicated append using a seen-set
+__attribute__((noinline)) void dedup_collect(
+    std::vector<IdScorePair>& vec,
+    const int64_t* ids,
+    const float* scores,
+    int n);
+
+// Merge two sorted id-score vectors
+__attribute__((noinline)) void merge_sorted_pairs(
+    const IdScorePair* a,
+    int na,
+    const IdScorePair* b,
+    int nb,
+    IdScorePair* out,
+    int* out_count);
+
+// ============================================================================
+// Memory/copy primitives (10.9% of prod cycles)
+// ============================================================================
+
+// Indirect-indexed array copy (feature layout copy pattern)
+__attribute__((noinline)) void indirect_array_copy(
+    const float* src,
+    float* dst,
+    const int* remap,
+    int n);
+
+// Scatter-gather copy with validation
+__attribute__((noinline)) void scatter_gather_copy(
+    const float* src,
+    float* dst,
+    const int* src_indices,
+    const int* dst_indices,
+    int n);
+
+// Block memcpy with stride (simulates struct field copy)
+__attribute__((noinline)) void strided_field_copy(
+    const float* src,
+    float* dst,
+    int stride,
+    int field_offset,
+    int num_records);
+
+// ============================================================================
+// Feature yield primitives (7.4% of prod cycles)
+// ============================================================================
+
+// Batch yield indexed features
+__attribute__((noinline)) void batch_yield_indexed(
+    MockFeatureExample& ex,
+    const MockFeature* features,
+    const int64_t* keys,
+    const float* vals,
+    int n);
+
+// Yield rate features with zero-check and impression bucketing
+__attribute__((noinline)) void yield_rate_features(
+    MockFeatureExample& ex,
+    const MockFeature* features,
+    const float* rates,
+    const int64_t* impressions,
+    int n,
+    int bucket_type);
+
+// Yield scalar features with type conversion
+__attribute__((noinline)) void yield_scalar_with_conversion(
+    MockFeatureExample& ex,
+    const MockFeature* features,
+    const double* values,
+    int n);
+
+// ============================================================================
+// Tree traversal primitives (2.6% of prod cycles)
+// ============================================================================
+
+// Range scan over sorted map
+__attribute__((noinline)) void map_range_scan(
+    const std::map<int64_t, float>& m,
+    int64_t lo,
+    int64_t hi,
+    float* out,
+    int* count);
+
+// Full map traversal with accumulation
+__attribute__((noinline)) void map_traverse_accumulate(
+    const std::map<int64_t, float>& m,
+    float* sum,
+    float* max_val,
+    int* count);
+
+// ============================================================================
+// Bitset primitives (5.2% of prod cycles)
+// ============================================================================
+
+// Random bitset checks
+__attribute__((noinline)) void bitset_random_checks(
+    const std::vector<uint64_t>& bits,
+    const int* indices,
+    int n,
+    bool* out);
+
+// Bitset popcount in range
+__attribute__((noinline)) void bitset_popcount_range(
+    const std::vector<uint64_t>& bits,
+    int start_bit,
+    int end_bit,
+    int* count);
+
+// ============================================================================
+// Float validation / conversion primitives (4.5% of prod cycles)
+// ============================================================================
+
+// Batch capped float conversion
+__attribute__((noinline)) void batch_capped_convert(
+    const double* src,
+    float* dst,
+    int n);
+
+// Validate and transform float array
+__attribute__((noinline)) void validate_and_transform(
+    float* data,
+    int n,
+    int transform_type);
+
+// ============================================================================
+// Embedding / dot product primitives (4% of prod cycles)
+// ============================================================================
+
+// Dense dot product
+__attribute__((noinline)) float dense_dot_product(
+    const float* a,
+    const float* b,
+    int n);
+
+// Cosine similarity
+__attribute__((noinline)) float cosine_similarity(
+    const float* a,
+    const float* b,
+    int n);
+
+// L2 distance
+__attribute__((noinline)) float l2_distance(
+    const float* a,
+    const float* b,
+    int n);
+
+// ============================================================================
+// Rate/counter computation primitives (12% of prod cycles)
+// ============================================================================
+
+// Compute impression buckets from raw counts
+__attribute__((noinline)) void compute_imp_buckets(
+    const int64_t* impressions,
+    float* buckets,
+    int n,
+    int bucket_type);
+
+// Compute rate ratios from numerator/denominator pairs
+__attribute__((noinline)) void compute_rate_ratios(
+    const float* numerators,
+    const float* denominators,
+    float* ratios,
+    int n);
+
+// ============================================================================
+// ID matching primitives (3% of prod cycles)
+// ============================================================================
+
+// Linear scan ID match with recency decay
+__attribute__((noinline)) void id_list_match_linear(
+    const int64_t* list,
+    int list_size,
+    int64_t target,
+    float* recency_score,
+    int* match_pos);
+
+// Hash-based ID set membership check
+__attribute__((noinline)) void id_set_membership_check(
+    const int64_t* set_data,
+    int set_size,
+    const int64_t* queries,
+    int num_queries,
+    bool* results);
+
+// ============================================================================
+// Prediction copy primitives (3% of prod cycles)
+// ============================================================================
+
+// Copy predictions with fallback values
+__attribute__((noinline)) void copy_predictions_with_fallback(
+    const float* predictions,
+    const bool* available,
+    float* output,
+    float fallback,
+    int n);
+
+// Calibrate prediction scores
+__attribute__((noinline)) void calibrate_predictions(
+    float* predictions,
+    int n,
+    float scale,
+    float bias,
+    int calibration_type);
+
+// ============================================================================
+// String/tokenizer primitives (1% of prod cycles)
+// ============================================================================
+
+// Simple hash-based tokenization
+__attribute__((noinline)) void hash_tokenize(
+    const char* input,
+    int input_len,
+    int vocab_size,
+    int* output_tokens,
+    int max_tokens,
+    int* num_tokens);
+
+// ============================================================================
+// Data provider read primitives (5% of prod cycles)
+// ============================================================================
+
+// Read and transform struct fields
+__attribute__((noinline)) void read_struct_fields(
+    const float* struct_data,
+    int struct_size,
+    const int* field_offsets,
+    float* output,
+    int num_fields);
+
+// Conditional field reads with null checks
+__attribute__((noinline)) void conditional_field_reads(
+    const float* struct_data,
+    const bool* field_valid,
+    int num_fields,
+    float* output,
+    int* valid_count);
+
+// ============================================================================
+// Sparse forward primitives (2% of prod cycles)
+// ============================================================================
+
+// Forward sparse features with threshold filter
+__attribute__((noinline)) void forward_sparse_filtered(
+    const IdScorePair* input,
+    int n,
+    float threshold,
+    IdScorePair* output,
+    int* out_count);
+
+// ============================================================================
+// Time-window stat primitives (8% of prod cycles)
+// ============================================================================
+
+// Read engagement stats for a time window
+__attribute__((noinline)) void read_time_window_stats(
+    const float* all_stats,
+    int total_stats,
+    int window_offset,
+    int num_stats,
+    float* output);
+
+// Aggregate stats across dimensions
+__attribute__((noinline)) void aggregate_dimension_stats(
+    const float* stats,
+    int num_stats,
+    int num_dimensions,
+    float* aggregated);
+
+} // namespace primitives
+} // namespace dcperf

--- a/packages/feedsim/third_party/src/workloads/ranking/if/ranking.thrift
+++ b/packages/feedsim/third_party/src/workloads/ranking/if/ranking.thrift
@@ -128,10 +128,28 @@ struct DLRMFeatures {
   5: i32 num_sparse_features;
 }
 
+// ============================================================================
+// Phase 3 (Plan): Client-Server Story Content Types (Silesia Dataset)
+// ============================================================================
+
+// A single story containing raw bytes from the Silesia corpus
+struct StoryContent {
+  1: i64 story_id;
+  2: binary content;        // Raw bytes from Silesia files
+  3: string source_file;    // Which Silesia file this snippet came from
+  4: i32 content_length;    // Length of content in bytes
+}
+
+// A batch of stories sent per request
+struct StoryBatch {
+  1: list<StoryContent> stories;
+}
+
 // Request structure for DLRM inference with client-provided features
 struct RankingRequest {
   1: i64 request_id;
   2: optional DLRMFeatures dlrm_features;
   3: i32 num_inferences = 1;
   4: map<string, string> metadata;
+  5: optional StoryBatch story_batch;
 }

--- a/packages/feedsim/third_party/src/workloads/ranking/utils.h
+++ b/packages/feedsim/third_party/src/workloads/ranking/utils.h
@@ -6,16 +6,19 @@
 #ifndef UTILS_H
 #define UTILS_H
 
+#include <cstdlib>
+#include <iostream>
 #include <sstream>
 #include <utility>
 
 namespace ranking {
 namespace utils {
-std::pair<std::string, int> parseHostnameAndPort(const std::string &address) {
+inline std::pair<std::string, int> parseHostnameAndPort(const std::string &address) {
   std::stringstream s_stream{address};
   std::string hostname;
   if (!s_stream.good()) {
-    DIE("Failed to parse %s", address.c_str());
+    std::cerr << "Failed to parse " << address << std::endl;
+    exit(1);
   }
   std::getline(s_stream, hostname, ':');
   int port = 11222;


### PR DESCRIPTION
Summary:

Phase 3 of FeedSim v2 refactor. Client loads the Silesia compression corpus
(203MB, 12 files) via mmap, picks random snippets as "stories," and sends them
to the server via thrift. Server uses story content to derive data-dependent
feature extraction inputs and DLRM features instead of random data.

Changes:
- Add StoryContent/StoryBatch thrift types and story_batch field on RankingRequest
- Add SilesiaLoader.h: mmap-based corpus loader with random snippet serving
- Update DriverNodeRank to load Silesia at startup, populate stories per request
- Update LeafNodeRank to extract stories, derive features from content bytes
  (byte frequency histogram -> dense features, rolling bigram hash -> sparse)
- Rewrite DLRMRequestHandler from sync to async with folly futures
  (I/O simulation + compression + pointer chase, pipelined)
- Add storyContent/storyContentLength fields to CopyContext for extractors
- Fix feature_suite missing from ThreadData (lost during rebase)
- Fix $feature_opts not passed to LeafNodeRank in run.sh
- Fix runFeatureExtraction() never called from request handlers
- Fix ICacheBuster SIGSEGV: init moved outside PAGERANK block
- Remove ICacheBuster from DLRMRequestHandler (DLRM inference is own workload)
- Add --silesia-dir, --stories-per-request, --story-size-min/max CLI options
- Download Silesia corpus during install (x86 + aarch64)

Reviewed By: charles-typ

Differential Revision: D104076734
