### PR TITLE
Fix django standalone topology

### DIFF
--- a/packages/django_workload/srcs/django-workload/django-workload/django_workload/settings.py
+++ b/packages/django_workload/srcs/django-workload/django-workload/django_workload/settings.py
@@ -86,8 +86,8 @@ DATABASES = {
         "HOST": "localhost",
         "OPTIONS": {
             "replication": {
-                "strategy_class": "SimpleStrategy",
-                "replication_factor": 1,
+                "strategy_class": "NetworkTopologyStrategy",
+                "datacenter1": 1,
             },
             "connection": {"protocol_version": 4},
         },


### PR DESCRIPTION
Django default standalone workload failed on x86 (and arm also) with the following error:

> cassandra.protocol.ConfigurationException: <Error from server: code=2300 [Query invalid because of configuration issue] message="replication_factor is an option for SimpleStrategy, not NetworkTopologyStrategy" 

### Steps to reproduce
### Install
sudo apt update
sudo apt install -y python3-pip git numactl sysstat
sudo pip3 install click pyyaml tabulate pandas packaging
git clone https://github.com/facebookresearch/DCPerf.git -b v2-beta
sudo ./benchpress_cli.py install django_workload_default

### Run
sudo ./benchpress_cli.py run django_workload_default -r standalone

