### PR TITLE
Add L3 MPKI and L3 Miss % for AMD Zen5

### DIFF
--- a/perfutils/generate_amd_perf_report.py
+++ b/perfutils/generate_amd_perf_report.py
@@ -1526,6 +1526,32 @@ def zen5_l3_miss_ptc(grouped_df):
 
 
 @skip_if_missing
+def zen5_l3_mpki(grouped_df):
+    l3_lookup_state_l3_miss_series = grouped_df.get_group(
+        "l3_lookup_state.l3_miss"
+    ).counter_value
+    inst_series = grouped_df.get_group("instructions").counter_value
+    l3_lookup_state_l3_miss_series.index = inst_series.index
+    l3_mpki_series = l3_lookup_state_l3_miss_series.div(inst_series)
+    return {"name": "L3 MPKI", "series": l3_mpki_series, "prefix": 1000}
+
+
+@skip_if_missing
+def zen5_l3_miss_rate(grouped_df):
+    l3_lookup_state_l3_miss_series = grouped_df.get_group(
+        "l3_lookup_state.l3_miss"
+    ).counter_value
+    l3_lookup_state_l3_accesses_series = grouped_df.get_group(
+        "l3_lookup_state.all_coherent_accesses_to_l3"
+    ).counter_value
+    l3_lookup_state_l3_miss_series.index = l3_lookup_state_l3_accesses_series.index
+    l3_miss_rate_series = l3_lookup_state_l3_miss_series.div(
+        l3_lookup_state_l3_accesses_series
+    )
+    return {"name": "L3 Miss %", "series": l3_miss_rate_series, "prefix": 100}
+
+
+@skip_if_missing
 def zen5_l3_miss_avg_load_to_use_latency_ns(grouped_df):
     l3_xi_sampled_latency_all_series = grouped_df.get_group(
         "l3_xi_sampled_latency.all"
@@ -2517,6 +2543,8 @@ def main(
             zen5_hardware_prefetch_l1_dc_fills_pki(grouped_df),
             zen5_hardware_prefetch_l1_dc_fills_from_other_ccx_pki(grouped_df),
             zen5_l3_miss_ptc(grouped_df),
+            zen5_l3_mpki(grouped_df),
+            zen5_l3_miss_rate(grouped_df),
             zen5_l3_miss_avg_load_to_use_latency_ns(grouped_df),
             zen5_l1_itlb_miss_pki(grouped_df),
             zen5_l2_itlb_hit_pki(grouped_df),


### PR DESCRIPTION
Summary:
The Zen5 perf report currently reports L3 activity only as "L3 Miss PTC"
(misses per thousand cycles) and L3 load-to-use latency. It does not expose
the two most commonly requested LLC health metrics: L3 MPKI (misses per
thousand instructions) and L3 Miss % (miss rate over accesses).

The underlying counters are already collected by
collect_amd_zen5_perf_counters.sh via the common core L3_LOOKUP_STATE event
group (l3_lookup_state.l3_miss and l3_lookup_state.all_coherent_accesses_to_l3),
plus retired instructions. The metrics just were not wired into the Zen5
report path. The existing llc_mpki/llc_miss_rate helpers are Zen3/Zen4-only
and read legacy event group names (l3_acceses/l3_misses) that Zen5 does not
emit, so they cannot be reused as-is.

This adds two Zen5-specific metric functions and registers them in the
zen5/zen5es output list, next to the existing L3 Miss PTC metric:
- zen5_l3_mpki: l3_lookup_state.l3_miss / instructions (prefix 1000)
- zen5_l3_miss_rate: l3_lookup_state.l3_miss /
  l3_lookup_state.all_coherent_accesses_to_l3 (prefix 100)

Both are decorated with skip_if_missing so they degrade gracefully when the
counters are absent, matching every other metric in the file.

Differential Revision: D110788381


