### PR TITLE
Fix prod_set div-by-zero on fast CPUs and nice -n -20 EPERM in unprivileged guests

### DIFF
--- a/packages/wdl_bench/run_prod.sh
+++ b/packages/wdl_bench/run_prod.sh
@@ -144,6 +144,16 @@ main() {
         #run
         benchreps_tell_state "start"
 
+        # Run benchmarks at highest CPU priority to reduce scheduler noise.
+        # nice -n -20 needs privilege (root/CAP_SYS_NICE); fall back to normal
+        # priority when unprivileged (e.g. inside an unprivileged VM guest) so
+        # the run does not abort with EPERM.
+        NICE="nice -n -20"
+        if ! $NICE true 2>/dev/null; then
+            NICE=""
+            echo "run_prod: cannot set nice -n -20 (no privilege); running at default priority"
+        fi
+
         for benchmark in $run_list; do
             # Remove old results
             rm -f "out_${benchmark}.txt" "out_${benchmark}.json"
@@ -156,14 +166,14 @@ main() {
             fi
             if [ "$benchmark" = "bench-memcmp" ]; then
                 pushd "${WDL_BUILD}/glibc-build"
-                bash -c "nice -n -20 ./testrun.sh ./benchtests/${benchmark} -- ${prod_benchmark_config[$benchmark]}" 2>&1 | tee -a "${WDL_ROOT}/${out_file}"
+                bash -c "$NICE ./testrun.sh ./benchtests/${benchmark} -- ${prod_benchmark_config[$benchmark]}" 2>&1 | tee -a "${WDL_ROOT}/${out_file}"
                 popd
             else
                 ENV_VARS=""
                 if [ "$benchmark" = "gemm_bench" ]; then
                     ENV_VARS="OMP_NUM_THREADS=1"
                 fi
-                bash -c "nice -n -20 env ${ENV_VARS} ./${benchmark} ${prod_benchmark_config[$benchmark]}" 2>&1 | tee -a "${out_file}"
+                bash -c "$NICE env ${ENV_VARS} ./${benchmark} ${prod_benchmark_config[$benchmark]}" 2>&1 | tee -a "${out_file}"
             fi
         done
 

--- a/packages/wdl_bench/scoring.py
+++ b/packages/wdl_bench/scoring.py
@@ -465,6 +465,12 @@ def compute_score_from_time(
     scores = []
     for key in sum_baseline:
         if key in sum_c and key not in skip_set:
+            # Some sub-metrics can measure 0 ns on fast CPUs (below the timer
+            # resolution), e.g. single_thread_lifo_trypost/trywait or the CHM
+            # empty()/size() ops. A 0 here is not a real data point; dividing by
+            # it would raise ZeroDivisionError and abort the whole prod_set run.
+            if sum_c[key] == 0:
+                continue
             scores.append(sum_baseline[key] / sum_c[key])
     score = geomean(scores)
     return score


### PR DESCRIPTION
Summary:
Two robustness fixes to the WDL prod_set runner, both hit while running the
suite on a fast Arm (Olympus) host and inside an unprivileged VM guest.

Problem 1 - scoring crash on fast cores. concurrency_concurrent_hash_map_bench
and synchronization_lifo_sem_bench fail with "score: error (float division by
zero)". On fast CPUs some sub-metrics (e.g. single_thread_lifo_trypost/trywait,
CHM empty()/size() ops) complete in 0 ns, below the timer resolution.
compute_score_from_time then does sum_baseline[key] / sum_c[key] and raises
ZeroDivisionError, losing the whole workload's score. A 0 ns sample is not a
real data point, so we skip those keys (the geomean of the remaining
sub-metrics is still valid). If every sub-metric is 0, geomean([]) raises and
the existing main() handler already reports a per-benchmark error without
aborting the set.

Problem 2 - nice -n -20 EPERM. run_prod.sh hard-codes nice -n -20, which needs
root/CAP_SYS_NICE. In an unprivileged environment (e.g. a VM guest) every
workload invocation fails with EPERM. We now probe nice -n -20 once and fall
back to default priority when it is not permitted, so the run proceeds instead
of failing.

Differential Revision: D111817632


