### PR TITLE
Add Thrift AllowLegacyMissingUris annotation to feedsim ranking Thrift

### DIFF
--- a/packages/feedsim/third_party/src/workloads/ranking/if/ranking.thrift
+++ b/packages/feedsim/third_party/src/workloads/ranking/if/ranking.thrift
@@ -1,6 +1,10 @@
 namespace cpp2 ranking
 
 include "thrift/annotation/cpp.thrift"
+include "thrift/annotation/thrift.thrift"
+
+@thrift.AllowLegacyMissingUris
+package;
 
 cpp_include "folly/small_vector.h"
 cpp_include "folly/container/F14Map.h"


### PR DESCRIPTION
Differential Revision: D114984901


