### PR TITLE
Update docs for v2: rewrite README, add ARCHITECTURE_v2, archive v1

### DIFF
--- a/packages/feedsim/ARCHITECTURE_v2.md
+++ b/packages/feedsim/ARCHITECTURE_v2.md
@@ -1,0 +1,338 @@
+<!--
+Copyright (c) Meta Platforms, Inc. and affiliates.
+
+This source code is licensed under the MIT license found in the
+LICENSE file in the root directory of this source tree.
+-->
+# FeedSim v2 architecture
+
+FeedSim v2 (`feedsim_dlrm`, `feedsim_autoscale_dlrm`) is a rewrite of the
+v1 aggregator benchmark that keeps v1's outer harness (driver ↔ leaf
+server ↔ runner script) but replaces the ranking core, the outbound-I/O
+model, and the thread-pool topology. Its goal is a CPU profile that
+represents a modern feed aggregator well enough to use for gen-over-gen
+datacenter CPU comparisons — not just latency-vs-QPS shape, but also
+microarchitectural behavior and hot function compositions (such as RPC,
+feature extraction, ranking, encryption, compression, etc).
+
+This document describes the v2 architecture end-to-end: what each process
+does, how a request flows through them, what data crosses which boundary,
+and where v2 diverges from v1.
+
+The companion diagram is [`docs/architecture_v2.svg`](docs/architecture_v2.svg).
+
+---
+
+## Processes
+
+A single-instance v2 run spawns three processes on the same host:
+
+| Process | Binary | Role |
+|---|---|---|
+| **DriverNodeRank** | `benchmarks/feedsim/src/build/workloads/ranking/DriverNodeRank` | Client-side load generator. Samples request sizes from `feed_aggregator_req_sizes.json`, opens connections to `LeafNodeRank`, sends requests at a target QPS, and records p50 / p95 / p99 end-to-end latency. |
+| **LeafNodeRank** | `benchmarks/feedsim/src/build/workloads/ranking/LeafNodeRank` | The system-under-test. Real fbthrift server. Receives ranking requests, runs feature extraction + story processors + DLRM inference, fans real outbound RPCs to `mock_services` to simulate outbound I/O (e.g. remote prediction, cache/database lookup) in production, and returns a Silesia-backed payload. |
+| **mock_services** | `benchmarks/feedsim/src/build/workloads/ranking/mock_services/mock_services` | Simulates RPC services that the feed aggregator in the prod interacts with (cache, key-value stores, feature stores, remote prediction, entity database, etc.). Runs its own fbthrift `ThriftServer`. TLS-terminating when `--mock-tls=1`. Sleeps/spins for a caller-supplied latency and returns a Silesia-derived payload sized by the caller. |
+
+`run-feedsim-multi.sh` is the wrapper that spawns one `LeafNodeRank`,
+one `mock_services`, and one driver per FeedSim instance. When it's asked to
+spawn multiple sets of instances, each set will be pinned to
+its own CPU range with `taskset`.
+
+All three binaries link statically against a self-contained folly / fbthrift
+/ wangle / fizz build produced by the install script. `mock_services` also
+links `libaegis` and `libsodium` as fizz crypto backends.
+
+---
+
+## Thread pools inside `LeafNodeRank`
+
+`LeafNodeRank` is where all the interesting CPU work lives. It uses four
+named pools:
+
+| Pool | Named factory | Sizing default | Role |
+|---|---|---|---|
+| **ThriftSrv.IO** | `NamedThreadFactory("ThriftSrv.IO")` | `nproc` | fbthrift server IO workers. Accept inbound driver connections and drive request dispatch. |
+| **SREventBase** | `NamedThreadFactory("SREventBase")` | `max(1, ⌈nproc * 7/10⌉)` | Outbound-RPC EventBase pool. Each thread owns one `folly::EventBase`; each EventBase owns one `MockServicesClient` (see below). This is where the fanout to `mock_services` runs. |
+| **RANKER** | `NamedThreadFactory("RANKER")` | `max(1, ⌈nproc/2⌉)` | CPU-heavy per-request work: feature-extractor pipeline, story processors, response compression when `--server-zstd=1`. |
+| **GlobalCPUThread** | `folly::getGlobalCPUExecutor()` | folly default | DLRM inference and the response Silesia-slicer continuation live here. Same executor LibTorch calls into for its intra-op work. |
+
+The pool naming matches the thread-pool names used by production feed-
+aggregator services so per-thread CPU attribution lines up directly with
+prod-side profiles.
+
+Two more helper pools live on the fringes:
+
+- **TimekeeperPool** — a small (`--timekeeper_threads`, default 1) pool of
+  `folly::HHWheelTimer`s used to schedule sleep / deadline futures for I/O
+  simulation and mock-fanout wave scheduling. Split off from folly's
+  global timekeeper so long spins in RANKER don't stall time-based futures.
+- **DLRM intra-op** — LibTorch's own pool, capped at `--dlrm-threads`
+  (default 1). Kept small to avoid an `nproc^2` GlobalCPUThread explosion
+  on high-core boxes.
+
+---
+
+## Request control flow
+
+A single request from `DriverNodeRank` to `LeafNodeRank` executes the
+following stages. Names in brackets show which thread pool the work lands
+on.
+
+```
+                             ┌───────────────────────────────────────┐
+                             │ DriverNodeRank (per driver thread)   │
+                             │                                       │
+                             │  1. Sample request from                │
+                             │     feed_aggregator_req_sizes.json     │
+                             │  2. Send request over Rocket           │
+                             │     (optionally TLS-wrapped)            │
+                             └────────────┬──────────────────────────┘
+                                          │  request
+                                          ▼
+                             ┌───────────────────────────────────────┐
+                             │ LeafNodeRank                          │
+                             │ [ThriftSrv.IO worker]                 │
+                             │                                       │
+                             │  3. Decode request; hop to RANKER      │
+                             └────────────┬──────────────────────────┘
+                                          │
+                                          ▼
+                             ┌───────────────────────────────────────┐
+                             │ [RANKER thread]                       │
+                             │                                       │
+                             │  4. Feature extraction pipeline        │
+                             │     (--feature-extractors,              │
+                             │      --num-stories × --extractors-      │
+                             │      per-story extractor invocations)   │
+                             │                                       │
+                             │  5. Story-processor pipeline            │
+                             │     (--story-processors-per-story ×     │
+                             │      --stories-per-processor-pass:      │
+                             │      scoring → filtering → blending →   │
+                             │      thrift serdes → topK)              │
+                             │                                       │
+                             │  6. Compute outbound RPC fan wave       │
+                             │     (rpc_dist.json × --rpc-fanout-      │
+                             │      scale). Hop each RPC to its owning │
+                             │      SREventBase.                       │
+                             └────────────┬──────────────────────────┘
+                                          │
+                                          ▼
+                             ┌───────────────────────────────────────┐
+                             │ [SREventBase worker, round-robin]     │
+                             │                                       │
+                             │  7. issueOutboundFanout via            │
+                             │     folly::window(K=32). Each RPC       │
+                             │     goes through the MockServicesClient │
+                             │     pinned to this EB (TLS + ZSTD when  │
+                             │     --mock-tls=1 / --mock-zstd-frac >0). │
+                             └────────────┬──────────────────────────┘
+                                          │  N-way fanout
+                                          ▼
+                             ┌───────────────────────────────────────┐
+                             │ mock_services                          │
+                             │ [mock_services IO worker]              │
+                             │                                       │
+                             │  8. semifuture_<method>(request,        │
+                             │     latency_us). Parse 4-byte BE        │
+                             │     response-size prefix; sleep/spin    │
+                             │     for latency_us; slice response      │
+                             │     bytes from the mmapped Silesia      │
+                             │     corpus; return.                     │
+                             └────────────┬──────────────────────────┘
+                                          │  N async responses
+                                          ▼
+                             ┌───────────────────────────────────────┐
+                             │ LeafNodeRank                          │
+                             │ [SREventBase worker → GlobalCPUThread]│
+                             │                                       │
+                             │  9. Await folly::collectAll of fanout. │
+                             │ 10. Hop back to GlobalCPUThread.        │
+                             │ 11. DLRM inference (LibTorch).          │
+                             │     --dlrm-batch-size × --dlrm-          │
+                             │     inferences per request.              │
+                             │ 12. Generate response payload from       │
+                             │     Silesia corpus (SilesiaResponse-     │
+                             │     Generator). Optionally ZSTD-         │
+                             │     compressed when --server-zstd=1.     │
+                             └────────────┬──────────────────────────┘
+                                          │  response
+                                          ▼
+                             ┌───────────────────────────────────────┐
+                             │ DriverNodeRank                        │
+                             │                                       │
+                             │ 13. Record end-to-end latency.          │
+                             └───────────────────────────────────────┘
+```
+
+The RANKER → SREventBase → mock_services → SREventBase → GlobalCPUThread
+executor hops are the load-bearing property of v2: they turn v1's
+single-threaded "sleep and generate" ranker into a real async-fanout
+profile that spends CPU in the same places a production aggregator does.
+
+### Single request-response for now — session support is future work
+
+`LeafNodeRank` exposes a multi-method, session-based Thrift interface
+(see `FeedSimServer.h` / `FeedSimDriver.h`) that would let a driver open
+a session, issue several sequential requests within it, and share state
+across them. In v2 today the driver does **not** use those session
+methods — every request is a stand-alone request-response pair. The
+multi-hop session-driven flow is planned future work and will let us
+model tail latency contributions that only appear across a full user
+session (e.g. warm-cache reuse, per-session state hits). Until then, the
+"session schedule" fields in `rpc_dist.json` are only used to shape the
+per-request outbound fanout, not to sequence multiple requests.
+
+---
+
+## Data flow — where bytes come from
+
+FeedSim v2 was designed so that request and response byte sizes match a
+production feed aggregator's percentile distribution end-to-end. The
+sources are:
+
+- **Request sizes (driver → leaf)** — sampled from
+  `packages/feedsim/feed_aggregator_req_sizes.json` by
+  `RequestSizeSampler` inside `DriverNodeRank`. This is a percentile CDF
+  extracted from a real production trace. Each request picks a size from
+  the CDF; the size is inserted into the Thrift request struct as
+  opaque padding.
+- **Response sizes (leaf → driver)** — sampled from
+  `packages/feedsim/feed_aggregator_resp_sizes.json` in the same way, and
+  materialized by `SilesiaResponseGenerator` (see
+  `workloads/ranking/generators/SilesiaResponseGenerator.h`). The
+  generator slices real bytes from the mmapped Silesia corpus rather
+  than running an RNG — this cuts ~15% of CPU that RNG-based response
+  generation used to burn.
+- **Outbound RPC fanout (leaf → mock_services)** — sampled from
+  `packages/feedsim/rpc_dist.json`. This is a per-method table of how
+  many RPCs each request issues to each downstream service, plus a
+  percentile distribution of per-RPC request/response sizes and
+  latencies. `--rpc-fanout-scale` scales the per-request RPC count
+  (default 0.05).
+- **`mock_services` responses** — sliced from the same Silesia corpus,
+  mmapped by `SilesiaLoader` at startup. The caller passes a 4-byte
+  big-endian `response_size` as the first bytes of its `binary request`
+  argument; the handler slices that many bytes out of the corpus and
+  returns them.
+- **DLRM model** — a small TorchScript file
+  (`packages/feedsim/models/dlrm_small.pt`) downloaded by the install
+  script. Same dense/sparse feature-slot layout as a typical
+  recommendation DLRM (13 dense, 26 sparse) so the LibTorch graph
+  exercises the similar op mix.
+
+Every one of those files is packaged with FeedSim and copied into
+`benchmarks/feedsim/` at install time.
+
+---
+
+## Wire protocol
+
+`LeafNodeRank`, `DriverNodeRank`, and `mock_services` all speak **fbthrift
+Rocket** on TLS 1.3. TLS is negotiated via fizz with ALPN `rs` so the
+server can route the connection into the Rocket transport. The client side
+is `RocketClientChannel::newChannel(AsyncSSLSocket)`; the server side is
+`ThriftServer` with a `wangle::SSLContextConfig`. When `--mock-tls=0` the
+TLS layer is skipped and the underlying `folly::AsyncSocket` is used
+directly.
+
+Per-channel ZSTD compression is negotiated via
+`RocketClientChannel::setCompressionSettings(CodecId::ZSTD)`. The
+`--mock-zstd-frac` knob picks the fraction of `MockServicesClient`
+channels that enable ZSTD (default 0.75). Server-side response
+compression is opt-in via `--server-zstd`.
+
+---
+
+## How v2 differs from v1
+
+| Concern | v1 (`feedsim_autoscale`) | v2 (`feedsim_dlrm`) |
+|---|---|---|
+| **Ranking core** | PageRank on a synthetic graph. | DLRM inference on real LibTorch model (pre-trained from Criteo dataset). |
+| **Outbound I/O model** | `folly::futures::sleep(io_time_ms)` — no real RPC, no network stack, no serialization. | Real Thrift RPCs to a separate `mock_services` process. Full RPC stack: fbthrift `RocketClientChannel`, `CompactProtocol` (de)serialization, `AsyncSSLSocket` when TLS is on, ZSTD encode/decode when compression is on. |
+| **Downstream target** | None (sleep). | ~20 Thrift methods on a co-located `mock_services` binary; each method is a distinct symbol so per-method fanout CPU is attributable in profiles. |
+| **Response payload** | Random bytes generated by an xor128 RNG on the server. | Compressible bytes sliced from the Silesia compression corpus (mmapped once at startup). Removes ~15% RNG cost and gives compression a realistic input. |
+| **Request payload** | Fixed size. | Sampled per request from `feed_aggregator_req_sizes.json`. |
+| **Feature extraction** | None. | 13 archetype extractors (bitset, container, embedding-lookup, feature-layout copy, hash-lookup, tree-traversal, …) plus generated variants. Per-request work is `num_stories × extractors_per_story` extractor invocations. |
+| **Story processors** | None. | Scoring → filtering → blending → thrift-serdes → topK pipeline. `--story-processors-per-story × --stories-per-processor-pass` per request. |
+| **Thread pools** | Single fbthrift IO pool + one CPU pool. | Four named pools (`ThriftSrv.IO`, `SREventBase`, `RANKER`, `GlobalCPUThread`) with per-pool sizing rules that mirror production configurations and improves scalability. |
+| **Outbound fanout channel** | N/A (no fanout). | One `MockServicesClient` per `SREventBase` thread. Fanout round-robins across all EBs via `folly::window(K=32)` so no single Rocket channel serializes the whole fanout. |
+| **Driver model** | One request per connection. | Single-request-response per driver call today (see above). Session-driven multi-hop is a planned extension. |
+| **TLS** | Off. | On by default. Server terminates via fizz + ALPN `rs`; client uses `AsyncSSLSocket` + `RocketClientChannel`. |
+| **Wire compression** | Off. | Per-channel ZSTD, fraction controlled by `--mock-zstd-frac` (default 0.75). |
+| **Cold-channel keepalive** | N/A. | Per-`MockServicesClient` keepalive ping every `--mock-keepalive-interval-ms` (default 200 ms). Prevents the low-QPS p95 cliff caused by deep-C-state channel idle. |
+| **SLA** | 500 ms p95. | 700 ms p95 — reflects the higher tail budget of the real RPC fanout between LeafNodeRank server and mock_services. |
+| **Scaling model** | Autoscale — one instance per 100 cores. | Single instance per host (`feedsim_dlrm`) works even on ultra-high-core-count CPUs thanks to the redesigned thread-pool model. Autoscale variant `feedsim_autoscale_dlrm` still exists for max-throughput / NUMA experiments. |
+| **Steady-state instrumentation** | Final 5-min pass at converged QPS. | Same, plus `breakdown.csv` runtime timestamps for post-hoc metric filtering. |
+
+---
+
+## Where each piece lives in the tree
+
+```
+packages/feedsim/
+├── README.md                     # user-facing docs (v2)
+├── README_v1.md                  # legacy v1 docs
+├── ARCHITECTURE_v2.md            # this document
+├── docs/
+│   └── architecture_v2.svg       # component + flow diagram
+├── feed_aggregator_req_sizes.json  # request-size CDF
+├── feed_aggregator_resp_sizes.json # response-size CDF
+├── rpc_dist.json                 # per-method fanout schedule + size/latency CDFs
+├── models/
+│   └── dlrm_small.pt             # TorchScript DLRM model (downloaded by installer)
+├── install_feedsim.sh            # CentOS x86 installer
+├── install_feedsim_aarch64.sh    # CentOS ARM installer
+├── install_feedsim_ubuntu.sh     # Ubuntu x86 installer
+├── install_feedsim_aarch64_ubuntu.sh  # Ubuntu ARM installer
+├── run.sh                        # per-instance runner (parses -q/-d/... and --dlrm-*/--mock-*)
+├── run-feedsim-multi.sh          # multi-instance launcher (spawns leaf + mock_services + drivers)
+└── third_party/src/workloads/ranking/
+    ├── LeafNodeRank.cc           # main leaf binary; owns the thread pools + request pipeline
+    ├── DriverNodeRank.cc         # driver binary; sends requests + records latency
+    ├── FeedSimServer.{cc,h}      # replaces v1 oldisim server; hosts the fbthrift ThriftServer
+    ├── FeedSimDriver.{cc,h}      # driver-side helpers (session-mode plumbing, request replay)
+    ├── MockServicesClient.{cc,h} # per-SREventBase client to mock_services (TLS + ZSTD + keepalive)
+    ├── SilesiaLoader.h           # mmap-based Silesia corpus loader (shared by leaf + mock_services)
+    ├── PercentileSampler.h       # CDF sampler used for request/response/fanout sizes
+    ├── RequestSizeSampler.h      # per-request payload sizing
+    ├── LatencyHistogram.h        # debug counters (dispatch_per_rpc, mock_handler_actual, ...)
+    ├── generators/
+    │   └── SilesiaResponseGenerator.h  # Silesia-backed response payload generator
+    ├── feature_extractors/
+    │   ├── FeatureExtractorSuite.{cc,h}
+    │   ├── BitsetExtractor.{cc,h}
+    │   ├── ContainerExtractor.{cc,h}
+    │   ├── EmbeddingLookupExtractor.{cc,h}
+    │   ├── FeatureLayoutExtractor.{cc,h}
+    │   ├── HashLookupExtractor.{cc,h}
+    │   ├── TreeTraversalExtractor.{cc,h}
+    │   └── generated/            # codegen'd registry + copy dispatch + variants
+    ├── story_processors/
+    │   ├── StoryProcessorSuite.{cc,h}
+    │   ├── ScoringPassProcessor.{cc,h}
+    │   ├── FilteringPassProcessor.{cc,h}
+    │   ├── BlendingPassProcessor.{cc,h}
+    │   ├── ThriftSerdesProcessor.{cc,h}
+    │   └── TopKProcessor.{cc,h}
+    ├── dwarfs/
+    │   ├── dlrm.{cpp,h}          # LibTorch DLRM inference wrapper
+    │   └── pagerank.{cpp,h}      # legacy v1 pagerank (still built; used by feedsim_autoscale)
+    └── mock_services/
+        ├── MockService.thrift    # ~20-method IDL
+        ├── MockServiceMain.cc    # server main + latency-shaping flags
+        ├── MockServiceHandler.{cc,h}  # single shared runSimulatedRpc body
+        ├── PercentileSamplerTest.cpp  # unit test
+        ├── BUCK
+        └── CMakeLists.txt
+```
+
+## Further reading
+
+- `mock_services/MockService.thrift` — the IDL for the fanout target.
+- `LeafNodeRank.cc` — top-level comments describe the thread-pool layout,
+  the per-SREventBase client construction, and the async continuation
+  chain.
+- `MockServicesClient.cc` — client-side TLS + ZSTD + keepalive wiring.
+- `run-feedsim-multi.sh` — the multi-instance launcher; shows how leaf +
+  mock_services + drivers are pinned via `taskset`.

--- a/packages/feedsim/README.md
+++ b/packages/feedsim/README.md
@@ -4,313 +4,282 @@ Copyright (c) Meta Platforms, Inc. and affiliates.
 This source code is licensed under the MIT license found in the
 LICENSE file in the root directory of this source tree.
 -->
-# Feedsim
+# FeedSim
 
-FeedSim is a benchmark that represents the aggregation and ranking workloads in
-recommendation systems. It searches for the maximum QPS that the system can
-achieve while keeping p95 latency to be no greater than 500ms.
+FeedSim is a benchmark that represents the aggregation and ranking workloads
+in production recommendation systems. It searches for the maximum QPS the
+system can sustain while keeping p95 latency ≤ **700 ms**. Though it's possible
+that on some platforms the CPU gets saturated before latency hitting the SLA.
 
-## Install feedsim
+The current recommended job is **`feedsim_dlrm`** (v2). It runs a
+single-instance aggregator with real DLRM inference, out-of-process
+`mock_services` RPC fanout over TLS + ZSTD, feature extraction and story
+processors modules. Data used in the request flow is backed by the Silesia corpus
+to ensure representative in compressibility. Because we replaced the fixed 200ms
+sleep with hundreds of concurrent real RPC communication to the `mock_services`
+module, the tail latency SLA is increased from 500ms to 700ms accordingly.
 
-```
-./benchpress_cli.py install feedsim_autoscale
-```
+For the legacy PageRank-based v1 job (`feedsim_autoscale`, 500 ms SLA), see
+[README_v1.md](README_v1.md).
 
-## Run feedsim
+For the software architecture and request control/data flow of v2, see
+[ARCHITECTURE_v2.md](ARCHITECTURE_v2.md).
 
-### Recommended job - `feedsim_autoscale`
+## Recommended job — `feedsim_dlrm`
 
-`feedsim_autoscale` is the version of Feedsim benchmark that can scale up on
-systems with CPUs of very large core counts. It will spawn multiple Feedsim
-workload instances at 100 cores per instance (rounded up), let them run in
-parallel and aggregate final results when they finish. For example, if your
-system has 256 cores, this job will spawn three Feedsim instances.
-
-To run Feedsim benchmark, simply execute the following command
-
-```
-./benchpress_cli.py run feedsim_autoscale
-```
-
-This job also has the following optional parameters:
-  - `num_instances`: manually specify the number of feedsim workload instances
-  to run in parallel instead of automatically scaling with the CPU core count
-  - `extra_args`: extra arguments you would like to pass to Feedsim's runner
-  script. Available arguments can be viewed by running
-  `./benchmarks/feedsim/run.sh -h`.
-
-For example, if you would like to run two instances regardless the CPU core
-count, you can run the following:
+### Install
 
 ```
-./benchpress_cli.py run feedsim_autoscale -i '{"num_instances": 2}'
+./benchpress_cli.py install feedsim_dlrm
 ```
 
-If you want to run an experiment with fixed 100 QPS, you can run:
+The installer downloads and builds folly, fbthrift, wangle, fizz, mvfst,
+LibTorch, the Silesia compression corpus, the DLRM TorchScript model, and
+the FeedSim binaries. It runs ~30 minutes on a fresh host.
+
+On memory-constrained hosts (e.g. machines with less than 1GB per core), we
+recommend that you cap the build parallelism to avoid OOM, for example:
 
 ```
-./benchpress_cli.py run feedsim_autoscale -i '{"extra_args": "-q 100"}'
+taskset -c 0-15 ./benchpress_cli.py install feedsim_dlrm
 ```
 
-This benchmark normally takes around 30 minutes to finish. It is recommended to
-turn on CPU boost before running this benchmark, otherwise feedsim might not
-converge and yield very low result.
-
-When feedsim finds the optimal QPS that meets the SLA of <=500ms p95 latency, it
-will execute a final run of 5 minutes using the optimal QPS. Therefore, if you
-would like to collect system and microarch metrics for performance analysis,
-collect those during the last 5 minutes of the benchmark. We expect the CPU
-utilization during this period to be in the range of 60%~75%.
-
-### Running on ARM Platforms
-If running on ARM platforms, please use the job `feedsim_autoscale_arm` (other usages will be the same):
-```
-./benchpress_cli.py run feedsim_autoscale_arm
-```
-
-### Running Feedsim Mini
-
-Feedsim Mini is a shrunken version of Feedsim
-that aims to reduce execution time to a few seconds.
-It includes runtime breakdown tracking capabilities that record
-benchmark timestamps to enable metric filtering for the actual benchmark time,
-which is essential for mini jobs where execution time is only a few seconds.
-
-To run Feedsim Mini, please follow these steps:
-
-1. Make sure that you get the latest version of DCPerf and check out the latest commit in the `v2-beta` branch.
-If you've installed Feedsim with an older version of DCPerf,
-we recommend you clean and re-install Feedsim.
-
-2. Run the `feedsim_autoscale_mini` job:
-
-```bash
-./benchpress_cli.py run feedsim_autoscale_mini
-```
-
-This mini job runs the same workload as the full Feedsim Autoscale but with
-minimal settings to enable quick testing and validation.
-A `breakdown.csv` file will be generated in the results to track runtime breakdowns,
-which can be used to filter metrics for the actual benchmark execution time.
-
-## Reporting and Measurement
-
-After the feedsim benchmark finishing, benchpress will report the results in
-JSON format like the following:
+### Run
 
 ```
+./benchpress_cli.py run feedsim_dlrm
+```
+
+Unlike FeedSim v1 which spawns a new FeedSim instance per 100 CPU cores,
+`feedsim_dlrm` is pinned to **one FeedSim instance per host** because the
+redesigned threading model in FeedSim v2 has overcome the scalability issue
+on ultra-high-core-count CPUs and ARM CPUs. 
+
+The runner searches for the QPS that keeps 95th-percentile end-to-end
+latency at or below **700 ms**. When it converges it runs a final 5-minute
+steady-state pass at that QPS; collect telemetry (perf, mpstat, µarch
+counters) during that final window. We expect the total wall-clock runtime
+to be around 30 minutes.
+
+Please make sure to turn CPU turbo-boost on before starting, or FeedSim may
+fail to converge and report a low QPS. 
+
+### Result report
+
+After the run finishes, benchpress prints a JSON result. Example from a
+AMD Zen4 host (176 logical cores, 256 GB RAM):
+
+```json
 {
-  "benchmark_args": [],
-  "benchmark_desc": "Aggregator like workload. Latency sensitive. Finds maximum QPS that system can sustain while keeping 95th percentile latency <= 500 msecs.\n",
-  "benchmark_hooks": [
-    "cpu-mpstat: {'args': ['-u', '1']}",
-    "copymove: {'is_move': True, 'after': ['benchmarks/feedsim/feedsim_results*.txt', 'benchmarks/feedsim/feedsim-multi-inst-*.log']}"
+  "benchmark_args": [
+    "-n 1",
+    "--async-io",
+    "--io-dist=fixed",
+    "--io-mean=200",
+    "--workload=dlrm",
+    "--dlrm-model=models/dlrm_small.pt",
+    "--dlrm-batch-size=64",
+    "--dlrm-threads=1",
+    "--dlrm-inferences=1",
+    "--client-side-features=0",
+    "--client-batch-size=256",
+    "--client-inferences=64",
+    "--client-feature-seed=42",
+    "--client-num-dense=13",
+    "--client-num-sparse=26",
+    "--feature-extractors",
+    "--feature-complexity=5",
+    "--num-stories=400",
+    "--extractors-per-story=280",
+    "--story-processors-per-story=2",
+    "--stories-per-processor-pass=100",
+    "--silesia-dir=silesia",
+    "--stories-per-request=10",
+    "--mock-tls=1",
+    "--mock-zstd-frac=0.75",
+    "--mock-keepalive-interval-ms=200",
+    "--rpc-fanout-scale=0.05",
+    "--server-zstd=0",
+    "--sla-p95-ms=700"
   ],
-  "benchmark_name": "feedsim_autoscale",
+  "benchmark_name": "feedsim_dlrm",
   "machines": [
     {
       "cpu_architecture": "x86_64",
       "cpu_model": "<CPU-name>",
       "hostname": "<server-hostname>",
-      "kernel_version": "5.19.0-0_xxxx",
-      "mem_total_kib": "2377231352 KiB",
-      "num_logical_cpus": "380",
+      "kernel_version": "6.13.2-0_fbk8_0_g8695f611147d",
+      "mem_total_kib": "263374740 KiB",
+      "num_cpus_usable": 176,
+      "num_logical_cpus": "176",
       "os_distro": "centos",
-      "os_release_name": "CentOS Stream 8"
+      "os_release_name": "CentOS Stream 9",
+      "threads_per_core": "2"
     }
   ],
   "metadata": {
-    "L1d cache": "6 MiB (192 instances)",
-    "L1i cache": "6 MiB (192 instances)",
-    "L2 cache": "192 MiB (192 instances)",
-    "L3 cache": "768 MiB (24 instances)"
+    "L1d cache": "2.8 MiB (88 instances)",
+    "L1i cache": "2.8 MiB (88 instances)",
+    "L2 cache": "88 MiB (88 instances)",
+    "L3 cache": "176 MiB (11 instances)"
   },
   "metrics": {
     "1": {
-      "final_achieved_qps": 248.38,
-      "final_latency_msec": 310.9,
-      "final_requested_qps": 251.82
+      "final_achieved_qps": 278.84,
+      "final_latency_msec": 644.04,
+      "final_requested_qps": 281.03
     },
-    "2": {
-      "final_achieved_qps": 248.98,
-      "final_latency_msec": 308.31,
-      "final_requested_qps": 252.61
-    },
-    "3": {
-      "final_achieved_qps": 249.73,
-      "final_latency_msec": 305.82,
-      "final_requested_qps": 252.98
-    },
-    "4": {
-      "final_achieved_qps": 248.98,
-      "final_latency_msec": 305.22,
-      "final_requested_qps": 251.99
-    },
+    "is_fixed_qps": 0,
+    "max_qps": 278.84,
+    "min_qps": 278.84,
     "overall": {
-      "average_latency_msec": 307.56,
-      "final_achieved_qps": 996.07,
-      "final_requested_qps": 1009.4
+      "average_latency_msec": 644.04,
+      "final_achieved_qps": 278.84,
+      "final_requested_qps": 281.03
     },
-    "spawned_instances": "4",
-    "successful_instances": 4,
-    "target_latency_msec": "500",
-    "target_percentile": "95p",
-    "score": 17.4736842105
+    "score": 4.8919,
+    "spawned_instances": "1",
+    "successful_instances": 1,
+    "target_latency_msec": "700",
+    "target_percentile": "95p"
   },
-  "run_id": "2ef4dfad",
-  "timestamp": 1702590806
+  "run_id": "d8c6a288",
+  "timestamp": 1782368295
 }
 ```
 
-The result above is from an experiment on a system of 380-core CPU, where
-`feedsim_autoscale` would spawn four instances. The result report will include
-performance numbers of each individual instance (named `1` to `4`) as well as
-the aggregated overall performance (named `overall`) in the `metrics` section.
+Key fields are in `metrics.overall`:
 
-`overall` performance is what we care about. Its metrics are calculated as follows:
-  * `final_achieved_qps` - sum of `final_achieved_qps` of all individual instances
-  * `final_requested_qps` - sum of `final_requested_qps` of all individual instances
-  * `average_latency_msec` - average of final P95 latency of all individual instances
+- `final_achieved_qps` — the primary performance number. Max QPS the host
+  sustained with p95 ≤ 700 ms.
+- `average_latency_msec` — the observed p95 at that QPS. The latency number
+  can be around or below `target_latency_msec` (700) for a converged run.
+  This field is called "average" because it's the average of p95 latency
+  values observed from all benchmark instances (which will be discussed later).
+  It itself still indicates the tail p95 latency.
+- `final_requested_qps` — what the driver asked for. Should be within a few
+  percent of `final_achieved_qps` on a converged run.
 
-`final_achieved_qps` is the metric that measures the performance, measuring
-the max QPS FeedSim could achieve with the contraint of p95 latency being
-less than 500ms.
+`score` is `final_achieved_qps` divided by the QPS number achieved on an
+older reference system to reflect the platform's relative speedup.
 
-We expect all the individual instances have similar final achieved QPS numbers.
-If you see one or more instances have significantly lower performance than the
-others, it indicates the experiment is probably unsuccessful because the
-low-performance instances may have got killed earlier than they should. In this
-case, we suggest running this benchmark again.
+`is_fixed_qps` is `0` for the default search mode. It is `1` when you pass
+`-q` (see [Fixed-QPS experiments](#fixed-qps-experiments) below), and the
+`overall` block then reports observed p95 at the fixed load rather than a
+saturation point.
 
-Feedsim will generate detailed metrics reports at
-`benchmark_metrics_<run_id>/feedsim_results_<1~N>.txt` (N is the workload instance ID
-and each instanec will have its own CSV)
-in CSV format like the following:
+Per-instance CSVs live at
+`benchmark_metrics_<run_id>/feedsim_results_<1>.txt`; instance logs at
+`benchmark_metrics_<run_id>/feedsim-multi-inst-<1>.log`; the runtime
+breakdown at `benchmark_metrics_<run_id>/breakdown.csv`.
 
-```
-duration_secs,total_queries,requested_qps,achieved_qps,total_bytes_rx,total_bytes_tx,rx_MBps,tx_MBps,min_ms,avg_ms,50p_ms,90p_ms,95p_ms,99p_ms,99.9p_ms
-120,5267,0.00,41.46,85637186,15927408,0.64,0.12,388.134,958.509,913.313,956.414,991.523,1812.133,12232.154
-120,5571,0.00,43.86,90618516,16846704,0.68,0.13,388.134,910.627,918.002,960.395,1010.386,1050.379,1848.997
-120,5040,39.97,39.67,82279002,15240960,0.62,0.11,388.134,457.068,446.739,524.929,535.555,569.859,593.868
-120,2737,20.49,21.55,44727453,8276688,0.34,0.06,352.849,423.693,406.253,486.015,509.429,535.926,556.451
-......
+## Advanced usage
 
-```
+### Fixed-QPS experiments
 
-Besides, logs of individual instances will also be recorded at
-`benchmark_metrics_<run_id>/feedsim-multi-inst-<1~N>.log` for debugging.
-
-## Advanced Usage - Fixed-QPS experiment
-
-Rather than let feedsim's runner script search for an optimal QPS that meets the
-SLA, you can also choose to run feedsim at a fixed QPS and observe the latency.
-To do so, simply run the following:
-
-```sh
-./benchpress_cli.py run feedsim_autoscale -i '{"extra_args": "-q <QPS>"}'
-```
-`-q` follows the desired QPS you would like **each instance** to drive,
-and `-d` is an optional parameter stating the duration of the experiment
-(default is 300s). Note that the total runtime could be longer because
-feedsim needs to populate object graphs and perform a warmup. The default
-warmup period is 120s, and can be changed by specifying the optional
-parameter `-w`. Reducing warmup (and experiment) time can make the run
-faster, but may affect accuracy and end up with lower QPS than the machine
-can actually achieve.
-
-For example, if you would like to drive 250 QPS in each feedsim instance
-on a 380-core CPU system:
+Instead of searching for the SLA-bound QPS, drive a fixed QPS and observe
+latency:
 
 ```
-[root@<hostname> ~/external]# ./benchpress_cli.py run feedsim_autoscale -i '{"extra_args": "-q 250"}'
-Will run 1 job(s)
-......
-Results Report:
-{
-  "benchmark_args": [
-    "{num_instances}",
-    "{extra_args}"
-  ],
-  "benchmark_desc": "Aggregator like workload. Latency sensitive. Finds maximum QPS that system can sustain while keeping 95th percentile latency <= 500 msecs. Automatically spawns multiple workload instances at 100 cores per instance (rounded
-up).\n",
-  "benchmark_hooks": [
-    "cpu-mpstat: {'args': ['-u', '1']}",
-    "copymove: {'is_move': True, 'after': ['benchmarks/feedsim/feedsim_results*.txt', 'benchmarks/feedsim/feedsim-multi-inst-*.log']}"
-  ],
-  "benchmark_name": "feedsim_autoscale",
-  "machines": [
-    {
-      "cpu_architecture": "x86_64",
-      "cpu_model": "<CPU name>",
-      "hostname": "<hostname>",
-      "kernel_version": "5.19.0_xxxxx",
-      "mem_total_kib": "2377504144 KiB",
-      "num_logical_cpus": "380",
-      "os_distro": "centos",
-      "os_release_name": "CentOS Stream 9"
-    }
-  ],
-  "metadata": {
-    "L1d cache": "6 MiB (192 instances)",
-    "L1i cache": "6 MiB (192 instances)",
-    "L2 cache": "192 MiB (192 instances)",
-    "L3 cache": "768 MiB (24 instances)"
-  },
-  "metrics": {
-    "1": {
-      "final_achieved_qps": 246.6,
-      "final_latency_msec": 317.93,
-      "final_requested_qps": 250.0
-    },
-    "2": {
-      "final_achieved_qps": 246.71,
-      "final_latency_msec": 312.45,
-      "final_requested_qps": 250.0
-    },
-    "3": {
-      "final_achieved_qps": 246.73,
-      "final_latency_msec": 311.64,
-      "final_requested_qps": 250.0
-    },
-    "4": {
-      "final_achieved_qps": 246.4,
-      "final_latency_msec": 316.28,
-      "final_requested_qps": 250.0
-    },
-    "overall": {
-      "average_latency_msec": 314,
-      "final_achieved_qps": 986.44,
-      "final_requested_qps": 1000.0
-    },
-    "successful_instances": 4,
-    "target_latency_msec": "",
-    "target_percentile": ""
-  },
-  "run_id": "80c1764b",
-  "timestamp": 1703179008
-}
-Finished running "feedsim_autoscale": Aggregator like workload. Latency sensitive. Finds maximum QPS that system can sustain while keeping 95th percentile latency <= 500 msecs. Automatically spawns multiple workload instances at 100 cores per instance (rounded up).
- with uuid: 80c1764b
+./benchpress_cli.py run feedsim_dlrm -i '{"extra_args": "-q <QPS>"}'
 ```
 
-## Other extra args
+`-q` accepts either a single value or a comma-separated list of QPS values;
+in the latter case, FeedSim runs one experiment per value in sequence.
+`-d <seconds>` sets the per-experiment duration (default 300 s). Warmup
+adds ~120 s to each experiment, and object-graph population adds ~1–2 min
+on top; a single fixed-QPS point takes ~7 min end-to-end.
 
-Please refer to `./benchmarks/feedsim/run.sh -h` to see other available
-parameters that you can supply to the `extra_args` parameter:
+Example — sweep low-load points to inspect the p95 cliff at cold-channel:
 
 ```
-Usage: run.sh [OPTION]...
-
-    -h Display this help and exit
-    -t Number of threads to use for thrift serving. Large dataset kept per thread. Default: 216
-    -c Number of threads to use for fanout ranking work. Heavy CPU work. Default: 134
-    -s Number of threads to use for task-based serialization cpu work. Default: 55
-    -a When searching for the optimal QPS, automatically adjust the number of client driver threads by
-       min(requested_qps / 4, 384 / 5) in each iteration (experimental feature).
-    -q Number of QPS to request. If this is present, feedsim will run a fixed-QPS experiment instead of searching
-       for a QPS that meets latency target. If multiple comma-separated values are specified, a fixed-QPS experiment
-       will be run for each QPS value.
-    -d Duration of each load testing experiment, in seconds. Default: 300
-    -p Port to use by the LeafNodeRank server and the load drivers. Default: 11222
-    -o Result output file name. Default: "feedsim_results.txt"
+./benchpress_cli.py run feedsim_dlrm -i '{"extra_args": "-q 5,20,50,100,150"}'
 ```
+
+### Multi-instance (max throughput)
+
+If you encounter insufficient scalability / low CPU utilization problem on some
+new hardware platform in the future, or you want to test multi NUMA-node systems,
+you can try the multi-instance option in Feedsim V2. There are two ways to launch
+multiple instances:
+
+1. Specify `num_instances` parameter when running the `feedsim_dlrm` job. For example,
+`./benchpress_cli.py run feedsim_dlrm -i '{"num_instances": 2}'` will launch 2 sets of
+feedsim server, driver and mock_services instances.
+
+2. Use the `feedsim_autoscale_dlrm` job. This autoscale job will spawn `ceil(nproc / 100)`
+FeedSim instances, each pinned to its own CPU range via `taskset`, plus one driver
+and one `mock_services` process per instance (also `taskset`-isolated). For example: 
+```
+./benchpress_cli.py run feedsim_autoscale_dlrm
+```
+
+In multi-instance mode, the overall QPS is the sum across all instances. and the
+average latency will be the average of p95 latency values observed across all
+instances.
+
+### Other parameters
+
+This section lists additional parameters in `feedsim_dlrm` benchmark. These parameters
+are carefully tuned to make the benchmark's performance characteristics closely match
+the ranking & aggregation systems in production, so we **do not** recommend you change
+them just for better performance, you should change them only for research purpose.
+
+Job-level parameters (can be passed via `-i` flag in Benchpress CLI):
+
+| Var | Purpose | Default (`feedsim_dlrm`) |
+|---|---|---|
+| `num_instances` | Number of FeedSim instances to run in parallel. Defaults to 1 in `feedsim_dlrm`; set to -1 to autoscale for `feedsim_autoscale_dlrm`. | `1` |
+| `sla_p95_ms` | SLA target in ms. The runner searches for the highest QPS keeping p95 ≤ this. | `700` |
+| `io_dist` | I/O latency distribution: `fixed`, `exponential`, or `lognormal`. | `fixed` |
+| `io_mean` | Mean I/O latency in ms. | `200` |
+| `workload` | Ranking workload: `pagerank` or `dlrm`. `dlrm` is v2. | `dlrm` |
+| `dlrm_model` | Path to the TorchScript DLRM model (`.pt`). | `models/dlrm_small.pt` |
+| `dlrm_batch_size` | Batch size for DLRM inference. | `64` |
+| `dlrm_threads` | LibTorch intra-op thread count. | `1` |
+| `dlrm_inferences` | DLRM inference calls per request. | `1` |
+| `feature_complexity` | Complexity level (1–10) of the feature-extractor pipeline. Higher = more work per story. | `5` |
+| `num_stories` | Stories per request (server-side feature extraction). | `400` |
+| `extractors_per_story` | Feature extractors randomly selected per story. | `280` |
+| `story_processors_per_story` | Story-processor pipeline passes per story (0 disables). Mirrors prod scoring + filter + blend + serdes + topK. | `2` |
+| `stories_per_processor_pass` | MockStories per story-processor pass. | `100` |
+| `stories_per_request` | Silesia snippet count per request. | `10` |
+| `mock_tls` | Enable TLS on outbound `MockServicesClient` channels. | `1` |
+| `mock_zstd_frac` | Fraction of `MockServicesClient` channels with ZSTD enabled. | `0.75` |
+| `mock_keepalive_interval_ms` | Keepalive ping interval per channel (0 disables). Defeats the cold-channel p95 cliff at low QPS. | `200` |
+| `rpc_fanout_scale` | Scale factor applied to per-session fanout counts. | `0.05` |
+| `server_zstd` | Enable ZSTD compression on server-side response payloads. | `0` |
+| `client_side_features` | Enable client-side DLRM feature generation. | `0` |
+| `silesia_dir` | Silesia corpus directory (auto-detected in benchmarks/feedsim/silesia/). | `silesia` |
+| `extra_args` | Escape hatch — appended to the runner CLI verbatim. | `""` |
+
+Note:
+1. `io_dist` and `io_mean` will not actually be used in Feedsim V2, the actual
+RPC latency distribution is controlled by `rpc_dist.json`.
+2. Changing `workload` will not only change the type of ranking workload, but
+also change the entire request workflow. `dlrm` will use the new FeedSim v2
+path, whereas `pagerank` will use the legacy Feedsim V1 path.
+3. Meaning of `rpc_fanout_scale`: when it's 1, each request will fan out over 2000
+RPC requests to the mock_services (which is the average number of outbound RPC calls
+the ranking server will do for each incoming request). That will be too heavy for this
+benchmark, so we need to set this to a lower number.
+
+Runner-level parameters (can be passed via `extra_args` parameter):
+
+| Flag | Purpose | Default |
+|---|---|---|
+| `-q <QPS[,QPS...]>` | Run at fixed QPS instead of searching. | search mode |
+| `-d <sec>` | Per-experiment duration. | `300` |
+| `-p <port>` | `LeafNodeRank` listen port. | `11222` |
+| `-N` | No-retry mode. Skip sleep and PID checking in load test startup. | off |
+| `-D <sec>` | Drain time after each experiment. | `5` |
+| `-R / -P / -C` | Seeds for LeafNodeRank / PageRank / PointerChase RNGs. | time-based |
+| `-o <file>` | Result output filename. | `feedsim_results.txt` |
+
+For the full list of runner flags, see
+`./benchmarks/feedsim/run.sh -h`.
+
+## Legacy — `feedsim_autoscale` (v1)
+
+The v1 PageRank-based job and its 500ms SLA are documented in
+[README_v1.md](README_v1.md).

--- a/packages/feedsim/README_v1.md
+++ b/packages/feedsim/README_v1.md
@@ -1,0 +1,227 @@
+<!--
+Copyright (c) Meta Platforms, Inc. and affiliates.
+
+This source code is licensed under the MIT license found in the
+LICENSE file in the root directory of this source tree.
+-->
+# FeedSim v1 (legacy) — `feedsim_autoscale`
+
+> **Deprecated.** New experiments should use `feedsim_dlrm` (v2). See
+> [README.md](README.md) for the current recommended job. This document is
+> preserved for reference and back-compat with older result sets that used
+> the 500ms SLA and PageRank workload.
+
+FeedSim v1 is the original aggregation/ranking benchmark shipped with DCPerf.
+It searches for the maximum QPS that the system can sustain while keeping
+95th-percentile latency at or below **500ms**. The workload is a synthetic
+PageRank-style ranking loop with a `folly::futures::sleep`-modeled I/O phase;
+outbound RPC fanout, TLS, and DLRM inference are not part of v1.
+
+## Install
+
+```
+./benchpress_cli.py install feedsim_autoscale
+```
+
+## Run
+
+### Recommended v1 job — `feedsim_autoscale`
+
+`feedsim_autoscale` scales up on systems with very large core counts. It
+spawns multiple FeedSim workload instances at 100 cores per instance
+(rounded up), runs them in parallel, and aggregates results. For example,
+on a 256-core system this job spawns three FeedSim instances.
+
+```
+./benchpress_cli.py run feedsim_autoscale
+```
+
+Optional parameters:
+
+- `num_instances`: manually specify how many workload instances to run in
+  parallel instead of autoscaling with the core count.
+- `extra_args`: extra arguments passed to FeedSim's runner script. Available
+  arguments can be viewed with `./benchmarks/feedsim/run.sh -h`.
+
+Example — force two instances regardless of core count:
+
+```
+./benchpress_cli.py run feedsim_autoscale -i '{"num_instances": 2}'
+```
+
+Example — fixed 100 QPS per instance:
+
+```
+./benchpress_cli.py run feedsim_autoscale -i '{"extra_args": "-q 100"}'
+```
+
+The benchmark takes ~30 minutes. Turn on CPU boost before running; otherwise
+FeedSim may not converge and will yield a very low result. When FeedSim finds
+the optimal QPS that meets the ≤500ms p95 SLA, it runs a final 5-minute
+steady-state pass at that QPS. Collect system and microarchitecture metrics
+during this final window. Expected CPU utilization: 60–75%.
+
+### ARM
+
+```
+./benchpress_cli.py run feedsim_autoscale_arm
+```
+
+### FeedSim Mini
+
+`feedsim_autoscale_mini` runs the same workload with minimal settings to keep
+execution time to a few seconds, for quick testing. A `breakdown.csv` is
+generated in the results so you can filter metrics to the actual benchmark
+window.
+
+```
+./benchpress_cli.py run feedsim_autoscale_mini
+```
+
+## Reporting
+
+After the benchmark finishes, benchpress reports results in JSON:
+
+```
+{
+  "benchmark_args": [],
+  "benchmark_desc": "Aggregator like workload. Latency sensitive. Finds maximum QPS that system can sustain while keeping 95th percentile latency <= 500 msecs.\n",
+  "benchmark_hooks": [
+    "cpu-mpstat: {'args': ['-u', '1']}",
+    "copymove: {'is_move': True, 'after': ['benchmarks/feedsim/feedsim_results*.txt', 'benchmarks/feedsim/feedsim-multi-inst-*.log']}"
+  ],
+  "benchmark_name": "feedsim_autoscale",
+  "machines": [
+    {
+      "cpu_architecture": "x86_64",
+      "cpu_model": "<CPU-name>",
+      "hostname": "<server-hostname>",
+      "kernel_version": "5.19.0-0_xxxx",
+      "mem_total_kib": "2377231352 KiB",
+      "num_logical_cpus": "380",
+      "os_distro": "centos",
+      "os_release_name": "CentOS Stream 8"
+    }
+  ],
+  "metadata": {
+    "L1d cache": "6 MiB (192 instances)",
+    "L1i cache": "6 MiB (192 instances)",
+    "L2 cache": "192 MiB (192 instances)",
+    "L3 cache": "768 MiB (24 instances)"
+  },
+  "metrics": {
+    "1": {
+      "final_achieved_qps": 248.38,
+      "final_latency_msec": 310.9,
+      "final_requested_qps": 251.82
+    },
+    "2": {
+      "final_achieved_qps": 248.98,
+      "final_latency_msec": 308.31,
+      "final_requested_qps": 252.61
+    },
+    "3": {
+      "final_achieved_qps": 249.73,
+      "final_latency_msec": 305.82,
+      "final_requested_qps": 252.98
+    },
+    "4": {
+      "final_achieved_qps": 248.98,
+      "final_latency_msec": 305.22,
+      "final_requested_qps": 251.99
+    },
+    "overall": {
+      "average_latency_msec": 307.56,
+      "final_achieved_qps": 996.07,
+      "final_requested_qps": 1009.4
+    },
+    "spawned_instances": "4",
+    "successful_instances": 4,
+    "target_latency_msec": "500",
+    "target_percentile": "95p",
+    "score": 17.4736842105
+  },
+  "run_id": "2ef4dfad",
+  "timestamp": 1702590806
+}
+```
+
+The result above is from a 380-core CPU, where `feedsim_autoscale` spawned
+four instances (`1` through `4`). `overall` is the aggregate we compare:
+
+- `final_achieved_qps` — sum of per-instance `final_achieved_qps`
+- `final_requested_qps` — sum of per-instance `final_requested_qps`
+- `average_latency_msec` — average of per-instance final p95 latency
+
+`final_achieved_qps` is the primary performance metric: max QPS with p95
+latency ≤500ms. Individual instances should all show similar QPS; if one is
+significantly lower than the others, the run likely didn't converge cleanly
+(a low-performance instance was probably killed early). Re-run in that case.
+
+Detailed per-instance metrics live at
+`benchmark_metrics_<run_id>/feedsim_results_<1..N>.txt` in CSV form:
+
+```
+duration_secs,total_queries,requested_qps,achieved_qps,total_bytes_rx,total_bytes_tx,rx_MBps,tx_MBps,min_ms,avg_ms,50p_ms,90p_ms,95p_ms,99p_ms,99.9p_ms
+120,5267,0.00,41.46,85637186,15927408,0.64,0.12,388.134,958.509,913.313,956.414,991.523,1812.133,12232.154
+120,5571,0.00,43.86,90618516,16846704,0.68,0.13,388.134,910.627,918.002,960.395,1010.386,1050.379,1848.997
+120,5040,39.97,39.67,82279002,15240960,0.62,0.11,388.134,457.068,446.739,524.929,535.555,569.859,593.868
+120,2737,20.49,21.55,44727453,8276688,0.34,0.06,352.849,423.693,406.253,486.015,509.429,535.926,556.451
+...
+```
+
+Per-instance logs are at `benchmark_metrics_<run_id>/feedsim-multi-inst-<1..N>.log`.
+
+## Advanced usage — fixed-QPS experiment
+
+Instead of letting the runner search for the optimal QPS, run FeedSim at a
+fixed QPS and observe latency:
+
+```sh
+./benchpress_cli.py run feedsim_autoscale -i '{"extra_args": "-q <QPS>"}'
+```
+
+`-q` is the QPS driven **per instance**; `-d` is the experiment duration
+(default 300s). Total wall-clock is longer because FeedSim also populates
+object graphs and warms up. Default warmup is 120s (change with `-w`).
+Shorter warmups reduce accuracy and can under-report the achievable QPS.
+
+Example — 250 QPS per instance on a 380-core system:
+
+```
+[root@<hostname> ~/external]# ./benchpress_cli.py run feedsim_autoscale -i '{"extra_args": "-q 250"}'
+...
+"metrics": {
+  "1": {"final_achieved_qps": 246.6,  "final_latency_msec": 317.93, "final_requested_qps": 250.0},
+  "2": {"final_achieved_qps": 246.71, "final_latency_msec": 312.45, "final_requested_qps": 250.0},
+  "3": {"final_achieved_qps": 246.73, "final_latency_msec": 311.64, "final_requested_qps": 250.0},
+  "4": {"final_achieved_qps": 246.4,  "final_latency_msec": 316.28, "final_requested_qps": 250.0},
+  "overall": {"average_latency_msec": 314, "final_achieved_qps": 986.44, "final_requested_qps": 1000.0}
+}
+```
+
+## Other extra args
+
+See `./benchmarks/feedsim/run.sh -h`. The v1-relevant subset:
+
+```
+Usage: run.sh [OPTION]...
+
+    -t Number of threads to use for thrift serving. Large dataset kept per thread. Default: 216
+    -c Number of threads to use for fanout ranking work. Heavy CPU work. Default: 134
+    -s Number of threads to use for task-based serialization cpu work. Default: 55
+    -a Auto-adjust client driver threads by min(requested_qps / 4, 384 / 5) per search iteration.
+    -q Fixed QPS. If multiple comma-separated values, one experiment per value.
+    -d Experiment duration in seconds. Default: 300
+    -p Port for LeafNodeRank + drivers. Default: 11222
+    -o Result output filename. Default: "feedsim_results.txt"
+```
+
+## Migrating to v2
+
+The v2 recommended job is `feedsim_dlrm` — DLRM inference, out-of-process
+`mock_services` fanout with TLS + ZSTD, session-mode driver, and a 700ms p95
+SLA that mirrors production `multifeed_aggregator`. See
+[README.md](README.md) for install/run instructions and
+[ARCHITECTURE_v2.md](ARCHITECTURE_v2.md) for the software architecture and
+control/data flow.

--- a/packages/feedsim/docs/architecture_v2.svg
+++ b/packages/feedsim/docs/architecture_v2.svg
@@ -1,0 +1,202 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1120 680" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif">
+  <title>FeedSim v2 architecture</title>
+  <desc>DriverNodeRank drives inbound Rocket/TLS requests into LeafNodeRank. Inside LeafNodeRank the request hops ThriftSrv.IO -> RANKER (feature extractors + story processors) -> SREventBase (fanout over MockServicesClient) -> mock_services -> GlobalCPUThread (DLRM inference + Silesia response). See ARCHITECTURE_v2.md for details.</desc>
+
+  <defs>
+    <marker id="arrow" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="8" markerHeight="8" orient="auto-start-reverse">
+      <path d="M0,0 L10,5 L0,10 Z" fill="#334155"/>
+    </marker>
+    <marker id="arrowBlue" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="8" markerHeight="8" orient="auto-start-reverse">
+      <path d="M0,0 L10,5 L0,10 Z" fill="#1d4ed8"/>
+    </marker>
+    <marker id="arrowGreen" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="8" markerHeight="8" orient="auto-start-reverse">
+      <path d="M0,0 L10,5 L0,10 Z" fill="#047857"/>
+    </marker>
+    <marker id="arrowOrange" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="8" markerHeight="8" orient="auto-start-reverse">
+      <path d="M0,0 L10,5 L0,10 Z" fill="#c2410c"/>
+    </marker>
+    <style>
+      .proc       { fill:#f8fafc; stroke:#0f172a; stroke-width:2.5; }
+      .procTitle  { font-size:20px; font-weight:800; fill:#0f172a; }
+      .procSub    { font-size:11px; fill:#64748b; }
+      .pool       { fill:#eef2ff; stroke:#4338ca; stroke-width:1.5; rx:6; }
+      .poolText   { font-size:12px; font-weight:700; fill:#3730a3; }
+      .poolSub    { font-size:10px; fill:#4338ca; }
+      .module     { fill:#fff7ed; stroke:#c2410c; stroke-width:1.2; rx:5; }
+      .moduleText { font-size:11px; fill:#7c2d12; }
+      .respPool   { fill:#dcfce7; stroke:#047857; stroke-width:1.5; rx:6; }
+      .respText   { font-size:12px; font-weight:700; fill:#065f46; }
+      .titleText  { font-size:22px; font-weight:800; fill:#0f172a; }
+      .subtitle   { font-size:12px; fill:#475569; }
+      .noteBox    { fill:#fef2f2; stroke:#b91c1c; stroke-width:1; rx:5; }
+      .noteText   { font-size:10.5px; fill:#7f1d1d; }
+      .legendText { font-size:11px; fill:#334155; }
+    </style>
+  </defs>
+
+  <!-- Title -->
+  <text x="560" y="34" class="titleText" text-anchor="middle">FeedSim v2 — components &amp; request flow</text>
+  <text x="560" y="52" class="subtitle" text-anchor="middle">Three processes on one host · fbthrift Rocket over TLS 1.3 · single request-response today</text>
+
+  <!-- Legend (single-column, wide gap between arrow and text, no overflow) -->
+  <g transform="translate(30,72)">
+    <rect x="0" y="0" width="340" height="112" rx="6" fill="#fff" stroke="#cbd5e1"/>
+
+    <line x1="16" y1="24" x2="72" y2="24" stroke="#1d4ed8" stroke-width="2.4" marker-end="url(#arrowBlue)"/>
+    <text x="82" y="28" class="legendText">inbound request (Rocket + TLS)</text>
+
+    <line x1="16" y1="48" x2="72" y2="48" stroke="#c2410c" stroke-width="2.4" marker-end="url(#arrowOrange)"/>
+    <text x="82" y="52" class="legendText">outbound fanout RPC (leaf → mock_services)</text>
+
+    <line x1="16" y1="72" x2="72" y2="72" stroke="#047857" stroke-width="2.4" stroke-dasharray="6 4" marker-end="url(#arrowGreen)"/>
+    <text x="82" y="76" class="legendText">response</text>
+
+    <line x1="16" y1="96" x2="72" y2="96" stroke="#334155" stroke-width="1.8" marker-end="url(#arrow)"/>
+    <text x="82" y="100" class="legendText">executor hop (between thread pools)</text>
+  </g>
+
+  <!-- Note about single request-response -->
+  <g transform="translate(620,72)">
+    <rect x="0" y="0" width="470" height="112" class="noteBox"/>
+    <text x="14" y="20" class="noteText" font-weight="700">Single request-response today</text>
+    <text x="14" y="42" class="noteText">Multi-method, session-based Thrift interfaces are wired in</text>
+    <text x="14" y="58" class="noteText">LeafNodeRank but not exercised: every driver request is</text>
+    <text x="14" y="74" class="noteText">stand-alone. Multi-hop, session-driven flow is planned</text>
+    <text x="14" y="90" class="noteText">future work — see ARCHITECTURE_v2.md for details.</text>
+  </g>
+
+  <!-- =========================== DRIVER =========================== -->
+  <g transform="translate(30,220)">
+    <rect x="0" y="0" width="220" height="300" rx="12" class="proc"/>
+    <text x="110" y="30" class="procTitle" text-anchor="middle">DriverNodeRank</text>
+    <text x="110" y="48" class="procSub" text-anchor="middle">client · load generator</text>
+
+    <rect x="16" y="70" width="188" height="60" class="pool"/>
+    <text x="110" y="92" class="poolText" text-anchor="middle">Driver threads</text>
+    <text x="110" y="112" class="poolSub" text-anchor="middle">~nproc / 4</text>
+
+    <rect x="16" y="150" width="188" height="52" class="module"/>
+    <text x="110" y="170" class="moduleText" text-anchor="middle" font-weight="700">Request sampler</text>
+    <text x="110" y="188" class="moduleText" text-anchor="middle">req sizes from CDF</text>
+
+    <rect x="16" y="220" width="188" height="52" class="module"/>
+    <text x="110" y="240" class="moduleText" text-anchor="middle" font-weight="700">Latency recorder</text>
+    <text x="110" y="258" class="moduleText" text-anchor="middle">p50 / p95 / p99</text>
+  </g>
+
+  <!-- =========================== LEAF =========================== -->
+  <!-- Pool y-positions (abs, translate y=220):
+        ThriftSrv.IO   y=290..342
+        RANKER         y=360..490  (with 3 module boxes)
+        SREventBase    y=508..568
+        GlobalCPUThread y=586..646
+       Executor-hop arrows placed strictly between pool bottom and next pool top. -->
+  <g transform="translate(320,220)">
+    <rect x="0" y="0" width="500" height="440" rx="12" class="proc"/>
+    <text x="250" y="30" class="procTitle" text-anchor="middle">LeafNodeRank</text>
+    <text x="250" y="48" class="procSub" text-anchor="middle">system-under-test · fbthrift ThriftServer</text>
+
+    <!-- ThriftSrv.IO -->
+    <rect x="20" y="70" width="460" height="52" class="pool"/>
+    <text x="30" y="92" class="poolText">ThriftSrv.IO pool</text>
+    <text x="30" y="110" class="poolSub">fbthrift IO workers · accept + dispatch</text>
+
+    <!-- RANKER + modules -->
+    <rect x="20" y="140" width="460" height="130" class="pool"/>
+    <text x="30" y="162" class="poolText">RANKER pool</text>
+    <text x="30" y="180" class="poolSub">CPU-heavy per-request work</text>
+    <g transform="translate(38,196)">
+      <rect x="0" y="0" width="140" height="60" class="module"/>
+      <text x="70" y="22" class="moduleText" text-anchor="middle" font-weight="700">Feature extractors</text>
+      <text x="70" y="40" class="moduleText" text-anchor="middle">13 archetypes</text>
+      <text x="70" y="54" class="moduleText" text-anchor="middle">num_stories × per-story</text>
+    </g>
+    <g transform="translate(188,196)">
+      <rect x="0" y="0" width="140" height="60" class="module"/>
+      <text x="70" y="22" class="moduleText" text-anchor="middle" font-weight="700">Story processors</text>
+      <text x="70" y="40" class="moduleText" text-anchor="middle">score · filter · blend</text>
+      <text x="70" y="54" class="moduleText" text-anchor="middle">serdes · topK</text>
+    </g>
+    <g transform="translate(338,196)">
+      <rect x="0" y="0" width="130" height="60" class="module"/>
+      <text x="65" y="22" class="moduleText" text-anchor="middle" font-weight="700">Fanout planner</text>
+      <text x="65" y="40" class="moduleText" text-anchor="middle">samples rpc_dist.json</text>
+      <text x="65" y="54" class="moduleText" text-anchor="middle">× rpc_fanout_scale</text>
+    </g>
+
+    <!-- SREventBase -->
+    <rect x="20" y="288" width="460" height="60" class="pool"/>
+    <text x="30" y="310" class="poolText">SREventBase pool</text>
+    <text x="30" y="328" class="poolSub">one EventBase = one MockServicesClient · TLS + ZSTD + keepalive</text>
+    <text x="470" y="328" class="poolSub" text-anchor="end">folly::window(K=32)</text>
+
+    <!-- GlobalCPUThread post-fanout -->
+    <rect x="20" y="366" width="460" height="60" class="respPool"/>
+    <text x="30" y="388" class="respText">GlobalCPUThread pool</text>
+    <text x="30" y="406" class="poolSub" fill="#065f46">DLRM inference (LibTorch) · Silesia response payload</text>
+  </g>
+
+  <!-- =========================== MOCK_SERVICES =========================== -->
+  <g transform="translate(870,220)">
+    <rect x="0" y="0" width="220" height="300" rx="12" class="proc"/>
+    <text x="110" y="30" class="procTitle" text-anchor="middle">mock_services</text>
+    <text x="110" y="48" class="procSub" text-anchor="middle">downstream · fbthrift server</text>
+
+    <rect x="16" y="70" width="188" height="60" class="pool"/>
+    <text x="110" y="92" class="poolText" text-anchor="middle">IO worker pool</text>
+    <text x="110" y="112" class="poolSub" text-anchor="middle">TLS terminating (fizz)</text>
+
+    <rect x="16" y="150" width="188" height="52" class="module"/>
+    <text x="110" y="170" class="moduleText" text-anchor="middle" font-weight="700">~20 Thrift methods</text>
+    <text x="110" y="188" class="moduleText" text-anchor="middle">mcGet · fetchTopK · …</text>
+
+    <rect x="16" y="220" width="188" height="52" class="module"/>
+    <text x="110" y="240" class="moduleText" text-anchor="middle" font-weight="700">runSimulatedRpc</text>
+    <text x="110" y="258" class="moduleText" text-anchor="middle">sleep/spin · slice Silesia</text>
+  </g>
+
+  <!-- =========================== ARROWS ===========================
+       All arrow labels removed — legend covers meaning. Endpoints
+       are aligned to the process-box edges (Driver right = x=250;
+       Leaf left = x=320; Leaf right = x=820; Mock left = x=870). -->
+
+  <!-- Driver -> Leaf: driver right edge into ThriftSrv.IO center.
+       Driver right = x=250, mid-y of Driver-threads pool = 220+70+30 = 320.
+       Leaf ThriftSrv.IO mid-y = 220+70+26 = 316. -->
+  <line x1="250" y1="320" x2="320" y2="316" stroke="#1d4ed8" stroke-width="2.4" marker-end="url(#arrowBlue)"/>
+
+  <!-- Leaf response back to Driver: from GlobalCPUThread out to Driver latency recorder.
+       GlobalCPUThread mid-y_abs = 220+366+30 = 616. Leaf left = 320.
+       Route down-and-left from Leaf, curving back to Driver right edge at y=480 (recorder mid). -->
+  <path d="M 320,616 C 300,616 285,530 285,490 C 285,462 265,462 250,462" stroke="#047857" stroke-width="2.4" stroke-dasharray="6 4" fill="none" marker-end="url(#arrowGreen)"/>
+
+  <!-- ThriftSrv.IO -> RANKER (internal executor hop).
+       ThriftSrv.IO bottom_abs = 220+70+52 = 342. RANKER top_abs = 220+140 = 360.
+       Draw vertical arrow x=570 (leaf-center) between them. -->
+  <line x1="570" y1="342" x2="570" y2="360" stroke="#334155" stroke-width="1.8" marker-end="url(#arrow)"/>
+
+  <!-- RANKER -> SREventBase (internal executor hop).
+       RANKER bottom_abs = 220+140+130 = 490. SREventBase top_abs = 220+288 = 508. -->
+  <line x1="570" y1="490" x2="570" y2="508" stroke="#334155" stroke-width="1.8" marker-end="url(#arrow)"/>
+
+  <!-- SREventBase -> GlobalCPUThread (post-fanout continuation hop).
+       SREventBase bottom_abs = 220+288+60 = 568. GlobalCPUThread top_abs = 220+366 = 586. -->
+  <line x1="570" y1="568" x2="570" y2="586" stroke="#334155" stroke-width="1.8" marker-end="url(#arrow)"/>
+
+  <!-- Also show RANKER dispatching CPU work to GlobalCPUThread (DLRM inference
+       can be scheduled on the global CPU executor from RANKER as well, not
+       only via the post-fanout .via() hop). Route this arrow around the right
+       side of the leaf box (x=815) so it doesn't cross SREventBase content. -->
+  <path d="M 800,470 C 815,470 815,606 800,606" stroke="#334155" stroke-width="1.8" fill="none" marker-end="url(#arrow)"/>
+
+  <!-- Leaf SREventBase -> mock_services (outbound fanout).
+       Enter mock at IO worker upper-half y=305 so the arrow visually
+       separates from the response arrow's return endpoint. -->
+  <path d="M 820,525 C 850,525 850,305 870,305" stroke="#c2410c" stroke-width="2.4" fill="none" marker-end="url(#arrowOrange)"/>
+
+  <!-- mock_services -> Leaf (fanout responses).
+       Depart mock at runSimulatedRpc module mid-y=466, return into
+       SREventBase pool lower-half y=551 so the two edges don't overlap. -->
+  <path d="M 870,466 C 850,466 850,551 820,551" stroke="#047857" stroke-width="2.4" stroke-dasharray="6 4" fill="none" marker-end="url(#arrowGreen)"/>
+</svg>


### PR DESCRIPTION
Summary:
Refresh the FeedSim documentation to reflect the v2 recommended job (`feedsim_dlrm`) and 700 ms p95 SLA:

- `README.md`: rewritten around `feedsim_dlrm` as the current recommended job — 700 ms SLA, one instance per host (no v1 autoscale-per-100-cores rule), a converged BGM result JSON with CPU model and hostname redacted, plus advanced usage sections for fixed-QPS sweeps, multi-instance mode (`num_instances` / `feedsim_autoscale_dlrm`), and both job-level and runner-level parameter tables. Legacy content moved out.
- `README_v1.md`: legacy `feedsim_autoscale` (PageRank, 500 ms SLA) docs preserved verbatim with a "Migrating to v2" pointer.
- `ARCHITECTURE_v2.md`: new public architecture doc covering the three processes (Driver, Leaf, mock_services), the four named thread pools inside `LeafNodeRank` (`ThriftSrv.IO`, `SREventBase`, `RANKER`, `GlobalCPUThread`), the request control flow with executor hops, the data flow (request/response CDFs + Silesia corpus + DLRM model), the wire protocol (Rocket over fizz+ALPN "rs", per-channel ZSTD), and a v1↔v2 comparison table. Explicitly notes that v2 today runs a single request-response per driver call and that multi-hop session flow is planned future work.
- `docs/architecture_v2.svg`: component-focused SVG diagram (Driver | Leaf with 4 named pools + modules | mock_services), colored legend for request / fanout / response / hop arrows, shared-inputs strip at the bottom.

No code changes.

Differential Revision: D110821423


