### PR TITLE
Apply AllowLegacyMissingUris annotation to Thrift files

### DIFF
--- a/packages/django_workload/install_django_workload_aarch64.sh
+++ b/packages/django_workload/install_django_workload_aarch64.sh
@@ -527,7 +527,7 @@ echo "Step 7: Building and Installing Proxygen"
 echo "====================================================================="
 
 # Clone Proxygen if not already present
-PROXYGEN_VERSION="v2025.10.13.00"
+PROXYGEN_VERSION="v2026.01.05.00"
 if [ ! -d "${DJANGO_WORKLOAD_ROOT}/proxygen" ]; then
     echo "Cloning Proxygen from GitHub..."
     cd "${DJANGO_WORKLOAD_ROOT}"
@@ -561,7 +561,7 @@ echo "====================================================================="
 echo "Step 7.5: Building and Installing fbthrift"
 echo "====================================================================="
 
-FBTHRIFT_VERSION="v2025.09.22.00"
+FBTHRIFT_VERSION="v2026.01.05.00"
 FBTHRIFT_PREFIX="${DJANGO_WORKLOAD_ROOT}/proxygen/proxygen/_build/deps"
 
 # Clone fbthrift if not already present

--- a/packages/django_workload/install_django_workload_aarch64_ubuntu22_24.sh
+++ b/packages/django_workload/install_django_workload_aarch64_ubuntu22_24.sh
@@ -562,7 +562,7 @@ echo "Step 7: Building and Installing Proxygen"
 echo "====================================================================="
 
 # Clone Proxygen if not already present
-PROXYGEN_VERSION="v2025.10.13.00"
+PROXYGEN_VERSION="v2026.01.05.00"
 if [ ! -d "${DJANGO_WORKLOAD_ROOT}/proxygen" ]; then
     echo "Cloning Proxygen from GitHub..."
     cd "${DJANGO_WORKLOAD_ROOT}"
@@ -596,7 +596,7 @@ echo "====================================================================="
 echo "Step 7.5: Building and Installing fbthrift"
 echo "====================================================================="
 
-FBTHRIFT_VERSION="v2025.09.22.00"
+FBTHRIFT_VERSION="v2026.01.05.00"
 FBTHRIFT_PREFIX="${DJANGO_WORKLOAD_ROOT}/proxygen/proxygen/_build/deps"
 
 # Clone fbthrift if not already present

--- a/packages/django_workload/install_django_workload_x86_64_centos.sh
+++ b/packages/django_workload/install_django_workload_x86_64_centos.sh
@@ -553,7 +553,7 @@ echo "Step 7: Building and Installing Proxygen"
 echo "====================================================================="
 
 # Clone Proxygen if not already present
-PROXYGEN_VERSION="v2025.10.13.00"
+PROXYGEN_VERSION="v2026.01.05.00"
 if [ ! -d "${DJANGO_WORKLOAD_ROOT}/proxygen" ]; then
     echo "Cloning Proxygen from GitHub..."
     cd "${DJANGO_WORKLOAD_ROOT}"
@@ -587,7 +587,7 @@ echo "====================================================================="
 echo "Step 7.5: Building and Installing fbthrift"
 echo "====================================================================="
 
-FBTHRIFT_VERSION="v2025.09.22.00"
+FBTHRIFT_VERSION="v2026.01.05.00"
 FBTHRIFT_PREFIX="${DJANGO_WORKLOAD_ROOT}/proxygen/proxygen/_build/deps"
 
 # Clone fbthrift if not already present

--- a/packages/django_workload/install_django_workload_x86_64_ubuntu22_24.sh
+++ b/packages/django_workload/install_django_workload_x86_64_ubuntu22_24.sh
@@ -564,7 +564,7 @@ echo "Step 7: Building and Installing Proxygen"
 echo "====================================================================="
 
 # Clone Proxygen if not already present
-PROXYGEN_VERSION="v2025.10.13.00"
+PROXYGEN_VERSION="v2026.01.05.00"
 if [ ! -d "${DJANGO_WORKLOAD_ROOT}/proxygen" ]; then
     echo "Cloning Proxygen from GitHub..."
     cd "${DJANGO_WORKLOAD_ROOT}"
@@ -598,7 +598,7 @@ echo "====================================================================="
 echo "Step 7.5: Building and Installing fbthrift"
 echo "====================================================================="
 
-FBTHRIFT_VERSION="v2025.09.22.00"
+FBTHRIFT_VERSION="v2026.01.05.00"
 FBTHRIFT_PREFIX="${DJANGO_WORKLOAD_ROOT}/proxygen/proxygen/_build/deps"
 
 # Clone fbthrift if not already present

--- a/packages/django_workload/srcs/django-workload/django-workload/django_workload/thrift/CMakeLists.txt
+++ b/packages/django_workload/srcs/django-workload/django-workload/django_workload/thrift/CMakeLists.txt
@@ -51,7 +51,11 @@ add_custom_command(
            ${GEN_DIR}/mock_services/MockAdsService.py
            ${GEN_DIR}/mock_services/__init__.py
     COMMAND ${CMAKE_COMMAND} -E make_directory ${GEN_DIR}
-    COMMAND ${THRIFT_COMPILER} --gen py -out ${GEN_DIR} ${THRIFT_SOURCE}
+    COMMAND ${THRIFT_COMPILER}
+            -I ${FBTHRIFT_PREFIX}/include
+            --gen py
+            -out ${GEN_DIR}
+            ${THRIFT_SOURCE}
     DEPENDS ${THRIFT_SOURCE}
     COMMENT "Generating Python Thrift bindings (OSS-compatible, pure Python, no async deps)"
     VERBATIM

--- a/packages/django_workload/srcs/django-workload/django-workload/django_workload/thrift/mock_services.thrift
+++ b/packages/django_workload/srcs/django-workload/django-workload/django_workload/thrift/mock_services.thrift
@@ -3,12 +3,10 @@
 // Mock Thrift service for DjangoBench V2 - SIMPLIFIED VERSION
 // Minimal structures for performance
 
-// Back out the change in https://github.com/facebookresearch/DCPerf/pull/387
-// Only uncomment the following 4 lines when we upgrade the version of fbthrift
-// include "thrift/annotation/thrift.thrift"
-//
-// @thrift.AllowLegacyMissingUris
-// package;
+include "thrift/annotation/thrift.thrift"
+
+@thrift.AllowLegacyMissingUris
+package;
 
 namespace py mock_services
 


### PR DESCRIPTION
Uncomment reverted `@thrift.AllowLegacyMissingUris` annotation in `mock_services.thrift` consistently using fbthrift version `v2026.01.05.00` containing this annotation (same version already pinned in `packages/feedsim/submodules.txt`).

Differential Revision: D114328618


