### PR TITLE
Increase minimum runtime of synchronization_small_locks benchmarks to 1s

### DIFF
--- a/packages/wdl_bench/run_prod.sh
+++ b/packages/wdl_bench/run_prod.sh
@@ -75,7 +75,7 @@ declare -A prod_benchmark_config=(
     ['hash_hash_benchmark']="--bm_mode=best-of --bm_regex=RapidHash --json"
     ['hash_checksum_benchmark']="--bm_mode=best-of --json"
     ['synchronization_lifo_sem_bench']="--bm_mode=best-of --bm_min_iters=1000000 --json"
-    ['synchronization_small_locks_benchmark']="--bm_mode=best-of --bm_min_iters=1000000 --bm_regex=\"(atomic_cas|atomics_fetch_add|std_mutex_simple).*\" -run_fairness=false -unlocked_work 0 --json"
+    ['synchronization_small_locks_benchmark']="--bm_mode=best-of --bm_min_iters=1000000 --bm_slice_usec=1000000 --bm_regex=\"(atomic_cas|atomics_fetch_add|std_mutex_simple).*\" -run_fairness=false -unlocked_work 0 --json"
     ['container_hash_maps_bench']="--bm_mode=best-of --bm_max_iters=1073741824 --bm_regex=\"f14(vec)|(val)\" --json" # filter find, insert, InsertSqBr, erase, and Iter operations in results parse script
     ['ProtocolBench']="--benchmark_filter='(^Binary)|(^Compact)Protocol' --benchmark_format=json"
     ['VarintUtilsBench']="--bm_mode=best-of --json"


### PR DESCRIPTION
Increase minimum runtime of folly synchronization_small_locks benchmarks to 1s from the default value of 1ms. This decreases the variability caused by thread setup and tear-down.

This changes the results of this benchmark, so results from before and after this patch are not directly comparable.

Our investigation showed that the default value of 1ms to be insufficient considering the overheads of spawning, joining, and synchronizing threads.