### PR TITLE
AMD Zen5 DRAM BW: count populated channels not DIMM slots

### DIFF
--- a/perfutils/generate_amd_perf_report.py
+++ b/perfutils/generate_amd_perf_report.py
@@ -2392,23 +2392,19 @@ def get_memory_info():
     dmidecode_out = subprocess.check_output(
         ["sudo", "dmidecode", "--type", "17"]
     ).decode("utf-8")
-    # Parse the output to find the relevant lines
-    lines = dmidecode_out.split("\n")
-    relevant_lines = []
-    p = False
-    for line in lines:
-        if line.strip() == "Memory Device":
-            p = True
-        elif line.strip() == "":
-            p = False
-        elif p:
-            relevant_lines.append(line)
-    # Filter out lines containing "cxl" and count the remaining lines with "Bank Locator"
+    # Count only POPULATED memory channels on socket 0. `dmidecode --type 17` prints a
+    # "Memory Device" block for every DIMM slot, including empty ones
+    # ("Size: No Module Installed"). Counting every "Bank Locator" over-counted channels
+    # on partially-populated systems (e.g. 10-of-12 on Turin), which inflated DRAM
+    # bandwidth by (slots / populated) since DRAM BW scales linearly with num_channels.
     num_channels = 0
-    for line in relevant_lines:
-        if "Bank Locator" in line and any(
-            x in line.lower() for x in ["p0", "socket 0", "node0"]
-        ):
+    for block in dmidecode_out.split("Memory Device")[1:]:
+        block_lines = block.split("\n")
+        bank_locator = next((ln for ln in block_lines if "Bank Locator" in ln), "")
+        size = next((ln for ln in block_lines if ln.strip().startswith("Size:")), "")
+        is_socket0 = any(x in bank_locator.lower() for x in ["p0", "socket 0", "node0"])
+        is_populated = bool(size.strip()) and "no module installed" not in size.lower()
+        if is_socket0 and is_populated:
             num_channels += 1
     # Get the DDR frequency
     ddr_freq_out = subprocess.check_output(["sudo", "dmidecode"]).decode("utf-8")


### PR DESCRIPTION
Summary:
On production Turin benchpress over-reported DRAM bandwidth by ~14-19% -- it even reported values
above the 512 GB/s physical ceiling (e.g. ~517-526 GB/s), which is impossible.

Root cause: get_memory_info() in perfutils/generate_amd_perf_report.py set
num_channels by counting every `dmidecode --type 17` "Bank Locator" line, i.e.
every DIMM SLOT, with no filter for empty slots ("Size: No Module Installed").
The zen5 DRAM-BW formula measures one coherent station and scales by channel
count (cs0_dram_read_beats * num_channels * 64 / duration), so counting 12
slots instead of 10 populated channels inflated BW by 12/10 = 1.20x -- matching
the observed 1.14-1.19x.

Fix: count only POPULATED memory-device blocks on socket 0 (skip
"Size: No Module Installed"). On a fully-populated system the result is
unchanged.

Validated on hardware:
Intel MLC --peak_injection_bandwidth ALL-Reads (software-timed ground truth) =
435.2 GB/s; dyno.mem_bw_total = ~431; per-UMC-sum = 438.2; old benchpress
CS0x12 = ~517 (1.19x, above ceiling). With num_channels 12->10 the reported BW
drops ~10/12 into line with MLC/dyno.

Follow-up (T279846011): move the zen5 path to the per-UMC-sum method already
used by zen5es, which removes the CS0 uniform-interleave assumption entirely.

Differential Revision: D112025513


