### PR TITLE
Fix duplicate $feature_opts in run.sh LeafNodeRank invocation

### DIFF
--- a/packages/feedsim/run.sh
+++ b/packages/feedsim/run.sh
@@ -867,7 +867,6 @@ main() {
         $store_graph \
         $load_graph \
         $instrument_graph \
-        $feature_opts \
         $story_opts \
         $server_silesia_opts \
         $mock_services_opts \


### PR DESCRIPTION
Summary:
run.sh line 866 and 870 both expand $feature_opts, causing LeafNodeRank to receive `--feature_extractors` twice. gengetopt rejects any bare flag given more than once and LeafNodeRank exits immediately during startup. run.sh's driver then times out waiting for LeafNodeRank on port 21212, and the shell's downstream `bc`-based aggregation trips a divide-by-zero on empty results (`Runtime error (func=(main), adr=18): Divide by zero`). Net effect: since the t43 c7 default-baking landed on 2026-07-03, every `feedsim_dlrm` run has silently produced null metrics — the JSON output has `"metrics": null` and no `final_achieved_qps` is emitted.

Remove the duplicate expansion at line 870. Verified locally that LeafNodeRank standalone with a single `--feature_extractors` starts and reaches port-listening state.

Differential Revision: D111533997


