### PR TITLE
DCPerf: drop corrupt first perf interval from AMD report

### DIFF
--- a/perfutils/generate_amd_perf_report.py
+++ b/perfutils/generate_amd_perf_report.py
@@ -2303,6 +2303,24 @@ def zen5es_total_cxl_write_bw_mbs(grouped_df):
     }
 
 
+def drop_first_interval(metrics, num_samples):
+    """Drop the first perf-stat interval from every metric's time series.
+
+    The uncore/DF memory-controller counters report a cumulative startup value
+    on their first ``perf stat -I`` read, and the first interval's duration is
+    often irregular, so the first sample's derived rates (e.g. DRAM bandwidth)
+    can exceed the hardware's physical limits. Excluding it keeps both the
+    aggregated summary and the emitted time series physically meaningful. One
+    interval spans ``num_samples`` rows (one per socket). Series shorter than
+    that are left untouched so short runs don't collapse to empty.
+    """
+    if any(m["series"].size <= num_samples for m in metrics):
+        return metrics
+    for m in metrics:
+        m["series"] = m["series"].iloc[num_samples:]
+    return metrics
+
+
 def aggregate_stats(derived_metric):
     derived_series = derived_metric["series"]
     prefix = derived_metric.get("prefix", 1.0)
@@ -2598,6 +2616,8 @@ def main(
             "No metrics could be calculated. All required counters are missing from the input data."
         )
         return
+
+    filtered_metrics = drop_first_interval(filtered_metrics, get_num_sockets(df))
 
     shortest_series = max(filtered_metrics, key=lambda m: m["series"].size)
     df_metrics = concat_series(filtered_metrics, shortest_series)


### PR DESCRIPTION
Summary:
On Turin , DCPerf `sleepbench` `overall-metrics.csv` reported a DRAM Read BW of ~620 GB/s — above the part's 512 GB/s physical ceiling.

Root cause: the first `perf stat -I` interval is corrupt. The uncore/DF memory-controller counters report a cumulative startup value on their first read, and the first interval's duration is often irregular, so its derived rate (~2,454 GB/s here, ~4.8x the max) is physically impossible. Nothing dropped or clamped that first sample before it was averaged into the summary.

Fix in `perfutils/generate_amd_perf_report.py`: add `drop_first_interval()`, called in `main()` after metrics are built and before aggregation/timeseries emission. It drops the first interval (`num_sockets` rows, one per socket) from every metric series so the summary and the timeseries stay aligned and physically meaningful. Short runs (series <= `num_sockets`) are left untouched to avoid collapsing to empty.

Excluding the first sample, sustained DRAM read ~252 GB/s (valid).

Differential Revision: D110798470


