### PR TITLE
Use cpu_cycles for core and nvidia_scf_pmu_0/cycles for SCF (#752)

### DIFF
--- a/perfutils/collect_nvda_neoversev2_perf_counters.sh
+++ b/perfutils/collect_nvda_neoversev2_perf_counters.sh
@@ -26,7 +26,7 @@ INTERVAL_SECS=5
 
 ### Cycles and Instructions
 # r08: ins
-INSTRUCTIONS_RATE='cycles,instructions,duration_time,task-clock'
+INSTRUCTIONS_RATE='cpu_cycles,instructions,duration_time,task-clock'
 
 ### Cache Effectiveness Metrics
 # l1d access, l1d miss

--- a/perfutils/generate_arm_perf_report.py
+++ b/perfutils/generate_arm_perf_report.py
@@ -142,7 +142,7 @@ def get_duration_series(group):
 
 @skip_if_missing
 def timestamp(grouped_df):
-    ts_series = grouped_df.get_group("cycles").timestamp
+    ts_series = grouped_df.get_group("cpu_cycles").timestamp
     return {"name": "Timestamp_Secs", "series": ts_series}
 
 
@@ -181,7 +181,7 @@ def muopps(grouped_df):
 
 @skip_if_missing
 def ipc(grouped_df):
-    cycles_series = grouped_df.get_group("cycles").counter_value
+    cycles_series = grouped_df.get_group("cpu_cycles").counter_value
     inst_series = grouped_df.get_group("instructions").counter_value
     cycles_series.index = inst_series.index
 
@@ -638,7 +638,7 @@ def retiring_slots(grouped_df):
     op_retired_series = grouped_df.get_group("r3A").counter_value  # OP_RETIRED
     op_spec_series = grouped_df.get_group("r3B").counter_value  # OP_SPEC
     stall_slot_series = grouped_df.get_group("r3F").counter_value  # STALL_SLOT
-    cycles_series = grouped_df.get_group("cycles").counter_value
+    cycles_series = grouped_df.get_group("cpu_cycles").counter_value
 
     op_retired_series.index = cycles_series.index
     op_spec_series.index = cycles_series.index
@@ -660,7 +660,7 @@ def frontend_bound_slots(grouped_df):
         "r3E"  # STALL_SLOT_FRONTEND
     ).counter_value
     br_mis_pred_series = grouped_df.get_group("r10").counter_value  # BR_MISPRED
-    cycles_series = grouped_df.get_group("cycles").counter_value
+    cycles_series = grouped_df.get_group("cpu_cycles").counter_value
 
     stall_slot_fe_series.index = cycles_series.index
     br_mis_pred_series.index = cycles_series.index
@@ -681,7 +681,7 @@ def backend_bound_slots(grouped_df):
         "r3D"  # STALL_SLOT_BACKEND
     ).counter_value
     br_mis_pred_series = grouped_df.get_group("r10").counter_value  # BR_MISPRED
-    cycles_series = grouped_df.get_group("cycles").counter_value
+    cycles_series = grouped_df.get_group("cpu_cycles").counter_value
 
     stall_slot_be_series.index = cycles_series.index
     br_mis_pred_series.index = cycles_series.index
@@ -716,7 +716,7 @@ def nvidia_grace_frontend_bound_cycles(grouped_df):
     stall_cycles_fe_series = grouped_df.get_group(
         "r23"  # STALL_CYCLES_FRONTEND
     ).counter_value
-    cycles_series = grouped_df.get_group("cycles").counter_value
+    cycles_series = grouped_df.get_group("cpu_cycles").counter_value
 
     stall_cycles_fe_series.index = cycles_series.index
     return {
@@ -731,7 +731,7 @@ def nvidia_grace_backend_bound_cycles(grouped_df):
     stall_cycles_be_series = grouped_df.get_group(
         "r24"  # STALL_CYCLES_BACKEND
     ).counter_value
-    cycles_series = grouped_df.get_group("cycles").counter_value
+    cycles_series = grouped_df.get_group("cpu_cycles").counter_value
 
     stall_cycles_be_series.index = cycles_series.index
 
@@ -748,7 +748,7 @@ def nvidia_grace_frontend_backend_boundness(grouped_df):
         "r3F"  # STALL_SLOTS
     ).counter_value
     br_mis_pred_series = grouped_df.get_group("r10").counter_value  # BR_MISPRED
-    cycles_series = grouped_df.get_group("cycles").counter_value
+    cycles_series = grouped_df.get_group("cpu_cycles").counter_value
 
     stall_slot_series.index = cycles_series.index
     br_mis_pred_series.index = cycles_series.index
@@ -769,7 +769,7 @@ def bad_speculation(grouped_df):
     op_spec_series = grouped_df.get_group("r3B").counter_value  # OP_SPEC
     stall_slot_series = grouped_df.get_group("r3F").counter_value  # STALL_SLOT
     br_mis_pred_series = grouped_df.get_group("r10").counter_value  # BR_MISPRED
-    cycles_series = grouped_df.get_group("cycles").counter_value
+    cycles_series = grouped_df.get_group("cpu_cycles").counter_value
 
     op_retired_series.index = cycles_series.index
     op_spec_series.index = cycles_series.index


### PR DESCRIPTION
Summary:

Switch the NVIDIA Grace (Neoverse V2) perf-counter collection from the generic `cycles` event to the core-only `cpu_cycles` alias.

On ARM Grace in system-wide mode (`perf stat -a`), requesting the generic `cycles` event auto-expands to open a cycles counter on **every** PMU, including the uncore SCF PMU (`nvidia_scf_pmu_0/cycles/`). This wastes a scarce SCF counter slot and produces a duplicate row. Requesting `cpu_cycles` targets only the core PMU, while the SCF group keeps its explicit `nvidia_scf_pmu_0/cycles/` event.

Changes:
- `collect_nvda_neoversev2_perf_counters.sh`: `INSTRUCTIONS_RATE` now uses `cpu_cycles` instead of `cycles`.
- `generate_arm_perf_report.py`: all core-cycles group lookups (`get_group("cycles")`) updated to `get_group("cpu_cycles")` to match the renamed event. The SCF cycles lookup (`nvidia_scf_pmu_0/cycles/`) is unchanged.

The two literals must change together, otherwise `skip_if_missing` would silently drop IPC/TopDown/timestamp metrics on a `KeyError`.

Ref: D99517233 reviewer feedback.

[Session trajectory link](https://www.internalfb.com/intern/devai/devmate/inspector/?id=1e5a7bee-9130-4920-83cd-fe4560ed1d0c)

Differential Revision: D111288659


